### PR TITLE
Strengthen tests for attendee merge/refund/roster logging and logic

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -209,3 +209,7 @@ src/shared/db/listing-prices.ts:109:45  ?? → ||    # foldGroupDayRows result.g
 # value equals the "" fallback.
 src/features/admin/attendee-page.ts:266:60  ?? → ||    # ctx.query.get("token"): string|null; the only falsy-non-null value "" equals the "" fallback
 src/features/admin/entity-pages.ts:230:28  ?? → ||    # opts.baseUrl: string|undefined; the only falsy-non-null value "" equals the "" fallback
+
+# attendee merge/refund route: mutants with no observable effect.
+src/features/admin/attendees-merge.ts:356:10  === → !=    # toBookingChoice: keep_target and skip_source are consumed identically (attendee-merge.ts "do nothing for this booking"), so normalizing one to the other is unobservable
+src/features/admin/attendee-refunds.ts:172:24  ?? → ||    # flash.error: string|undefined from applyFlash; a refund error flash is always a non-empty message, so the only falsy-non-null value "" never occurs and ?? / || agree

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
+import { spy, stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { attendeesApi } from "#shared/db/attendees.ts";
 import { getDb } from "#shared/db/client.ts";
@@ -407,6 +407,18 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       const { getAttendeeRaw } = await import("#shared/db/attendees.ts");
       const deleted = await getAttendeeRaw(attendee.id);
       expect(deleted).toBeNull();
+
+      // The deletion is recorded in the listing activity log.
+      const { getListingActivityLog } = await import("#test-utils");
+      const log = (await getListingActivityLog(listing.id)).find((l) =>
+        l.message.includes("Incomplete attendee deleted"),
+      );
+      expect(log).toBeDefined();
+
+      // The delete releases the booking by default, so the reserved spot is
+      // freed (booked count returns to zero).
+      const counted = await getListingWithCount(listing.id);
+      expect(counted?.attendee_count).toBe(0);
     });
 
     test("refuses to delete complete attendee via delete-incomplete", async () => {
@@ -572,6 +584,13 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "checkin_name=John",
         "#message",
       );
+
+      // The check-in is recorded in the listing activity log.
+      const { getListingActivityLog } = await import("#test-utils");
+      const log = (await getListingActivityLog(listing.id)).find((l) =>
+        l.message.includes("checked in"),
+      );
+      expect(log).toBeDefined();
     });
 
     test("redirects to filtered page when return_filter is set", async () => {
@@ -729,7 +748,13 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         "checkin",
         "listing",
       );
-      expectFlash(response, "Cannot check in a no-quantity line", false);
+      // With no return_url the refusal lands back on the listing page (not an
+      // empty redirect), carrying the flash.
+      await expectFlashRedirect(
+        `/admin/listing/${listingId}`,
+        "Cannot check in a no-quantity line",
+        false,
+      )(response);
       const row = await getDb().execute({
         args: [listingId],
         sql: "SELECT checked_in FROM listing_attendees WHERE listing_id = ?",
@@ -820,6 +845,52 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
 
       const attendees = await getAttendeesRaw(listing.id);
       expect(attendees.length).toBe(1);
+
+      // The manual add is recorded in the listing activity log, naming the
+      // attendee.
+      const { getListingActivityLog } = await import("#test-utils");
+      const log = (await getListingActivityLog(listing.id)).find((l) =>
+        l.message.includes("added manually"),
+      );
+      expect(log?.message).toContain("Jane Doe");
+    });
+
+    test("persists every submitted contact field, not just the name", async () => {
+      const { listing, cookie, csrfToken } = await setupListingAndLogin({
+        fields: "email,phone,address,special_instructions",
+        maxAttendees: 100,
+      });
+
+      const response = await handleRequest(
+        mockFormRequest(
+          `/admin/listing/${listing.id}/attendee`,
+          {
+            address: "9 Persistence Way",
+            csrf_token: csrfToken,
+            email: "persist@example.com",
+            name: "Persist Person",
+            phone: "555-7777",
+            quantity: "1",
+            special_instructions: "Aisle seat",
+          },
+          cookie,
+        ),
+      );
+      expect(response.status).toBe(302);
+
+      // Each contact field round-trips to the edit form; a field dropped to ""
+      // on the way in would be missing here.
+      const [added] = await getAttendeesRaw(listing.id);
+      const edit = await adminGet(`/admin/attendees/${added!.id}/edit`);
+      await expectHtmlResponse(
+        edit,
+        200,
+        "Persist Person",
+        "persist@example.com",
+        "555-7777",
+        "9 Persistence Way",
+        "Aisle seat",
+      );
     });
 
     test("adds a customisable daily attendee spanning the chosen day count", async () => {
@@ -962,20 +1033,31 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
             }),
           ),
         async () => {
-          const response = await handleRequest(
-            mockFormRequest(
-              `/admin/listing/${listing.id}/attendee`,
-              {
-                csrf_token: csrfToken,
-                email: "enc@example.com",
-                name: "Enc Fail",
-                quantity: "1",
-              },
-              cookie,
-            ),
-          );
-          expect(response.status).toBe(302);
-          expectFlash(response, expect.stringContaining("Encryption"), false);
+          const errorSpy = spy(console, "error");
+          try {
+            const response = await handleRequest(
+              mockFormRequest(
+                `/admin/listing/${listing.id}/attendee`,
+                {
+                  csrf_token: csrfToken,
+                  email: "enc@example.com",
+                  name: "Enc Fail",
+                  quantity: "1",
+                },
+                cookie,
+              ),
+            );
+            expect(response.status).toBe(302);
+            expectFlash(response, expect.stringContaining("Encryption"), false);
+            // An encryption failure (and only that reason) is logged to the
+            // error log — a capacity failure is a normal outcome and isn't.
+            const logged = errorSpy.calls.map((c) => String(c.args[0]));
+            expect(logged.some((s) => s.includes("manual add attendee"))).toBe(
+              true,
+            );
+          } finally {
+            errorSpy.restore();
+          }
         },
       );
     });
@@ -2689,10 +2771,22 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
         { merge_version: mergeVersion, source_token: sourceToken },
       );
 
+      // The flash names both attendees, and with no PII chosen the kept name is
+      // the target's — so it reads "into Jane Doe", never "into John Smith".
       await expectFlashRedirect(
         `/admin/attendees/${target.id}`,
-        expect.stringContaining("Merged"),
+        expect.stringContaining("Merged John Smith into Jane Doe"),
       )(response);
+
+      // The merge is recorded on the target's listing activity log, naming the
+      // source and the kept (target) attendee.
+      const { getListingActivityLog } = await import("#test-utils");
+      const mergeLog = (await getListingActivityLog(listing1.id)).find((l) =>
+        l.message.includes("merged into"),
+      );
+      expect(mergeLog?.message).toContain(
+        "Attendee 'John Smith' merged into 'Jane Doe'",
+      );
 
       // Source attendee should be deleted
       const { getAttendeeRaw } = await import("#shared/db/attendees.ts");

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -18,6 +18,7 @@ import {
   expectFlash,
   expectFlashRedirect,
   expectHtmlResponse,
+  getListingActivityLog,
   mockFormRequest,
   mockProviderType,
   setupListingAndLogin,
@@ -26,6 +27,7 @@ import {
   testRequiresAuth,
   withMocks,
 } from "#test-utils";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
 
 // -- URL builders --------------------------------------------------------- //
 
@@ -598,6 +600,13 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
         )(response);
         expect(mockRefund.calls.length).toBe(2);
       });
+
+      // The bulk refund records the exact success count in the activity log —
+      // "all 2", never "all -2" (a mis-signed tally would flip the count).
+      const log = (await getListingActivityLog(listing.id)).find((l) =>
+        l.message.includes("Bulk refund: all"),
+      );
+      expect(log?.message).toContain("all 2 attendee(s) refunded");
     });
 
     test("counts a refund the ledger could not record as errored, not refunded", async () => {
@@ -640,6 +649,13 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
         )(response);
         expectFlash(response, expect.stringContaining("2 remaining"), true);
       });
+
+      // The continuation batch logs its progress with the count out of the
+      // total refundable ("30 of 32").
+      const log = (await getListingActivityLog(listing.id)).find((l) =>
+        l.message.includes("Bulk refund: 30 of"),
+      );
+      expect(log?.message).toContain("Bulk refund: 30 of 32 refunded");
     });
 
     test("reports failures with remaining count when batch has errors", async () => {
@@ -677,6 +693,12 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
           await expectPartialRefund(listing, await postRefundAll(listing));
         },
       );
+
+      // The mixed outcome is logged with both tallies for the audit trail.
+      const log = (await getListingActivityLog(listing.id)).find((l) =>
+        l.message.includes("Bulk refund: 1 succeeded"),
+      );
+      expect(log?.message).toContain("1 succeeded, 1 failed");
     });
 
     test("catches thrown refund errors and reports them in the flash", async () => {
@@ -846,6 +868,60 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
       expect(html).toContain(
         `/admin/attendees/${attendee.id}/resend-notification`,
       );
+    });
+  });
+
+  // A provider refund that fails or throws is a silent-money hazard: the flash
+  // reports it, but the durable record is the error log. These assert each
+  // failure path actually logs, since a dropped logError is otherwise invisible.
+  describe("provider refund failures reach the error log", () => {
+    const errors = setupErrorSpy();
+    const loggedDetails = (): string[] =>
+      errors.calls.map((call) => String(call.args[0]));
+
+    test("a single refund the provider rejects is logged", async () => {
+      const ctx = await setupRefundTest("pi_logfail_single");
+      await withRefundMock(false, async () => {
+        await submitRefund(ctx);
+      });
+      expect(
+        loggedDetails().some((s) => s.includes("Admin refund failed")),
+      ).toBe(true);
+    });
+
+    test("a bulk refund the provider rejects is logged per attendee", async () => {
+      const listing = await createPaidListing();
+      await createPaidTestAttendee(
+        listing.id,
+        "Bulk Fail",
+        "bulkfail@example.com",
+        "pi_logfail_bulk",
+      );
+      await withRefundMock(false, async () => {
+        await postRefundAll(listing);
+      });
+      expect(
+        loggedDetails().some((s) => s.includes("Admin bulk refund failed")),
+      ).toBe(true);
+    });
+
+    test("a bulk refund the provider throws on is logged as errored", async () => {
+      const listing = await createPaidListing();
+      await createPaidTestAttendee(
+        listing.id,
+        "Bulk Throw",
+        "bulkthrow@example.com",
+        "pi_logfail_throw",
+      );
+      await withRefundMock(
+        () => Promise.reject(new Error("provider boom")),
+        async () => {
+          await postRefundAll(listing);
+        },
+      );
+      expect(
+        loggedDetails().some((s) => s.includes("Admin bulk refund errored")),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Follow-up to the attendee tab migration (#1500/#1502/#1508). The post-merge mutation gate surfaced pre-existing test-strength gaps in attendee feature code that predates the gate — logging and logic that no test asserted. This adds regression coverage for the genuine ones and allowlists two equivalent mutants. **Test-only: no production code changes.**

I ran each feature file's mutation gate against its *full* covering suite (not just the changed-set the precommit gate uses) to find what the whole suite actually leaves unkilled, then targeted those.

## attendee-refunds.ts — now 100% killed (38/38, 1 equivalent suppressed)
- Bulk-refund **activity-log** entries (all-done, continuation, and partial-failure branches) were unasserted, so a dropped `logActivity` was invisible. The existing bulk tests now assert the log — anchored on the exact count (`all 2`, `30 of 32`) so a mis-signed tally (`all -2`) also fails, which additionally kills the increment mutant that `stringContaining` was masking.
- Provider refund **failures** (single reject, bulk reject, bulk throw) now assert they reach the error log, via a `console.error` spy — a removed `logError` is otherwise unobservable.

## attendees-merge.ts — 29/31 killed (1 equivalent suppressed)
- The merge now asserts it names the **kept** attendee in its flash/log (`into Jane Doe`, never `into John Smith`) and writes an **activity-log** entry.

## attendees.ts — 40/41 killed
- **Check-in**, **manual add**, and **incomplete delete** each now assert their activity-log entry; incomplete delete also asserts the booking is **released** (freed spot — the default that a flipped `releaseBookings` would drop).
- Manual add asserts **every contact field persists**, not just the name (a field defaulted to `""` on the way in would be missing).
- The no-quantity check-in refusal asserts it lands **back on the listing** (not an empty redirect).
- The encryption-failure path asserts it **logs**.

## Allowlisted as equivalent (`scripts/mutation/equivalent-mutants.txt`)
- `attendees-merge.ts` `toBookingChoice`: `keep_target` and `skip_source` are consumed identically ("do nothing for this booking"), so normalizing one to the other is unobservable.
- `attendee-refunds.ts` `flash.error ?? …`: a refund error flash is always a non-empty message, so the only falsy-non-null value (`""`) never occurs and `??`/`||` agree.

## Remaining survivors (documented follow-ups, low value)
- `attendees-merge.ts` 109/110 — the merge diff's question-listing-id collection (needs a two-listing-with-questions setup to observe).
- `attendees.ts` 261 — the add-form day-count gate (a field-validation edge).

## Verification
Targeted mutation runs confirm every new kill; lint, typecheck, jscpd, and build all pass. (The full-suite coverage run hits a file-descriptor limit in the sandbox — `os error 24` copying the golden DB per test in an unrelated file — so I rely on CI for the coverage gate; a test-only change cannot lower source coverage.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cxaah8zWSD8vW6x8RoDnwR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxaah8zWSD8vW6x8RoDnwR)_