### PR TITLE
Fix parallel-suite fd exhaustion behind the CI flakiness (+ harden describeWithEnv storage option)

### DIFF
--- a/scripts/test-harness.ts
+++ b/scripts/test-harness.ts
@@ -174,6 +174,13 @@ const buildDenoTestArgs = (
     "--allow-sys",
     "--allow-ffi",
     "--parallel",
+    // Expose `globalThis.gc` so the test DB layer can reclaim libsql's
+    // file-descriptor leak (a fresh client per test + every interactive
+    // transaction leaks an fd that close() never releases — only GC does). Under
+    // high --parallel worker counts these outrun GC and exhaust the process fd
+    // limit ("Too many open files"), which surfaces as flaky, moving failures.
+    // See maybeReclaimLeakedFds in test/test-utils/db.ts.
+    "--v8-flags=--expose-gc",
   ];
   if (reporter) args.push("--reporter", reporter);
   if (useCoverage) args.push("--coverage=coverage");

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -7,7 +7,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as BunnyStorageSDK from "@bunny.net/storage-sdk";
-import { sort } from "#fp";
+import { lazyRef, sort } from "#fp";
 import { decryptBytes, encryptBytes } from "#shared/crypto/encryption.ts";
 import { getEnv } from "#shared/env.ts";
 import {
@@ -37,9 +37,24 @@ export const runWithStorageConfig = <T>(
   fn: () => T,
 ): T => storageConfigStore.run(config, fn);
 
-/** Read storage config: AsyncLocalStorage context first, then env vars. */
+// Suite-level storage config for tests (describeWithEnv's `storage` option).
+// Layered *under* the per-call runWithStorageConfig scope and *over* the process
+// env, so a whole suite can declare its backend once — without wrapping each test
+// body or mutating STORAGE_ZONE_*/LOCAL_STORAGE_PATH env vars. Held as a typed
+// StorageConfig object, not env strings, so it can't reintroduce the env-var
+// races runWithStorageConfig exists to avoid; a per-test runWithStorageConfig
+// scope still wins over it.
+const [getTestStorageConfig, setTestStorageConfig] =
+  lazyRef<StorageConfig | null>(() => null);
+
+export { setTestStorageConfig };
+
+/**
+ * Read storage config: per-call AsyncLocalStorage scope first, then the
+ * suite-level test default, then env vars.
+ */
 const getStorageConfig = (): StorageConfig => {
-  const ctx = storageConfigStore.getStore();
+  const ctx = storageConfigStore.getStore() ?? getTestStorageConfig();
   if (ctx) return ctx;
   return {
     zoneKey: getEnv("STORAGE_ZONE_KEY") ?? "",
@@ -52,7 +67,7 @@ const getStorageConfig = (): StorageConfig => {
  * Returns null if local storage is not configured or explicitly disabled.
  */
 const getLocalStoragePath = (): string | null => {
-  const ctx = storageConfigStore.getStore();
+  const ctx = storageConfigStore.getStore() ?? getTestStorageConfig();
   if (ctx && "localPath" in ctx) {
     return ctx.localPath || null;
   }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -44,10 +44,20 @@ export const runWithStorageConfig = <T>(
 // StorageConfig object, not env strings, so it can't reintroduce the env-var
 // races runWithStorageConfig exists to avoid; a per-test runWithStorageConfig
 // scope still wins over it.
-const [getTestStorageConfig, setTestStorageConfig] =
-  lazyRef<StorageConfig | null>(() => null);
+const [getTestStorageConfig, storageConfigRef] = lazyRef<StorageConfig | null>(
+  () => null,
+);
 
-export { setTestStorageConfig };
+/**
+ * Test-only: set the suite-level storage config that describeWithEnv's `storage`
+ * option applies. A directly-exported named function (not an `export {}` list,
+ * which the test-hook scanner does not detect, nor a module-level alias) so it is
+ * visible to and registered in `ALLOWED_TEST_HOOKS`
+ * (test/lib/code-quality.test.ts), alongside `runWithStorageConfig`.
+ */
+export function setStorageConfigForTest(config: StorageConfig | null): void {
+  storageConfigRef(config);
+}
 
 /**
  * Read storage config: per-call AsyncLocalStorage scope first, then the

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -194,6 +194,8 @@ const ALLOWED_TEST_HOOKS: string[] = [
   "shared/storage.ts:MAX_ATTACHMENT_SIZE",
   // AsyncLocalStorage-based storage config for concurrent test isolation
   "shared/storage.ts:runWithStorageConfig",
+  // Suite-level storage config setter for describeWithEnv's `storage` option
+  "shared/storage.ts:setStorageConfigForTest",
   // readLimit used in production (module-level constants) but test pattern doesn't detect same-file usage
   "shared/limits.ts:readLimit",
   // Set log suppression directly to avoid env var races between parallel tests

--- a/test/lib/describe-with-env-storage.test.ts
+++ b/test/lib/describe-with-env-storage.test.ts
@@ -86,4 +86,31 @@ describe("describeWithEnv storage option", () => {
       expect(getTestStoragePath()).toBeNull();
     });
   });
+
+  // Regression: the storage option must resolve the backend through a typed
+  // StorageConfig (layered under runWithStorageConfig, over env) and must NOT
+  // mutate STORAGE_ZONE_*/LOCAL_STORAGE_PATH — reintroducing that env-var route
+  // is exactly the race AsyncLocalStorage was added to avoid. A suite that pins
+  // sentinel values for all three vars must still resolve local from config, and
+  // find every sentinel untouched afterwards. Fails on the prior env-based
+  // implementation, which overwrote LOCAL_STORAGE_PATH and cleared the zone vars.
+  describeWithEnv(
+    "storage option resolves via config, not env vars",
+    {
+      env: {
+        LOCAL_STORAGE_PATH: "sentinel-path",
+        STORAGE_ZONE_KEY: "sentinel-key",
+        STORAGE_ZONE_NAME: "sentinel-name",
+      },
+      storage: "local",
+    },
+    () => {
+      test("selects local from config while leaving the env sentinels intact", () => {
+        expect(getStorageBackend()).toBe("local");
+        expect(Deno.env.get("LOCAL_STORAGE_PATH")).toBe("sentinel-path");
+        expect(Deno.env.get("STORAGE_ZONE_KEY")).toBe("sentinel-key");
+        expect(Deno.env.get("STORAGE_ZONE_NAME")).toBe("sentinel-name");
+      });
+    },
+  );
 });

--- a/test/lib/reclaim-fds.test.ts
+++ b/test/lib/reclaim-fds.test.ts
@@ -5,12 +5,12 @@ import {
   RECLAIM_FDS_EVERY,
 } from "#test-utils/reclaim-fds.ts";
 
-// Any window of N consecutive calls straddles exactly N / RECLAIM_FDS_EVERY
-// reclaim boundaries, regardless of the shared counter's starting phase — so
-// these assertions are independent of test order and of any DB setups that also
+// Any run of N consecutive calls straddles exactly N / RECLAIM_FDS_EVERY reclaim
+// boundaries regardless of the shared counter's starting phase, so these
+// assertions are independent of test order and of any DB setups that also
 // advanced the counter.
 describe("maybeReclaimLeakedFds", () => {
-  test("invokes gc exactly once per RECLAIM_FDS_EVERY calls", () => {
+  test("invokes an explicitly injected gc once per RECLAIM_FDS_EVERY calls", () => {
     let calls = 0;
     const gc = () => {
       calls += 1;
@@ -19,17 +19,24 @@ describe("maybeReclaimLeakedFds", () => {
     expect(calls).toBe(3);
   });
 
-  test("is a safe no-op when gc is unavailable, even on a boundary call", () => {
-    let threw = false;
+  test("is a safe no-op on a boundary call when gc is genuinely unavailable", () => {
+    // The harness runs with --expose-gc, so passing `undefined` would fall back
+    // to the (present) default. Actually clear globalThis.gc to exercise the
+    // absent path — a bare `deno test` without the flag.
+    const glob = globalThis as { gc?: (() => void) | undefined };
+    const original = glob.gc;
+    glob.gc = undefined;
     try {
-      // Spans a reclaim boundary with no gc — must not throw.
-      for (let i = 0; i < RECLAIM_FDS_EVERY; i++) {
-        maybeReclaimLeakedFds(undefined);
+      let threw = false;
+      try {
+        for (let i = 0; i < RECLAIM_FDS_EVERY; i++) maybeReclaimLeakedFds();
+      } catch {
+        threw = true;
       }
-    } catch {
-      threw = true;
+      expect(threw).toBe(false);
+    } finally {
+      glob.gc = original;
     }
-    expect(threw).toBe(false);
   });
 
   test("defaults to globalThis.gc when called without an argument", () => {

--- a/test/lib/reclaim-fds.test.ts
+++ b/test/lib/reclaim-fds.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  maybeReclaimLeakedFds,
+  RECLAIM_FDS_EVERY,
+} from "#test-utils/reclaim-fds.ts";
+
+// Any window of N consecutive calls straddles exactly N / RECLAIM_FDS_EVERY
+// reclaim boundaries, regardless of the shared counter's starting phase — so
+// these assertions are independent of test order and of any DB setups that also
+// advanced the counter.
+describe("maybeReclaimLeakedFds", () => {
+  test("invokes gc exactly once per RECLAIM_FDS_EVERY calls", () => {
+    let calls = 0;
+    const gc = () => {
+      calls += 1;
+    };
+    for (let i = 0; i < RECLAIM_FDS_EVERY * 3; i++) maybeReclaimLeakedFds(gc);
+    expect(calls).toBe(3);
+  });
+
+  test("is a safe no-op when gc is unavailable, even on a boundary call", () => {
+    let threw = false;
+    try {
+      // Spans a reclaim boundary with no gc — must not throw.
+      for (let i = 0; i < RECLAIM_FDS_EVERY; i++) {
+        maybeReclaimLeakedFds(undefined);
+      }
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+  });
+
+  test("defaults to globalThis.gc when called without an argument", () => {
+    const glob = globalThis as { gc?: (() => void) | undefined };
+    const original = glob.gc;
+    let called = 0;
+    glob.gc = () => {
+      called += 1;
+    };
+    try {
+      for (let i = 0; i < RECLAIM_FDS_EVERY; i++) maybeReclaimLeakedFds();
+      expect(called).toBe(1);
+    } finally {
+      glob.gc = original;
+    }
+  });
+});

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -50,6 +50,7 @@ import {
   TEST_ADMIN_USERNAME,
   TEST_STORAGE_ZONE,
 } from "#test-utils/internal.ts";
+import { maybeReclaimLeakedFds } from "#test-utils/reclaim-fds.ts";
 
 type SchemaEntry = (typeof SCHEMA)[number];
 type SchemaIndex = NonNullable<SchemaEntry[1]["indexes"]>[number];
@@ -108,6 +109,9 @@ const getOrCreateGoldenDb: () => Promise<string> = once(
 );
 
 const prepareTestClient = async (triggers = false): Promise<void> => {
+  // Keep libsql's leaked file descriptors from exhausting the process limit
+  // under high `--parallel` worker counts (see reclaim-fds.ts).
+  maybeReclaimLeakedFds();
   setupTestEncryptionKey();
   settings.setup.clearCache();
   resetSessionCache();

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -31,7 +31,7 @@ import {
   setHostEmailConfigForTest,
 } from "#shared/email.ts";
 import { getEnv } from "#shared/env.ts";
-import { setTestStorageConfig } from "#shared/storage.ts";
+import { setStorageConfigForTest } from "#shared/storage.ts";
 import { setTestEnv, setupTestEncryptionKey } from "#test-utils/env.ts";
 import {
   type DescribeEnvOptions,
@@ -161,6 +161,9 @@ export const createTestDb = async (triggers = false): Promise<void> => {
 export const setupTransactionalTestDb = async (): Promise<
   () => Promise<void>
 > => {
+  // Same libsql fd leak as prepareTestClient: this path also mints a fresh
+  // file-backed client per test and runs many `withTransaction` writes.
+  maybeReclaimLeakedFds();
   setupTestEncryptionKey();
   const goldenPath = await getOrCreateGoldenDb();
   const path = await Deno.makeTempFile({ suffix: ".db" });
@@ -356,7 +359,7 @@ const applyStorageConfig = async (
   storage: DescribeEnvOptions["storage"],
 ): Promise<void> => {
   if (storage === "cdn") {
-    setTestStorageConfig({
+    setStorageConfigForTest({
       localPath: "",
       zoneKey: TEST_STORAGE_ZONE.zoneKey,
       zoneName: TEST_STORAGE_ZONE.zoneName,
@@ -366,13 +369,13 @@ const applyStorageConfig = async (
   if (storage === "local") {
     const dir = await Deno.makeTempDir();
     setTestStoragePath(dir);
-    setTestStorageConfig({ localPath: dir, zoneKey: "", zoneName: "" });
+    setStorageConfigForTest({ localPath: dir, zoneKey: "", zoneName: "" });
   }
 };
 
 /** Clear the suite-level storage config and remove any `"local"` temp dir. */
 const teardownStorageConfig = async (): Promise<void> => {
-  setTestStorageConfig(null);
+  setStorageConfigForTest(null);
   const dir = getTestStoragePath();
   if (!dir) return;
   setTestStoragePath(null);

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -31,6 +31,7 @@ import {
   setHostEmailConfigForTest,
 } from "#shared/email.ts";
 import { getEnv } from "#shared/env.ts";
+import { setTestStorageConfig } from "#shared/storage.ts";
 import { setTestEnv, setupTestEncryptionKey } from "#test-utils/env.ts";
 import {
   type DescribeEnvOptions,
@@ -337,38 +338,37 @@ export const invalidateTestDbCache = (): void => {
 };
 
 /**
- * Env additions that establish the requested `storage` backend for a test.
- * `"local"` also allocates a fresh temp dir and records it for `getTestStoragePath`.
- * Storage config is read env-first with an AsyncLocalStorage override, so a
- * per-test `runWithStorageConfig` scope still overrides this suite default.
+ * Establish the requested `storage` backend for a test as a typed suite-level
+ * `StorageConfig` (read via `#shared/storage.ts`, layered under any per-test
+ * `runWithStorageConfig` scope and over env). Each backend fully specifies both
+ * dimensions so it resolves deterministically regardless of ambient env — no
+ * `STORAGE_ZONE_*` / `LOCAL_STORAGE_PATH` vars are touched:
+ * - `"cdn"`: the Bunny test zone, with `localPath: ""` so an ambient local path
+ *   can't route uploads to disk instead of the CDN.
+ * - `"local"`: a fresh temp dir (recorded for `getTestStoragePath`) with empty
+ *   zone creds, so ambient Bunny creds can't shadow the local backend.
  */
-const setupStorageEnv = async (
+const applyStorageConfig = async (
   storage: DescribeEnvOptions["storage"],
-): Promise<Record<string, string | undefined>> => {
+): Promise<void> => {
   if (storage === "cdn") {
-    // Clear any ambient local path so the Bunny backend resolves deterministically.
-    return {
-      LOCAL_STORAGE_PATH: undefined,
-      STORAGE_ZONE_KEY: TEST_STORAGE_ZONE.zoneKey,
-      STORAGE_ZONE_NAME: TEST_STORAGE_ZONE.zoneName,
-    };
+    setTestStorageConfig({
+      localPath: "",
+      zoneKey: TEST_STORAGE_ZONE.zoneKey,
+      zoneName: TEST_STORAGE_ZONE.zoneName,
+    });
+    return;
   }
   if (storage === "local") {
     const dir = await Deno.makeTempDir();
     setTestStoragePath(dir);
-    // Clear any ambient Bunny creds — getStorageBackend() checks those before
-    // the local path, so leaving them set would resolve to "bunny", not "local".
-    return {
-      LOCAL_STORAGE_PATH: dir,
-      STORAGE_ZONE_KEY: undefined,
-      STORAGE_ZONE_NAME: undefined,
-    };
+    setTestStorageConfig({ localPath: dir, zoneKey: "", zoneName: "" });
   }
-  return {};
 };
 
-/** Remove the `storage: "local"` temp dir and clear the recorded path. */
-const teardownStorageEnv = async (): Promise<void> => {
+/** Clear the suite-level storage config and remove any `"local"` temp dir. */
+const teardownStorageConfig = async (): Promise<void> => {
+  setTestStorageConfig(null);
   const dir = getTestStoragePath();
   if (!dir) return;
   setTestStoragePath(null);
@@ -391,17 +391,14 @@ export const describeWithEnv = (
         settings.googleWallet.setHostConfigForTest(null);
         await createTestDbWithSetup("GB", options.triggers ?? false);
       }
-      const env = {
-        ...options.env,
-        ...(await setupStorageEnv(options.storage)),
-      };
-      if (Object.keys(env).length > 0) restoreEnv = setTestEnv(env);
+      if (options.env) restoreEnv = setTestEnv(options.env);
+      await applyStorageConfig(options.storage);
     });
     afterEach(async () => {
       if (options.db) resetDb();
       if (restoreEnv) restoreEnv();
       restoreEnv = undefined;
-      await teardownStorageEnv();
+      await teardownStorageConfig();
     });
     fn();
   });

--- a/test/test-utils/reclaim-fds.ts
+++ b/test/test-utils/reclaim-fds.ts
@@ -1,0 +1,35 @@
+/**
+ * Reclaim libsql's leaked file descriptors during long test runs.
+ *
+ * libsql's file-backed client leaks one file descriptor per client creation and
+ * per interactive transaction: `close()` never releases it — a transaction
+ * orphans its connection and neither `commit()` nor `close()` shuts it down, so
+ * only garbage collection reclaims it. The suite mints a fresh client every test
+ * and runs many `withTransaction` writes, so under high `--parallel` worker
+ * counts these leaked descriptors outrun GC and exhaust the process limit
+ * ("Too many open files"). That exhaustion lands on whichever test is unlucky
+ * enough to hit the wall — a flaky failure that moves between runs.
+ *
+ * Calling `gc()` periodically keeps the descriptor count bounded. `gc` is only
+ * exposed when the harness passes `--v8-flags=--expose-gc` (see
+ * `buildDenoTestArgs`); without it — a bare `deno test` — this is a safe no-op.
+ */
+
+/** Force a GC every this many calls, amortising its cost across the run. */
+export const RECLAIM_FDS_EVERY = 20;
+
+const state = { count: 0 };
+
+/**
+ * Call once per test DB setup. Forces a GC every {@link RECLAIM_FDS_EVERY}
+ * invocations to reclaim libsql's leaked descriptors. `gc` defaults to the
+ * runtime's `globalThis.gc` (present only under `--expose-gc`); it is injectable
+ * so the behaviour is unit-testable without depending on the V8 flag.
+ */
+export const maybeReclaimLeakedFds = (
+  gc: (() => void) | undefined = (globalThis as { gc?: () => void }).gc,
+): void => {
+  state.count += 1;
+  if (state.count % RECLAIM_FDS_EVERY !== 0) return;
+  if (gc) gc();
+};


### PR DESCRIPTION
## The flakiness — root cause

The intermittent CI failures (a single, *moving* test failing ~1-in-N runs, only in the full `--parallel` suite, "no flakiness the day before") trace to a **file-descriptor leak in libsql's file-backed client**, not to any one test.

- libsql leaks **one fd per client creation and per interactive transaction**. `close()` never releases it — `transaction()` orphans its connection (`this.#db = null`) and neither `commit()` nor `close()` shuts that connection down. Only **GC** reclaims the fd (verified empirically: plain `execute()` holds fds flat, each `transaction()` adds one, `gc()` drops them all back; `@libsql/client` 0.17.4 has the same code).
- The suite mints a fresh client every test and runs many `withTransaction` writes, so at high worker counts the leaked fds **outrun GC and exhaust the process limit**. Reproduced locally: at 4 parallel jobs the full suite dies with `Too many open files` partway through; at 2 jobs it passes clean.
- On CI the limit is crossed only occasionally, so it surfaces as a flaky failure landing on **whichever test happens to allocate the fd that tips over the limit** — hence the failing test keeps moving and always sits in whatever ran under peak load.

### When it started
Bisected via CI history: the merge queue was green for every PR through #1503, then **#1462 "Groups as packages" (`d9e7770`, merged 2026-07-02 16:48 UTC)** — which added 445 lines of package tests and rewrote 328 lines of the booking tests, i.e. many transaction-heavy tests — was the first to flake, and failures then spread to every branch rebased onto it. The recent `describeWithEnv` change was **not** the cause.

## Fix

**fd reclamation (the flakiness fix).** Expose `gc` via `--v8-flags=--expose-gc` in the test harness and force a GC every 20 DB setups from `prepareTestClient`, keeping the descriptor count bounded. Extracted as `reclaim-fds.ts` with an injectable `gc` so both the present and absent paths are unit-tested; a bare `deno test` without the flag is a safe no-op. Test-only — production uses a remote libsql client (HTTP), not file fds.

**describeWithEnv storage option → typed config (hardening, first commit).** The suite-level `storage` option resolved the backend by mutating `STORAGE_ZONE_*`/`LOCAL_STORAGE_PATH` env vars — re-introducing the exact env-var dependency `runWithStorageConfig` (AsyncLocalStorage) exists to avoid. Now routed through a typed `StorageConfig` layered under the per-call scope and over env; no env vars touched. Regression test asserts the option resolves from config while leaving pinned env sentinels intact (fails on the old implementation).

## Verification

- **fd fix:** before it, a 4-job full run crashes on fds every time; after it, **five consecutive 4-job full runs complete cleanly** (only the stripe-mock *download* tests fail, and only because this sandbox can't reach GitHub releases — they pass on CI).
- `deno task lint:ci` ✅ · `deno task typecheck` ✅ · `deno task cpd` (0%) ✅ · `reclaim-fds.ts` 100% line+branch coverage ✅
- storage change: `describe-with-env-storage.test.ts` green incl. the new regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)