### PR TITLE
Unify admin and public navs onto one shared leveled-nav renderer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -120,23 +120,6 @@ Migration is deliberately gradual and hardest-first.
 
 ---
 
-## Admin nav on the recursive renderer
-
-*Origin: `pages.md` (step 6, flagged optional/non-blocking).*
-
-**Background.** Site → Pages shipped (PR #1496): user-created content pages
-(`site_pages` / `site_page_items`), an admin CRUD + item manager, a public
-`/page` route, and a recursive contextual public nav built from `buildNavModel`
-(`src/features/public/site-nav.ts`, consumed in
-`src/ui/templates/public/shared.tsx`).
-
-**Remaining.** The *admin* nav (`src/ui/templates/admin/nav.tsx`) still uses
-hand-coded fixed-depth `Section` / `NestedSub` markup. Migrate it onto the same
-shared recursive renderer the public nav uses, deleting the last of the
-fixed-depth code. Purely a simplification — no behaviour change expected.
-
----
-
 ## Servicing — read-only guard (optional variant)
 
 *Origin: `servicing.md` (+ its review docs `review.md`, `tests.md`).*

--- a/src/features/admin/attendee-page-data.ts
+++ b/src/features/admin/attendee-page-data.ts
@@ -236,9 +236,9 @@ const overbookedListingIds = async (
     excludeAttendeeId,
   );
   const overbooked = new Set<number>();
-  checkable.forEach((line, i) => {
+  for (const [i, line] of checkable.entries()) {
     if (!fits[i]) overbooked.add(line.listingId);
-  });
+  }
   return overbooked;
 };
 

--- a/src/shared/db/attendees/queries.ts
+++ b/src/shared/db/attendees/queries.ts
@@ -409,14 +409,14 @@ export const hasPaidLine = (
   listingIds: number[],
 ): Promise<boolean> =>
   rowExists(
-    `SELECT 1 FROM listing_attendees la
-     WHERE la.attendee_id = ? AND la.listing_id IN (${inPlaceholders(listingIds)})
+    `SELECT 1 FROM listing_attendees AS listingAttendee
+     WHERE listingAttendee.attendee_id = ? AND listingAttendee.listing_id IN (${inPlaceholders(listingIds)})
        AND EXISTS (
          SELECT 1 FROM transfers
          WHERE ${saleLegPredicate(
-           "la.attendee_id",
-           "la.listing_id",
-           "la.ledger_event_group",
+           "listingAttendee.attendee_id",
+           "listingAttendee.listing_id",
+           "listingAttendee.ledger_event_group",
          )}
        ) LIMIT 1`,
     [attendeeId, ...listingIds],

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -756,14 +756,14 @@ const copyPackageOverridesStatement = (
   newListingId: number,
 ) => ({
   args: [sourceListingId, newListingId, sourceListingId],
-  sql: `UPDATE group_listings AS dst
+  sql: `UPDATE group_listings AS cloneMembership
         SET quantity = (
-              SELECT src.quantity FROM group_listings AS src
-               WHERE src.group_id = dst.group_id AND src.listing_id = ?)
-      WHERE dst.listing_id = ?
-        AND dst.group_id IN (
+              SELECT sourceMembership.quantity FROM group_listings AS sourceMembership
+               WHERE sourceMembership.group_id = cloneMembership.group_id AND sourceMembership.listing_id = ?)
+      WHERE cloneMembership.listing_id = ?
+        AND cloneMembership.group_id IN (
               SELECT group_id FROM group_listings WHERE listing_id = ?)
-        AND dst.group_id IN (SELECT id FROM groups WHERE is_package = 1)`,
+        AND cloneMembership.group_id IN (SELECT id FROM groups WHERE is_package = 1)`,
 });
 
 /** Copy the source's package overrides onto the duplicate's membership rows in

--- a/src/shared/db/listing-overview-stats.ts
+++ b/src/shared/db/listing-overview-stats.ts
@@ -60,22 +60,22 @@ export type ListingOverviewStats = {
   incompleteSales: number;
 };
 
-/** SQL boolean (0/1) marking a `listing_attendees` row `la` as an incomplete
- *  payment: a recognised `sale` leg for the booking with no `payment` leg ever
- *  received into the attendee for that same ledger event group. Only paid
- *  listings can carry one, so `false` collapses the CASE arms for a free
- *  listing to their confirmed side. */
+/** SQL boolean (0/1) marking a `listing_attendees` row `listingAttendee` as an
+ *  incomplete payment: a recognised `sale` leg for the booking with no
+ *  `payment` leg ever received into the attendee for that same ledger event
+ *  group. Only paid listings can carry one, so `false` collapses the CASE arms
+ *  for a free listing to their confirmed side. */
 const incompleteRowPredicate = (paid: boolean): string => {
   if (!paid) return "0";
   const hasSale = `EXISTS (SELECT 1 FROM transfers WHERE ${saleLegPredicate(
-    "la.attendee_id",
-    "la.listing_id",
-    "la.ledger_event_group",
+    "listingAttendee.attendee_id",
+    "listingAttendee.listing_id",
+    "listingAttendee.ledger_event_group",
   )})`;
   const hasPayment =
     `EXISTS (SELECT 1 FROM transfers WHERE kind = '${KIND.payment}'` +
-    ` AND ${accountPredicate("dest", ATTENDEE, "la.attendee_id")}` +
-    " AND event_group = la.ledger_event_group)";
+    ` AND ${accountPredicate("dest", ATTENDEE, "listingAttendee.attendee_id")}` +
+    " AND event_group = listingAttendee.ledger_event_group)";
   return `(${hasSale} AND NOT ${hasPayment})`;
 };
 
@@ -92,18 +92,18 @@ type OverviewCountsRow = {
  *  bookings that never received a payment — the revenue to exclude from the
  *  confirmed total. Zero for a free listing (queried only when paid). */
 const incompleteSales = async (listingId: number): Promise<number> => {
-  const saleToRevenue = `t.kind = '${KIND.sale}' AND ${accountPredicate(
+  const saleToRevenue = `saleLeg.kind = '${KIND.sale}' AND ${accountPredicate(
     "dest",
     REVENUE,
     "?",
   )}`;
   const noPayment =
-    `NOT EXISTS (SELECT 1 FROM transfers AS p WHERE p.kind = '${KIND.payment}'` +
-    " AND p.dest_type = 'attendee' AND p.dest_id = t.source_id" +
-    " AND p.event_group = t.event_group)";
+    `NOT EXISTS (SELECT 1 FROM transfers AS paymentLeg WHERE paymentLeg.kind = '${KIND.payment}'` +
+    " AND paymentLeg.dest_type = 'attendee' AND paymentLeg.dest_id = saleLeg.source_id" +
+    " AND paymentLeg.event_group = saleLeg.event_group)";
   const row = (await queryOne<{ incomplete_sales: number | bigint }>(
-    `SELECT COALESCE(SUM(t.amount), 0) AS incomplete_sales
-       FROM transfers AS t
+    `SELECT COALESCE(SUM(saleLeg.amount), 0) AS incomplete_sales
+       FROM transfers AS saleLeg
       WHERE ${saleToRevenue} AND ${noPayment}`,
     [String(listingId)],
   ))!;
@@ -124,18 +124,18 @@ export const getListingOverviewStats = async (
 ): Promise<ListingOverviewStats> => {
   const paid = isPaidListing(listing);
   const incomplete = incompleteRowPredicate(paid);
-  const confirmed = `NOT ${incomplete} AND la.quantity > 0`;
+  const confirmed = `NOT ${incomplete} AND listingAttendee.quantity > 0`;
   const countsPromise = queryOne<OverviewCountsRow>(
     `SELECT
-       COALESCE(SUM(CASE WHEN ${incomplete} THEN la.quantity ELSE 0 END), 0) AS incomplete_quantity,
-       COALESCE(SUM(CASE WHEN NOT ${incomplete} THEN la.quantity ELSE 0 END), 0) AS complete_quantity_sum,
-       COALESCE(SUM(CASE WHEN ${confirmed} THEN la.quantity ELSE 0 END), 0) AS tickets_total,
+       COALESCE(SUM(CASE WHEN ${incomplete} THEN listingAttendee.quantity ELSE 0 END), 0) AS incomplete_quantity,
+       COALESCE(SUM(CASE WHEN NOT ${incomplete} THEN listingAttendee.quantity ELSE 0 END), 0) AS complete_quantity_sum,
+       COALESCE(SUM(CASE WHEN ${confirmed} THEN listingAttendee.quantity ELSE 0 END), 0) AS tickets_total,
        COALESCE(SUM(CASE WHEN ${confirmed} THEN 1 ELSE 0 END), 0) AS rows_total,
-       COALESCE(SUM(CASE WHEN ${confirmed} AND la.checked_in = 1 THEN la.quantity ELSE 0 END), 0) AS tickets_checked_in,
-       COALESCE(SUM(CASE WHEN ${confirmed} AND la.checked_in = 1 THEN 1 ELSE 0 END), 0) AS rows_checked_in
-     FROM listing_attendees AS la
-     JOIN attendees AS a ON a.id = la.attendee_id
-     WHERE la.listing_id = ? AND a.kind = '${ATTENDEE_KIND}'`,
+       COALESCE(SUM(CASE WHEN ${confirmed} AND listingAttendee.checked_in = 1 THEN listingAttendee.quantity ELSE 0 END), 0) AS tickets_checked_in,
+       COALESCE(SUM(CASE WHEN ${confirmed} AND listingAttendee.checked_in = 1 THEN 1 ELSE 0 END), 0) AS rows_checked_in
+     FROM listing_attendees AS listingAttendee
+     JOIN attendees AS attendee ON attendee.id = listingAttendee.attendee_id
+     WHERE listingAttendee.listing_id = ? AND attendee.kind = '${ATTENDEE_KIND}'`,
     [listing.id],
   );
   // Only a paid listing can carry never-paid sales, so a free listing skips the

--- a/src/shared/db/migrations/schema-sync.ts
+++ b/src/shared/db/migrations/schema-sync.ts
@@ -84,9 +84,9 @@ export const snapshotLiveSchema = async (): Promise<LiveSchema> => {
     {
       args: [],
       sql:
-        "SELECT m.name AS tbl, ti.name AS col " +
-        "FROM sqlite_master m JOIN pragma_table_info(m.name) ti " +
-        "WHERE m.type = 'table'",
+        "SELECT master.name AS tbl, tableInfo.name AS col " +
+        "FROM sqlite_master AS master JOIN pragma_table_info(master.name) AS tableInfo " +
+        "WHERE master.type = 'table'",
     },
     {
       args: [],

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -175,10 +175,11 @@ type JoinedRow = {
 };
 
 /** Shared SELECT columns and JOIN for question + answers */
-const QA_COLS = `q.id AS q_id, q.assign_all AS q_assign_all, q.display_type AS q_display_type, q.text AS q_text,
-       a.id AS a_id, a.text AS a_text,
-       a.question_id AS a_question_id, a.sort_order AS a_sort_order, a.active AS a_active`;
-const QA_JOIN = "questions q LEFT JOIN answers a ON a.question_id = q.id";
+const QA_COLS = `question.id AS q_id, question.assign_all AS q_assign_all, question.display_type AS q_display_type, question.text AS q_text,
+       answer.id AS a_id, answer.text AS a_text,
+       answer.question_id AS a_question_id, answer.sort_order AS a_sort_order, answer.active AS a_active`;
+const QA_JOIN =
+  "questions AS question LEFT JOIN answers AS answer ON answer.question_id = question.id";
 
 /** Group flat joined rows into QuestionWithAnswers[], preserving row order.
  * Decrypts question and answer text in parallel. */
@@ -250,10 +251,10 @@ const decryptQuestion = async (
   return { ...question, answers };
 };
 
-/** Fetch questions with answers by a WHERE clause on q.id */
+/** Fetch questions with answers by a WHERE clause on question.id */
 const fetchQuestions = (where: string, args: InValue[]) =>
   queryAll<JoinedRow>(
-    `SELECT ${QA_COLS} FROM ${QA_JOIN} ${where} ORDER BY a.sort_order`,
+    `SELECT ${QA_COLS} FROM ${QA_JOIN} ${where} ORDER BY answer.sort_order`,
     args,
   );
 
@@ -263,7 +264,7 @@ export const getAllQuestionsWithAnswers = async (): Promise<
 > =>
   groupJoinedRows(
     await queryAll<JoinedRow>(
-      `SELECT ${QA_COLS} FROM ${QA_JOIN} ORDER BY q.sort_order, q.id, a.sort_order`,
+      `SELECT ${QA_COLS} FROM ${QA_JOIN} ORDER BY question.sort_order, question.id, answer.sort_order`,
     ),
   );
 
@@ -276,11 +277,11 @@ export const getQuestionsForListing = async (
     await groupJoinedRows(
       await queryAll<JoinedRow>(
         `SELECT ${QA_COLS}
-       FROM questions q
-       LEFT JOIN listing_questions eq ON q.id = eq.question_id AND eq.listing_id = ?
-       LEFT JOIN answers a ON a.question_id = q.id
-       WHERE q.assign_all = 1 OR eq.listing_id IS NOT NULL
-       ORDER BY q.sort_order, q.id, a.sort_order`,
+       FROM questions AS question
+       LEFT JOIN listing_questions AS listingQuestion ON question.id = listingQuestion.question_id AND listingQuestion.listing_id = ?
+       LEFT JOIN answers AS answer ON answer.question_id = question.id
+       WHERE question.assign_all = 1 OR listingQuestion.listing_id IS NOT NULL
+       ORDER BY question.sort_order, question.id, answer.sort_order`,
         [listingId],
       ),
     ),
@@ -292,11 +293,11 @@ export const getListingQuestionIds = async (
 ): Promise<number[]> =>
   map((r: { question_id: number }) => r.question_id)(
     await queryAll<{ question_id: number }>(
-      `SELECT q.id AS question_id
-       FROM questions q
-       LEFT JOIN listing_questions eq ON q.id = eq.question_id AND eq.listing_id = ?
-       WHERE q.assign_all = 1 OR eq.listing_id IS NOT NULL
-       ORDER BY q.sort_order, q.id`,
+      `SELECT question.id AS question_id
+       FROM questions AS question
+       LEFT JOIN listing_questions AS listingQuestion ON question.id = listingQuestion.question_id AND listingQuestion.listing_id = ?
+       WHERE question.assign_all = 1 OR listingQuestion.listing_id IS NOT NULL
+       ORDER BY question.sort_order, question.id`,
       [listingId],
     ),
   );
@@ -384,13 +385,13 @@ export const getQuestionsWithListingIds = async (
   const ph = inPlaceholders(listingIds);
   const rows = await queryAll<JoinedRowWithListings>(
     `SELECT ${QA_COLS},
-            CASE WHEN q.assign_all = 1 THEN NULL ELSE
-              (SELECT GROUP_CONCAT(eq.listing_id) FROM listing_questions eq
-               WHERE eq.question_id = q.id AND eq.listing_id IN (${ph}))
+            CASE WHEN question.assign_all = 1 THEN NULL ELSE
+              (SELECT GROUP_CONCAT(listingQuestion.listing_id) FROM listing_questions AS listingQuestion
+               WHERE listingQuestion.question_id = question.id AND listingQuestion.listing_id IN (${ph}))
             END AS listing_ids
      FROM ${QA_JOIN}
-     WHERE q.assign_all = 1 OR q.id IN (SELECT question_id FROM listing_questions WHERE listing_id IN (${ph}))
-     ORDER BY q.sort_order, q.id, a.sort_order`,
+     WHERE question.assign_all = 1 OR question.id IN (SELECT question_id FROM listing_questions WHERE listing_id IN (${ph}))
+     ORDER BY question.sort_order, question.id, answer.sort_order`,
     [...listingIds, ...listingIds],
   );
 
@@ -1023,10 +1024,10 @@ export const getAttendeeAnswersByQuestion = async (
     answer_id: number;
     answer_text: string;
   }>(
-    `SELECT a.question_id, aa.answer_id, a.text AS answer_text
-     FROM attendee_answers aa
-     JOIN answers a ON a.id = aa.answer_id
-     WHERE aa.answer_id IS NOT NULL AND aa.attendee_id = ?`,
+    `SELECT answer.question_id, attendeeAnswer.answer_id, answer.text AS answer_text
+     FROM attendee_answers AS attendeeAnswer
+     JOIN answers AS answer ON answer.id = attendeeAnswer.answer_id
+     WHERE attendeeAnswer.answer_id IS NOT NULL AND attendeeAnswer.attendee_id = ?`,
     [attendeeId],
   );
 
@@ -1082,7 +1083,7 @@ export const deleteAnswer = async (answerId: number): Promise<void> => {
 export const getQuestionWithAnswers = async (
   id: number,
 ): Promise<QuestionWithAnswers | null> => {
-  const rows = await fetchQuestions("WHERE q.id = ?", [id]);
+  const rows = await fetchQuestions("WHERE question.id = ?", [id]);
   if (rows.length === 0) return null;
   // rows is non-empty so groupJoinedRows always returns at least one entry
   return (await groupJoinedRows(rows))[0]!;

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -3,14 +3,9 @@
  *
  * AdminNav builds the whole menu for the current page from one schema: the
  * top-level links, plus — for the section the page belongs to — that section's
- * sub-nav. It emits two structures and lets CSS show whichever fits:
- *
- *  - a desktop sidebar, where the sub-nav is nested inside its parent <li>, and
- *  - mobile bars, where the sub-nav follows the top-level row as its own bar.
- *
- * Each layout keeps its own correctly-ordered DOM, so tab/reading order always
- * matches what's shown — no CSS `order` reshuffling, and the two can diverge
- * freely in future.
+ * sub-nav. The schema is lifted into the shared leveled-nav model and rendered
+ * by the same `leveledNav` renderer the public nav uses (the desktop sidebar
+ * with nested levels, and the stacked mobile bars).
  */
 
 import { compact } from "#fp";
@@ -28,7 +23,12 @@ import { isSupportEnabled } from "#shared/support.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { markAdminFooter } from "#templates/admin/footer.tsx";
 import { SettingsNagBanner } from "#templates/admin/settings-nag-banner.tsx";
-import { desktopNavShell, mobileNavBar } from "#templates/components/nav.tsx";
+import {
+  type LeveledNavLevel,
+  type LeveledNavNode,
+  leveledNav,
+  nodeLis,
+} from "#templates/components/nav.tsx";
 
 /** One navigation link. */
 interface NavItem {
@@ -211,50 +211,20 @@ const resolveSection = (
   return null;
 };
 
-/** A single link, highlighted when its href is the active top-level link. */
-const navAnchor = (item: NavItem, highlight: string): JSX.Element => (
-  <a class={item.href === highlight ? "active" : undefined} href={item.href}>
-    {item.label}
-  </a>
-);
+/** Lift the plain link schema into leveled-nav nodes: every admin link is live
+ * (the schema already omits links the viewer's role can't open), and `active`
+ * highlights the current section's top-level link. Sub-navs pass an empty
+ * `highlight` since the section route alone can't tell which sub-page is open. */
+const toNodes = (items: NavItem[], highlight: string): LeveledNavNode[] =>
+  items.map((item) => ({
+    ...item,
+    active: item.href === highlight,
+    live: true,
+  }));
 
-/** Flat <li> list of links. Sub-navs pass an empty `highlight` since the
- * section route alone can't tell which sub-page is open. */
-const navItems = (items: NavItem[], highlight: string): JSX.Element[] =>
-  items.map((item) => <li>{navAnchor(item, highlight)}</li>);
-
-/** The props both viewport-specific navs render from. */
-type LeveledNavProps = {
-  items: NavItem[];
-  highlight: string;
-  section: Section | null;
-};
-
-/** Desktop sidebar: one nav with the sub-nav nested inside its parent <li>, and
- * the site third level nested again — DOM order matches the stacked visual.
- * `#main-nav` marks the page as an admin page for the stylesheet. */
-const DesktopNav = ({ items, highlight, section }: LeveledNavProps) =>
-  desktopNavShell(
-    t("nav.admin"),
-    items.map((item) => (
-      <li>
-        {navAnchor(item, highlight)}
-        {section && item.href === highlight && (
-          <ul class="admin-subnav">{navItems(section.items, "")}</ul>
-        )}
-      </li>
-    )),
-    "main-nav",
-  );
-
-/** Mobile: the top-level bar, then each sub-nav level as its own bar below —
- * the separate stacked bars admin has always shown on small screens. */
-const MobileNav = ({ items, highlight, section }: LeveledNavProps) => (
-  <>
-    {mobileNavBar(t("nav.admin"), navItems(items, highlight))}
-    {section && mobileNavBar(section.label, navItems(section.items, ""))}
-  </>
-);
+/** The section's sub-nav as the model's submenu levels — one level, or none. */
+const sectionLevels = (section: Section | null): LeveledNavLevel[] =>
+  section ? [{ label: section.label, nodes: toNodes(section.items, "") }] : [];
 
 interface AdminNavProps {
   active: string;
@@ -270,9 +240,9 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => {
   // Flag this render as an admin page so the Layout emits the admin footer
   // (Chobble link, optional debug menu, and the logout button).
   markAdminFooter(session.adminLevel);
-  const items = topLevelItems(session, active);
   const section = resolveSection(active, session.adminLevel);
   const highlight = section?.topHref ?? active;
+  const rootNodes = toNodes(topLevelItems(session, active), highlight);
   return (
     <>
       {renderReadOnlyBanner(
@@ -288,12 +258,12 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => {
             : {})}
         />
       )}
-      {/* The desktop sidebar nav and the mobile bars share one wrapper so the
-          desktop grid can pin it as a single sticky left-hand column. */}
-      <div class="admin-nav-group">
-        <DesktopNav highlight={highlight} items={items} section={section} />
-        <MobileNav highlight={highlight} items={items} section={section} />
-      </div>
+      {leveledNav({
+        id: "main-nav",
+        label: t("nav.admin"),
+        levels: sectionLevels(section),
+        rootLis: (nested) => nodeLis(rootNodes, nested),
+      })}
     </>
   );
 };

--- a/src/ui/templates/components/nav.tsx
+++ b/src/ui/templates/components/nav.tsx
@@ -1,25 +1,91 @@
 /**
- * Shared nav shells for the two site navigations (admin and public), which
- * render the same stacked-bars-on-mobile / pinned-sidebar-on-desktop pattern
- * from the same CSS (`admin-nav--mobile` / `admin-nav--desktop`; the
- * `.admin-nav-group` wrapper is what the desktop grid pins left).
+ * The one leveled navigation both site navigations (admin and public) render
+ * through: a plain node/level data model plus a single renderer that emits the
+ * stacked-bars-on-mobile / pinned-sidebar-on-desktop pattern from the same CSS
+ * (`admin-nav--mobile` / `admin-nav--desktop`; the `.admin-nav-group` wrapper
+ * is what the desktop grid pins left).
+ *
+ * Each viewport keeps its own correctly-ordered DOM, so tab/reading order
+ * always matches what's shown — no CSS `order` reshuffling:
+ *
+ *  - a desktop sidebar, where the submenu levels nest recursively beneath the
+ *    active node of the level above, and
+ *  - mobile bars, where each level follows the top-level row as its own bar.
  */
+
+/** One nav entry. The public site-pages `NavNode` is structurally one of
+ * these; the admin nav lifts its link schema into them. */
+export interface LeveledNavNode {
+  href: string;
+  label: string;
+  /** false ⇒ render as text, not a link (never a dead link). */
+  live: boolean;
+  /** Highlighted; on desktop the next submenu level nests beneath it. */
+  active: boolean;
+}
+
+/** One stacked submenu level: one mobile bar / one desktop nesting step. */
+export interface LeveledNavLevel {
+  /** The level's accessible name (the mobile bar's aria-label). */
+  label: string;
+  nodes: readonly LeveledNavNode[];
+}
+
+/** A node as a link — or plain text when its target isn't reachable by the
+ * viewer (never render a dead or forbidden link). */
+export const NodeLink = ({ node }: { node: LeveledNavNode }): JSX.Element =>
+  node.live ? (
+    <a class={node.active ? "active" : undefined} href={node.href}>
+      {node.label}
+    </a>
+  ) : (
+    <span>{node.label}</span>
+  );
+
+/** Flat `<li>` list of nodes. `nested` supplies a node's extra children (the
+ * desktop level nesting beneath the active node); omit it for a plain list. */
+export const nodeLis = (
+  nodes: readonly LeveledNavNode[],
+  nested: (node: LeveledNavNode) => JSX.Element | null = () => null,
+): JSX.Element[] =>
+  nodes.map((node) => (
+    <li>
+      <NodeLink node={node} />
+      {nested(node)}
+    </li>
+  ));
+
+/** Desktop: the submenu levels nested recursively — level `depth` renders
+ * beneath the active node of the level above (the next step on the active
+ * chain), indenting one step per level. The model never carries an empty
+ * level, so every rendered `<ul>` has children. */
+const DesktopLevels = ({
+  levels,
+  depth,
+}: {
+  levels: readonly LeveledNavLevel[];
+  depth: number;
+}): JSX.Element | null =>
+  depth >= levels.length ? null : (
+    <ul class="admin-subnav">
+      {nodeLis(levels[depth]!.nodes, (node) =>
+        node.active ? (
+          <DesktopLevels depth={depth + 1} levels={levels} />
+        ) : null,
+      )}
+    </ul>
+  );
 
 /** One mobile nav bar (the top-level row, or a submenu level beneath it), with
  * an accessible name so screen-reader users can tell the stacked bars apart. */
-export const mobileNavBar = (
-  label: string,
-  lis: JSX.Element[],
-): JSX.Element => (
+const mobileNavBar = (label: string, lis: JSX.Element[]): JSX.Element => (
   <nav aria-label={label} class="admin-nav admin-nav--mobile">
     <ul>{lis}</ul>
   </nav>
 );
 
-/** The desktop sidebar shell around the top-level `<li>`s. `id` is the admin
- * nav's `#main-nav` marker — the stylesheet reads it as "this is an admin
- * page", so the public nav must not pass one. */
-export const desktopNavShell = (
+/** The desktop sidebar shell around the top-level `<li>`s. */
+const desktopNavShell = (
   label: string,
   lis: JSX.Element[],
   id?: string,
@@ -27,4 +93,38 @@ export const desktopNavShell = (
   <nav aria-label={label} class="admin-nav admin-nav--desktop" id={id}>
     <ul>{lis}</ul>
   </nav>
+);
+
+/** Render one whole leveled navigation. `rootLis` builds the top-level row for
+ * each viewport; its `nested` argument is the desktop nesting to hang beneath
+ * the active root (always null on mobile), so callers that splice fixed links
+ * around their nodes stay in control of the row. `id` is the admin nav's
+ * `#main-nav` marker — the stylesheet reads it as "this is an admin page", so
+ * the public nav must not pass one. The desktop sidebar and the mobile bars
+ * share one wrapper so the desktop grid can pin it as a single sticky
+ * left-hand column. */
+export const leveledNav = (opts: {
+  label: string;
+  rootLis: (
+    nested: (node: LeveledNavNode) => JSX.Element | null,
+  ) => JSX.Element[];
+  levels: readonly LeveledNavLevel[];
+  id?: string;
+}): JSX.Element => (
+  <div class="admin-nav-group">
+    {desktopNavShell(
+      opts.label,
+      opts.rootLis((node) =>
+        node.active ? <DesktopLevels depth={0} levels={opts.levels} /> : null,
+      ),
+      opts.id,
+    )}
+    {mobileNavBar(
+      opts.label,
+      opts.rootLis(() => null),
+    )}
+    {opts.levels.map((level) =>
+      mobileNavBar(level.label, nodeLis(level.nodes)),
+    )}
+  </div>
 );

--- a/src/ui/templates/public/shared.tsx
+++ b/src/ui/templates/public/shared.tsx
@@ -4,7 +4,7 @@ import { getBookableStartDates, isBookingRangeValid } from "#shared/dates.ts";
 import { settings } from "#shared/db/settings.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
-import type { NavLevel, NavModel, NavNode } from "#shared/site-pages/types.ts";
+import type { NavModel } from "#shared/site-pages/types.ts";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import {
   dayPriceFor,
@@ -14,7 +14,11 @@ import {
   PARENT_CHILD_GROUP_UNITS,
   type SharedGroupCapacity,
 } from "#shared/types.ts";
-import { desktopNavShell, mobileNavBar } from "#templates/components/nav.tsx";
+import {
+  type LeveledNavNode,
+  leveledNav,
+  nodeLis,
+} from "#templates/components/nav.tsx";
 import { escapeHtml } from "#templates/layout.tsx";
 
 /** Everything {@link PublicNav} renders: the settings-driven page flags plus
@@ -26,45 +30,12 @@ export type PublicNavProps = {
   pages: NavModel;
 };
 
-/** A nav node as a link — or plain text when the target isn't publicly
- * reachable (never render a dead link). The active-chain node is marked. */
-export const NodeLink = ({ node }: { node: NavNode }): JSX.Element =>
-  node.live ? (
-    <a class={node.active ? "active" : undefined} href={node.href}>
-      {node.label}
-    </a>
-  ) : (
-    <span>{node.label}</span>
-  );
-
-/** Desktop: the submenu levels nested recursively — level `depth` renders
- * beneath the active node of the level above (the next page on the active
- * chain), indenting one step per level like the admin sub-nav. The model
- * never carries an empty level, so every rendered `<ul>` has children. */
-const DesktopLevels = ({
-  levels,
-  depth,
-}: {
-  levels: readonly NavLevel[];
-  depth: number;
-}): JSX.Element | null =>
-  depth >= levels.length ? null : (
-    <ul class="admin-subnav">
-      {levels[depth]!.nodes.map((node) => (
-        <li>
-          <NodeLink node={node} />
-          {node.active && <DesktopLevels depth={depth + 1} levels={levels} />}
-        </li>
-      ))}
-    </ul>
-  );
-
 /** The fixed root links, with the root page nodes spliced between Listings and
  * the Order/Terms/Contact group ("between listings and contact"). Each page
  * `<li>` may carry extra children (the desktop nesting), supplied per node. */
 const rootItems = (
   { hasTerms, hasContact, hasOrder, pages }: PublicNavProps,
-  nested: (node: NavNode) => JSX.Element | null,
+  nested: (node: LeveledNavNode) => JSX.Element | null,
 ): JSX.Element[] => [
   <li>
     <a href="/">{t("nav.public.home")}</a>
@@ -72,12 +43,7 @@ const rootItems = (
   <li>
     <a href="/listings">{t("terms.listings")}</a>
   </li>,
-  ...pages.rootPageNodes.map((node) => (
-    <li>
-      <NodeLink node={node} />
-      {nested(node)}
-    </li>
-  )),
+  ...nodeLis(pages.rootPageNodes, nested),
   ...(hasOrder
     ? [
         <li>
@@ -103,51 +69,21 @@ const rootItems = (
     : []),
 ];
 
-/** Mobile: the root bar, then one bar per active-chain level (root-first),
- * each carrying its page's name as the bar's accessible label. */
-const MobilePublicNav = (props: PublicNavProps): JSX.Element => (
-  <>
-    {mobileNavBar(
-      t("nav.public.main"),
-      rootItems(props, () => null),
-    )}
-    {props.pages.submenuLevels.map((level) =>
-      mobileNavBar(
-        level.label,
-        level.nodes.map((node) => (
-          <li>
-            <NodeLink node={node} />
-          </li>
-        )),
-      ),
-    )}
-  </>
-);
-
 /**
  * Public site navigation: the fixed links (Home, Listings, Order/Terms/Contact
  * when enabled) with the operator's root pages spliced in between, plus the
- * recursive contextual submenus along the active chain. Mirrors the admin
- * pattern — one nested sidebar on desktop, separate stacked bars on mobile —
- * by reusing its proven CSS (`admin-nav--desktop` / `admin-subnav` /
- * `admin-nav--mobile`; `.admin-nav-group` pins the desktop sidebar). It must
- * NOT carry the admin nav's `#main-nav` id: the stylesheet reads that id as
- * "this is an admin page" (full-bleed main, admin textarea sizing), while a
- * public page keeps the shared 800px reading width.
+ * recursive contextual submenus along the active chain — rendered by the same
+ * shared `leveledNav` the admin nav uses. It must NOT carry the admin nav's
+ * `#main-nav` id: the stylesheet reads that id as "this is an admin page"
+ * (full-bleed main, admin textarea sizing), while a public page keeps the
+ * shared 800px reading width.
  */
-export const PublicNav = (props: PublicNavProps): JSX.Element => (
-  <div class="admin-nav-group">
-    {desktopNavShell(
-      t("nav.public.main"),
-      rootItems(props, (node) =>
-        node.active ? (
-          <DesktopLevels depth={0} levels={props.pages.submenuLevels} />
-        ) : null,
-      ),
-    )}
-    <MobilePublicNav {...props} />
-  </div>
-);
+export const PublicNav = (props: PublicNavProps): JSX.Element =>
+  leveledNav({
+    label: t("nav.public.main"),
+    levels: props.pages.submenuLevels,
+    rootLis: (nested) => rootItems(props, nested),
+  });
 
 /** Compute which public pages have content.
  * The Contact link also shows when the contact form is active, even if the

--- a/src/ui/templates/public/site-page.tsx
+++ b/src/ui/templates/public/site-page.tsx
@@ -7,12 +7,12 @@
 
 import type { NavNode } from "#shared/site-pages/types.ts";
 import type { SitePage } from "#shared/types.ts";
+import { nodeLis } from "#templates/components/nav.tsx";
 import { escapeHtml, Layout } from "#templates/layout.tsx";
 import {
   FEED_DISCOVERY_TAGS,
   LoginFooter,
   MarkdownProse,
-  NodeLink,
   PublicNav,
   type PublicNavProps,
 } from "./shared.tsx";
@@ -35,15 +35,7 @@ export const sitePagePage = (
       <PublicNav {...nav} />
       <h1>{page.name}</h1>
       <MarkdownProse markdown={page.content} />
-      {items.length > 0 && (
-        <ul class="page-items">
-          {items.map((node) => (
-            <li>
-              <NodeLink node={node} />
-            </li>
-          ))}
-        </ul>
-      )}
+      {items.length > 0 && <ul class="page-items">{nodeLis(items)}</ul>}
       <LoginFooter />
     </Layout>,
   );


### PR DESCRIPTION
## What

Closes the "Admin nav on the recursive renderer" TODO item: the admin nav still hand-composed its fixed-depth desktop/mobile markup while the public nav rendered the same stacked-bars / nested-sidebar pattern through a recursive model. Both now go through **one** schema-driven renderer, per the AGENTS.md principles this repo asks for ("Unify systems — the answer is yes", "Schema over organic structure").

- `src/ui/templates/components/nav.tsx` now owns the whole leveled-nav system: a plain `LeveledNavNode` / `LeveledNavLevel` model, `NodeLink`, `nodeLis`, the recursive `DesktopLevels`, and one `leveledNav()` renderer. The `mobileNavBar` / `desktopNavShell` shells became private — nothing composes them by hand anymore.
- `AdminNav` lifts its link schema into the shared model (`toNodes` / `sectionLevels`) and deletes its fixed-depth `DesktopNav` / `MobileNav` / `navAnchor` / `navItems` copies. Its sub-nav now nests recursively for free if a deeper section ever appears.
- `PublicNav` collapses to a `leveledNav()` call; `DesktopLevels`, `MobilePublicNav`, and its `NodeLink` copy are deleted. The public site-pages `NavNode` is structurally a `LeveledNavNode`, so no adapting layer is needed.
- The site-page item list renders through the same shared `nodeLis`.

No behaviour change: both navs emit the same markup as before (the existing admin/public nav tests pass unchanged, including the exact-markup assertions on active links and sub-nav placement).

## In passing (AGENTS.md preferences, "good citizen" fixes)

- **Full-word SQL table aliases** replacing single-letter/abbreviated ones: `questions.ts` (`q`/`a`/`eq` → `question`/`answer`/`listingQuestion`, `aa` → `attendeeAnswer`), `listing-overview-stats.ts` (`la`/`a`/`t`/`p` → `listingAttendee`/`attendee`/`saleLeg`/`paymentLeg`), `attendees/queries.ts` (`la` → `listingAttendee`), `groups.ts` (`src`/`dst` → `sourceMembership`/`cloneMembership`), `schema-sync.ts` (`m`/`ti` → `master`/`tableInfo`).
- The last `forEach` in `attendee-page-data.ts` is now `for…of` per the FP guidance.

## Verification

- `deno task precommit`: lint ✓, typecheck ✓, cpd (0% duplication) ✓, build:edge ✓; 13,482 tests pass. The only 2 failures are `test/lib/stripe-mock.test.ts` download tests, which need live GitHub release access that the sandbox this ran in blocks — unrelated to this diff and expected to pass in CI.
- Coverage: 100% branch + line on every changed file (verified via `deno coverage` over the full run).
- Targeted mutation (`deno task mutation` on `components/nav.tsx` against the admin-nav, public-nav, and site-page route tests): 12/14 killed. The 2 survivors are the pre-existing `admin-nav--mobile` / `admin-nav--desktop` class-string literals in the untouched shell functions — a gap that exists on `main` too; left un-suppressed since they're real (not equivalent) mutants. Fixing them needs test-file changes that can't ride along with this branch's src-only SQL-alias edits without tripping the branch-scoped precommit mutation gate with false survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYYigsby8d3246PtjWdXwb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYYigsby8d3246PtjWdXwb)_