### PR TITLE
Kill the mutation-gate survivors the attendee tab migration left behind

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -209,3 +209,8 @@ src/shared/site-pages/core.ts:322:43  ?? → ||    # levelOf: forest.itemsByPage
 src/shared/db/listing-prices.ts:197:19  ?? → ||    # sourceRowStatements row.unit_price: number|null; the only falsy-non-null value is 0 and 0 ?? 0 === 0 || 0
 src/shared/db/listing-prices.ts:83:54  ?? → ||    # groupDayPriceStatements member.dayPrices: DayPrices|undefined — an object is always truthy, undefined→{} either way
 src/shared/db/listing-prices.ts:109:45  ?? → ||    # foldGroupDayRows result.get(): Map|undefined — a Map is always truthy
+
+# attendee entity page: `?? → ||` where the operand's only falsy-non-null
+# value equals the "" fallback.
+src/features/admin/attendee-page.ts:266:60  ?? → ||    # ctx.query.get("token"): string|null; the only falsy-non-null value "" equals the "" fallback
+src/features/admin/entity-pages.ts:230:28  ?? → ||    # opts.baseUrl: string|undefined; the only falsy-non-null value "" equals the "" fallback

--- a/test/lib/server-admin-balance.test.ts
+++ b/test/lib/server-admin-balance.test.ts
@@ -6,9 +6,12 @@ import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
 import { createAttendeeAtomic } from "#shared/db/attendees.ts";
 import {
   adminGet,
+  awaitTestRequest,
   createTestListing,
+  createTestManagerSession,
   describeWithEnv,
   expectHtml,
+  expectHtmlResponse,
   setupStripe,
   testRequiresAuth,
 } from "#test-utils";
@@ -160,5 +163,24 @@ describeWithEnv("server (admin attendee balance)", { db: true }, () => {
     const html = await response.text();
     expect(html).toContain("Balance outstanding");
     expect(html).toContain(`/admin/attendees/${attendeeId}/balance`);
+    // The tab strip alone also carries that href, so pin the payment-details
+    // link itself by its anchor text — it must render for owners.
+    expect(html).toContain("view balance &amp; payment link");
+  });
+
+  test("a manager's overview shows the balance owed but never the owner-only balance link", async () => {
+    // The Balance tab is owner-only, so its link must never render for a
+    // manager (never render a forbidden link) — neither in the payment-details
+    // panel nor in the tab strip.
+    const { attendeeId } = await createReservedAttendee(1500, {
+      paymentId: "pi_deposit",
+    });
+    const overview = await awaitTestRequest(`/admin/attendees/${attendeeId}`, {
+      cookie: await createTestManagerSession(),
+    });
+    const html = await expectHtmlResponse(overview, 200);
+    expect(html).toContain("Balance outstanding");
+    expect(html).not.toContain(`/admin/attendees/${attendeeId}/balance`);
+    expect(html).not.toContain("view balance &amp; payment link");
   });
 });

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -2537,6 +2537,40 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "Merge and Delete Source Attendee",
       );
     });
+
+    test("the token search box focuses when idle and echoes the searched token", async () => {
+      const listing = await createTestListing({ maxAttendees: 10 });
+      const { attendee: target } = await createTestAttendeeDirect(
+        listing.id,
+        "Jane Doe",
+        "jane@example.com",
+      );
+      const { token: sourceToken } = await createTestAttendeeDirect(
+        listing.id,
+        "John Smith",
+        "john@example.com",
+      );
+      // Idle panel: the search box is the tab's one job, so it takes focus
+      // and starts empty.
+      const idle = await expectHtmlResponse(
+        await adminGet(`/admin/attendees/${target.id}/actions`),
+        200,
+      );
+      expect(idle).toContain(" autofocus");
+      expect(extractInputValue(idle, "token")).toBe("");
+      // After a successful search the box echoes the token back (so the admin
+      // can see what matched) and cedes focus to the decision form.
+      const searched = await expectHtmlResponse(
+        await adminGet(
+          `/admin/attendees/${target.id}/actions?token=${encodeURIComponent(
+            sourceToken,
+          )}`,
+        ),
+        200,
+      );
+      expect(searched).not.toContain("autofocus");
+      expect(extractInputValue(searched, "token")).toBe(sourceToken);
+    });
   });
 
   /** Extract merge_version from the merge preview HTML page */


### PR DESCRIPTION
#1502 merged before its mutation gate finished; the gate then reported survivors on six of the lines that PR added. Four were real test-strength gaps, two were equivalent mutants. Test-only change — no behavior touched.

## Real gaps, now killed

- **Owner-only balance link on the Overview tab was unpinned.** The existing owner assertion (`/admin/attendees/:id/balance` in the page) was satisfied by the tab strip's href alone, so flipping the `adminLevel === "owner"` gate (`attendee-page.ts:173`) or the template's `showBalanceLink &&` (`attendees.tsx:217`) went unnoticed. The owner test now pins the payment-details anchor text itself, and a new manager test asserts the link never renders for managers — neither in the panel nor the strip (never render a forbidden link).
- **Merge panel search box had no markup assertions** (`attendees.tsx:588`, `594`): dropping the idle autofocus or the searched-token echo survived. A new test covers both states, using `extractInputValue` so the hidden `source_token` input can't mask a broken echo.

## Equivalent mutants, allowlisted

`?? ""` → `|| ""` on `ctx.query.get("token")` (`attendee-page.ts:266`) and `opts.baseUrl` (`entity-pages.ts:230`) are behaviorally identical — the only falsy-non-null string is `""`, which equals the fallback. Recorded in `scripts/mutation/equivalent-mutants.txt` per its convention.

## Verification

Targeted mutation runs confirm all four real survivors are killed (plus `attendees.tsx:213` as a side effect of the manager test) and the two allowlisted entries suppress. The remaining survivors in those files sit on pre-existing lines outside #1502's obligation (killed elsewhere in the suite, or long-standing gaps in code that predates the gate). Both edited test files pass; jscpd 0 clones; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cxaah8zWSD8vW6x8RoDnwR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxaah8zWSD8vW6x8RoDnwR)_