### PR TITLE
Harden catalog transfer: strict keys, editor export links, cell-fidelity

### DIFF
--- a/src/features/admin/catalog-transfer/schema.ts
+++ b/src/features/admin/catalog-transfer/schema.ts
@@ -162,8 +162,14 @@ const optPositiveInt = v.optional(PositiveIntSchema);
  * import) and the image/attachment columns (out of scope). Optional fields are
  * omitted rather than defaulted so the importing table applies its own column
  * defaults; `name` and `maxAttendees` are the only structural requirements.
+ *
+ * `strictObject` (here and in every transfer schema below): the format is
+ * versioned and exact-version gated, so an unknown key is a mistake — a
+ * misspelled field (`hidde`) or relationship key (`parent` for `parents`) is
+ * rejected with a field error rather than silently dropped, which would
+ * otherwise import a listing missing that column or its whole parent/group set.
  */
-const ListingFieldsSchema = v.object({
+const ListingFieldsSchema = v.strictObject({
   active: optBoolean,
   assignBuiltSite: optBoolean,
   // A child listing that keeps its own standalone `/ticket` page. Carried so an
@@ -225,7 +231,7 @@ export type ListingData = v.InferOutput<typeof ListingDataSchema>;
 
 /** The transferable columns of a group, keyed to match `GroupInput` (members
  * live on the envelope, not here). */
-export const GroupDataSchema = v.object({
+export const GroupDataSchema = v.strictObject({
   description: optString,
   hidden: optBoolean,
   hidePackageListings: optBoolean,
@@ -245,14 +251,14 @@ const membershipOverrideEntries = {
 };
 
 /** A group a listing belongs to (listing-side view), referenced by group name. */
-export const ListingMembershipSchema = v.object({
+export const ListingMembershipSchema = v.strictObject({
   group: NameRefSchema,
   ...membershipOverrideEntries,
 });
 export type ListingMembership = v.InferOutput<typeof ListingMembershipSchema>;
 
 /** A member of a group (group-side view), referenced by listing name. */
-export const GroupMemberSchema = v.object({
+export const GroupMemberSchema = v.strictObject({
   listing: NameRefSchema,
   ...membershipOverrideEntries,
 });
@@ -265,7 +271,7 @@ const VersionSchema = v.literal(
 
 /** A listing export: the listing's own fields plus its group memberships (by
  * name) and its parent listings (by name). */
-export const ListingTransferSchema = v.object({
+export const ListingTransferSchema = v.strictObject({
   groups: v.optional(v.array(ListingMembershipSchema), []),
   kind: v.literal("listing"),
   listing: ListingDataSchema,
@@ -275,7 +281,7 @@ export const ListingTransferSchema = v.object({
 export type ListingTransfer = v.InferOutput<typeof ListingTransferSchema>;
 
 /** A group export: the group's own fields plus its member listings (by name). */
-export const GroupTransferSchema = v.object({
+export const GroupTransferSchema = v.strictObject({
   group: GroupDataSchema,
   kind: v.literal("group"),
   members: v.optional(v.array(GroupMemberSchema), []),

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -269,6 +269,18 @@ export const adminGroupEditPage = (
   String(
     <Layout title={t("groups.edit.heading")}>
       <AdminNav active="/admin/groups" session={session} />
+      {/* Export lives here too, not only on the (staff-only) detail page, so a
+          content editor — who reaches this edit form but not the detail page —
+          can still download the group's catalog blob. */}
+      <nav>
+        <ul>
+          <li>
+            <a href={`/admin/groups/${group.id}/export.json`}>
+              {t("catalog_transfer.export_link")}
+            </a>
+          </li>
+        </ul>
+      </nav>
       <CsrfForm action={`/admin/groups/${group.id}/edit`}>
         <h1>{t("groups.edit.heading")}</h1>
         <Flash error={error} />

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -2484,6 +2484,18 @@ export const ListingEditPanel = ({
   return (
     <>
       <Flash error={error} />
+      {/* Export lives on the editor-visible Edit tab too, not only the staff-only
+          Actions tab, so a content editor can download the listing's catalog
+          blob (the export route is content-gated, matching import). */}
+      <nav>
+        <ul>
+          <li>
+            <a href={`/admin/listing/${listing.id}/export.json`}>
+              {t("catalog_transfer.export_link")}
+            </a>
+          </li>
+        </ul>
+      </nav>
       {childOfNames !== null && (
         <p class="notice listing-child-banner">
           {t("listings_table.child_banner", { names: childOfNames })}

--- a/test/lib/catalog-transfer.test.ts
+++ b/test/lib/catalog-transfer.test.ts
@@ -108,6 +108,34 @@ describeWithEnv("catalog-transfer", { db: true }, () => {
       expect(imported.bookable_alone).toBe(true);
     });
 
+    test("carries a listing's own stored cells, not resolved site defaults", async () => {
+      // Export/import mirror database cells, never the read-time overlay. A site
+      // default of hidden=true is in force, but the imported listing sets its OWN
+      // cell to hidden=false with useDefaults=true — the operator's call, even
+      // though it conflicts with the default and is inert while use_defaults is
+      // on. The export must then reflect that cell (false), not the resolved
+      // default (true) a cache read would overlay.
+      await settings.update.listingDefaults({ hidden: true });
+      const created = await importCatalog({
+        kind: "listing",
+        listing: {
+          hidden: false,
+          maxAttendees: 5,
+          name: "Defaulter",
+          thankYouUrl: "https://thanks.example.com",
+          useDefaults: true,
+        },
+        version: 1,
+      });
+      if (!created.ok) throw new Error(created.error);
+
+      const blob = unwrapExport(await exportListing(created.id));
+      expect(blob.listing.useDefaults).toBe(true);
+      // The row's own cell (false), not the resolved default (true).
+      expect(blob.listing.hidden).toBe(false);
+      expect(blob.listing.thankYouUrl).toBe("https://thanks.example.com");
+    });
+
     test("preserves closesAt and re-syncs the derived price rows", async () => {
       const result = await importCatalog({
         kind: "listing",
@@ -304,6 +332,21 @@ describeWithEnv("catalog-transfer", { db: true }, () => {
       if (result.ok) throw new Error("unreachable");
       expect(result.error).toContain("Invalid catalog file — Invalid type");
       expect(result.error).toContain("Object");
+    });
+
+    test("rejects a blob with an unknown relationship key", async () => {
+      // `parent` (singular) is not a known key. The format is versioned and
+      // exact-version gated, so a misspelled relationship key must be a field
+      // error, not silently imported as a standalone listing with no parents.
+      const result = await importCatalog({
+        kind: "listing",
+        listing: { maxAttendees: 5, name: "Typo Kid" },
+        parent: ["Whatever"],
+        version: 1,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.error).toContain("parent");
     });
 
     test("rejects a group whose member listing does not exist", async () => {

--- a/test/templates/admin/groups.test.ts
+++ b/test/templates/admin/groups.test.ts
@@ -215,4 +215,12 @@ describe("adminGroupEditPage package members table", () => {
     const html = adminGroupEditPage(group, [], new Map(), TEST_SESSION);
     expect(html).toContain("Add listings to this group");
   });
+
+  test("links to the JSON export (reachable by a content editor)", () => {
+    const group = testGroup({ id: 7, name: "Exportable" });
+    const html = adminGroupEditPage(group, [], new Map(), TEST_SESSION);
+    // The edit form is content-gated, so an editor who never sees the staff-only
+    // detail page can still export the group from here.
+    expect(html).toContain(`/admin/groups/${group.id}/export.json`);
+  });
 });

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -80,6 +80,16 @@ describe("adminListingEditPage group select", () => {
     expect(html).toContain('value="2"');
     expect(html).toContain("checked");
   });
+
+  test("links to the JSON export (reachable by a content editor)", () => {
+    const listing = testListingWithCount({ id: 9 });
+    const html = String(
+      ListingEditPanel({ groups: [], listing, session: TEST_SESSION }),
+    );
+    // The Edit tab is editor-visible, so the export link here reaches editors
+    // who never see the staff-only Actions tab that also carries it.
+    expect(html).toContain(`/admin/listing/${listing.id}/export.json`);
+  });
 });
 
 describe("adminListingEditPage duration warning", () => {


### PR DESCRIPTION
Follow-up to the three Codex P2 findings on #1511 (which merged before they could be addressed).

## Reject unknown / misspelled keys (`schema.ts`)
The transfer format is versioned and exact-version gated, but the schemas were plain `v.object`, so an unknown key was silently ignored. A misspelled relationship key — `parent` for `parents`, `group` for `groups` — was accepted as "no parents/no memberships", importing a standalone listing and silently dropping structure; a misspelled field (`hidde`) fell back to a column default.

- Every transfer schema is now `v.strictObject`, so an unknown key is an intelligible field error.
- The exporter builds these objects to the exact schema shape, so export round-trips unaffected (verified by the existing round-trip + 422 tests).
- New test: an unknown relationship key (`parent`) is rejected.

## Editor-visible export links (`listings.tsx`, `groups.tsx`)
The export routes are content-gated (owner/manager/**editor**) and the import buttons are editor-visible, but the export links only lived on staff-only surfaces (the listing Actions tab, the group detail page) — so an editor could import a catalog file but not discover/export one without hand-crafting the URL.

- The listing export link now also renders on the editor-visible **Edit tab**; the group export link on the editor-visible **group edit form**.
- The existing staff placements are unchanged, so nothing regresses in read-only mode.
- New tests assert both edit surfaces carry the export link.

## Lock in cell-fidelity, not resolved defaults (`export.ts` behaviour)
Codex suggested materialising inherited defaults into exports. We deliberately do the opposite: **exports and imports mirror raw database cells, never the read-time default overlay.** A `use_defaults` listing carries its own stored `hidden`/`thankYouUrl`/`useDefaults` cells; import writes those cells even when they conflict with a site default (the operator's call), inert though they are while `use_defaults` is on.

- No source change — the export already reads the stored (un-overlaid) row.
- New test: with a conflicting site default in force, the imported row keeps its own cell values and the export reflects those cells, not the resolved defaults.

## Testing
Typecheck, lint:ci, cpd (0 clones), and the affected suites pass; the new/changed source lines are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zHSr7TjvPW4WVciygozHX

---
_Generated by [Claude Code](https://claude.ai/code/session_013zHSr7TjvPW4WVciygozHX)_