### PR TITLE
Explain why un-enhanceable order links are skipped

### DIFF
--- a/src/ui/client/order.ts
+++ b/src/ui/client/order.ts
@@ -111,6 +111,24 @@ const resolvePackageSlug = (raw: string): string | null => {
   return slug && Object.hasOwn(CATALOG.packages, slug) ? slug : null;
 };
 
+/** Explain why a `data-add-listing` value can't be enhanced, so the skip log
+ * says WHY rather than just naming the link. Mirrors the checks in
+ * `ticketSlug`/`resolveListing`/`resolvePackageSlug`. */
+const skipReason = (raw: string): string => {
+  if (!raw) return "no data-add-listing value";
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return "not a valid URL";
+  }
+  if (url.origin !== CATALOG.origin)
+    return `origin ${url.origin} is not the tickets origin ${CATALOG.origin}`;
+  const slug = url.pathname.match(/^\/ticket\/([^/+]+)$/)?.[1];
+  if (!slug) return `path ${url.pathname} is not a /ticket/<slug> URL`;
+  return `slug "${slug}" is not a known listing or package`;
+};
+
 class CartController {
   private lines: CartLine[];
   private readonly storageKey = STORAGE_PREFIX + CATALOG.origin;
@@ -446,7 +464,11 @@ const init = (): void => {
     if (link.dataset.chobbleEnhanced) return;
     const raw = link.dataset.addListing ?? "";
     if (!resolveListing(raw) && !resolvePackageSlug(raw)) {
-      debugLog("skipped un-enhanceable link", link.dataset.addListing);
+      debugLog(
+        "skipped un-enhanceable link",
+        link.dataset.addListing,
+        `- ${skipReason(raw)}`,
+      );
       return;
     }
     link.dataset.chobbleEnhanced = "1";

--- a/test/lib/order-widget.test.ts
+++ b/test/lib/order-widget.test.ts
@@ -309,6 +309,31 @@ describe("order widget", {
     expect(logHas(h, "skipped un-enhanceable link")).toBe(true);
   });
 
+  test("explains WHY each un-enhanceable link is skipped", () => {
+    setBody(
+      h,
+      [
+        `<a data-add-listing="">empty</a>`,
+        `<a data-add-listing="bad">not-a-url</a>`,
+        `<a data-add-listing="https://elsewhere.test/ticket/open">origin</a>`,
+        `<a data-add-listing="${ORIGIN}/not-a-ticket">path</a>`,
+        `<a data-add-listing="${ORIGIN}/ticket/register">slug</a>`,
+      ].join(""),
+    );
+    h.run(makeCatalog([listing({ id: 1, slug: "open" })], true));
+
+    const reasons = h.logs
+      .filter((entry) => entry[1] === "skipped un-enhanceable link")
+      .map((entry) => entry[3]);
+    expect(reasons).toEqual([
+      "- no data-add-listing value",
+      "- not a valid URL",
+      `- origin https://elsewhere.test is not the tickets origin ${ORIGIN}`,
+      "- path /not-a-ticket is not a /ticket/<slug> URL",
+      `- slug "register" is not a known listing or package`,
+    ]);
+  });
+
   test("stays silent when debug is off", () => {
     mountOpenListing(h);
     clickAnchor(h, "open");


### PR DESCRIPTION
## What

The order widget's debug log previously printed only the URL when it skipped a link it couldn't enhance:

```
[chobble-order] skipped un-enhanceable link https://tix.chobble.com/ticket/register
```

This left you guessing *why* the link was skipped. Now it appends the reason:

```
[chobble-order] skipped un-enhanceable link https://tix.chobble.com/ticket/register - slug "register" is not a known listing or package
```

## How

- Added a `skipReason` helper in `src/ui/client/order.ts` that mirrors the checks in `ticketSlug`/`resolveListing`/`resolvePackageSlug` and returns a human-readable cause: missing `data-add-listing` value, not a valid URL, foreign origin, non-`/ticket/<slug>` path, or an unknown slug.
- Passed the reason as a third argument to the existing `debugLog` skip call.

## Testing

- Added a test that mounts one link per failure mode and asserts each logged reason string, covering every branch of `skipReason` (needed for the repo's 100% branch-coverage gate).
- `deno test -A test/lib/order-widget.test.ts` passes; `deno check` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnpzQorZq2CqAvBjgr8qSt)_