### PR TITLE
Make listing Overview tab read collated aggregates, not every attendee

### DIFF
--- a/src/features/admin/listing-page-data.ts
+++ b/src/features/admin/listing-page-data.ts
@@ -10,6 +10,7 @@
  * tabs render the same data the single detail page used to.
  */
 
+import { unique } from "#fp";
 import type { PageCtx } from "#routes/admin/entity-pages.ts";
 import { resolveRecipientEmails } from "#shared/bulk-email.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
@@ -19,8 +20,12 @@ import {
   getListingActivityLog,
   getListingWithActivityLog,
 } from "#shared/db/activityLog.ts";
-import { decryptAttendees } from "#shared/db/attendees.ts";
+import {
+  decryptAttendees,
+  getAttendeeNamesByIds,
+} from "#shared/db/attendees.ts";
 import { getHiddenPackageMemberIds } from "#shared/db/groups.ts";
+import { getListingOverviewStats } from "#shared/db/listing-overview-stats.ts";
 import {
   anyNonStandaloneChild,
   getChildrenForParents,
@@ -34,12 +39,22 @@ import {
 import { deleteAllStaleReservations } from "#shared/db/processed-payments.ts";
 import {
   getAllQuestionsWithAnswers,
+  getListingChoiceAnswerMap,
   getListingQuestionIds,
+  getQuestionsForListing,
 } from "#shared/db/questions.ts";
 import { settings } from "#shared/db/settings.ts";
-import { loadNotesForAttendees } from "#shared/db/system-notes.ts";
+import {
+  loadNotesForAttendees,
+  loadNotesForListing,
+  type SystemNote,
+} from "#shared/db/system-notes.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
-import type { Attendee, ListingWithCount } from "#shared/types.ts";
+import {
+  type Attendee,
+  isPaidListing,
+  type ListingWithCount,
+} from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import { ListingQrPanel } from "#templates/admin/listing-qr.tsx";
 import {
@@ -47,8 +62,10 @@ import {
   ListingEditPanel,
   ListingOverviewPanel,
   ListingRosterPanel,
+  overviewStatsFromDbStats,
 } from "#templates/admin/listings.tsx";
 import { ListingQuestionsPanel } from "#templates/admin/questions.tsx";
+import type { TableQuestionData } from "#templates/attendee-table.tsx";
 import { EMPTY_QR_VALUES, loadQrFormContext } from "./listing-qr.ts";
 import { getListingAndGroups } from "./listings-edit.ts";
 import { loadListingParentsSection } from "./listings-parents.ts";
@@ -164,8 +181,36 @@ const availableDatesFor = (
   return dates.map((value) => ({ label: formatDateLabel(value), value }));
 };
 
+/** The Overview's answer summary needs only the questions and each attendee's
+ *  chosen answer ids (counted per option) — never the free-text answers. So it
+ *  reads the choice ids scoped to the listing in SQL, decrypting nothing.
+ *  Returns undefined when the listing has no questions. */
+const loadOverviewQuestionData = async (
+  listingId: number,
+): Promise<TableQuestionData | undefined> => {
+  const [questions, attendeeAnswerMap] = await Promise.all([
+    getQuestionsForListing(listingId),
+    getListingChoiceAnswerMap(listingId),
+  ]);
+  return questions.length > 0 ? { attendeeAnswerMap, questions } : undefined;
+};
+
+/** Display names for the (few) attendees that authored a note, decrypting just
+ *  their names — no key unwrap when the listing has no notes. */
+const noteAuthorNames = async (
+  notes: SystemNote[],
+): Promise<Map<number, string>> =>
+  notes.length === 0
+    ? new Map()
+    : getAttendeeNamesByIds(
+        unique(notes.map((note) => note.attendee_id)),
+        await requireRequestPrivateKey(),
+      );
+
 /** Build the Overview tab: the read-only details table, the income breakdown,
- *  and the attendee-notes summary. */
+ *  and the attendee-notes summary. Reads only collated aggregates — the listing's
+ *  individual attendee rows are never loaded or decrypted here (see
+ *  {@link getListingOverviewStats}). */
 export const loadListingOverviewPanel = async ({
   listing,
   isChild,
@@ -173,38 +218,41 @@ export const loadListingOverviewPanel = async ({
 }: LoadedListing): Promise<JSX.Element> => {
   // Housekeeping the old detail view ran on every load: clear reservations
   // whose payment window lapsed, concurrently with the page's own reads.
-  const [attendees] = await Promise.all([
-    loadDecryptedListingAttendees(listing.id),
+  const [
+    stats,
+    recalc,
+    revenueBreakdown,
+    groupContext,
+    systemNotes,
+    questionData,
+  ] = await Promise.all([
+    getListingOverviewStats(listing),
+    getListingAggregateRecalculation(listing),
+    listingRevenueBreakdown(listing.id),
+    // The Overview tab shows whole-listing totals (no date picker), so the
+    // group cap is the all-dates figure.
+    loadGroupContext(listing, null),
+    loadNotesForListing(listing.id, requireRequestPrivateKey),
+    loadOverviewQuestionData(listing.id),
     deleteAllStaleReservations(),
   ]);
-  const [recalc, revenueBreakdown, groupContext, systemNotes, questionData] =
-    await Promise.all([
-      getListingAggregateRecalculation(listing),
-      listingRevenueBreakdown(listing.id),
-      // The Overview tab shows whole-listing totals (no date picker), so the
-      // group cap is the all-dates figure.
-      loadGroupContext(listing, null),
-      loadNotesForAttendees(
-        attendees.map((a) => a.id),
-        requireRequestPrivateKey,
-      ),
-      // Whole-listing answer aggregates for the details table's answer-summary
-      // rows (all attendees, not the roster's date-filtered subset).
-      loadListingQuestionData(
-        listing.id,
-        attendees.map((a) => a.id),
-      ),
-    ]);
+  const noteNames = await noteAuthorNames(systemNotes);
   return ListingOverviewPanel({
     aggregateRecalculation: recalc,
     allowedDomain: getEffectiveDomain(),
-    attendees,
     groupContext,
     isChild,
     isHiddenPackageMember,
     listing,
-    questionData,
+    noteNames,
+    ...(questionData !== undefined ? { questionData } : {}),
     revenueBreakdown,
+    stats: overviewStatsFromDbStats(
+      stats,
+      listing.attendee_count,
+      revenueBreakdown.grossSales,
+      isPaidListing(listing),
+    ),
     systemNotes,
   });
 };

--- a/src/shared/db/listing-overview-stats.ts
+++ b/src/shared/db/listing-overview-stats.ts
@@ -1,0 +1,157 @@
+/**
+ * Collated Overview-tab statistics for a single listing, computed entirely in
+ * SQL from the trigger-maintained columns and the transfers ledger — so the
+ * Overview never loads (nor decrypts) a listing's individual attendee rows.
+ *
+ * The one figure that historically forced a full attendee scan was the
+ * "incomplete payment" split: a booking that recognised a sale but never linked
+ * a payment reference. That reference lives only inside the encrypted PII blob,
+ * but the ledger already carries its shadow — an abandoned/failed checkout posts
+ * its `sale` leg with NO `payment` leg, while every real booking (including a
+ * deposit that still owes a balance) keeps its payment leg. So "incomplete" is
+ * exactly *a recognised sale with no cash ever received*, which projects
+ * straight off `transfers` with no decryption:
+ *
+ *   incomplete  ⇔  EXISTS(sale leg for this booking) AND NOT EXISTS(payment leg)
+ *
+ * Everything the Overview shows is derived from that split plus the plain
+ * quantity/check-in columns, matching the pre-existing template derivation
+ * (`computeAttendeeStats` / `getCheckedInStats` / `calculateTotalRevenue`) row
+ * for row while reading only aggregates.
+ */
+
+import { ATTENDEE, REVENUE } from "#shared/accounting/accounts.ts";
+import { KIND } from "#shared/accounting/kinds.ts";
+import {
+  accountPredicate,
+  saleLegPredicate,
+} from "#shared/accounting/projection-sql.ts";
+import { ATTENDEE_KIND } from "#shared/db/attendees/kind.ts";
+import { queryOne } from "#shared/db/client.ts";
+import type { Listing } from "#shared/types.ts";
+import { isPaidListing } from "#shared/types.ts";
+
+/**
+ * The collated attendee numbers the Overview tab renders. All figures cover the
+ * listing's real (`kind = 'attendee'`) bookings and exclude the incomplete
+ * (unpaid-recognised-sale) rows, exactly as the roster's in-memory derivation
+ * does — except `incompleteQuantity`, which is that excluded quantity.
+ */
+export type ListingOverviewStats = {
+  /** Σ quantity of incomplete (recognised sale, no payment) bookings. Zero for a
+   *  free listing, where no booking can be "incomplete". Subtracted from the
+   *  listing's trigger-maintained count to get the confirmed attendee count. */
+  incompleteQuantity: number;
+  /** Σ quantity of the confirmed (non-incomplete) bookings. */
+  completeQuantitySum: number;
+  /** Σ quantity of confirmed bookings with a real (> 0) quantity — the
+   *  check-in progress denominator in ticket terms. */
+  ticketsTotal: number;
+  /** Confirmed real-quantity booking rows — the row-terms denominator. */
+  rowsTotal: number;
+  /** Σ quantity of confirmed, checked-in bookings. */
+  ticketsCheckedIn: number;
+  /** Confirmed, checked-in booking rows. */
+  rowsCheckedIn: number;
+  /** Σ of the `sale` legs recognised for incomplete (never-paid) bookings. The
+   *  received revenue the Overview shows is the listing's gross sales minus this
+   *  — computed by the caller, which already holds the gross figure. Zero for a
+   *  free listing (no ledger scan runs). */
+  incompleteSales: number;
+};
+
+/** SQL boolean (0/1) marking a `listing_attendees` row `la` as an incomplete
+ *  payment: a recognised `sale` leg for the booking with no `payment` leg ever
+ *  received into the attendee for that same ledger event group. Only paid
+ *  listings can carry one, so `false` collapses the CASE arms for a free
+ *  listing to their confirmed side. */
+const incompleteRowPredicate = (paid: boolean): string => {
+  if (!paid) return "0";
+  const hasSale = `EXISTS (SELECT 1 FROM transfers WHERE ${saleLegPredicate(
+    "la.attendee_id",
+    "la.listing_id",
+    "la.ledger_event_group",
+  )})`;
+  const hasPayment =
+    `EXISTS (SELECT 1 FROM transfers WHERE kind = '${KIND.payment}'` +
+    ` AND ${accountPredicate("dest", ATTENDEE, "la.attendee_id")}` +
+    " AND event_group = la.ledger_event_group)";
+  return `(${hasSale} AND NOT ${hasPayment})`;
+};
+
+type OverviewCountsRow = {
+  incomplete_quantity: number | bigint;
+  complete_quantity_sum: number | bigint;
+  tickets_total: number | bigint;
+  rows_total: number | bigint;
+  tickets_checked_in: number | bigint;
+  rows_checked_in: number | bigint;
+};
+
+/** Σ of the `sale` legs recognised into the listing's revenue account for
+ *  bookings that never received a payment — the revenue to exclude from the
+ *  confirmed total. Zero for a free listing (queried only when paid). */
+const incompleteSales = async (listingId: number): Promise<number> => {
+  const saleToRevenue = `t.kind = '${KIND.sale}' AND ${accountPredicate(
+    "dest",
+    REVENUE,
+    "?",
+  )}`;
+  const noPayment =
+    `NOT EXISTS (SELECT 1 FROM transfers AS p WHERE p.kind = '${KIND.payment}'` +
+    " AND p.dest_type = 'attendee' AND p.dest_id = t.source_id" +
+    " AND p.event_group = t.event_group)";
+  const row = (await queryOne<{ incomplete_sales: number | bigint }>(
+    `SELECT COALESCE(SUM(t.amount), 0) AS incomplete_sales
+       FROM transfers AS t
+      WHERE ${saleToRevenue} AND ${noPayment}`,
+    [String(listingId)],
+  ))!;
+  return Number(row.incomplete_sales);
+};
+
+/**
+ * Load the Overview tab's collated stats for one listing without touching its
+ * attendee rows. The caller subtracts {@link ListingOverviewStats.incompleteSales}
+ * from the listing's gross sales (which it already holds) to show received
+ * revenue.
+ */
+export const getListingOverviewStats = async (
+  listing: Pick<
+    Listing,
+    "id" | "unit_price" | "can_pay_more" | "customisable_days" | "day_prices"
+  >,
+): Promise<ListingOverviewStats> => {
+  const paid = isPaidListing(listing);
+  const incomplete = incompleteRowPredicate(paid);
+  const confirmed = `NOT ${incomplete} AND la.quantity > 0`;
+  const countsPromise = queryOne<OverviewCountsRow>(
+    `SELECT
+       COALESCE(SUM(CASE WHEN ${incomplete} THEN la.quantity ELSE 0 END), 0) AS incomplete_quantity,
+       COALESCE(SUM(CASE WHEN NOT ${incomplete} THEN la.quantity ELSE 0 END), 0) AS complete_quantity_sum,
+       COALESCE(SUM(CASE WHEN ${confirmed} THEN la.quantity ELSE 0 END), 0) AS tickets_total,
+       COALESCE(SUM(CASE WHEN ${confirmed} THEN 1 ELSE 0 END), 0) AS rows_total,
+       COALESCE(SUM(CASE WHEN ${confirmed} AND la.checked_in = 1 THEN la.quantity ELSE 0 END), 0) AS tickets_checked_in,
+       COALESCE(SUM(CASE WHEN ${confirmed} AND la.checked_in = 1 THEN 1 ELSE 0 END), 0) AS rows_checked_in
+     FROM listing_attendees AS la
+     JOIN attendees AS a ON a.id = la.attendee_id
+     WHERE la.listing_id = ? AND a.kind = '${ATTENDEE_KIND}'`,
+    [listing.id],
+  );
+  // Only a paid listing can carry never-paid sales, so a free listing skips the
+  // ledger scan entirely.
+  const [counts, incompleteSaleTotal] = await Promise.all([
+    countsPromise,
+    paid ? incompleteSales(listing.id) : Promise.resolve(0),
+  ]);
+  const row = counts!;
+  return {
+    completeQuantitySum: Number(row.complete_quantity_sum),
+    incompleteQuantity: Number(row.incomplete_quantity),
+    incompleteSales: incompleteSaleTotal,
+    rowsCheckedIn: Number(row.rows_checked_in),
+    rowsTotal: Number(row.rows_total),
+    ticketsCheckedIn: Number(row.tickets_checked_in),
+    ticketsTotal: Number(row.tickets_total),
+  };
+};

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -14,6 +14,7 @@ import {
   decryptWithOwnerKey,
   encryptWithOwnerKey,
 } from "#shared/crypto/keys.ts";
+import { ATTENDEE_KIND } from "#shared/db/attendees/kind.ts";
 import {
   execute,
   executeBatch,
@@ -838,16 +839,11 @@ export const groupListingAnswers = (
   return answersByAttendee;
 };
 
-const choiceAnswerIdsBatch = async (
-  attendeeIds: number[],
-): Promise<Map<number, number[]>> => {
-  if (attendeeIds.length === 0) return new Map();
-  const rows = await queryAll<{ attendee_id: number; answer_id: number }>(
-    `SELECT attendee_id, answer_id FROM attendee_answers
-     WHERE answer_id IS NOT NULL AND attendee_id IN (${inPlaceholders(attendeeIds)})`,
-    attendeeIds,
-  );
-  return reduce(
+/** Group `(attendee_id, answer_id)` rows into an attendee → answer-ids map. */
+const choiceAnswerMapFromRows = (
+  rows: { attendee_id: number; answer_id: number }[],
+): Map<number, number[]> =>
+  reduce(
     (
       acc: Map<number, number[]>,
       { attendee_id, answer_id }: { attendee_id: number; answer_id: number },
@@ -859,6 +855,41 @@ const choiceAnswerIdsBatch = async (
     },
     new Map(),
   )(rows);
+
+const choiceAnswerIdsBatch = async (
+  attendeeIds: number[],
+): Promise<Map<number, number[]>> => {
+  if (attendeeIds.length === 0) return new Map();
+  const rows = await queryAll<{ attendee_id: number; answer_id: number }>(
+    `SELECT attendee_id, answer_id FROM attendee_answers
+     WHERE answer_id IS NOT NULL AND attendee_id IN (${inPlaceholders(attendeeIds)})`,
+    attendeeIds,
+  );
+  return choiceAnswerMapFromRows(rows);
+};
+
+/**
+ * Attendee → chosen-answer-ids map for every real (`kind = 'attendee'`)
+ * attendee booked onto one listing, scoped in SQL rather than by a per-attendee
+ * id list. Choice ids are plaintext, so this needs no key material — the
+ * Overview's answer summary counts them without decrypting any free text.
+ */
+export const getListingChoiceAnswerMap = async (
+  listingId: number,
+): Promise<Map<number, number[]>> => {
+  const rows = await queryAll<{ attendee_id: number; answer_id: number }>(
+    `SELECT attendee_answer.attendee_id, attendee_answer.answer_id
+       FROM attendee_answers AS attendee_answer
+      WHERE attendee_answer.answer_id IS NOT NULL
+        AND attendee_answer.attendee_id IN (
+          SELECT listingAttendee.attendee_id
+            FROM listing_attendees AS listingAttendee
+            JOIN attendees AS attendee
+              ON attendee.id = listingAttendee.attendee_id
+           WHERE listingAttendee.listing_id = ? AND attendee.kind = '${ATTENDEE_KIND}')`,
+    [listingId],
+  );
+  return choiceAnswerMapFromRows(rows);
 };
 
 /** Decrypted free-text answers for several attendees: attendeeId → (questionId

--- a/src/shared/db/system-notes.ts
+++ b/src/shared/db/system-notes.ts
@@ -10,11 +10,13 @@
  *    be written without a session but read only with the owner private key.
  */
 
+import type { InValue } from "@libsql/client";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import {
   decryptWithOwnerKey,
   encryptWithOwnerKey,
 } from "#shared/crypto/keys.ts";
+import { ATTENDEE_KIND } from "#shared/db/attendees/kind.ts";
 import {
   execute,
   inPlaceholders,
@@ -101,6 +103,18 @@ export const decryptNotes = (
     })),
   );
 
+/** Fetch the still-encrypted note rows matching a WHERE body (no leading
+ *  `WHERE`), oldest first per attendee. Shared by the by-ids and by-listing
+ *  reads so the column list and ordering live in one place. */
+const noteRowsWhere = (
+  where: string,
+  args: InValue[],
+): Promise<SystemNoteRow[]> =>
+  queryAll<SystemNoteRow>(
+    `SELECT ${NOTE_COLUMNS} FROM system_notes WHERE ${where} ORDER BY attendee_id, id`,
+    args,
+  );
+
 /**
  * The still-encrypted note rows for a set of attendees, oldest first. Cheap (no
  * key material): a caller can use it to decide whether any notes exist before
@@ -109,12 +123,27 @@ export const decryptNotes = (
 export const getNoteRows = (attendeeIds: number[]): Promise<SystemNoteRow[]> =>
   attendeeIds.length === 0
     ? Promise.resolve([])
-    : queryAll<SystemNoteRow>(
-        `SELECT ${NOTE_COLUMNS} FROM system_notes WHERE attendee_id IN (${inPlaceholders(
-          attendeeIds,
-        )}) ORDER BY attendee_id, id`,
+    : noteRowsWhere(
+        `attendee_id IN (${inPlaceholders(attendeeIds)})`,
         attendeeIds,
       );
+
+/**
+ * The still-encrypted note rows for every real (`kind = 'attendee'`) attendee
+ * booked onto one listing, oldest first — scoped in SQL rather than by passing
+ * a per-attendee id list, so the Overview never materialises (nor binds) a row
+ * per attendee just to find the handful with notes.
+ */
+export const getNoteRowsForListing = (
+  listingId: number,
+): Promise<SystemNoteRow[]> =>
+  noteRowsWhere(
+    `attendee_id IN (SELECT listingAttendee.attendee_id
+       FROM listing_attendees AS listingAttendee
+       JOIN attendees AS attendee ON attendee.id = listingAttendee.attendee_id
+       WHERE listingAttendee.listing_id = ? AND attendee.kind = '${ATTENDEE_KIND}')`,
+    [listingId],
+  );
 
 /** All decrypted notes for one attendee, oldest first. */
 export const getNotesForAttendee = async (
@@ -124,18 +153,40 @@ export const getNotesForAttendee = async (
   decryptNotes(await getNoteRows([attendeeId]), privateKey);
 
 /**
- * Decrypted notes for a set of attendees, oldest first, for an attendee-list
- * view. The private key is derived lazily — only when at least one of the listed
- * attendees actually has a note — so a list with no notes never forces a key
- * unwrap. Returns [] when none have notes.
+ * A "load decrypted notes for <selector>" reader: fetch the still-encrypted rows
+ * for a selector value, then decrypt them, deriving the owner private key lazily
+ * — only when at least one note exists — so a note-free view never forces a key
+ * unwrap. Curried over the row-fetcher so the attendee-list and listing-scoped
+ * loaders share one body.
  */
-export const loadNotesForAttendees = async (
+const notesLoaderVia =
+  <A>(fetchRows: (selector: A) => Promise<SystemNoteRow[]>) =>
+  async (
+    selector: A,
+    getPrivateKey: () => Promise<CryptoKey>,
+  ): Promise<SystemNote[]> => {
+    const rows = await fetchRows(selector);
+    return rows.length === 0 ? [] : decryptNotes(rows, await getPrivateKey());
+  };
+
+/**
+ * Decrypted notes for a set of attendees, oldest first, for an attendee-list
+ * view. Returns [] when none have notes.
+ */
+export const loadNotesForAttendees: (
   attendeeIds: number[],
   getPrivateKey: () => Promise<CryptoKey>,
-): Promise<SystemNote[]> => {
-  const rows = await getNoteRows(attendeeIds);
-  return rows.length === 0 ? [] : decryptNotes(rows, await getPrivateKey());
-};
+) => Promise<SystemNote[]> = notesLoaderVia(getNoteRows);
+
+/**
+ * Decrypted notes for every real attendee on one listing, oldest first —
+ * scoped in SQL (see {@link getNoteRowsForListing}). Returns [] when none have
+ * notes, so the Overview's key unwrap is skipped for a note-free listing.
+ */
+export const loadNotesForListing: (
+  listingId: number,
+  getPrivateKey: () => Promise<CryptoKey>,
+) => Promise<SystemNote[]> = notesLoaderVia(getNoteRowsForListing);
 
 /** Group decrypted notes by attendee id (input order preserved within a group). */
 export const groupNotesByAttendee = (

--- a/src/ui/templates/admin/detail-rows.tsx
+++ b/src/ui/templates/admin/detail-rows.tsx
@@ -46,8 +46,11 @@ export const calculateTotalRevenue = (attendees: Attendee[]): number =>
 // Checked-in stats
 // ---------------------------------------------------------------------------
 
-/** Computed checked-in statistics for an attendee list */
-type CheckedInStats = {
+/** Computed checked-in statistics for an attendee list. Exported so a caller
+ *  that computes these figures in SQL (the Overview tab, which never loads the
+ *  attendee rows) can feed {@link buildStatDetailRows} the same shape the
+ *  in-memory {@link getCheckedInStats} produces. */
+export type CheckedInStats = {
   ticketsCheckedIn: number;
   ticketsTotal: number;
   rowsCheckedIn: number;
@@ -60,7 +63,7 @@ type CheckedInStats = {
  * rowsTotal/remaining or force a spurious multi-quantity split (one real + one
  * ghost would otherwise read as 1 ticket across 2 rows). The ghost still shows
  * in the unfiltered admin roster. */
-const getCheckedInStats = (allAttendees: Attendee[]): CheckedInStats => {
+export const getCheckedInStats = (allAttendees: Attendee[]): CheckedInStats => {
   const attendees = allAttendees.filter(hasTicketQuantity);
   const ticketsTotal = sumQuantity(attendees);
   return {
@@ -187,6 +190,34 @@ const buildRevenueRow = (revenue: number): DetailRow => ({
   value: formatCurrency(revenue),
 });
 
+/** The stat rows shared by the attendee-derived and SQL-derived detail tables:
+ *  check-in progress, the (paid-only) revenue total, and the answer summary. The
+ *  attendee-count row is prepended separately by {@link buildSharedDetailRows},
+ *  since a stat-only caller renders its own count. */
+export type StatDetailInput = {
+  checkedInStats: CheckedInStats;
+  hasPaidListing: boolean;
+  /** Received revenue in minor units — only rendered for a paid listing. */
+  revenue: number;
+  questionData?: TableQuestionData | undefined;
+  labelSuffix?: string;
+};
+
+/** Build the check-in / revenue / answer-summary rows from precomputed stats.
+ *  Shared so the Overview tab (SQL aggregates) and the roster/group/calendar
+ *  pages (in-memory attendee lists) render byte-identical rows. */
+export const buildStatDetailRows = ({
+  checkedInStats,
+  hasPaidListing,
+  revenue,
+  questionData,
+  labelSuffix = "",
+}: StatDetailInput): DetailRow[] => [
+  ...buildCheckedInRows(checkedInStats, labelSuffix),
+  ...(hasPaidListing ? [buildRevenueRow(revenue)] : []),
+  ...buildAnswerSummaryRows(questionData),
+];
+
 /** Build the shared detail rows: attendees, checked-in, revenue, question summary */
 export const buildSharedDetailRows = ({
   attendees,
@@ -201,9 +232,13 @@ export const buildSharedDetailRows = ({
   ...(skipAttendees
     ? []
     : [buildAttendeeRow(attendeeCount, maxCapacity, labelSuffix)]),
-  ...buildCheckedInRows(getCheckedInStats(attendees), labelSuffix),
-  ...(hasPaidListing
-    ? [buildRevenueRow(revenue ?? calculateTotalRevenue(attendees))]
-    : []),
-  ...buildAnswerSummaryRows(questionData),
+  ...buildStatDetailRows({
+    checkedInStats: getCheckedInStats(attendees),
+    hasPaidListing,
+    // Compute the attendee-summed revenue only for a paid listing (it is the
+    // only case the row renders), matching the prior lazy `??` evaluation.
+    revenue: hasPaidListing ? (revenue ?? calculateTotalRevenue(attendees)) : 0,
+    ...(questionData !== undefined ? { questionData } : {}),
+    labelSuffix,
+  }),
 ];

--- a/src/ui/templates/admin/listings.tsx
+++ b/src/ui/templates/admin/listings.tsx
@@ -12,6 +12,7 @@ import {
   formatDatetimeLabel,
   formatDatetimeShort,
 } from "#shared/dates.ts";
+import type { ListingOverviewStats } from "#shared/db/listing-overview-stats.ts";
 import type {
   ListingAggregateField,
   ListingAggregateRecalculation,
@@ -120,6 +121,10 @@ export { formatAddressInline } from "#templates/attendee-table.tsx";
 
 import {
   buildAnswerSummaryRows as buildAnswerSummaryDetailRows,
+  buildStatDetailRows,
+  type CheckedInStats,
+  calculateTotalRevenue,
+  getCheckedInStats,
   renderDetailRows,
   sumQuantity,
 } from "#templates/admin/detail-rows.tsx";
@@ -1325,6 +1330,31 @@ export const ListingDeactivatedBanner = ({
     </div>
   );
 
+/** The listing's public booking URL and its two embed snippets — the
+ *  attendee-independent links both panels render. Shared so the Overview (which
+ *  loads no attendee rows) and the roster derive them identically. */
+const deriveListingLinks = (
+  listing: ListingWithCount,
+  allowedDomain: string,
+): { ticketUrl: string; embedScriptCode: string; embedIframeCode: string } => {
+  const ticketUrl = `https://${allowedDomain}/ticket/${listing.slug}`;
+  const { script: embedScriptCode, iframe: embedIframeCode } =
+    buildEmbedSnippets(ticketUrl);
+  return { embedIframeCode, embedScriptCode, ticketUrl };
+};
+
+/** The daily "(total)" / "(date)" suffix on the attendee count and check-in
+ *  labels; empty for a non-daily listing. */
+const dailyLabelSuffix = (
+  isDaily: boolean,
+  dateFilter: string | null,
+): string =>
+  isDaily
+    ? dateFilter
+      ? ` (${formatDateLabel(dateFilter)})`
+      : " (total)"
+    : "";
+
 const deriveListingView = (opts: ListingPanelOptions) => {
   const {
     listing,
@@ -1334,9 +1364,10 @@ const deriveListingView = (opts: ListingPanelOptions) => {
     dateFilter = null,
     questionData,
   } = opts;
-  const ticketUrl = `https://${allowedDomain}/ticket/${listing.slug}`;
-  const { script: embedScriptCode, iframe: embedIframeCode } =
-    buildEmbedSnippets(ticketUrl);
+  const { ticketUrl, embedScriptCode, embedIframeCode } = deriveListingLinks(
+    listing,
+    allowedDomain,
+  );
   const isDaily = listing.listing_type === "daily";
   const hasPaidListing = isPaidListing(listing);
 
@@ -1348,11 +1379,7 @@ const deriveListingView = (opts: ListingPanelOptions) => {
   } = computeAttendeeStats(listing, attendees, hasPaidListing);
 
   const filteredAttendees = filterAttendees(completeAttendees, activeFilter);
-  const dailySuffix = isDaily
-    ? dateFilter
-      ? ` (${formatDateLabel(dateFilter)})`
-      : " (total)"
-    : "";
+  const dailySuffix = dailyLabelSuffix(isDaily, dateFilter);
   const sharedRows = buildSharedDetailRows({
     attendeeCount: isDaily && dateFilter ? completeQuantitySum : adjustedCount,
     attendees: completeAttendees,
@@ -1395,44 +1422,139 @@ const deriveListingView = (opts: ListingPanelOptions) => {
 };
 
 /**
+ * The Overview tab's collated attendee figures — the confirmed count, the
+ * check-in progress, and the received revenue. The entity page computes these
+ * in SQL ({@link getListingOverviewStats}); {@link overviewStatsFromAttendees}
+ * derives the identical shape from an in-memory attendee list for callers (and
+ * tests) that already hold the rows.
+ */
+export type OverviewStats = {
+  adjustedCount: number;
+  completeQuantitySum: number;
+  checkedInStats: CheckedInStats;
+  /** Received revenue in minor units (Σ price paid by confirmed bookings). */
+  completeRevenue: number;
+};
+
+/** Derive the Overview stats from a decrypted attendee list — the reference
+ *  implementation the SQL aggregates reproduce. Kept here (beside
+ *  {@link computeAttendeeStats}) so the two derivations share one definition of
+ *  "confirmed" and can't drift. */
+export const overviewStatsFromAttendees = (
+  listing: ListingWithCount,
+  attendees: Attendee[],
+): OverviewStats => {
+  const hasPaidListing = isPaidListing(listing);
+  const { adjustedCount, completeQuantitySum, completeAttendees } =
+    computeAttendeeStats(listing, attendees, hasPaidListing);
+  return {
+    adjustedCount,
+    checkedInStats: getCheckedInStats(completeAttendees),
+    completeQuantitySum,
+    completeRevenue: hasPaidListing
+      ? calculateTotalRevenue(completeAttendees)
+      : 0,
+  };
+};
+
+/**
+ * Assemble the Overview stats from the SQL-projected {@link ListingOverviewStats},
+ * the listing's trigger-maintained booked count, and its gross recognised sales
+ * — the counterpart to {@link overviewStatsFromAttendees} for the no-attendee-load
+ * path. Confirmed count = booked − incomplete; received revenue = gross − the
+ * sales of never-paid bookings (zero for a free listing, which shows no revenue).
+ */
+export const overviewStatsFromDbStats = (
+  stats: ListingOverviewStats,
+  attendeeCount: number,
+  grossSales: number,
+  hasPaidListing: boolean,
+): OverviewStats => ({
+  adjustedCount: attendeeCount - stats.incompleteQuantity,
+  checkedInStats: {
+    hasMultiQuantity: stats.ticketsTotal !== stats.rowsTotal,
+    rowsCheckedIn: stats.rowsCheckedIn,
+    rowsTotal: stats.rowsTotal,
+    ticketsCheckedIn: stats.ticketsCheckedIn,
+    ticketsTotal: stats.ticketsTotal,
+  },
+  completeQuantitySum: stats.completeQuantitySum,
+  completeRevenue: hasPaidListing ? grossSales - stats.incompleteSales : 0,
+});
+
+/** Options for the listing "Overview" panel. Unlike the roster, it renders no
+ *  per-attendee rows, so it takes precomputed {@link OverviewStats} and a
+ *  note-author name map rather than the full decrypted attendee list. */
+export type ListingOverviewPanelOptions = {
+  listing: ListingWithCount;
+  allowedDomain: string;
+  stats: OverviewStats;
+  /** attendee id → display name, for the note authors only (empty when no
+   *  attendee on the listing has a note). */
+  noteNames: Map<number, string>;
+  aggregateRecalculation?: ListingAggregateRecalculation | undefined;
+  questionData?: TableQuestionData | undefined;
+  groupContext?: GroupContext | undefined;
+  revenueBreakdown?: ListingRevenueBreakdown | undefined;
+  ledger?: AccountLedgerData | undefined;
+  isChild?: boolean | undefined;
+  isHiddenPackageMember?: boolean | undefined;
+  systemNotes?: SystemNote[] | undefined;
+};
+
+/**
  * The listing "Overview" panel: the read-only details table, the income/ledger
  * money sections (owner-only callers pass them), and the attendee-notes
- * summary. Rendered as the listing entity page's Overview tab.
+ * summary. Rendered as the listing entity page's Overview tab. Builds entirely
+ * from precomputed stats — it never loads or decrypts the listing's attendees.
  */
 export const ListingOverviewPanel = (
-  opts: ListingPanelOptions,
+  opts: ListingOverviewPanelOptions,
 ): JSX.Element => {
-  const v = deriveListingView(opts);
   const {
     listing,
-    aggregateRecalculation,
     allowedDomain,
+    stats,
+    noteNames,
+    aggregateRecalculation,
+    questionData,
     groupContext,
     revenueBreakdown,
     ledger,
-    attendees,
     isChild = false,
     isHiddenPackageMember = false,
     systemNotes = [],
   } = opts;
+  const links = deriveListingLinks(listing, allowedDomain);
+  const isDaily = listing.listing_type === "daily";
+  // The Overview shows whole-listing totals (no date picker), so the daily
+  // suffix is always the "(total)" form.
+  const dailySuffix = dailyLabelSuffix(isDaily, null);
+  const sharedRows = buildStatDetailRows({
+    checkedInStats: stats.checkedInStats,
+    hasPaidListing: isPaidListing(listing),
+    revenue: stats.completeRevenue,
+    ...(questionData !== undefined ? { questionData } : {}),
+    labelSuffix: dailySuffix,
+  });
   return (
     <>
       <ListingDetailsTable
-        adjustedCount={v.adjustedCount}
+        adjustedCount={stats.adjustedCount}
         aggregateRecalculation={aggregateRecalculation}
         allowedDomain={allowedDomain}
-        completeQuantitySum={v.completeQuantitySum}
-        dailySuffix={v.dailySuffix}
-        dateFilter={v.dateFilter}
-        embedIframeCode={v.embedIframeCode}
-        embedScriptCode={v.embedScriptCode}
+        completeQuantitySum={stats.completeQuantitySum}
+        dailySuffix={dailySuffix}
+        dateFilter={null}
+        embedIframeCode={links.embedIframeCode}
+        embedScriptCode={links.embedScriptCode}
         groupContext={groupContext}
         isChild={isChild}
-        isDaily={v.isDaily}
+        isDaily={isDaily}
         isHiddenPackageMember={isHiddenPackageMember}
         listing={listing}
-        sharedRowsHtml={renderDetailRows(v.sharedRows)}
-        ticketUrl={v.ticketUrl}
+        sharedRowsHtml={renderDetailRows(sharedRows)}
+        ticketUrl={links.ticketUrl}
       />
       {revenueBreakdown && (
         <ListingIncomeLedgerSection
@@ -1443,10 +1565,7 @@ export const ListingOverviewPanel = (
       {ledger && (
         <ListingLedgerSection ledger={ledger} listingId={listing.id} />
       )}
-      <AttendeeNotesSummary
-        names={attendeeNameMap(attendees)}
-        notes={systemNotes}
-      />
+      <AttendeeNotesSummary names={noteNames} notes={systemNotes} />
     </>
   );
 };

--- a/test/lib/db/listing-overview-stats.test.ts
+++ b/test/lib/db/listing-overview-stats.test.ts
@@ -1,0 +1,192 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { decryptAttendees } from "#shared/db/attendees.ts";
+import { execute } from "#shared/db/client.ts";
+import { getListingOverviewStats } from "#shared/db/listing-overview-stats.ts";
+import {
+  getAttendeesByListingIds,
+  getListingWithCount,
+  listingRevenueBreakdown,
+} from "#shared/db/listings.ts";
+import { isPaidListing } from "#shared/types.ts";
+import {
+  overviewStatsFromAttendees,
+  overviewStatsFromDbStats,
+} from "#templates/admin/listings.tsx";
+import {
+  createPaidAttendeeWithoutLedger,
+  createPaidTestAttendee,
+  createTestListing,
+  describeWithEnv,
+  getTestPrivateKey,
+} from "#test-utils";
+import { postListingSale } from "#test-utils/ledger.ts";
+
+const checkIn = (attendeeId: number, listingId: number): Promise<unknown> =>
+  execute(
+    "UPDATE listing_attendees SET checked_in = 1 WHERE attendee_id = ? AND listing_id = ?",
+    [attendeeId, listingId],
+  );
+
+/** The listing-with-count plus the attendee-derived reference stats the SQL
+ *  path must reproduce — loads and decrypts the real attendee rows. */
+const referenceFor = async (listingId: number) => {
+  const withCount = (await getListingWithCount(listingId))!;
+  const raw = await getAttendeesByListingIds([listingId]);
+  const decrypted = await decryptAttendees(raw, await getTestPrivateKey());
+  return {
+    reference: overviewStatsFromAttendees(withCount, decrypted),
+    withCount,
+  };
+};
+
+/** Post a recognised sale with no payment ever received — the ledger signature
+ *  of an abandoned/incomplete checkout (a `sale` leg, no `payment` leg). */
+const postIncompleteSale = (
+  attendeeId: number,
+  listingId: number,
+  gross: number,
+): Promise<void> =>
+  postListingSale({ amountPaid: 0, attendeeId, gross, listingId });
+
+describeWithEnv("db > listing-overview-stats", { db: true }, () => {
+  test("matches the attendee-derived reference across payment states", async () => {
+    const listing = await createTestListing({
+      maxAttendees: 100,
+      unitPrice: 500,
+    });
+    // A1: paid in full (sale + payment), qty 1, checked in.
+    const a1 = await createPaidTestAttendee(
+      listing.id,
+      "A1",
+      "a1@example.com",
+      "pi_a1",
+      500,
+      1,
+    );
+    await checkIn(a1.id, listing.id);
+    // A2: paid in full, qty 2, not checked in.
+    await createPaidTestAttendee(
+      listing.id,
+      "A2",
+      "a2@example.com",
+      "pi_a2",
+      500,
+      2,
+    );
+    // A3: incomplete — a recognised sale but no payment linked, empty payment id.
+    const a3 = await createPaidAttendeeWithoutLedger(
+      listing.id,
+      "A3",
+      "a3@example.com",
+      "",
+      300,
+      1,
+    );
+    await postIncompleteSale(a3.id, listing.id, 300);
+    // A4: deposit — a full sale but only part paid (owes a balance), qty 1,
+    // checked in. It keeps its payment leg + payment id, so it is NOT incomplete.
+    const a4 = await createPaidAttendeeWithoutLedger(
+      listing.id,
+      "A4",
+      "a4@example.com",
+      "pi_a4",
+      800,
+      1,
+    );
+    await postListingSale({
+      amountPaid: 400,
+      attendeeId: a4.id,
+      gross: 800,
+      listingId: listing.id,
+    });
+    await checkIn(a4.id, listing.id);
+    // A5: admin comp — no sale leg (price 0), so never "incomplete".
+    await createPaidAttendeeWithoutLedger(
+      listing.id,
+      "A5",
+      "a5@example.com",
+      "",
+      0,
+      1,
+    );
+
+    const { withCount, reference } = await referenceFor(listing.id);
+    const stats = await getListingOverviewStats(listing);
+    const { grossSales } = await listingRevenueBreakdown(listing.id);
+
+    // Exact expected figures for the seeded scenario.
+    expect(stats.incompleteQuantity).toBe(1); // A3
+    expect(stats.completeQuantitySum).toBe(5); // A1+A2+A4+A5 = 1+2+1+1
+    expect(stats.ticketsTotal).toBe(5);
+    expect(stats.rowsTotal).toBe(4);
+    expect(stats.ticketsCheckedIn).toBe(2); // A1 + A4
+    expect(stats.rowsCheckedIn).toBe(2);
+    expect(stats.incompleteSales).toBe(300); // A3's unpaid sale
+    expect(grossSales).toBe(2100); // 500 + 500 + 300 + 800
+
+    // …and the assembled view reproduces the attendee-derived reference exactly.
+    const view = overviewStatsFromDbStats(
+      stats,
+      withCount.attendee_count,
+      grossSales,
+      isPaidListing(withCount),
+    );
+    expect(view).toEqual(reference);
+    expect(view.adjustedCount).toBe(5); // 6 booked − 1 incomplete
+    expect(view.completeRevenue).toBe(1800); // 2100 gross − 300 unpaid
+  });
+
+  test("counts nothing incomplete and skips the ledger scan for a free listing", async () => {
+    const listing = await createTestListing({
+      maxAttendees: 50,
+      unitPrice: 0,
+    });
+    await createPaidTestAttendee(listing.id, "F1", "f1@example.com", "", 0, 3);
+
+    const stats = await getListingOverviewStats(listing);
+    expect(stats.incompleteQuantity).toBe(0);
+    expect(stats.incompleteSales).toBe(0);
+    expect(stats.completeQuantitySum).toBe(3);
+    expect(stats.ticketsTotal).toBe(3);
+    expect(stats.rowsTotal).toBe(1);
+
+    const { withCount, reference } = await referenceFor(listing.id);
+    const view = overviewStatsFromDbStats(
+      stats,
+      withCount.attendee_count,
+      0,
+      isPaidListing(withCount),
+    );
+    expect(view).toEqual(reference);
+    expect(view.completeRevenue).toBe(0);
+  });
+
+  test("ignores servicing rows and other listings' bookings", async () => {
+    const other = await createTestListing({ maxAttendees: 10, unitPrice: 500 });
+    await createPaidTestAttendee(
+      other.id,
+      "Other",
+      "o@example.com",
+      "pi_o",
+      500,
+      1,
+    );
+    const listing = await createTestListing({
+      maxAttendees: 10,
+      unitPrice: 500,
+    });
+    await createPaidTestAttendee(
+      listing.id,
+      "Mine",
+      "m@example.com",
+      "pi_m",
+      500,
+      1,
+    );
+
+    const stats = await getListingOverviewStats(listing);
+    expect(stats.completeQuantitySum).toBe(1);
+    expect(stats.incompleteQuantity).toBe(0);
+  });
+});

--- a/test/lib/db/system-notes.test.ts
+++ b/test/lib/db/system-notes.test.ts
@@ -9,9 +9,11 @@ import {
   deleteAttendeeNote,
   getAttendeeNote,
   getNoteRows,
+  getNoteRowsForListing,
   getNotesForAttendee,
   groupNotesByAttendee,
   loadNotesForAttendees,
+  loadNotesForListing,
 } from "#shared/db/system-notes.ts";
 import {
   createTestAttendee,
@@ -42,6 +44,46 @@ const rawNote = (attendeeId: number): Promise<{ note: string } | null> =>
   );
 
 describeWithEnv("db > system-notes", { db: true }, () => {
+  test("loads notes scoped to one listing's attendees only", async () => {
+    const listing = await createTestListing({ maxAttendees: 50 });
+    const other = await createTestListing({ maxAttendees: 50 });
+    const mine = await createTestAttendee(
+      listing.id,
+      listing.slug,
+      "Mine",
+      "mine@example.com",
+    );
+    const theirs = await createTestAttendee(
+      other.id,
+      other.slug,
+      "Theirs",
+      "theirs@example.com",
+    );
+    await createSystemNote(mine.id, "Note on this listing");
+    await createSystemNote(theirs.id, "Note on another listing");
+
+    const rows = await getNoteRowsForListing(listing.id);
+    expect(rows.map((r) => r.attendee_id)).toEqual([mine.id]);
+
+    const notes = await loadNotesForListing(listing.id, getTestPrivateKey);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.note).toBe("Note on this listing");
+  });
+
+  test("loadNotesForListing returns [] without a key unwrap when none exist", async () => {
+    const listing = await createTestListing({ maxAttendees: 50 });
+    await createTestAttendee(
+      listing.id,
+      listing.slug,
+      "NoNotes",
+      "nonotes@example.com",
+    );
+    const key = spy(getTestPrivateKey);
+    const notes = await loadNotesForListing(listing.id, key);
+    expect(notes).toEqual([]);
+    expect(key.calls).toHaveLength(0);
+  });
+
   test("stores and reads back a decrypted system note", async () => {
     const attendeeId = await makeAttendee();
     await createSystemNote(attendeeId, "Refunded: price changed");

--- a/test/lib/questions.test.ts
+++ b/test/lib/questions.test.ts
@@ -15,6 +15,7 @@ import {
   getAnswerSelectionTotals,
   getAttendeeAnswersBatch,
   getAttendeeTextAnswers,
+  getListingChoiceAnswerMap,
   getListingQuestionIds,
   getNextAnswerSortOrder,
   getOrCreateStringIds,
@@ -620,6 +621,35 @@ describeWithEnv("custom questions", { db: true }, () => {
     test("empty batch for no attendees", async () => {
       const batch = await getAttendeeAnswersBatch([], { texts: false });
       expect(batch.size).toBe(0);
+    });
+
+    test("getListingChoiceAnswerMap scopes answers to one listing's attendees", async () => {
+      const q = await questionsTable.insert({
+        displayType: "radio",
+        text: "Size?",
+      });
+      const a1 = await answersTable.insert({
+        questionId: q.id,
+        sortOrder: 0,
+        text: "Small",
+      });
+      const listing = await createTestListing();
+      const other = await createTestListing();
+      const mine = await createAttendee(listing.id, "Mine");
+      const theirs = await createAttendee(other.id, "Theirs");
+      await saveAttendeeAnswers(new Map([[mine.id, [a1.id]]]));
+      await saveAttendeeAnswers(new Map([[theirs.id, [a1.id]]]));
+
+      const map = await getListingChoiceAnswerMap(listing.id);
+      expect([...map.keys()]).toEqual([mine.id]);
+      expect(map.get(mine.id)).toEqual([a1.id]);
+    });
+
+    test("getListingChoiceAnswerMap is empty for a listing with no answers", async () => {
+      const listing = await createTestListing();
+      await createAttendee(listing.id);
+      const map = await getListingChoiceAnswerMap(listing.id);
+      expect(map.size).toBe(0);
     });
 
     test("saveAttendeeAnswers does nothing for an empty map", async () => {

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -27,6 +27,7 @@ import {
   setListingQuestions,
 } from "#shared/db/questions.ts";
 import { settings } from "#shared/db/settings.ts";
+import { createSystemNote } from "#shared/db/system-notes.ts";
 import { setDemoModeForTest } from "#shared/demo.ts";
 import { nowMs } from "#shared/now.ts";
 import { runWithStorageConfig } from "#shared/storage.ts";
@@ -773,6 +774,54 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       const html = await response.text();
       expect(html).toContain("Size");
       expect(html).toContain("Small (1)");
+    });
+
+    test("Overview collates counts, revenue and notes without loading attendees", async () => {
+      const { listing, cookie } = await setupListingAndLogin({
+        maxAttendees: 100,
+        name: "Collated Overview",
+        thankYouUrl: "https://example.com",
+        unitPrice: 500,
+      });
+      // A confirmed buyer (sale + full payment) who has an operator note.
+      const confirmed = await createTestAttendee(
+        listing.id,
+        listing.slug,
+        "Grace Hopper",
+        "grace@example.com",
+      );
+      await postListingSale({
+        attendeeId: confirmed.id,
+        gross: 5000,
+        listingId: listing.id,
+      });
+      await createSystemNote(confirmed.id, "Called ahead about access");
+      // An incomplete booking: a recognised sale that was never paid.
+      const incomplete = await createTestAttendee(
+        listing.id,
+        listing.slug,
+        "Abandoned Cart",
+        "cart@example.com",
+      );
+      await postListingSale({
+        amountPaid: 0,
+        attendeeId: incomplete.id,
+        gross: 3000,
+        listingId: listing.id,
+      });
+
+      const response = await awaitTestRequest(`/admin/listing/${listing.id}`, {
+        cookie,
+      });
+      const html = await response.text();
+      // The confirmed count excludes the incomplete booking (2 booked − 1).
+      expect(html).toContain("1 / 100");
+      // Received revenue is the paid sale only (£50), not the £80 gross.
+      expect(html).toContain("Total Revenue");
+      expect(html).toContain("£50");
+      // The note (with its author's decrypted name) renders on the Overview.
+      expect(html).toContain("Called ahead about access");
+      expect(html).toContain("Grace Hopper");
     });
 
     test("shows the full activity log on the Activity tab", async () => {

--- a/test/templates/admin/listings.test.ts
+++ b/test/templates/admin/listings.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
+import { attendeeNameMap } from "#shared/db/system-notes.ts";
 import { detectIframeMode } from "#shared/iframe.ts";
 import { account } from "#shared/ledger/account.ts";
 import { runWithStorageConfig } from "#shared/storage.ts";
@@ -16,6 +17,8 @@ import {
   ListingOverviewPanel,
   ListingRosterPanel,
   nearCapacity,
+  overviewStatsFromAttendees,
+  overviewStatsFromDbStats,
 } from "#templates/admin/listings.tsx";
 import { getListingFields } from "#templates/fields.ts";
 import {
@@ -51,9 +54,27 @@ const withoutBuilder = withBuilderEnv(undefined);
  *  table, filters, failed payments, add-attendee). The legacy `adminListingPage`
  *  composer was removed, so these tests assert against the live panels. */
 const renderListingDetail = (
-  opts: Parameters<typeof ListingOverviewPanel>[0],
+  opts: Parameters<typeof ListingRosterPanel>[0],
 ): string =>
-  String(ListingOverviewPanel(opts)) + String(ListingRosterPanel(opts));
+  String(
+    ListingOverviewPanel({
+      aggregateRecalculation: opts.aggregateRecalculation,
+      allowedDomain: opts.allowedDomain,
+      groupContext: opts.groupContext,
+      isChild: opts.isChild,
+      isHiddenPackageMember: opts.isHiddenPackageMember,
+      ledger: opts.ledger,
+      listing: opts.listing,
+      // The Overview now takes precomputed stats + note-author names instead of
+      // the raw attendee list; derive them from the fixture's attendees so these
+      // tests exercise the same rendered output the SQL path produces.
+      noteNames: attendeeNameMap(opts.attendees),
+      questionData: opts.questionData,
+      revenueBreakdown: opts.revenueBreakdown,
+      stats: overviewStatsFromAttendees(opts.listing, opts.attendees),
+      systemNotes: opts.systemNotes,
+    }),
+  ) + String(ListingRosterPanel(opts));
 
 beforeAll(async () => {
   setupTestEncryptionKey();
@@ -1476,6 +1497,39 @@ describe("nearCapacity", () => {
       max_attendees: 100,
     });
     expect(nearCapacity(listing)).toBe(true);
+  });
+});
+
+describe("overviewStatsFromDbStats", () => {
+  const dbStats = {
+    completeQuantitySum: 5,
+    incompleteQuantity: 2,
+    incompleteSales: 300,
+    rowsCheckedIn: 1,
+    rowsTotal: 3,
+    ticketsCheckedIn: 2,
+    ticketsTotal: 4,
+  };
+
+  test("subtracts incomplete count and unpaid sales for a paid listing", () => {
+    const view = overviewStatsFromDbStats(dbStats, 7, 2100, true);
+    expect(view.adjustedCount).toBe(5); // 7 booked − 2 incomplete
+    expect(view.completeQuantitySum).toBe(5);
+    expect(view.completeRevenue).toBe(1800); // 2100 gross − 300 unpaid
+    expect(view.checkedInStats).toEqual({
+      hasMultiQuantity: true, // ticketsTotal 4 ≠ rowsTotal 3
+      rowsCheckedIn: 1,
+      rowsTotal: 3,
+      ticketsCheckedIn: 2,
+      ticketsTotal: 4,
+    });
+  });
+
+  test("reports zero revenue for a free listing and flat multi-quantity", () => {
+    const flat = { ...dbStats, rowsTotal: 4, ticketsTotal: 4 };
+    const view = overviewStatsFromDbStats(flat, 6, 999, false);
+    expect(view.completeRevenue).toBe(0);
+    expect(view.checkedInStats.hasMultiQuantity).toBe(false);
   });
 });
 

--- a/test/templates/admin/questions.test.ts
+++ b/test/templates/admin/questions.test.ts
@@ -4,6 +4,7 @@ import { signCsrfToken } from "#shared/csrf.ts";
 import {
   buildAnswerSummaryRows,
   ListingOverviewPanel,
+  overviewStatsFromAttendees,
 } from "#templates/admin/listings.tsx";
 import {
   adminAnswerDeletePage,
@@ -666,12 +667,14 @@ describe("buildAnswerSummaryRows", () => {
 
 describe("adminListingPage with questionData", () => {
   test("renders answer summary rows in details table", () => {
+    const listing = testListingWithCount({ id: 1, name: "E" });
     const html = String(
       ListingOverviewPanel({
         allowedDomain: "example.com",
-        attendees: [],
-        listing: testListingWithCount({ id: 1, name: "E" }),
+        listing,
+        noteNames: new Map(),
         questionData: singleAnswerSizeQuestionData(),
+        stats: overviewStatsFromAttendees(listing, []),
       }),
     );
     expect(html).toContain("<th>Size?</th>");


### PR DESCRIPTION
## Problem

Viewing a listing's admin **Overview** tab was slow (~1.1s in SQL alone) when the listing had thousands of attendees. The tab loaded and **decrypted every attendee row** — the correlated-subquery join that computes per-row `price_paid` / `remaining_balance` / `refunded` — and fired giant `IN (…thousands…)` queries for notes and answers (plus decrypting every free-text answer). Yet the Overview only renders *collated* numbers: attendee/check-in counts, revenue, a question-answer summary, and a notes list.

## Fix

Compute those figures from SQL aggregates and the existing trigger-maintained / ledger columns, so the Overview never loads or decrypts an attendee row. The **roster tab is unchanged** — it still loads the full attendee list it needs to render the table.

- **`getListingOverviewStats`** (`src/shared/db/listing-overview-stats.ts`) — one aggregate query over `listing_attendees` for the confirmed/incomplete quantities and check-in progress, plus a small ledger scan for never-paid sales.
  - "Incomplete payment" is the one figure that historically forced the full attendee scan, because it depends on `payment_id` which lives only in the encrypted PII blob. The ledger already carries its shadow: an abandoned/failed checkout posts a `sale` leg with **no** `payment` leg, while every real booking (including a deposit that still owes a balance) keeps its payment leg. So it projects straight off `transfers` as *a recognised sale with no payment received* — matching the prior behaviour for every real booking, with no decryption.
- **Received revenue** = gross recognised sales − never-paid sales, using the revenue breakdown the page already loads.
- **`getListingChoiceAnswerMap`** (`questions.ts`) and **`getNoteRowsForListing`** / **`loadNotesForListing`** (`system-notes.ts`) scope the answer-count and note reads to the listing in SQL — no per-attendee id list, no free-text decryption. Only the handful of note authors are name-decrypted.
- **`overviewStatsFromDbStats`** (`listings.tsx`) assembles the panel view from those aggregates. It's the SQL counterpart to the existing `overviewStatsFromAttendees`, which stays the reference the two derivations are pinned together with.

## Tests

- `test/lib/db/listing-overview-stats.test.ts` — seeds complete / incomplete / deposit / comp / checked-in bookings, a free listing, and cross-listing isolation, then asserts the SQL aggregates reproduce the attendee-derived reference (`overviewStatsFromAttendees`) **exactly**, plus concrete expected figures.
- Scoped-query coverage added to `system-notes` and `questions` DB tests; a pure `overviewStatsFromDbStats` test in the listings template tests; and a server test rendering the Overview end-to-end (counts, revenue, note author) in `server-listings.test.ts`.
- The existing listings/questions template tests are unchanged in intent — a small adapter derives the Overview panel's precomputed props from the same fixtures, so the rendered output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhL62rKhhZpxeuk7PV1hGG)_