### PR TITLE
Fix cross-worker READ_ONLY_FROM leak behind the merge-queue flakes

### DIFF
--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -20,6 +20,7 @@ import {
 import { getListingFields } from "#templates/fields.ts";
 import {
   describeWithEnv,
+  setTestEnv,
   setupTestEncryptionKey,
   TEST_STORAGE_ZONE,
   testAttendee,
@@ -29,6 +30,21 @@ import {
 } from "#test-utils";
 
 const TEST_SESSION = { adminLevel: "owner" as const };
+
+/** Run fn with CAN_BUILD_SITES pinned to `value` in this worker's env overlay
+ *  — never the real process env, which every parallel test worker shares. */
+const withBuilderEnv =
+  (value: string | undefined) =>
+  (fn: () => void): void => {
+    const restore = setTestEnv({ CAN_BUILD_SITES: value });
+    try {
+      fn();
+    } finally {
+      restore();
+    }
+  };
+const withBuilder = withBuilderEnv("true");
+const withoutBuilder = withBuilderEnv(undefined);
 
 /** Render the listing detail view the way the entity page composes it: the
  *  Overview panel (details table, income/ledger) plus the Roster panel (attendee
@@ -323,15 +339,6 @@ describe("adminListingNewPage Advanced section", () => {
 });
 
 describe("adminListingEditPage Advanced section auto-open (builder fields)", () => {
-  const withBuilder = (fn: () => void): void => {
-    Deno.env.set("CAN_BUILD_SITES", "true");
-    try {
-      fn();
-    } finally {
-      Deno.env.delete("CAN_BUILD_SITES");
-    }
-  };
-
   test("opens when a renewal tier (months per unit) is set", () => {
     withBuilder(() => {
       const listing = testListingWithCount({
@@ -1906,74 +1913,63 @@ describeWithEnv(
 
     describe("assign_built_site field", () => {
       test("shows assign built site field when CAN_BUILD_SITES is true", () => {
-        Deno.env.set("CAN_BUILD_SITES", "true");
-        try {
+        withBuilder(() => {
           const html = adminListingNewPage([], TEST_SESSION);
           expect(html).toContain("assign_built_site");
           expect(html).toContain("Assign a site on booking");
-        } finally {
-          Deno.env.delete("CAN_BUILD_SITES");
-        }
+        });
       });
 
       test("hides assign built site field when CAN_BUILD_SITES is not set", () => {
-        Deno.env.delete("CAN_BUILD_SITES");
-        const html = adminListingNewPage([], TEST_SESSION);
-        expect(html).not.toContain("assign_built_site");
+        withoutBuilder(() => {
+          const html = adminListingNewPage([], TEST_SESSION);
+          expect(html).not.toContain("assign_built_site");
+        });
       });
 
       test("shows on edit page when CAN_BUILD_SITES is true", () => {
-        Deno.env.set("CAN_BUILD_SITES", "true");
-        try {
+        withBuilder(() => {
           const listing = testListingWithCount({ assign_built_site: true });
           const html = String(
             ListingEditPanel({ groups: [], listing, session: TEST_SESSION }),
           );
           expect(html).toContain("assign_built_site");
           expect(html).toContain("checked");
-        } finally {
-          Deno.env.delete("CAN_BUILD_SITES");
-        }
+        });
       });
 
       test("shows on duplicate page when CAN_BUILD_SITES is true", () => {
-        Deno.env.set("CAN_BUILD_SITES", "true");
-        try {
+        withBuilder(() => {
           const listing = testListingWithCount({ assign_built_site: true });
           const html = adminDuplicateListingPage(listing, [], TEST_SESSION);
           expect(html).toContain("assign_built_site");
-        } finally {
-          Deno.env.delete("CAN_BUILD_SITES");
-        }
+        });
       });
     });
 
     describe("months_per_unit and initial_site_months fields", () => {
       test("shows months_per_unit and initial_site_months when CAN_BUILD_SITES is true", () => {
-        Deno.env.set("CAN_BUILD_SITES", "true");
-        try {
+        withBuilder(() => {
           const html = adminListingNewPage([], TEST_SESSION);
           expect(html).toContain("months_per_unit");
           expect(html).toContain("Months Per Unit");
           expect(html).toContain("initial_site_months");
           expect(html).toContain("Initial Site Months");
-        } finally {
-          Deno.env.delete("CAN_BUILD_SITES");
-        }
+        });
       });
 
       test("hides months_per_unit and initial_site_months when CAN_BUILD_SITES is not set", () => {
-        Deno.env.delete("CAN_BUILD_SITES");
-        const html = adminListingNewPage([], TEST_SESSION);
-        expect(html).not.toContain("months_per_unit");
-        expect(html).not.toContain("Months Per Unit");
-        expect(html).not.toContain("initial_site_months");
-        expect(html).not.toContain("Initial Site Months");
+        withoutBuilder(() => {
+          const html = adminListingNewPage([], TEST_SESSION);
+          expect(html).not.toContain("months_per_unit");
+          expect(html).not.toContain("Months Per Unit");
+          expect(html).not.toContain("initial_site_months");
+          expect(html).not.toContain("Initial Site Months");
+        });
       });
 
       test("shows on edit page when CAN_BUILD_SITES is true", () => {
-        Deno.env.set("CAN_BUILD_SITES", "true");
-        try {
+        withBuilder(() => {
           const listing = testListingWithCount({
             initial_site_months: 6,
             months_per_unit: 3,
@@ -1983,27 +1979,25 @@ describeWithEnv(
           );
           expect(html).toContain("months_per_unit");
           expect(html).toContain("initial_site_months");
-        } finally {
-          Deno.env.delete("CAN_BUILD_SITES");
-        }
+        });
       });
 
       test("hides on edit page when CAN_BUILD_SITES is not set", () => {
-        Deno.env.delete("CAN_BUILD_SITES");
-        const listing = testListingWithCount({
-          initial_site_months: 6,
-          months_per_unit: 3,
+        withoutBuilder(() => {
+          const listing = testListingWithCount({
+            initial_site_months: 6,
+            months_per_unit: 3,
+          });
+          const html = String(
+            ListingEditPanel({ groups: [], listing, session: TEST_SESSION }),
+          );
+          expect(html).not.toContain("months_per_unit");
+          expect(html).not.toContain("initial_site_months");
         });
-        const html = String(
-          ListingEditPanel({ groups: [], listing, session: TEST_SESSION }),
-        );
-        expect(html).not.toContain("months_per_unit");
-        expect(html).not.toContain("initial_site_months");
       });
 
       test("shows on duplicate page when CAN_BUILD_SITES is true", () => {
-        Deno.env.set("CAN_BUILD_SITES", "true");
-        try {
+        withBuilder(() => {
           const listing = testListingWithCount({
             initial_site_months: 6,
             months_per_unit: 3,
@@ -2011,20 +2005,19 @@ describeWithEnv(
           const html = adminDuplicateListingPage(listing, [], TEST_SESSION);
           expect(html).toContain("months_per_unit");
           expect(html).toContain("initial_site_months");
-        } finally {
-          Deno.env.delete("CAN_BUILD_SITES");
-        }
+        });
       });
 
       test("hides on duplicate page when CAN_BUILD_SITES is not set", () => {
-        Deno.env.delete("CAN_BUILD_SITES");
-        const listing = testListingWithCount({
-          initial_site_months: 6,
-          months_per_unit: 3,
+        withoutBuilder(() => {
+          const listing = testListingWithCount({
+            initial_site_months: 6,
+            months_per_unit: 3,
+          });
+          const html = adminDuplicateListingPage(listing, [], TEST_SESSION);
+          expect(html).not.toContain("months_per_unit");
+          expect(html).not.toContain("initial_site_months");
         });
-        const html = adminDuplicateListingPage(listing, [], TEST_SESSION);
-        expect(html).not.toContain("months_per_unit");
-        expect(html).not.toContain("initial_site_months");
       });
     });
   },

--- a/test/templates/public/order-gallery.test.ts
+++ b/test/templates/public/order-gallery.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "@std/expect";
-import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { orderGalleryPage } from "#templates/public/order-gallery.tsx";
 import type { PublicNavProps } from "#templates/public/shared.tsx";
-import { testGroup } from "#test-utils";
+import { getRealEnv, setTestEnv, testGroup } from "#test-utils";
 
 /** A nav with no operator pages and every optional link off. */
 const emptyNav: PublicNavProps = {
@@ -18,10 +18,6 @@ const emptyNav: PublicNavProps = {
 };
 
 describe("orderGalleryPage packages", () => {
-  afterEach(() => {
-    Deno.env.delete("READ_ONLY_FROM");
-  });
-
   test("renders package groups as direct book links, sorted by name", () => {
     // No individual listings — only packages — so the page is not the empty
     // state and renders no selection form, just the package link cards.
@@ -57,16 +53,32 @@ describe("orderGalleryPage packages", () => {
   });
 
   test("renders packages as unavailable, not book links, in read-only mode", () => {
-    Deno.env.set("READ_ONLY_FROM", "2020-01-01T00:00:00.000Z");
-    const html = orderGalleryPage(
-      [],
-      [testGroup({ is_package: true, name: "Frozen Bundle", slug: "frozen" })],
-      emptyNav,
-    );
-    expect(html).toContain("Frozen Bundle");
-    expect(html).toContain("order-card--unavailable");
-    expect(html).toContain("Registration Closed");
-    // No live booking link while the site is read-only.
-    expect(html).not.toContain('href="/ticket/frozen"');
+    const restore = setTestEnv({
+      READ_ONLY_FROM: "2020-01-01T00:00:00.000Z",
+    });
+    try {
+      const html = orderGalleryPage(
+        [],
+        [
+          testGroup({
+            is_package: true,
+            name: "Frozen Bundle",
+            slug: "frozen",
+          }),
+        ],
+        emptyNav,
+      );
+      expect(html).toContain("Frozen Bundle");
+      expect(html).toContain("order-card--unavailable");
+      expect(html).toContain("Registration Closed");
+      // No live booking link while the site is read-only.
+      expect(html).not.toContain('href="/ticket/frozen"');
+      // The cutoff must stay in this worker's env overlay: a write to the real
+      // process env is visible to every parallel test worker and flips the
+      // whole app read-only under them mid-test.
+      expect(getRealEnv("READ_ONLY_FROM")).toBeUndefined();
+    } finally {
+      restore();
+    }
   });
 });

--- a/test/test-utils/env.ts
+++ b/test/test-utils/env.ts
@@ -61,6 +61,14 @@ Deno.env.delete = (key: string): void => {
   else _realDelete(key);
 };
 
+/**
+ * Read a key from the real process environment, bypassing the overlay.
+ * Test workers under `deno test --parallel` share one OS process, so the real
+ * env is visible to every concurrently-running test file — tests assert with
+ * this that their env changes stayed inside the worker-local overlay.
+ */
+export const getRealEnv = (key: string): string | undefined => _realGet(key);
+
 export const setTestEnv = (
   vars: Record<string, string | undefined>,
 ): (() => void) => {

--- a/test/test-utils/mocks.ts
+++ b/test/test-utils/mocks.ts
@@ -141,12 +141,10 @@ export const urlFromFetchInput = (input: string | URL | Request): string =>
       : input.url;
 
 export const withExpectedError = bracket(
-  () => {
-    Deno.env.set("TEST_EXPECT_ERROR", "1");
-  },
-  () => {
-    Deno.env.delete("TEST_EXPECT_ERROR");
-  },
+  // Overlay-scoped so the flag stays inside this worker: written to the real
+  // process env it would make every parallel test worker swallow its errors.
+  () => setTestEnv({ TEST_EXPECT_ERROR: "1" }),
+  (restore) => restore(),
 );
 
 export const withFetchMock = bracket(


### PR DESCRIPTION
# The flake

The merge queue has flaked regularly since **#1462** (`d9e7770`, merged 2026‑07‑02 16:48). Every `merge_group` run from 2026‑06‑29 through 2026‑07‑02 13:06 was green; the first failure (16:40) was #1462's own queue run, and every failing run since contains it via main. Six failed runs, six *different* victim tests — the classic cross-test-leakage signature:

| Run | Victim test | Symptom |
|---|---|---|
| 28606346437 | `ticket-payment` "parent+child sharing a capped group…" | `undefined.id` after a booking POST |
| 28612540621 | `public.test.ts` "includes CSRF token in form" | page rendered **"Registration closed."** |
| 28614745666 | `public.test.ts` "hides quantity selector when max_quantity is 1" | selector missing |
| 28618325826 | `public.test.ts` "restores the submitted package quantity…" + `server-attendees` "rejects self-merge" | "Registration closed." / missing flash cookie |
| 28646860140 | `public.test.ts` "hides header and description in iframe mode" | "Registration closed." |
| 28647812649 | `dashboard.test.ts` "servicing mutation routes return not found…" | not a 404 |

(#1510's fd-exhaustion fix addressed a different, real leak — these continued after it, on 2026‑07‑03.)

# The line

#1462 added `test/templates/public/order-gallery.test.ts`, whose read-only test did:

```ts
Deno.env.set("READ_ONLY_FROM", "2020-01-01T00:00:00.000Z");
```

directly, instead of through the `setTestEnv` overlay. The suite runs `deno test --parallel`: worker isolates share **one OS process**, and `Deno.env` is process-global. From that `set` until the suite's `afterEach` `delete`, every concurrently-running test file saw `READ_ONLY_FROM` in the past, so `isReadOnly()` flipped true suite-wide:

- public pages hit `unavailableMessage` → `<div class="error">Registration closed.</div>` instead of the booking form (`src/ui/templates/public/reservations.tsx:1475`),
- `readOnlyGuard` default-denies every mutating request → booking/merge/servicing POSTs got a 302 to `/read-only` → `undefined.id`, missing flash cookies, wrong statuses (`src/features/index.ts:558`).

On the 30-core CI runner ~30 test files overlap each poison window, so a victim render was frequent (~20% of queue runs); locally, with few workers, it's nearly impossible to hit. A minimal two-file `deno test --parallel` demo confirms one worker's `Deno.env.set` is immediately visible in another worker, even on a 2-core box.

Why the sibling tests never leaked: `setTestEnv` snapshots keys into a worker-local overlay and the patched `Deno.env.set/get/delete` route overlaid keys there, never touching the real env — `env.test.ts`'s `process.env.READ_ONLY_FROM =` writes go through the same patched path because its `describeWithEnv` declares the key. The new test bypassed all of that.

# The fix

- **`order-gallery.test.ts`**: scope the override with `setTestEnv` + `try/finally`, exactly like `modifiers.test.ts:87`.
- **Regression test** (fails before, passes after): a new `getRealEnv` helper in `test/test-utils/env.ts` reads the *real* process env past the overlay, and the test now asserts `READ_ONLY_FROM` is absent from it while the override is active — verified red against the old direct write.
- **Same-class hygiene** (the only other real-env writers in the test tree):
  - `listings.test.ts`: the 7 `CAN_BUILD_SITES` set/delete sites → one curried `withBuilderEnv` helper (`withBuilder` / `withoutBuilder`).
  - `withExpectedError` in `test-utils/mocks.ts`: `TEST_EXPECT_ERROR` now overlay-scoped — written for real it makes every parallel worker swallow its errors while held.
  - `test/setup.ts`'s `STRIPE_MOCK_*` writes are left as-is deliberately: identical constants in every worker, set once at load.

# Verification

- `order-gallery`, `listings`, `env`, `server-misc-routing`, `server-setup`, `server-images` test files all green.
- `deno task lint:ci`, `deno task typecheck`, `deno task cpd` all pass.
- The full `deno task precommit` suite could not run in this sandbox (the proxy blocks the stripe-mock download); this PR's CI run is the authoritative check. Only test files changed, so the mutation gate skips.

We'll know it's fixed when the queue stops flaking — nothing here touches production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oy7G6Rcbk2tr5vqrB3nAt

---
_Generated by [Claude Code](https://claude.ai/code/session_019oy7G6Rcbk2tr5vqrB3nAt)_