### PR TITLE
Group attendee tables by attendee with an ordered Listings column

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -247,3 +247,8 @@ src/shared/listings-actions.ts:120:17  ?? → ||   # validateListingGroup existi
 # attendee merge/refund route: mutants with no observable effect.
 src/features/admin/attendees-merge.ts:356:10  === → !=    # toBookingChoice: keep_target and skip_source are consumed identically (attendee-merge.ts "do nothing for this booking"), so normalizing one to the other is unobservable
 src/features/admin/attendee-refunds.ts:172:24  ?? → ||    # flash.error: string|undefined from applyFlash; a refund error flash is always a non-empty message, so the only falsy-non-null value "" never occurs and ?? / || agree
+
+# attendee columns Listings/answers rework
+src/shared/columns/attendee-columns.ts:133:67  ?? → ||    # getAnswerDisplay attendeeAnswerMap.get(): number[]|undefined — an array is always truthy, so ?? and || coincide
+src/ui/templates/attendee-table.tsx:146:39  ?? → ||    # compareAttendeeRows listingA = a.listings[0]?.name ?? "": string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
+src/ui/templates/attendee-table.tsx:147:39  ?? → ||    # compareAttendeeRows listingB = b.listings[0]?.name ?? "": string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""

--- a/src/features/admin/attendees-list.ts
+++ b/src/features/admin/attendees-list.ts
@@ -4,7 +4,7 @@
  * listing detail and attendee edit pages.
  */
 
-import { map, unique } from "#fp";
+import { filter, map, unique } from "#fp";
 import { csvResponse } from "#routes/admin/actions.ts";
 import {
   generateCalendarCsv,
@@ -14,6 +14,7 @@ import { type AuthSession, requireSessionOr } from "#routes/auth.ts";
 import { htmlResponse } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { getSearchParam } from "#routes/url.ts";
+import { groupAttendeeRows } from "#shared/attendee-table-rows.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import {
@@ -21,6 +22,7 @@ import {
   decryptAttendees,
   getAttendeesPage,
 } from "#shared/db/attendees.ts";
+import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
@@ -33,11 +35,8 @@ import {
   listingTypeFromRequest,
 } from "#shared/listing-filter.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
-import type {
-  Attendee,
-  AttendeeTableRow,
-  ListingWithCount,
-} from "#shared/types.ts";
+import { sortListings } from "#shared/sort-listings.ts";
+import type { Attendee, ListingWithCount } from "#shared/types.ts";
 import {
   parsePositiveInt,
   parsePositiveIntId,
@@ -82,20 +81,6 @@ const resolveListingIds = (
   return listings.filter((e) => listingCategory(e) === type).map((e) => e.id);
 };
 
-/** Join decrypted attendees with their listing context for the table */
-const buildRows = (
-  attendees: Attendee[],
-  listings: ListingWithCount[],
-): AttendeeTableRow[] => {
-  const listingById = new Map(listings.map((e) => [e.id, e] as const));
-  // Every row comes from an INNER JOIN on listing_attendees, so its listing_id
-  // always references a listing present in the (unfiltered) cache.
-  return map((attendee: Attendee): AttendeeTableRow => {
-    const listing = listingById.get(attendee.listing_id)!;
-    return { attendee, listingId: listing.id, listingName: listing.name };
-  })(attendees);
-};
-
 /** Auth, then load every listing and hand both to the handler. Shared by the
  * attendees page and its CSV export, which both start from the full set. */
 const withListings = (
@@ -125,14 +110,22 @@ export const handleAttendeesListGet: TypedRouteHandler<
     const page = parsePage(request);
     const listingIds = resolveListingIds(listingId, type, listings);
 
-    const privateKey = await requireRequestPrivateKey();
+    const [privateKey, holidays] = await Promise.all([
+      requireRequestPrivateKey(),
+      getActiveHolidays(),
+    ]);
     const { rows, hasNext } = await getAttendeesPage({
       listingIds,
       page,
       sort,
     });
     const decrypted = await decryptAttendees(rows, privateKey);
-    const built = buildRows(decrypted, listings);
+    // One row per attendee, its listings in the same display order as the
+    // listings page (sortListings decides that order for both).
+    const built = groupAttendeeRows(
+      decrypted,
+      sortListings(listings, holidays),
+    );
     const attendeeIds = unique(decrypted.map((a) => a.id));
     const systemNotes = await loadNotesForAttendees(attendeeIds, () =>
       Promise.resolve(privateKey),
@@ -158,9 +151,11 @@ export const handleAttendeesListGet: TypedRouteHandler<
     );
   });
 
-/** Every attendee booking matching the filter, across all pages — the export
- * isn't paginated. Reuses the page query, so the all-listings case (null) stays
- * an unfiltered query rather than an enormous `IN (...)` clause. */
+/** Every booking row of every attendee matching the filter, across all pages —
+ * the export isn't paginated. Reuses the page query, so the all-listings case
+ * (null) stays an unfiltered query rather than an enormous `IN (...)` clause.
+ * Note the page query matches ATTENDEES: a filtered call also returns a matched
+ * attendee's bookings on other listings — the CSV handler re-narrows. */
 const allAttendeeBookings = async (
   listingIds: number[] | null,
 ): Promise<Attendee[]> => {
@@ -194,7 +189,14 @@ export const handleAttendeesCsvExport: TypedRouteHandler<
     );
     const privateKey = await requireRequestPrivateKey();
     const raw = await allAttendeeBookings(listingIds);
-    const attendees = await decryptAttendees(raw, privateKey);
+    // Keep one CSV row per booking on the FILTERED listings only: the page
+    // query returns a matched attendee's other listings too (for the grouped
+    // table), which the export must not include.
+    const inFilter = listingIds && new Set(listingIds);
+    const bookings = inFilter
+      ? filter((a: Attendee) => inFilter.has(a.listing_id))(raw)
+      : raw;
+    const attendees = await decryptAttendees(bookings, privateKey);
     const csv = generateCalendarCsv(
       toCalendarAttendees(attendees, listings),
       undefined,

--- a/src/shared/attendee-table-rows.ts
+++ b/src/shared/attendee-table-rows.ts
@@ -1,0 +1,55 @@
+/**
+ * Attendee table row construction — the one place that turns attendee booking
+ * lines into `AttendeeTableRow`s for the unified attendee table.
+ *
+ * This module is pure: callers fetch (and decrypt) the attendees and listings;
+ * these helpers only reshape them.
+ */
+
+import { sumOf } from "#fp";
+import type {
+  Attendee,
+  AttendeeRowListing,
+  AttendeeTableRow,
+} from "#shared/types.ts";
+
+/** One table row for a single booking line — the roster, check-in, calendar,
+ * and group tables, where each line keeps its own date, quantity, and
+ * per-listing check-in action. */
+export const attendeeLineRow = (
+  attendee: Attendee,
+  listing: AttendeeRowListing,
+): AttendeeTableRow => ({
+  attendee,
+  listings: [{ id: listing.id, name: listing.name }],
+});
+
+/**
+ * Group booking lines into one row per attendee, for the browsing tables
+ * (the attendees list and the dashboard's newest attendees).
+ *
+ * `orderedListings` is the listing set in display order (see sortListings);
+ * each row's listings keep that order, so the Listings cell matches the
+ * listings page. Quantities sum across the attendee's lines — the order's
+ * total tickets. Attendee order follows first appearance in `attendees`.
+ * A line whose listing is absent from `orderedListings` (the LEFT-JOIN
+ * `listing_id = 0` broken-linkage sentinel) is dropped, and an attendee with
+ * no surviving listing is omitted entirely — exactly which lines the
+ * per-line tables skipped before grouping.
+ */
+export const groupAttendeeRows = (
+  attendees: Attendee[],
+  orderedListings: readonly AttendeeRowListing[],
+): AttendeeTableRow[] => {
+  const rows: AttendeeTableRow[] = [];
+  for (const lines of Map.groupBy(attendees, (a) => a.id).values()) {
+    const bookedIds = new Set(lines.map((line) => line.listing_id));
+    const listings = orderedListings
+      .filter((listing) => bookedIds.has(listing.id))
+      .map((listing) => ({ id: listing.id, name: listing.name }));
+    if (listings.length === 0) continue;
+    const quantity = sumOf((line: Attendee) => line.quantity)(lines);
+    rows.push({ attendee: { ...lines[0]!, quantity }, listings });
+  }
+  return rows;
+};

--- a/src/shared/columns/attendee-columns.ts
+++ b/src/shared/columns/attendee-columns.ts
@@ -39,12 +39,21 @@ const status = componentRenderedCol(
   (row, opts) => opts.renderStatus(row),
 );
 
-const listing: AttendeeCol = {
-  cell: (row) =>
-    `<a href="/admin/listing/${row.listingId}">${escapeHtml(row.listingName)}</a>`,
-  description: "Listing name with link to the listing detail page",
+const listings: AttendeeCol = {
+  // The wrapping span carries the full comma-separated list in its title and
+  // the .listings-cell truncation styles, so a long list ellipsizes at 30rem
+  // while hovering reveals every listing name.
+  cell: (row) => {
+    const fullList = escapeHtml(row.listings.map((l) => l.name).join(", "));
+    const links = row.listings
+      .map((l) => `<a href="/admin/listing/${l.id}">${escapeHtml(l.name)}</a>`)
+      .join(", ");
+    return `<span class="listings-cell" title="${fullList}">${links}</span>`;
+  },
+  description:
+    "The row's listings in display order, each linked to its detail page",
   isHtml: true,
-  label: "Listing",
+  label: "Listings",
 };
 
 const date: AttendeeCol = {
@@ -220,7 +229,7 @@ export const ATTENDEE_TABLE_COLUMNS: ColumnGenerators<
   answers,
   date,
   email,
-  listing,
+  listings,
   name,
   phone,
   qty,
@@ -233,9 +242,9 @@ export const ATTENDEE_TABLE_COLUMNS: ColumnGenerators<
 /** Default column order for the attendee table */
 export const ATTENDEE_DEFAULT_ORDER = [
   "status",
-  "listing",
   "date",
   "name",
+  "listings",
   "email",
   "phone",
   "address",

--- a/src/shared/db/attendees/queries.ts
+++ b/src/shared/db/attendees/queries.ts
@@ -194,18 +194,25 @@ export const getAttendeePackageRowsRaw = (
 /**
  * Get the newest attendees across all listings without decrypting PII.
  * Used for the admin dashboard to show recent registrations.
+ *
+ * The limit counts ATTENDEES, not booking lines: the inner subquery picks the
+ * newest `limit` attendee ids — by id, which is AUTOINCREMENT and so
+ * co-monotonic with created but index-backed (no sort over the whole
+ * unbounded attendees table) — and the outer LEFT JOIN returns every booking
+ * line for those attendees, so the dashboard's grouped rows always carry an
+ * attendee's complete listings.
  */
 export const getNewestAttendeesRaw = (limit: number): Promise<Attendee[]> =>
-  // Order by attendee.id DESC, not attendee.created: id is AUTOINCREMENT so it is
-  // co-monotonic with created (newest attendee = highest id), but ordering by
-  // the rowid drives the scan off the primary key with no sort over the whole
-  // (unbounded) attendees table.
   queryAll<Attendee>(
     `SELECT ${ATTENDEE_LEFT_JOIN_SELECT}
      FROM attendees AS attendee
      LEFT JOIN listing_attendees AS listingAttendee ON listingAttendee.attendee_id = attendee.id
-     WHERE attendee.kind = '${ATTENDEE_KIND}'
-     ORDER BY attendee.id DESC LIMIT ?`,
+     WHERE attendee.id IN (
+       SELECT newest.id FROM attendees AS newest
+       WHERE newest.kind = '${ATTENDEE_KIND}'
+       ORDER BY newest.id DESC LIMIT ?
+     )
+     ORDER BY attendee.id DESC, listingAttendee.listing_id ASC`,
     [limit],
   );
 
@@ -213,29 +220,50 @@ export const getNewestAttendeesRaw = (limit: number): Promise<Attendee[]> =>
 export type AttendeeSort = "newest" | "oldest";
 
 /**
- * Attendee rows per page in the admin attendees browser. Fixed here so the
+ * Attendees per page in the admin attendees browser. Fixed here so the
  * page size is never derived from the request — callers choose only the page.
  */
 export const ATTENDEES_PAGE_SIZE = 100;
 
-/** One page of attendee rows, plus whether a further page exists */
+/** One page of attendee booking rows, plus whether a further page exists */
 export type AttendeesPage = {
   rows: Attendee[];
   hasNext: boolean;
 };
 
 /**
- * Get one page of attendee+booking rows for the admin attendees browser.
+ * Collapse the one-extra-attendee overread into `hasNext`, dropping the extra
+ * attendee's lines. Rows arrive grouped by attendee id (the outer ORDER BY),
+ * so the extra attendee is exactly the last distinct id.
+ */
+const trimAttendeePage = (rows: Attendee[]): AttendeesPage => {
+  const ids: number[] = [];
+  for (const row of rows) {
+    if (ids[ids.length - 1] !== row.id) ids.push(row.id);
+  }
+  if (ids.length <= ATTENDEES_PAGE_SIZE) return { hasNext: false, rows };
+  const extraId = ids[ids.length - 1];
+  return { hasNext: true, rows: rows.filter((row) => row.id !== extraId) };
+};
+
+/**
+ * Get one page of attendees — with every one of their booking rows — for the
+ * admin attendees browser.
  *
- * Returns one row per (attendee, listing) booking, ordered by attendee id —
- * newest or oldest first. id is AUTOINCREMENT, so it is co-monotonic with the
- * registration date but unique, making paging deterministic and index-backed
- * (no sort over the whole attendees table). When `listingId` is given, only
- * that listing's bookings are returned; otherwise every booking is included.
+ * Pagination counts ATTENDEES, not booking lines: the inner subquery selects
+ * one page of attendee ids, ordered by id — AUTOINCREMENT, so co-monotonic
+ * with the registration date but unique, making paging deterministic and
+ * index-backed — and the outer query returns every listing_attendees line for
+ * those attendees. A grouped attendee row therefore always carries their
+ * complete listings list and never splits across a page boundary. When
+ * `listingIds` is given it decides WHICH attendees match (any booking on
+ * those listings); the returned rows still cover all of a matched attendee's
+ * listings.
  *
- * The page size is fixed; callers pass a zero-based `page`. One extra row is
- * read to report `hasNext` without a separate count query, then trimmed off.
- * PII stays encrypted — decrypt with decryptAttendees before display.
+ * The page size is fixed; callers pass a zero-based `page`. One extra
+ * attendee is read to report `hasNext` without a separate count query, then
+ * trimmed off. PII stays encrypted — decrypt with decryptAttendees before
+ * display.
  */
 export const getAttendeesPage = async ({
   listingIds,
@@ -250,14 +278,12 @@ export const getAttendeesPage = async ({
 }): Promise<AttendeesPage> => {
   // An empty filter set matches nothing — e.g. a type with no listings yet.
   if (listingIds?.length === 0) return { hasNext: false, rows: [] };
-  // `dir` is derived from the AttendeeSort enum and the WHERE clause is fixed
+  // `dir` is derived from the AttendeeSort enum and the filter clause is fixed
   // text, so neither is user-controlled — only the bound args are.
   const dir = sort === "oldest" ? "ASC" : "DESC";
-  const where = listingIds
-    ? `WHERE attendee.kind = '${ATTENDEE_KIND}' AND listingAttendee.listing_id IN (${inPlaceholders(
-        listingIds,
-      )})`
-    : `WHERE attendee.kind = '${ATTENDEE_KIND}'`;
+  const lineFilter = listingIds
+    ? ` AND pageLine.listing_id IN (${inPlaceholders(listingIds)})`
+    : "";
   const limit = ATTENDEES_PAGE_SIZE + 1;
   const offset = page * ATTENDEES_PAGE_SIZE;
   const args = listingIds ? [...listingIds, limit, offset] : [limit, offset];
@@ -265,13 +291,19 @@ export const getAttendeesPage = async ({
     `SELECT ${ATTENDEE_JOIN_SELECT}
      FROM attendees AS attendee
      JOIN listing_attendees AS listingAttendee ON listingAttendee.attendee_id = attendee.id
-     ${where}
-     ORDER BY attendee.id ${dir}
-     LIMIT ? OFFSET ?`,
+     WHERE attendee.id IN (
+       SELECT pageAttendee.id
+       FROM attendees AS pageAttendee
+       JOIN listing_attendees AS pageLine ON pageLine.attendee_id = pageAttendee.id
+       WHERE pageAttendee.kind = '${ATTENDEE_KIND}'${lineFilter}
+       GROUP BY pageAttendee.id
+       ORDER BY pageAttendee.id ${dir}
+       LIMIT ? OFFSET ?
+     )
+     ORDER BY attendee.id ${dir}, listingAttendee.listing_id ASC`,
     args,
   );
-  const hasNext = rows.length > ATTENDEES_PAGE_SIZE;
-  return { hasNext, rows: hasNext ? rows.slice(0, ATTENDEES_PAGE_SIZE) : rows };
+  return trimAttendeePage(rows);
 };
 
 /**

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -91,6 +91,7 @@ import sitePagesMigration from "./migrations/2026-07-01_site_pages.ts";
 import bookableAloneMigration from "./migrations/2026-07-02_bookable_alone.ts";
 import dropListingsDayPricesMigration from "./migrations/2026-07-02_drop_listings_day_prices.ts";
 import groupFlatPricesMigration from "./migrations/2026-07-02_group_flat_prices.ts";
+import attendeeListingsTagMigration from "./migrations/2026-07-03_attendee_listings_tag.ts";
 import { repairLegacyRenames } from "./migrations/rename-utils.ts";
 import {
   LATEST_UPDATE,
@@ -292,6 +293,9 @@ export const MIGRATIONS: Migration[] = [
   // Move per-day-count prices off listings.day_prices into listing_prices'
   // "day_count" dimension and drop the column — only unit_price stays a column.
   dropListingsDayPricesMigration,
+  // Data-only: rewrite {{listing}} → {{listings}} in the stored attendee
+  // column-order template, matching the renamed grouped Listings column.
+  attendeeListingsTagMigration,
 ].map((build) => build(migrationContext));
 
 export const MIGRATION_IDS: string[] = MIGRATIONS.map(

--- a/src/shared/db/migrations/2026-07-03_attendee_listings_tag.ts
+++ b/src/shared/db/migrations/2026-07-03_attendee_listings_tag.ts
@@ -1,0 +1,34 @@
+import { schemaMigration } from "./define.ts";
+
+/** Matches the old {{listing}} column tag (with optional inner whitespace and
+ * an optional trailing filter) without touching the new {{listings}} tag —
+ * the required non-word delimiter after "listing" can't be an "s". */
+const LISTING_TAG = /\{\{(\s*)listing(\s*[|}])/g;
+
+/**
+ * The attendee table's per-booking "Listing" column became the grouped
+ * "Listings" column, renaming its column-order template tag from {{listing}}
+ * to {{listings}}. Rewrite the tag inside any stored attendee_column_order
+ * setting so an operator's custom column order keeps its listings column
+ * (an unknown tag would otherwise make the whole template fall back to the
+ * default order). Data-only — no schema requirement — and a no-op when the
+ * setting is unset or never used the tag.
+ */
+export default schemaMigration(
+  "2026-07-03_attendee_listings_tag",
+  "Rename the {{listing}} tag to {{listings}} in the stored attendee column-order template.",
+  {},
+  async ({ getDb }) => {
+    const result = await getDb().execute(
+      "SELECT value FROM settings WHERE key = 'attendee_column_order'",
+    );
+    const value = result.rows[0]?.value;
+    if (typeof value !== "string") return;
+    const updated = value.replace(LISTING_TAG, "{{$1listings$2");
+    if (updated === value) return;
+    await getDb().execute(
+      "UPDATE settings SET value = ? WHERE key = 'attendee_column_order'",
+      [updated],
+    );
+  },
+);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -699,9 +699,19 @@ export interface ListingWithCount extends Listing {
  */
 export type AdminListing = Omit<ListingWithCount, "slug_index">;
 
-/** A single row in the attendee table (attendee + parent listing context) */
+/** One listing shown in an attendee row's Listings cell */
+export type AttendeeRowListing = {
+  id: number;
+  name: string;
+};
+
+/**
+ * A single row in the attendee table: an attendee plus the listings the row
+ * covers, in display order. Roster/check-in tables render one row per booking
+ * line (a one-listing array); the browsing tables (attendees list, dashboard)
+ * group an attendee's lines into one row carrying every listing.
+ */
 export type AttendeeTableRow = {
   attendee: Attendee;
-  listingId: number;
-  listingName: string;
+  listings: AttendeeRowListing[];
 };

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -2354,6 +2354,17 @@ button.secondary:hover,
   font-size: smaller;
 }
 
+/* Listings cell in attendee table — cap the width and ellipsize long lists;
+ * the cell's title attribute carries the full list for hover. display:block
+ * and nowrap are what let max-width/overflow take effect inside a table cell. */
+.listings-cell {
+  display: block;
+  max-width: 30rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Skip navigation link (SC 2.4.1 Bypass Blocks) */
 .skip-nav:not(:focus-visible) {
   clip-path: inset(50%);

--- a/src/ui/templates/admin/calendar.tsx
+++ b/src/ui/templates/admin/calendar.tsx
@@ -4,6 +4,7 @@
 
 import { map, pipe } from "#fp";
 import { t } from "#i18n";
+import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
 import { formatDateLabel } from "#shared/dates.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import {
@@ -58,11 +59,8 @@ export const adminCalendarPage = (
 ): string => {
   const tableRows: AttendeeTableRow[] = pipe(
     map(
-      (a: CalendarAttendeeRow): AttendeeTableRow => ({
-        attendee: a,
-        listingId: a.listingId,
-        listingName: a.listingName,
-      }),
+      (a: CalendarAttendeeRow): AttendeeTableRow =>
+        attendeeLineRow(a, { id: a.listingId, name: a.listingName }),
     ),
   )(attendees);
 

--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -2,8 +2,9 @@
  * Admin dashboard page template
  */
 
-import { filter, joinStrings, map, pipe, reduce, unique } from "#fp";
+import { filter, joinStrings, map, pipe, unique } from "#fp";
 import { t } from "#i18n";
+import { groupAttendeeRows } from "#shared/attendee-table-rows.ts";
 import {
   type ColumnGenerators,
   getHeaderText,
@@ -33,7 +34,6 @@ import {
 import type {
   AdminSession,
   Attendee,
-  AttendeeTableRow,
   Holiday,
   ListingWithCount,
 } from "#shared/types.ts";
@@ -156,23 +156,14 @@ export const activeListingStatsSection = (stats: ActiveListingStats): string =>
     </details>,
   );
 
-/** Build the newest attendees section with a details/summary wrapper */
+/** Build the newest attendees section with a details/summary wrapper.
+ * One row per attendee: `listings` arrives in display order, so each grouped
+ * row's Listings cell follows the listings page ordering. */
 const newestAttendeesSection = (
   attendees: Attendee[],
   listings: ListingWithCount[],
 ): string => {
-  const listingMap = new Map(listings.map((e) => [e.id, e]));
-  const tableRows = reduce((acc: AttendeeTableRow[], a: Attendee) => {
-    const listing = listingMap.get(a.listing_id);
-    if (listing) {
-      acc.push({
-        attendee: a,
-        listingId: listing.id,
-        listingName: listing.name,
-      });
-    }
-    return acc;
-  }, [] as AttendeeTableRow[])(attendees);
+  const tableRows = groupAttendeeRows(attendees, listings);
 
   if (tableRows.length === 0) return "";
 

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -5,6 +5,7 @@
 import { joinStrings, map, pipe, sumOf } from "#fp";
 import { t } from "#i18n";
 import { groupReturnPath } from "#shared/admin-paths.ts";
+import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
 import { resolveColumnLayout } from "#shared/column-order.ts";
 import {
   LISTING_DEFAULT_ORDER,
@@ -314,7 +315,9 @@ export const adminGroupDeletePage = (
     </Layout>,
   );
 
-/** Build AttendeeTableRows from attendees with listing lookup */
+/** Build one AttendeeTableRow per booking line, looking up each line's listing.
+ * Stays per-line (not grouped by attendee) so every line keeps its own
+ * check-in button. */
 const buildAttendeeRows = (
   attendees: Attendee[],
   listings: ListingWithCount[],
@@ -323,14 +326,10 @@ const buildAttendeeRows = (
     map((e: ListingWithCount) => [e.id, e] as const)(listings),
   );
   return pipe(
-    map((a: Attendee): AttendeeTableRow => {
-      const listing = listingMap.get(a.listing_id)!;
-      return {
-        attendee: a,
-        listingId: listing.id,
-        listingName: listing.name,
-      };
-    }),
+    map(
+      (a: Attendee): AttendeeTableRow =>
+        attendeeLineRow(a, listingMap.get(a.listing_id)!),
+    ),
   )(attendees);
 };
 

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -6,6 +6,7 @@ import { filter, joinStrings, map, mapNotNullish, pipe } from "#fp";
 import { t } from "#i18n";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { formatCountdown } from "#routes/format.ts";
+import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
 import { formatCurrency, toMajorUnits } from "#shared/currency.ts";
 import {
   formatDateLabel,
@@ -1368,13 +1369,7 @@ const deriveListingView = (opts: ListingPanelOptions) => {
   const basePath = `/admin/listing/${listing.id}`;
   const returnUrl = rosterHref(listing.id, activeFilter, dateFilter);
   const tableRows: AttendeeTableRow[] = pipe(
-    map(
-      (a: Attendee): AttendeeTableRow => ({
-        attendee: a,
-        listingId: listing.id,
-        listingName: listing.name,
-      }),
-    ),
+    map((a: Attendee): AttendeeTableRow => attendeeLineRow(a, listing)),
   )(filteredAttendees);
   return {
     activeFilter,

--- a/src/ui/templates/attendee-table.tsx
+++ b/src/ui/templates/attendee-table.tsx
@@ -94,7 +94,7 @@ const computeVisibilityMap = (
     answers: !!opts.questionData && opts.questionData.questions.length > 0,
     date: opts.showDate,
     email: rows.some((r) => !!r.attendee.email),
-    listing: opts.showListing,
+    listings: opts.showListing,
     name: true,
     phone: rows.some((r) => !!r.attendee.phone),
     qty: true,
@@ -143,7 +143,9 @@ const compareAttendeeRows = (
     const dateCmp = dateA.localeCompare(dateB);
     if (dateCmp !== 0) return dateCmp;
   }
-  const nameCmp = a.listingName.localeCompare(b.listingName);
+  const listingA = a.listings[0]?.name ?? "";
+  const listingB = b.listings[0]?.name ?? "";
+  const nameCmp = listingA.localeCompare(listingB);
   if (nameCmp !== 0) return nameCmp;
   const attendeeCmp = a.attendee.name.localeCompare(b.attendee.name);
   if (attendeeCmp !== 0) return attendeeCmp;
@@ -247,10 +249,13 @@ const createStatusRenderer =
         </span>,
       );
     }
+    // Check-in is a per-booking-line action, and every table that shows it
+    // renders one row per line — a one-listing array (grouped browsing tables
+    // pass showCheckin: false), so the row's first listing IS the line's.
     return CheckinButton({
       a: row.attendee,
       activeFilter: opts.activeFilter ?? "all",
-      listingId: row.listingId,
+      listingId: row.listings[0]!.id,
       returnUrl: opts.returnUrl,
     });
   };

--- a/src/ui/templates/checkin.tsx
+++ b/src/ui/templates/checkin.tsx
@@ -7,6 +7,7 @@
 import { map, pipe } from "#fp";
 import { t } from "#i18n";
 import type { TokenEntry } from "#routes/tickets/token-utils.ts";
+import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import {
@@ -31,11 +32,8 @@ export const checkinAdminPage = (
   const showDate = entries.some((e) => e.attendee.date !== null);
   const tableRows: AttendeeTableRow[] = pipe(
     map(
-      (e: TokenEntry): AttendeeTableRow => ({
-        attendee: e.attendee,
-        listingId: e.listing.id,
-        listingName: e.listing.name,
-      }),
+      (e: TokenEntry): AttendeeTableRow =>
+        attendeeLineRow(e.attendee, e.listing),
     ),
   )(entries);
 

--- a/test/lib/attendee-table-rows.test.ts
+++ b/test/lib/attendee-table-rows.test.ts
@@ -1,0 +1,134 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  attendeeLineRow,
+  groupAttendeeRows,
+} from "#shared/attendee-table-rows.ts";
+import type { AttendeeRowListing } from "#shared/types.ts";
+import { testAttendee } from "#test-utils";
+
+/** Listings in display order: Gala (3) before Workshop (7) before Zumba (9) */
+const DISPLAY_ORDER: AttendeeRowListing[] = [
+  { id: 3, name: "Gala" },
+  { id: 7, name: "Workshop" },
+  { id: 9, name: "Zumba" },
+];
+
+describe("attendeeLineRow", () => {
+  test("builds a one-listing row copying only the listing's id and name", () => {
+    const attendee = testAttendee({ id: 5 });
+    const row = attendeeLineRow(attendee, {
+      extra: "ignored",
+      id: 7,
+      name: "Workshop",
+    } as AttendeeRowListing);
+    expect(row.attendee).toBe(attendee);
+    expect(row.listings).toEqual([{ id: 7, name: "Workshop" }]);
+  });
+});
+
+describe("groupAttendeeRows", () => {
+  test("merges one attendee's lines into a single row with every listing", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ id: 1, listing_id: 7 }),
+        testAttendee({ id: 1, listing_id: 3 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.listings).toEqual([
+      { id: 3, name: "Gala" },
+      { id: 7, name: "Workshop" },
+    ]);
+  });
+
+  test("orders each row's listings by display order, not booking order", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ id: 1, listing_id: 9 }),
+        testAttendee({ id: 1, listing_id: 7 }),
+        testAttendee({ id: 1, listing_id: 3 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows[0]!.listings.map((l) => l.name)).toEqual([
+      "Gala",
+      "Workshop",
+      "Zumba",
+    ]);
+  });
+
+  test("sums the quantity across an attendee's lines", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ id: 1, listing_id: 3, quantity: 2 }),
+        testAttendee({ id: 1, listing_id: 7, quantity: 3 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows[0]!.attendee.quantity).toBe(5);
+  });
+
+  test("keeps the first line's other attendee fields", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ date: "2026-03-01", id: 1, listing_id: 3 }),
+        testAttendee({ date: "2026-04-01", id: 1, listing_id: 7 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows[0]!.attendee.date).toBe("2026-03-01");
+  });
+
+  test("lists a listing once even when the attendee has several lines on it", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ date: "2026-03-01", id: 1, listing_id: 3 }),
+        testAttendee({ date: "2026-03-02", id: 1, listing_id: 3 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows[0]!.listings).toEqual([{ id: 3, name: "Gala" }]);
+  });
+
+  test("keeps distinct attendees on separate rows in first-seen order", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ id: 2, listing_id: 7, name: "Bob" }),
+        testAttendee({ id: 1, listing_id: 3, name: "Alice" }),
+        testAttendee({ id: 2, listing_id: 3, name: "Bob" }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows.map((r) => r.attendee.id)).toEqual([2, 1]);
+    expect(rows[0]!.listings.map((l) => l.id)).toEqual([3, 7]);
+    expect(rows[1]!.listings.map((l) => l.id)).toEqual([3]);
+  });
+
+  test("drops a line whose listing is unknown but keeps the attendee's other lines", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ id: 1, listing_id: 0 }),
+        testAttendee({ id: 1, listing_id: 3 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows[0]!.listings).toEqual([{ id: 3, name: "Gala" }]);
+  });
+
+  test("omits an attendee whose every line has an unknown listing", () => {
+    const rows = groupAttendeeRows(
+      [
+        testAttendee({ id: 1, listing_id: 0 }),
+        testAttendee({ id: 2, listing_id: 3 }),
+      ],
+      DISPLAY_ORDER,
+    );
+    expect(rows.map((r) => r.attendee.id)).toEqual([2]);
+  });
+
+  test("returns no rows for no lines", () => {
+    expect(groupAttendeeRows([], DISPLAY_ORDER)).toEqual([]);
+  });
+});

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -27,10 +27,15 @@ const makeRow = (
   overrides: Partial<AttendeeTableRow> = {},
 ): AttendeeTableRow => ({
   attendee: testAttendee(),
-  listingId: 1,
-  listingName: "Test Listing",
+  listings: [{ id: 1, name: "Test Listing" }],
   ...overrides,
 });
+
+/** A one-listing row whose listing is named `name` (id 1) */
+const namedListingRow = (
+  name: string,
+  attendee = testAttendee(),
+): AttendeeTableRow => makeRow({ attendee, listings: [{ id: 1, name }] });
 
 const makeOpts = (
   overrides: Partial<AttendeeTableOptions> = {},
@@ -44,14 +49,8 @@ const makeOpts = (
 
 /** Zara (id=1, B Listing) then Alice (id=2, A Listing) — unsorted input order */
 const zaraAliceRows = (): AttendeeTableRow[] => [
-  makeRow({
-    attendee: testAttendee({ id: 1, name: "Zara" }),
-    listingName: "B Listing",
-  }),
-  makeRow({
-    attendee: testAttendee({ id: 2, name: "Alice" }),
-    listingName: "A Listing",
-  }),
+  namedListingRow("B Listing", testAttendee({ id: 1, name: "Zara" })),
+  namedListingRow("A Listing", testAttendee({ id: 2, name: "Alice" })),
 ];
 
 /** Render zaraAliceRows with default sorting and assert Alice appears before Zara */
@@ -112,17 +111,17 @@ describe("AttendeeTable", () => {
   });
 
   describe("column order", () => {
-    test("renders columns in correct order", () => {
+    test("renders columns in correct order, Listings directly after Name", () => {
       const rows = [
-        makeRow({
-          attendee: testAttendee({
+        namedListingRow(
+          "Gala",
+          testAttendee({
             address: "123 Main",
             email: "a@b.com",
             phone: "555",
             special_instructions: "VIP",
           }),
-          listingName: "Gala",
-        }),
+        ),
       ];
       const html = AttendeeTable(
         makeOpts({ rows, showDate: true, showListing: true }),
@@ -133,9 +132,9 @@ describe("AttendeeTable", () => {
       // The single empty header is for the Checked In / status column (first)
       expect(headers).toEqual([
         "",
-        "Listing",
         "Date",
         "Name",
+        "Listings",
         "Email",
         "Phone",
         "Address",
@@ -147,18 +146,58 @@ describe("AttendeeTable", () => {
     });
   });
 
-  describe("Listing column", () => {
+  describe("Listings column", () => {
     test("hidden when showListing is false", () => {
       const html = AttendeeTable(makeOpts({ showListing: false }));
-      expect(html).not.toContain("<th>Listing</th>");
+      expect(html).not.toContain("<th>Listings</th>");
+      expect(html).not.toContain("listings-cell");
     });
 
     test("shown with linked listing name when showListing is true", () => {
-      const rows = [makeRow({ listingId: 42, listingName: "Test Gala" })];
+      const rows = [makeRow({ listings: [{ id: 42, name: "Test Gala" }] })];
       const html = AttendeeTable(makeOpts({ rows, showListing: true }));
-      expect(html).toContain("<th>Listing</th>");
-      expect(html).toContain("/admin/listing/42");
-      expect(html).toContain("Test Gala");
+      expect(html).toContain("<th>Listings</th>");
+      expect(html).toContain('<a href="/admin/listing/42">Test Gala</a>');
+    });
+
+    /** Render a two-listing grouped row (Spring Fair before Autumn Ball) */
+    const groupedRowHtml = (): string =>
+      AttendeeTable(
+        makeOpts({
+          rows: [
+            makeRow({
+              listings: [
+                { id: 5, name: "Spring Fair" },
+                { id: 3, name: "Autumn Ball" },
+              ],
+            }),
+          ],
+          showListing: true,
+        }),
+      );
+
+    test("links every listing of a grouped row, comma-separated, in row order", () => {
+      expect(groupedRowHtml()).toContain(
+        '<a href="/admin/listing/5">Spring Fair</a>, ' +
+          '<a href="/admin/listing/3">Autumn Ball</a>',
+      );
+    });
+
+    test("wraps the links in a truncating cell carrying the full list as its title", () => {
+      expect(groupedRowHtml()).toContain(
+        '<span class="listings-cell" title="Spring Fair, Autumn Ball">',
+      );
+    });
+
+    test("escapes listing names in both the links and the title attribute", () => {
+      const rows = [
+        makeRow({ listings: [{ id: 9, name: 'A <b>"wild"</b> & odd one' }] }),
+      ];
+      const html = AttendeeTable(makeOpts({ rows, showListing: true }));
+      expect(html).toContain(
+        'title="A &lt;b&gt;&quot;wild&quot;&lt;/b&gt; &amp; odd one"',
+      );
+      expect(html).not.toContain("<b>");
     });
   });
 
@@ -317,8 +356,8 @@ describe("AttendeeTable", () => {
       expect(html).toContain(`value="${getCurrentCsrfToken()}"`);
     });
 
-    test("form action points to correct endpoint", () => {
-      const rows = [makeRow({ listingId: 42 })];
+    test("form action points to the row's own listing", () => {
+      const rows = [makeRow({ listings: [{ id: 42, name: "Test Listing" }] })];
       const html = AttendeeTable(makeOpts({ rows }));
       expect(html).toContain("/admin/listing/42/attendee/1/checkin");
     });
@@ -466,33 +505,18 @@ describe("AttendeeTable", () => {
 describe("sortAttendeeRows", () => {
   test("sorts by listing date ascending, null dates last", () => {
     const rows = [
-      makeRow({
-        attendee: testAttendee({ date: null, id: 1 }),
-        listingName: "A",
-      }),
-      makeRow({
-        attendee: testAttendee({ date: "2026-03-01", id: 2 }),
-        listingName: "A",
-      }),
-      makeRow({
-        attendee: testAttendee({ date: "2026-01-15", id: 3 }),
-        listingName: "A",
-      }),
+      namedListingRow("A", testAttendee({ date: null, id: 1 })),
+      namedListingRow("A", testAttendee({ date: "2026-03-01", id: 2 })),
+      namedListingRow("A", testAttendee({ date: "2026-01-15", id: 3 })),
     ];
     const sorted = sortAttendeeRows(rows);
     expect(sorted.map((r) => r.attendee.id)).toEqual([3, 2, 1]);
   });
 
-  test("sorts by listing name when dates are equal", () => {
+  test("sorts by first listing name when dates are equal", () => {
     const rows = [
-      makeRow({
-        attendee: testAttendee({ date: "2026-03-01", id: 1 }),
-        listingName: "Zebra",
-      }),
-      makeRow({
-        attendee: testAttendee({ date: "2026-03-01", id: 2 }),
-        listingName: "Alpha",
-      }),
+      namedListingRow("Zebra", testAttendee({ date: "2026-03-01", id: 1 })),
+      namedListingRow("Alpha", testAttendee({ date: "2026-03-01", id: 2 })),
     ];
     const sorted = sortAttendeeRows(rows);
     expect(sorted.map((r) => r.attendee.id)).toEqual([2, 1]);
@@ -500,14 +524,8 @@ describe("sortAttendeeRows", () => {
 
   test("sorts by attendee name when date and listing name are equal", () => {
     const rows = [
-      makeRow({
-        attendee: testAttendee({ id: 1, name: "Zara" }),
-        listingName: "Gala",
-      }),
-      makeRow({
-        attendee: testAttendee({ id: 2, name: "Alice" }),
-        listingName: "Gala",
-      }),
+      namedListingRow("Gala", testAttendee({ id: 1, name: "Zara" })),
+      namedListingRow("Gala", testAttendee({ id: 2, name: "Alice" })),
     ];
     const sorted = sortAttendeeRows(rows);
     expect(sorted.map((r) => r.attendee.id)).toEqual([2, 1]);
@@ -515,14 +533,8 @@ describe("sortAttendeeRows", () => {
 
   test("sorts by id when all other fields are equal", () => {
     const rows = [
-      makeRow({
-        attendee: testAttendee({ id: 5, name: "Sam" }),
-        listingName: "Gala",
-      }),
-      makeRow({
-        attendee: testAttendee({ id: 2, name: "Sam" }),
-        listingName: "Gala",
-      }),
+      namedListingRow("Gala", testAttendee({ id: 5, name: "Sam" })),
+      namedListingRow("Gala", testAttendee({ id: 2, name: "Sam" })),
     ];
     const sorted = sortAttendeeRows(rows);
     expect(sorted.map((r) => r.attendee.id)).toEqual([2, 5]);
@@ -530,32 +542,41 @@ describe("sortAttendeeRows", () => {
 
   test("applies full multi-key sort order", () => {
     const rows = [
-      makeRow({
-        attendee: testAttendee({ date: "2026-02-01", id: 1, name: "Bob" }),
-        listingName: "Concert",
-      }),
-      makeRow({
-        attendee: testAttendee({ date: null, id: 2, name: "Alice" }),
-        listingName: "Gala",
-      }),
-      makeRow({
-        attendee: testAttendee({ date: "2026-01-15", id: 3, name: "Alice" }),
-        listingName: "Concert",
-      }),
-      makeRow({
-        attendee: testAttendee({ date: "2026-02-01", id: 4, name: "Alice" }),
-        listingName: "Concert",
-      }),
+      namedListingRow(
+        "Concert",
+        testAttendee({ date: "2026-02-01", id: 1, name: "Bob" }),
+      ),
+      namedListingRow(
+        "Gala",
+        testAttendee({ date: null, id: 2, name: "Alice" }),
+      ),
+      namedListingRow(
+        "Concert",
+        testAttendee({ date: "2026-01-15", id: 3, name: "Alice" }),
+      ),
+      namedListingRow(
+        "Concert",
+        testAttendee({ date: "2026-02-01", id: 4, name: "Alice" }),
+      ),
     ];
     const sorted = sortAttendeeRows(rows);
     // date 2026-01-15 first, then 2026-02-01 (Alice before Bob by name), then null date last
     expect(sorted.map((r) => r.attendee.id)).toEqual([3, 4, 1, 2]);
   });
 
+  test("sorts a listing-less row before a named listing (empty name first)", () => {
+    const rows = [
+      namedListingRow("Gala", testAttendee({ id: 1 })),
+      makeRow({ attendee: testAttendee({ id: 2 }), listings: [] }),
+    ];
+    const sorted = sortAttendeeRows(rows);
+    expect(sorted.map((r) => r.attendee.id)).toEqual([2, 1]);
+  });
+
   test("does not mutate the original array", () => {
     const rows = [
-      makeRow({ attendee: testAttendee({ id: 2 }), listingName: "B" }),
-      makeRow({ attendee: testAttendee({ id: 1 }), listingName: "A" }),
+      namedListingRow("B", testAttendee({ id: 2 })),
+      namedListingRow("A", testAttendee({ id: 1 })),
     ];
     const original = [...rows];
     sortAttendeeRows(rows);

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -573,6 +573,21 @@ describe("sortAttendeeRows", () => {
     expect(sorted.map((r) => r.attendee.id)).toEqual([2, 1]);
   });
 
+  test("sorts two listing-less rows by attendee name", () => {
+    const rows = [
+      makeRow({
+        attendee: testAttendee({ id: 1, name: "Zara" }),
+        listings: [],
+      }),
+      makeRow({
+        attendee: testAttendee({ id: 2, name: "Alice" }),
+        listings: [],
+      }),
+    ];
+    const sorted = sortAttendeeRows(rows);
+    expect(sorted.map((r) => r.attendee.id)).toEqual([2, 1]);
+  });
+
   test("does not mutate the original array", () => {
     const rows = [
       namedListingRow("B", testAttendee({ id: 2 })),

--- a/test/lib/attendee-table.test.ts
+++ b/test/lib/attendee-table.test.ts
@@ -91,8 +91,11 @@ describe("AttendeeTable", () => {
     test("renders Ticket column with link", () => {
       const html = AttendeeTable(makeOpts());
       expect(html).toContain("<th>Ticket</th>");
-      expect(html).toContain(`https://${ALLOWED_DOMAIN}/t/test-token-1`);
-      expect(html).toContain("test-token-1");
+      // Assert the unescaped anchor (not just the URL substring), so the ticket
+      // column's isHtml flag is exercised — an escaped cell would fail this.
+      expect(html).toContain(
+        `<a href="https://${ALLOWED_DOMAIN}/t/test-token-1">test-token-1</a>`,
+      );
     });
 
     test("renders Registered column", () => {

--- a/test/lib/column-order/columns.test.ts
+++ b/test/lib/column-order/columns.test.ts
@@ -196,18 +196,32 @@ describe("ATTENDEE_TABLE_COLUMNS cell renderers", () => {
     overrides: Partial<AttendeeTableRow> = {},
   ): AttendeeTableRow => ({
     attendee: testAttendee(),
-    listingId: 1,
-    listingName: "Test Listing",
+    listings: [{ id: 1, name: "Test Listing" }],
     ...overrides,
   });
 
-  test("listing cell renders link to admin listing page", () => {
-    const html = ATTENDEE_TABLE_COLUMNS.listing!.cell(
-      makeRow({ listingId: 42, listingName: "Gala" }),
+  /** The listings cell rendered for a two-listing grouped row */
+  const twoListingCell = (): string =>
+    ATTENDEE_TABLE_COLUMNS.listings!.cell(
+      makeRow({
+        listings: [
+          { id: 42, name: "Gala" },
+          { id: 7, name: "Quiz Night" },
+        ],
+      }),
       opts,
     );
-    expect(html).toContain("/admin/listing/42");
-    expect(html).toContain("Gala");
+
+  test("listings cell renders a link per listing to its admin page", () => {
+    expect(twoListingCell()).toContain(
+      '<a href="/admin/listing/42">Gala</a>, <a href="/admin/listing/7">Quiz Night</a>',
+    );
+  });
+
+  test("listings cell carries the full name list in its title attribute", () => {
+    expect(twoListingCell()).toContain(
+      '<span class="listings-cell" title="Gala, Quiz Night">',
+    );
   });
 
   test("date cell formats date labels", () => {

--- a/test/lib/column-order/columns.test.ts
+++ b/test/lib/column-order/columns.test.ts
@@ -337,4 +337,44 @@ describe("ATTENDEE_TABLE_COLUMNS cell renderers", () => {
       "2026-01-01T12:00:00Z",
     );
   });
+
+  test("answers cell renders a free-text answer and its Question: Answer tooltip", () => {
+    const questionData = {
+      attendeeAnswerMap: new Map<number, number[]>(),
+      questions: [
+        {
+          answers: [],
+          display_type: "free_text" as const,
+          id: 5,
+          text: "Access needs?",
+        },
+      ],
+      textAnswerMap: new Map([[1, new Map([[5, "Wheelchair ramp"]])]]),
+    };
+    const html = ATTENDEE_TABLE_COLUMNS.answers!.cell(
+      makeRow({ attendee: testAttendee({ id: 1 }) }),
+      { ...opts, questionData },
+    );
+    expect(html).toContain(">Wheelchair ramp</span>");
+    expect(html).toContain('title="Access needs?: Wheelchair ramp"');
+  });
+
+  test("answers cell shows a radio answer with no tooltip when its question text is unknown", () => {
+    // The answer id resolves to text but not to a question, so the tooltip part
+    // (which needs both) is skipped while the short value still renders.
+    const questionData = {
+      attendeeAnswerMap: new Map([[1, [10]]]),
+      questions: [],
+    };
+    const html = ATTENDEE_TABLE_COLUMNS.answers!.cell(
+      makeRow({ attendee: testAttendee({ id: 1 }) }),
+      {
+        ...opts,
+        answerQuestionMap: new Map<number, string>(),
+        answerTextMap: new Map([[10, "Red"]]),
+        questionData,
+      },
+    );
+    expect(html).toBe('<span title="">Red</span>');
+  });
 });

--- a/test/lib/db/attendees/get-newest-attendees-raw.test.ts
+++ b/test/lib/db/attendees/get-newest-attendees-raw.test.ts
@@ -5,6 +5,7 @@ import {
   getNewestAttendeesRaw,
 } from "#shared/db/attendees.ts";
 import {
+  createMultiBookingAttendee,
   createTestAttendee,
   createTestListing,
   describeWithEnv,
@@ -56,6 +57,29 @@ describeWithEnv("db > attendees > getNewestAttendeesRaw", { db: true }, () => {
 
     const raw = await getNewestAttendeesRaw(2);
     expect(raw.length).toBe(2);
+  });
+
+  test("counts the limit in attendees and returns each one's every booking line", async () => {
+    const listing1 = await createTestListing({ maxAttendees: 10 });
+    const listing2 = await createTestListing({ maxAttendees: 10 });
+    await createTestAttendee(
+      listing1.id,
+      listing1.slug,
+      "Old",
+      "old@example.com",
+    );
+    const multi = await createMultiBookingAttendee(
+      "Newest",
+      "new@example.com",
+      [{ listingId: listing1.id }, { listingId: listing2.id }],
+    );
+
+    // Limit 1 = the newest attendee — BOTH of their lines, nothing of "Old".
+    const raw = await getNewestAttendeesRaw(1);
+    expect(raw.map((row) => row.id)).toEqual([multi.id, multi.id]);
+    expect(raw.map((row) => row.listing_id).toSorted()).toEqual(
+      [listing1.id, listing2.id].toSorted(),
+    );
   });
 
   test("returns empty array when no attendees", async () => {

--- a/test/lib/db/migration-restore.test.ts
+++ b/test/lib/db/migration-restore.test.ts
@@ -321,9 +321,11 @@ describeWithEnv("db > migration restore", { db: true, triggers: true }, () => {
     // rebuilds the day_count rows from listings.day_prices then drops that
     // column), the ticket-count-no-quantity trigger rewrite (it drops and
     // re-syncs the aggregate triggers from SCHEMA, owning no additive objects to
-    // rebuild), and the attendees.kind NOT NULL tightening (an empty-`requires`
-    // constraint rebuild owning no additive objects to drop/restore).
-    expect(additiveMigrations.length).toBe(MIGRATIONS.length - 15);
+    // rebuild), the attendees.kind NOT NULL tightening (an empty-`requires`
+    // constraint rebuild owning no additive objects to drop/restore), and the
+    // attendee-listings-tag settings rewrite (data-only; covered by its own
+    // data test).
+    expect(additiveMigrations.length).toBe(MIGRATIONS.length - 16);
   });
 
   for (const migration of additiveMigrations) {

--- a/test/lib/db/migration-schema-guard.test.ts
+++ b/test/lib/db/migration-schema-guard.test.ts
@@ -71,6 +71,7 @@ describe("db > migrations > schema change guard", () => {
         "2026-07-02_bookable_alone",
         "2026-07-02_group_flat_prices",
         "2026-07-02_drop_listings_day_prices",
+        "2026-07-03_attendee_listings_tag",
       ],
       schemaHash: "zv2582",
     });

--- a/test/lib/db/migrations/2026-07-03_attendee_listings_tag.test.ts
+++ b/test/lib/db/migrations/2026-07-03_attendee_listings_tag.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { getDb, queryOne } from "#shared/db/client.ts";
+import attendeeListingsTagMigration from "#shared/db/migrations/2026-07-03_attendee_listings_tag.ts";
+import { buildMigrationContext, describeWithEnv } from "#test-utils";
+
+// Data-only migration: it reads and rewrites one settings row via getDb.
+const context = buildMigrationContext({});
+const runMigration = () => attendeeListingsTagMigration(context).up();
+
+const setStoredTemplate = (value: string): Promise<unknown> =>
+  getDb().execute({
+    args: [value],
+    sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('attendee_column_order', ?)",
+  });
+
+const storedTemplate = async (): Promise<string | null> => {
+  const row = await queryOne<{ value: string }>(
+    "SELECT value FROM settings WHERE key = 'attendee_column_order'",
+  );
+  return row?.value ?? null;
+};
+
+describeWithEnv(
+  "db > migrations > 2026-07-03_attendee_listings_tag",
+  { db: true },
+  () => {
+    test("rewrites {{listing}} to {{listings}} preserving the rest of the template", async () => {
+      await setStoredTemplate("{{name}}, {{listing}}, {{email}}");
+      await runMigration();
+      expect(await storedTemplate()).toBe("{{name}}, {{listings}}, {{email}}");
+    });
+
+    test("rewrites the tag with inner whitespace and a trailing filter", async () => {
+      await setStoredTemplate("{{ listing }}, {{listing | upcase}}");
+      await runMigration();
+      expect(await storedTemplate()).toBe(
+        "{{ listings }}, {{listings | upcase}}",
+      );
+    });
+
+    test("leaves an already-migrated {{listings}} tag alone (idempotent re-run)", async () => {
+      await setStoredTemplate("{{listings}}, {{name}}");
+      await runMigration();
+      expect(await storedTemplate()).toBe("{{listings}}, {{name}}");
+    });
+
+    test("is a no-op when the setting is unset", async () => {
+      await getDb().execute(
+        "DELETE FROM settings WHERE key = 'attendee_column_order'",
+      );
+      await runMigration();
+      expect(await storedTemplate()).toBe(null);
+    });
+  },
+);

--- a/test/lib/server-attendees-csv.test.ts
+++ b/test/lib/server-attendees-csv.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   adminGet,
+  createMultiBookingAttendee,
   createTestAttendeeDirect,
   createTestListing,
   describeWithEnv,
@@ -44,6 +45,26 @@ describeWithEnv("server (admin attendees CSV)", { db: true }, () => {
       const csv = await response.text();
       expect(csv).toContain("AliceOne");
       expect(csv).not.toContain("BobTwo");
+    });
+
+    test("a filtered export omits a matched attendee's other-listing bookings", async () => {
+      const wanted = await makeListing("Wanted Show");
+      const other = await makeListing("Other Show");
+      await createMultiBookingAttendee("DoubleBooker", "db@example.com", [
+        { listingId: wanted.id },
+        { listingId: other.id },
+      ]);
+
+      const response = await adminGet(
+        `/admin/attendees/csv?listing=${wanted.id}`,
+      );
+      const csv = await response.text();
+      // One row: the booking on the filtered listing only — the grouped
+      // attendees PAGE shows their other listings, but the export must not.
+      expect(csv).toContain("DoubleBooker");
+      expect(csv).toContain("Wanted Show");
+      expect(csv).not.toContain("Other Show");
+      expect(csv.split("\n")).toHaveLength(2);
     });
 
     test("returns just the header when the type filter matches no listings", async () => {

--- a/test/lib/server-attendees-list.test.ts
+++ b/test/lib/server-attendees-list.test.ts
@@ -5,6 +5,7 @@ import { createSystemNote } from "#shared/db/system-notes.ts";
 import {
   adminGet,
   assertAdminHtml,
+  createMultiBookingAttendee,
   createTestAttendeeDirect,
   createTestListing,
   deactivateTestListing,
@@ -120,14 +121,15 @@ describeWithEnv("server (admin attendees list)", { db: true }, () => {
       expect(html).not.toContain('rel="prev"');
     });
 
-    test("paginates results at the page size", async () => {
+    test("paginates by attendee, keeping a grouped row's bookings together", async () => {
       const listing = await makeListing("Big Listing", ATTENDEES_PAGE_SIZE * 2);
-      // Oldest registration is created first, so it lands on the second page.
-      await createTestAttendeeDirect(
-        listing.id,
-        "OldestPerson",
-        "oldest@example.com",
-      );
+      const other = await makeListing("Other Show", ATTENDEES_PAGE_SIZE * 2);
+      // Oldest registration is created first, so it lands on the second page —
+      // with BOTH of its booking lines, despite the page-size cut falling on it.
+      await createMultiBookingAttendee("OldestPerson", "oldest@example.com", [
+        { listingId: listing.id },
+        { listingId: other.id },
+      ]);
       for (let i = 0; i < ATTENDEES_PAGE_SIZE; i++) {
         await createTestAttendeeDirect(
           listing.id,
@@ -136,7 +138,7 @@ describeWithEnv("server (admin attendees list)", { db: true }, () => {
         );
       }
 
-      // Page 0: newest PAGE_SIZE rows, a next link, no previous link.
+      // Page 0: newest PAGE_SIZE attendees, a next link, no previous link.
       const first = await adminGet("/admin/attendees");
       const firstHtml = await first.text();
       expect(firstHtml).not.toContain("OldestPerson");
@@ -144,12 +146,74 @@ describeWithEnv("server (admin attendees list)", { db: true }, () => {
       expect(firstHtml).toContain('href="/admin/attendees?page=1"');
       expect(firstHtml).not.toContain('rel="prev"');
 
-      // Page 1: the remaining oldest row, a previous link, no next link.
+      // Page 1: the remaining oldest attendee — one row carrying both
+      // listings — a previous link, no next link.
       const second = await adminGet("/admin/attendees?page=1");
       const secondHtml = await second.text();
       expect(secondHtml).toContain("OldestPerson");
+      expect(secondHtml).toContain('title="Big Listing, Other Show"');
       expect(secondHtml).toContain('rel="prev"');
       expect(secondHtml).not.toContain('rel="next"');
+    });
+
+    test("groups an attendee's bookings into one row, listings in display order", async () => {
+      const beta = await makeListing("Beta Show");
+      const alpha = await makeListing("Alpha Show");
+      // Booked in reverse-alphabetical order; the cell must follow the
+      // listings page order (no-date standard listings sort by name).
+      const attendee = await createMultiBookingAttendee(
+        "CarolMulti",
+        "carol@example.com",
+        [{ listingId: beta.id }, { listingId: alpha.id }],
+      );
+
+      const response = await adminGet("/admin/attendees");
+      const html = await response.text();
+      expect(html).toContain(
+        '<span class="listings-cell" title="Alpha Show, Beta Show">' +
+          `<a href="/admin/listing/${alpha.id}">Alpha Show</a>, ` +
+          `<a href="/admin/listing/${beta.id}">Beta Show</a></span>`,
+      );
+      // One grouped row: the attendee's edit link renders exactly once.
+      const nameLinks = html.match(
+        new RegExp(`href="/admin/attendees/${attendee.id}"`, "g"),
+      );
+      expect(nameLinks?.length).toBe(1);
+    });
+
+    test("sums the ticket quantity across a grouped row's bookings", async () => {
+      const first = await makeListing("First Show");
+      const second = await makeListing("Second Show");
+      await createMultiBookingAttendee("QtyPerson", "qty@example.com", [
+        { listingId: first.id, quantity: 2 },
+        { listingId: second.id, quantity: 3 },
+      ]);
+
+      const response = await adminGet("/admin/attendees");
+      const html = await response.text();
+      expect(html).toContain('<td class="col-quantity">5</td>');
+    });
+
+    test("a listing filter matches attendees but still shows their other listings", async () => {
+      const booked = await makeListing("Booked Show");
+      const also = await makeListing("Also Booked");
+      const unrelated = await makeListing("Unrelated Show");
+      await createMultiBookingAttendee("DoubleBooker", "db@example.com", [
+        { listingId: booked.id },
+        { listingId: also.id },
+      ]);
+      await createTestAttendeeDirect(
+        unrelated.id,
+        "OtherPerson",
+        "other@example.com",
+      );
+
+      const response = await adminGet(`/admin/attendees?listing=${booked.id}`);
+      const html = await response.text();
+      expect(html).toContain("DoubleBooker");
+      // The matched attendee's full listing list renders, filter or not.
+      expect(html).toContain('title="Also Booked, Booked Show"');
+      expect(html).not.toContain("OtherPerson");
     });
   });
 

--- a/test/lib/server-attendees-list.test.ts
+++ b/test/lib/server-attendees-list.test.ts
@@ -121,6 +121,37 @@ describeWithEnv("server (admin attendees list)", { db: true }, () => {
       expect(html).not.toContain('rel="prev"');
     });
 
+    /** Register `count` throwaway attendees on the listing */
+    const seedFillerAttendees = async (
+      listingId: number,
+      count: number,
+    ): Promise<void> => {
+      for (let i = 0; i < count; i++) {
+        await createTestAttendeeDirect(
+          listingId,
+          `Filler ${i}`,
+          `filler${i}@example.com`,
+        );
+      }
+    };
+
+    test("shows the whole page with no paging links when the attendees exactly fill it", async () => {
+      const listing = await makeListing("Full Page", ATTENDEES_PAGE_SIZE * 2);
+      // Created first = oldest = the row a broken hasNext would trim off.
+      await createTestAttendeeDirect(
+        listing.id,
+        "OldestExact",
+        "oldest-exact@example.com",
+      );
+      await seedFillerAttendees(listing.id, ATTENDEES_PAGE_SIZE - 1);
+
+      const response = await adminGet("/admin/attendees");
+      const html = await response.text();
+      expect(html).toContain("OldestExact");
+      expect(html).not.toContain('rel="next"');
+      expect(html).not.toContain('rel="prev"');
+    });
+
     test("paginates by attendee, keeping a grouped row's bookings together", async () => {
       const listing = await makeListing("Big Listing", ATTENDEES_PAGE_SIZE * 2);
       const other = await makeListing("Other Show", ATTENDEES_PAGE_SIZE * 2);
@@ -130,13 +161,7 @@ describeWithEnv("server (admin attendees list)", { db: true }, () => {
         { listingId: listing.id },
         { listingId: other.id },
       ]);
-      for (let i = 0; i < ATTENDEES_PAGE_SIZE; i++) {
-        await createTestAttendeeDirect(
-          listing.id,
-          `Filler ${i}`,
-          `filler${i}@example.com`,
-        );
-      }
+      await seedFillerAttendees(listing.id, ATTENDEES_PAGE_SIZE);
 
       // Page 0: newest PAGE_SIZE attendees, a next link, no previous link.
       const first = await adminGet("/admin/attendees");

--- a/test/lib/server-checkin.test.ts
+++ b/test/lib/server-checkin.test.ts
@@ -7,6 +7,7 @@ import {
   awaitTestRequest,
   bookAttendee,
   createDailyTestAttendee,
+  createMultiBookingAttendee,
   createTestAttendeeWithToken,
   createTestListing,
   describeWithEnv,
@@ -85,6 +86,36 @@ describeWithEnv("check-in (/checkin/:tokens)", { db: true }, () => {
       expect(body).toContain("Check in");
       expect(body).toContain("Check In All");
       expect(body).not.toContain('class="success"');
+    });
+
+    test("keeps one row per booking line, each with its own listing's check-in button", async () => {
+      const first = await createTestListing({
+        maxAttendees: 10,
+        name: "First Listing",
+      });
+      const second = await createTestListing({
+        maxAttendees: 10,
+        name: "Second Listing",
+      });
+      const attendee = await createMultiBookingAttendee(
+        "Multi",
+        "multi@test.com",
+        [{ listingId: first.id }, { listingId: second.id }],
+      );
+      const cookie = await testCookie();
+
+      const response = await awaitTestRequest(
+        `/checkin/${attendee.ticket_token}`,
+        { cookie },
+      );
+      const body = await response.text();
+      // The bookings stay separate rows so each listing checks in on its own.
+      expect(body).toContain(
+        `/admin/listing/${first.id}/attendee/${attendee.id}/checkin`,
+      );
+      expect(body).toContain(
+        `/admin/listing/${second.id}/attendee/${attendee.id}/checkin`,
+      );
     });
 
     test("shows attendee contact details in admin view", async () => {

--- a/test/templates/admin/attendees-list.test.ts
+++ b/test/templates/admin/attendees-list.test.ts
@@ -42,8 +42,7 @@ const row = (
   listingName: string,
 ): AttendeeTableRow => ({
   attendee: testAttendee({ id: attendeeId, listing_id: listingId, name }),
-  listingId,
-  listingName,
+  listings: [{ id: listingId, name: listingName }],
 });
 
 beforeAll(async () => {

--- a/test/templates/admin/calendar.test.ts
+++ b/test/templates/admin/calendar.test.ts
@@ -133,9 +133,9 @@ describe("adminCalendarPage", () => {
     expect(html).toContain("John Doe");
   });
 
-  test("renders Listing column header", () => {
+  test("renders Listings column header", () => {
     const html = calendarHtml();
-    expect(html).toContain("<th>Listing</th>");
+    expect(html).toContain("<th>Listings</th>");
   });
 
   test("shows CSV export link when date has attendees", () => {

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -165,7 +165,7 @@ describe("adminDashboardPage", () => {
     expect(html).toContain("Newest 1 Attendee</summary>");
   });
 
-  test("newest attendees shows listing column", () => {
+  test("newest attendees shows the Listings column", () => {
     const listings = [testListingWithCount({ id: 1, name: "Workshop" })];
     const attendees = [testAttendee({ id: 1, listing_id: 1 })];
     const html = adminDashboardPage(
@@ -174,8 +174,33 @@ describe("adminDashboardPage", () => {
       undefined,
       attendees,
     );
-    expect(html).toContain("<th>Listing</th>");
+    expect(html).toContain("<th>Listings</th>");
     expect(html).toContain("Workshop");
+  });
+
+  test("newest attendees groups an attendee's bookings into one row, listings in display order", () => {
+    // `listings` arrives pre-sorted (Gala first); the attendee's lines arrive
+    // in the opposite order, so the cell order proves the display order wins.
+    const listings = [
+      testListingWithCount({ id: 1, name: "Gala" }),
+      testListingWithCount({ id: 2, name: "Workshop" }),
+    ];
+    const attendees = [
+      testAttendee({ id: 1, listing_id: 2, name: "Alice" }),
+      testAttendee({ id: 1, listing_id: 1, name: "Alice" }),
+    ];
+    const html = adminDashboardPage(
+      listings,
+      TEST_SESSION,
+      undefined,
+      attendees,
+    );
+    expect(html).toContain("Newest 1 Attendee</summary>");
+    expect(html).toContain(
+      '<span class="listings-cell" title="Gala, Workshop">' +
+        '<a href="/admin/listing/1">Gala</a>, ' +
+        '<a href="/admin/listing/2">Workshop</a></span>',
+    );
   });
 
   test("newest attendees not shown when all attendees have unknown listing_id", () => {

--- a/test/templates/admin/groups.test.ts
+++ b/test/templates/admin/groups.test.ts
@@ -44,6 +44,34 @@ describe("adminGroupDetailPage", () => {
     expect(html).toContain(`/admin/groups/${group.id}/export.json`);
   });
 
+  test("keeps one attendee row per booking line, each with its own check-in action", () => {
+    const group = testGroup({ name: "Roster Group" });
+    const listings = [
+      testListingWithCount({ id: 1, name: "First Listing" }),
+      testListingWithCount({ id: 2, name: "Second Listing" }),
+    ];
+    const attendees = [
+      testAttendee({ id: 9, listing_id: 1, name: "Repeat Visitor" }),
+      testAttendee({ id: 9, listing_id: 2, name: "Repeat Visitor" }),
+    ];
+    const html = adminGroupDetailPage(
+      group,
+      listings,
+      [],
+      attendees,
+      TEST_SESSION,
+      "localhost",
+      false,
+      true,
+    );
+    // Per-line check-in is the point of this roster: the attendee's two
+    // bookings stay two rows, each acting on its own listing.
+    expect(html).toContain("/admin/listing/1/attendee/9/checkin");
+    expect(html).toContain("/admin/listing/2/attendee/9/checkin");
+    expect(html).toContain('title="First Listing"');
+    expect(html).toContain('title="Second Listing"');
+  });
+
   test("Group Attendees row drops cap fragment when group is uncapped", () => {
     const group = testGroup({ max_attendees: 0, name: "Open Group" });
     const listings = [testListingWithCount({ attendee_count: 5 })];

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -657,6 +657,19 @@ describe("adminListingPage", () => {
     expect(html).toContain("2 remain");
   });
 
+  test("roster keeps one row per booking line, with no Listings column", () => {
+    const attendees = [testAttendee({ id: 8, listing_id: listing.id })];
+    const html = renderListingDetail({
+      allowedDomain: "localhost",
+      attendees,
+      listing,
+    });
+    // The roster is scoped to one listing, so the Listings column stays off
+    // and each line keeps its own per-listing check-in action.
+    expect(html).not.toContain("<th>Listings</th>");
+    expect(html).toContain(`/admin/listing/${listing.id}/attendee/8/checkin`);
+  });
+
   test("shows dual checked-in rows when attendees have multi-quantity", () => {
     const attendees = [
       testAttendee({ checked_in: true, id: 1, quantity: 2 }),

--- a/test/test-utils/db-helpers.ts
+++ b/test/test-utils/db-helpers.ts
@@ -611,6 +611,29 @@ export const buildAttendeeEditForm = async (
   return form;
 };
 
+/** Create one attendee booked across several listings in a single order —
+ *  one booking line per listing, each with its own quantity (default 1).
+ *  Used by the grouped attendee-table suites. */
+export const createMultiBookingAttendee = async (
+  name: string,
+  email: string,
+  bookings: Array<{ listingId: number; quantity?: number }>,
+): Promise<Attendee> => {
+  const { createAttendeeAtomic } = await import("#shared/db/attendees.ts");
+  const result = await createAttendeeAtomic({
+    bookings: bookings.map((booking) => ({
+      listingId: booking.listingId,
+      quantity: booking.quantity ?? 1,
+    })),
+    email,
+    name,
+  });
+  if (!result.success) {
+    throw new Error(`Failed to create attendee: ${result.reason}`);
+  }
+  return result.attendees[0]!;
+};
+
 export const createTestAttendeeWithToken = async (
   name: string,
   email: string,

--- a/test/test-utils/db-helpers.ts
+++ b/test/test-utils/db-helpers.ts
@@ -628,10 +628,10 @@ export const createMultiBookingAttendee = async (
     email,
     name,
   });
-  if (!result.success) {
-    throw new Error(`Failed to create attendee: ${result.reason}`);
-  }
-  return result.attendees[0]!;
+  // Callers pass listings with capacity, so the booking always succeeds; cast
+  // the union rather than guard, mirroring createPaidAttendeeWithoutLedger (a
+  // never-taken failure branch would be an uncovered line).
+  return (result as { success: true; attendees: Attendee[] }).attendees[0]!;
 };
 
 export const createTestAttendeeWithToken = async (


### PR DESCRIPTION
## What & why

On the attendee **browsing** tables (the admin attendees list and the dashboard's newest attendees) an attendee who booked several listings previously appeared as one row per booking line. This groups them into **one row per attendee**, and replaces the per-line **"Listing"** column with a grouped **"Listings"** column.

The Listings cell renders each listing as a link, comma-separated, in the **same display order as the listings page** (`sortListings`). The links are wrapped in a `<span class="listings-cell" title="…">` whose `title` carries the full comma-separated list and whose CSS truncates the cell:

```css
max-width: 30rem;
text-overflow: ellipsis;
overflow: hidden;
```

(`display: block` + `white-space: nowrap` are added so those three take effect inside a table cell.) The column moves to **directly after Name** in the default order (name, listings, email, …).

## How

- **`AttendeeTableRow` now carries a `listings` array** (`{id, name}[]`) instead of a single `listingId`/`listingName`. Two builders in the new `src/shared/attendee-table-rows.ts` (pure module):
  - `attendeeLineRow` — one row per booking line, used by the **roster, check-in, calendar, and group** tables where each line keeps its own per-listing check-in button.
  - `groupAttendeeRows` — merges an attendee's lines into one row, listings deduped and ordered by the supplied display order, quantities summed.
- **`getAttendeesPage` and `getNewestAttendeesRaw` now count attendees, not booking lines**, and return every line of each matched attendee, so a grouped row never splits across a page boundary and a filtered view still shows the attendee's full listings. The CSV export re-narrows to the filtered listings, keeping its one-row-per-booking shape.
- **Column-order tag renamed `{{listing}}` → `{{listings}}`**; a data-only migration (`2026-07-03_attendee_listings_tag`) rewrites any stored `attendee_column_order` template so custom orders keep their listings column instead of silently falling back to the default.

## Tests

- New pure-unit suite for `groupAttendeeRows`/`attendeeLineRow` (ordering, dedup, quantity sum, unknown-listing handling).
- New migration test (tag rewrite, whitespace/filter variants, idempotent re-run, unset no-op) plus schema-guard/restore registry updates.
- Grouped-row rendering, ordering, `title` attribute, truncation class, and HTML escaping asserted on the attendees list, dashboard, and column cells.
- Per-line rows + per-listing check-in actions pinned on the roster, group detail, and scanned-ticket check-in pages.
- Attendee-pagination-by-attendee (grouped rows stay whole across pages; exactly-full page reports no next page) and filtered-CSV narrowing.

100% coverage and 0% duplication maintained; the changed modules pass targeted mutation testing (two provably-equivalent `?? / ||` mutants recorded in the registry). `lint:ci`, `typecheck`, `cpd`, and the full test suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ehzJXaapiSMUm6vxueW8R)_