### PR TITLE
Address mutation-suite review comments: elision crash + ambient declaration mutants

### DIFF
--- a/scripts/mutation/generate.ts
+++ b/scripts/mutation/generate.ts
@@ -383,18 +383,22 @@ const NON_RUNTIME_FIELDS = new Set([
 
 /**
  * Depth-first stream of every typed node, tagged with whether it sits inside a
- * non-runtime context. Types are erased at runtime, and module specifiers are
- * load wiring rather than application behavior, so those nodes are skipped.
+ * non-runtime context. Types are erased at runtime, module specifiers are load
+ * wiring rather than application behavior, and `declare` statements are
+ * ambient (erased) declarations, so those nodes are skipped. Array elisions
+ * (`const [, year] = parts`) appear as `null` children, hence the guard.
  */
 function* walk(
   node: unknown,
   inNonRuntime = false,
 ): Generator<{ inNonRuntime: boolean; node: AstNode }> {
+  if (!node || typeof node !== "object") return;
   const record = node as Record<string, unknown>;
+  const nonRuntime = inNonRuntime || record.declare === true;
   if (typeof record.type === "string")
-    yield { inNonRuntime, node: record as AstNode };
+    yield { inNonRuntime: nonRuntime, node: record as AstNode };
   for (const [key, value] of Object.entries(record)) {
-    const childInNonRuntime = inNonRuntime || NON_RUNTIME_FIELDS.has(key);
+    const childInNonRuntime = nonRuntime || NON_RUNTIME_FIELDS.has(key);
     if (Array.isArray(value)) {
       for (const child of value) yield* walk(child, childInNonRuntime);
     } else if (value && typeof value === "object") {
@@ -403,12 +407,17 @@ function* walk(
   }
 }
 
-/** Generate every mutant for a source file's contents. */
+/**
+ * Generate every mutant for a source file's contents. Declaration files are
+ * entirely ambient — erased at runtime, run with `--no-check` — so no test can
+ * observe a mutation to one; they yield no mutants rather than false survivors.
+ */
 export const generateMutants = (
   content: string,
   filePath: string,
   exhaustive: boolean,
 ): Mutant[] => {
+  if (filePath.endsWith(".d.ts")) return [];
   const fileName = filePath.split("/").pop() as string;
   const { program } = parseSync(fileName, content);
   const mutate = mutantsForNode(content, exhaustive);

--- a/test/scripts/mutation-generate.test.ts
+++ b/test/scripts/mutation-generate.test.ts
@@ -75,6 +75,39 @@ describe("generateMutants", () => {
     expect(labels).toContain("+ -> -");
   });
 
+  test("walks array destructuring holes without crashing", () => {
+    const labels = mutationLabels(`
+      const [, year, month] = parts;
+      export const stamp = year + month;
+    `);
+
+    expect(labels).toContain("+ -> *");
+  });
+
+  test("generates no mutants for declaration files", () => {
+    const content = `
+      declare module "*.svg" {
+        const content: string;
+        export default content;
+      }
+    `;
+
+    expect(generateMutants(content, "static.d.ts", true)).toEqual([]);
+  });
+
+  test("skips ambient declare contexts but mutates runtime code", () => {
+    const labels = mutationLabels(`
+      declare module "*.svg" {
+        const content: string;
+        export default content;
+      }
+      export const runtime = "value";
+    `);
+
+    expect(labels).not.toContain('*.svg -> ""');
+    expect(labels).toContain('value -> ""');
+  });
+
   test("does not invent mutants for unsupported expression shapes", () => {
     const labels = mutationLabels(`
       let value = 1;


### PR DESCRIPTION
## What

Addresses the two open Codex review comments on #1521 (targets that PR's branch, so merging this updates it):

- **Restore the AST-walk null guard** ([comment](https://github.com/chobbledotcom/tickets/pull/1521#discussion_r3521304939)): an array destructuring hole (e.g. `const [, year] = parts` in `src/shared/update.ts`) is a `null` child in the oxc AST, and `walk()` crashed in `Object.entries(null)` before generating any mutants. The `if (!node || typeof node !== "object") return;` guard is restored, with a doc note explaining why it exists.

- **Exclude declaration-only literals from mutation** ([comment](https://github.com/chobbledotcom/tickets/pull/1521#discussion_r3521304951)): `.d.ts` files now yield no mutants at all, and `declare` statements in regular files mark their whole subtree non-runtime (reusing the existing `inNonRuntime` mechanism). Ambient declarations are erased and mutant runs use `--no-check`, so mutating them (e.g. `declare module "*.svg"` in `src/static.d.ts`) could only ever produce false survivors.

The third review comment (ignore-list fixture portability) was already fixed by f5a2977 on the PR branch.

## Tests

Three regression tests in `test/scripts/mutation-generate.test.ts`, each verified to fail before the fix:

- `walks array destructuring holes without crashing`
- `generates no mutants for declaration files`
- `skips ambient declare contexts but mutates runtime code`

Also verified against the reviewer's cited files directly: `generateMutants` on `src/shared/update.ts` now produces 59 mutants without crashing, and `src/static.d.ts` produces 0.

## Checks

`deno task precommit`: lint, typecheck, cpd, build:edge all pass; the full suite passes 13,482 tests with 2 failures in `test/lib/stripe-mock.test.ts` — those tests download the stripe-mock binary from GitHub, which this sandbox's network policy blocks; they are unrelated to this diff. The `precommit:mutation` gate skips (no changed `src/` files on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016297JjvYE5PRVsNKh2GiPD

---
_Generated by [Claude Code](https://claude.ai/code/session_016297JjvYE5PRVsNKh2GiPD)_