### PR TITLE
Run the listings-tag data migration on upgraded sites (LATEST_UPDATE bump)

### DIFF
--- a/src/shared/db/migrations/schema.ts
+++ b/src/shared/db/migrations/schema.ts
@@ -34,7 +34,7 @@ export type Trigger = {
 // ─── Version — update LATEST_UPDATE to describe each change ─────
 
 export const LATEST_UPDATE =
-  "Migrate listings.day_prices into the listing_prices 'day_count' dimension and drop the column.";
+  "Rewrite the {{listing}} attendee column-order tag to {{listings}} for the grouped Listings column.";
 
 // ─── Schema (ordered: tables with no FK deps first) ─────────────
 

--- a/test/lib/db/migrations.test.ts
+++ b/test/lib/db/migrations.test.ts
@@ -169,6 +169,50 @@ describeWithEnv("db > migrations", { db: true }, () => {
       expect(await appliedMigrationIds()).toEqual([...MIGRATION_IDS].sort());
     });
 
+    test("runs a schema-hash-neutral data migration on a site upgrading from the previous release", async () => {
+      // Reproduces the upgrade path for a data-only migration (one whose
+      // `requires` is empty, so SCHEMA_HASH is unchanged). A site last migrated
+      // at the previous release carries that release's `latest_db_update` marker
+      // and every migration EXCEPT the newly appended one. If LATEST_UPDATE were
+      // not bumped alongside the migration, the stored marker would still equal
+      // the code's, so getDbState() returns "up_to_date" and
+      // baselineCurrentSchemaIfNeeded() marks the migration applied WITHOUT
+      // running its up() — the {{listing}} → {{listings}} rewrite would silently
+      // never happen on real upgrades. Bumping LATEST_UPDATE flips the state to
+      // "needs_migration" so the migration actually runs.
+      const PREVIOUS_RELEASE_MARKER =
+        "Migrate listings.day_prices into the listing_prices 'day_count' dimension and drop the column.";
+      // Sanity: the previous marker must differ from the current one, else the
+      // upgrade would read as up_to_date and this scenario couldn't arise.
+      expect(PREVIOUS_RELEASE_MARKER).not.toBe(LATEST_UPDATE);
+
+      await getDb().execute({
+        args: [PREVIOUS_RELEASE_MARKER],
+        sql: "UPDATE settings SET value = ? WHERE key = 'latest_db_update'",
+      });
+      await getDb().execute(
+        "DELETE FROM schema_migrations WHERE id = '2026-07-03_attendee_listings_tag'",
+      );
+      await getDb().execute({
+        args: ["{{name}}, {{listing}}, {{email}}"],
+        sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('attendee_column_order', ?)",
+      });
+      invalidateInitDbCache();
+
+      await initDb();
+
+      // The migration ran: the stored template's tag is rewritten...
+      expect(await settingValue("attendee_column_order")).toBe(
+        "{{name}}, {{listings}}, {{email}}",
+      );
+      // ...it is now recorded in schema_migrations...
+      expect(await appliedMigrationIds()).toContain(
+        "2026-07-03_attendee_listings_tag",
+      );
+      // ...and the markers are refreshed to the current release.
+      expect(await settingValue("latest_db_update")).toBe(LATEST_UPDATE);
+    });
+
     test("initDb restores stale markers after a crash between recording migrations and writing markers", async () => {
       // Crash state: all named migrations recorded in schema_migrations,
       // but the isolate died before refreshing the settings markers.


### PR DESCRIPTION
## What & why

Follow-up to #1517. Codex flagged (P2) that the `2026-07-03_attendee_listings_tag` migration merged in #1517 never runs on a site upgrading from the previous release — and it's correct.

The migration is **data-only** (empty `requires`), so it leaves `SCHEMA_HASH` unchanged. `LATEST_UPDATE` was not bumped alongside it, so a site already on the previous release still matched **both** version markers:

- `getDbState()` sees `latest_db_update` and `db_schema_hash` unchanged → returns `up_to_date`
- `initDb` takes the `up_to_date` branch → `baselineCurrentSchemaIfNeeded()` marks the appended migration applied **without calling its `up()`**

So on real upgrades the `{{listing}}` → `{{listings}}` rewrite never happens, and any custom `attendee_column_order` still containing `{{listing}}` silently falls back to the default column order — losing the Listings column, the exact regression the migration exists to prevent. (Fresh installs and CI were unaffected because they run every migration from scratch.)

## Fix

Bump `LATEST_UPDATE` to describe this migration (the schema comment mandates this for every change: "update LATEST_UPDATE to describe each change"). An upgraded site's stored `latest_db_update` no longer matches the code's, so `getDbState()` returns `needs_migration`, `pendingMigrations()` includes the not-yet-applied migration, and its `up()` runs and rewrites stored templates.

## Test

Adds a regression test in `test/lib/db/migrations.test.ts` that reproduces the upgrade path: it seeds the **previous** release's `latest_db_update` marker (schema hash unchanged), removes the migration from `schema_migrations`, stores a `{{listing}}` column-order template, boots `initDb`, and asserts the tag is rewritten to `{{listings}}`, the migration is recorded, and the markers are refreshed. Verified it fails without the `LATEST_UPDATE` bump and passes with it. `lint:ci`, `typecheck`, `cpd`, and the migration suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ehzJXaapiSMUm6vxueW8R)_