### PR TITLE
Link public groups from the order widget, not just packages

### DIFF
--- a/src/features/public/order-js.ts
+++ b/src/features/public/order-js.ts
@@ -89,21 +89,23 @@ export const handleOrderJs = async (request: Request): Promise<Response> => {
     getCatalogListings(),
     loadPublicGroups(),
   ]);
-  // Package bundles are booked as a whole via /ticket/<group>, so the widget
-  // links to them directly rather than as cart lines (mirroring the /order
-  // gallery). Only bookable, non-hidden packages — hidden-package MEMBERS are
-  // already excluded from the listing catalog by getCatalogListings.
-  const packages = publicGroups
-    .filter((group) => group.is_package)
-    .map((group) => ({ name: group.name, slug: group.slug }));
+  // Public groups (both regular galleries and package bundles) are reached via
+  // their own /ticket/<group> page, so the widget links to them directly rather
+  // than as cart lines (mirroring the /order gallery). loadPublicGroups already
+  // gates to non-hidden groups whose page can sell; hidden-package MEMBERS are
+  // excluded from the listing catalog by getCatalogListings.
+  const groups = publicGroups.map((group) => ({
+    name: group.name,
+    slug: group.slug,
+  }));
   const catalog = buildCatalog({
     currency,
     debug: url.searchParams.get("debug") === "true",
     decimalPlaces: getDecimalPlaces(currency),
     generatedAt: nowIso(),
+    groups,
     listings,
     origin: url.origin,
-    packages,
   });
 
   return jsResponse(

--- a/src/shared/external-order.ts
+++ b/src/shared/external-order.ts
@@ -89,11 +89,12 @@ export interface CatalogListing {
   variablePrice: boolean;
 }
 
-/** A package bundle the visitor books as a whole via its own `/ticket/<group>`
- * page. Unlike a listing it never joins the multi-listing cart (a package is
- * all-or-nothing at fixed quantities), so it carries no price — the widget links
- * straight to the package page, where the bundle is priced. */
-export interface CatalogPackage {
+/** A public group the visitor reaches via its own `/ticket/<group>` page. Both a
+ * regular group (a gallery of standalone-bookable members) and a package bundle
+ * (booked all-or-nothing) are represented here: neither joins the multi-listing
+ * cart, so the widget links straight to the group page rather than adding a cart
+ * line, and neither carries a price (the group page prices whatever it sells). */
+export interface CatalogGroup {
   slug: string;
   name: string;
 }
@@ -108,10 +109,11 @@ export interface Catalog {
    * it happens. Toggled per request with `?debug=true` on `/order.js`. */
   debug: boolean;
   listings: Record<string, CatalogListing>;
-  /** Bookable package groups keyed by group slug. A `data-add-listing` link to
-   * one of these navigates straight to `/ticket/<slug>` instead of adding a cart
-   * line. Empty when the site has no bookable packages. */
-  packages: Record<string, CatalogPackage>;
+  /** Public, bookable groups keyed by group slug — both regular groups and
+   * package bundles. A `data-add-listing` link to one of these navigates
+   * straight to `/ticket/<slug>` instead of adding a cart line. Empty when the
+   * site has no public bookable groups. */
+  groups: Record<string, CatalogGroup>;
 }
 
 type VariablePriceFields = Pick<
@@ -152,27 +154,28 @@ export const buildCatalog = (params: {
   generatedAt: string;
   debug: boolean;
   listings: CatalogSourceListing[];
-  /** Bookable package groups (slug + decrypted name). The caller has already
-   * gated these to whole-bundle-bookable, non-hidden packages — the same set
-   * `/listings` and `/order` advertise. */
-  packages?: CatalogPackage[];
+  /** Public bookable groups (slug + decrypted name), both regular groups and
+   * package bundles. The caller has already gated these to non-hidden groups
+   * whose page can actually sell — the same set `/listings` and `/order`
+   * advertise. */
+  groups?: CatalogGroup[];
 }): Catalog => ({
   currency: params.currency,
   debug: params.debug,
   decimalPlaces: params.decimalPlaces,
   generatedAt: params.generatedAt,
+  groups: Object.fromEntries(
+    (params.groups ?? []).map((group) => [
+      group.slug,
+      { name: group.name, slug: group.slug },
+    ]),
+  ),
   listings: Object.fromEntries(
     params.listings
       .filter((listing) => listing.active && !listing.hidden)
       .map((listing) => [listing.slug, buildCatalogEntry(listing)]),
   ),
   origin: params.origin,
-  packages: Object.fromEntries(
-    (params.packages ?? []).map((pkg) => [
-      pkg.slug,
-      { name: pkg.name, slug: pkg.slug },
-    ]),
-  ),
 });
 
 /** Characters that are safe in JSON but unsafe verbatim in served JS: `<`

--- a/src/ui/client/order.ts
+++ b/src/ui/client/order.ts
@@ -103,17 +103,17 @@ const resolveListing = (raw: string): CatalogEntry | null => {
   return slug ? (catalogEntry(slug) ?? null) : null;
 };
 
-/** Resolve a `data-add-listing` URL to a PACKAGE group slug, or null. A package
- * is booked as a whole via its own page, so the widget navigates straight there
- * rather than adding a cart line. */
-const resolvePackageSlug = (raw: string): string | null => {
+/** Resolve a `data-add-listing` URL to a GROUP slug, or null. A group (a regular
+ * gallery or a package bundle) is reached via its own page, so the widget
+ * navigates straight there rather than adding a cart line. */
+const resolveGroupSlug = (raw: string): string | null => {
   const slug = ticketSlug(raw);
-  return slug && Object.hasOwn(CATALOG.packages, slug) ? slug : null;
+  return slug && Object.hasOwn(CATALOG.groups, slug) ? slug : null;
 };
 
 /** Explain why a `data-add-listing` value can't be enhanced, so the skip log
  * says WHY rather than just naming the link. Mirrors the checks in
- * `ticketSlug`/`resolveListing`/`resolvePackageSlug`. */
+ * `ticketSlug`/`resolveListing`/`resolveGroupSlug`. */
 const skipReason = (raw: string): string => {
   if (!raw) return "no data-add-listing value";
   let url: URL;
@@ -126,7 +126,7 @@ const skipReason = (raw: string): string => {
     return `origin ${url.origin} is not the tickets origin ${CATALOG.origin}`;
   const slug = url.pathname.match(/^\/ticket\/([^/+]+)$/)?.[1];
   if (!slug) return `path ${url.pathname} is not a /ticket/<slug> URL`;
-  return `slug "${slug}" is not a known listing or package`;
+  return `slug "${slug}" is not a known listing or group`;
 };
 
 class CartController {
@@ -463,7 +463,7 @@ const init = (): void => {
   const enhance = (link: HTMLAnchorElement): void => {
     if (link.dataset.chobbleEnhanced) return;
     const raw = link.dataset.addListing ?? "";
-    if (!resolveListing(raw) && !resolvePackageSlug(raw)) {
+    if (!resolveListing(raw) && !resolveGroupSlug(raw)) {
       debugLog(
         "skipped un-enhanceable link",
         link.dataset.addListing,
@@ -484,12 +484,13 @@ const init = (): void => {
         controller.add(entry, parseAddQuantity(link.dataset.addQuantity));
         return;
       }
-      // A package books as a whole bundle: navigate straight to its page rather
-      // than adding a cart line it could never combine with other listings.
-      const packageSlug = resolvePackageSlug(current);
-      if (packageSlug) {
+      // A group (regular gallery or package bundle) is reached via its own page:
+      // navigate straight there rather than adding a cart line it could never
+      // combine with the standalone listings.
+      const groupSlug = resolveGroupSlug(current);
+      if (groupSlug) {
         event.preventDefault();
-        globalThis.location.assign(`${CATALOG.origin}/ticket/${packageSlug}`);
+        globalThis.location.assign(`${CATALOG.origin}/ticket/${groupSlug}`);
       }
     });
   };

--- a/test/lib/order-js.test.ts
+++ b/test/lib/order-js.test.ts
@@ -72,7 +72,7 @@ describeWithEnv("order.js handler", { db: true, triggers: true }, () => {
     expect(body).not.toContain(memberSlug);
   });
 
-  test("advertises a bookable package's bundle slug in the catalog packages", async () => {
+  test("advertises a bookable package's bundle slug in the catalog groups", async () => {
     await settings.update.externalOrderEnabled(true);
     const group = await createTestGroup({
       isPackage: true,
@@ -83,9 +83,26 @@ describeWithEnv("order.js handler", { db: true, triggers: true }, () => {
 
     const body = await (await orderJs()).text();
     // The bundle is bookable via /ticket/<group>, so its slug rides in the
-    // packages map even though it's not a listing cart line.
-    expect(body).toContain('"packages"');
+    // groups map even though it's not a listing cart line.
+    expect(body).toContain('"groups"');
     expect(body).toContain('"camp-bundle"');
+  });
+
+  test("advertises a bookable REGULAR group's slug in the catalog groups", async () => {
+    await settings.update.externalOrderEnabled(true);
+    // A non-package group is reached via its own /ticket/<group> page too, so a
+    // public one with a bookable member must ride in the groups map — not just
+    // packages (the previous behaviour silently dropped it).
+    const group = await createTestGroup({
+      isPackage: false,
+      name: "Registration",
+      slug: "register",
+    });
+    await createTestListing({ groupId: group.id, name: "Adult Ticket" });
+
+    const body = await (await orderJs()).text();
+    expect(body).toContain('"groups"');
+    expect(body).toContain('"register"');
   });
 
   test("a hidden package's bundle is still bookable from the widget", async () => {

--- a/test/lib/order-widget.test.ts
+++ b/test/lib/order-widget.test.ts
@@ -38,12 +38,17 @@ const runnableBody = orderWidgetBody().replace(
   `;globalThis.${MODULE_MARKER}=$1;`,
 );
 
-const makeCatalog = (listings: CatalogSourceListing[], debug: boolean) =>
+const makeCatalog = (
+  listings: CatalogSourceListing[],
+  debug: boolean,
+  groups: { slug: string; name: string }[] = [],
+) =>
   buildCatalog({
     currency: "GBP",
     debug,
     decimalPlaces: 2,
     generatedAt: "2026-06-30T00:00:00Z",
+    groups,
     listings,
     origin: ORIGIN,
   });
@@ -330,7 +335,7 @@ describe("order widget", {
       "- not a valid URL",
       `- origin https://elsewhere.test is not the tickets origin ${ORIGIN}`,
       "- path /not-a-ticket is not a /ticket/<slug> URL",
-      `- slug "register" is not a known listing or package`,
+      `- slug "register" is not a known listing or group`,
     ]);
   });
 
@@ -339,6 +344,28 @@ describe("order widget", {
     clickAnchor(h, "open");
 
     expect(h.logs).toHaveLength(0);
+  });
+
+  test("navigates to a group page instead of adding a cart line", () => {
+    // A regular group (like a package) is booked via its own /ticket/<slug>
+    // page, so a link to it is enhanced to navigate straight there rather than
+    // joining the multi-listing cart.
+    setBody(h, `<a data-add-listing="${ORIGIN}/ticket/register">Register</a>`);
+    h.run(
+      makeCatalog([listing({ id: 1, slug: "open" })], false, [
+        { name: "Registration", slug: "register" },
+      ]),
+    );
+
+    const anchor = h.document.querySelector(
+      `a[data-add-listing="${ORIGIN}/ticket/register"]`,
+    );
+    expect(anchor?.getAttribute("data-chobble-enhanced")).toBe("1");
+    const prevented = clickAnchor(h, "register");
+    expect(prevented).toBe(true);
+    expect(h.navigations).toEqual([`${ORIGIN}/ticket/register`]);
+    // Navigating to the group page must not add a cart line.
+    expect(storedCart(h)).toEqual([]);
   });
 
   test("adding a listing reveals the cart button with a live count", () => {

--- a/test/shared/external-order.test.ts
+++ b/test/shared/external-order.test.ts
@@ -135,25 +135,25 @@ describe("external-order", () => {
       ).toBe(false);
     });
 
-    test("keys package bundles by slug, separate from listings", () => {
+    test("keys groups by slug, separate from listings", () => {
       const catalog = buildCatalog({
         ...base,
-        listings: [testListing({ id: 1, name: "Solo", slug: "solo" })],
-        packages: [
+        groups: [
           { name: "Camp Bundle", slug: "camp" },
-          { name: "Beach Bundle", slug: "beach" },
+          { name: "Registration", slug: "register" },
         ],
+        listings: [testListing({ id: 1, name: "Solo", slug: "solo" })],
       });
       expect(Object.keys(catalog.listings)).toEqual(["solo"]);
-      expect(catalog.packages).toEqual({
-        beach: { name: "Beach Bundle", slug: "beach" },
+      expect(catalog.groups).toEqual({
         camp: { name: "Camp Bundle", slug: "camp" },
+        register: { name: "Registration", slug: "register" },
       });
     });
 
-    test("defaults packages to an empty object when none are given", () => {
+    test("defaults groups to an empty object when none are given", () => {
       const catalog = buildCatalog({ ...base, listings: [] });
-      expect(catalog.packages).toEqual({});
+      expect(catalog.groups).toEqual({});
     });
   });
 


### PR DESCRIPTION
## What

`register` is a public **group**, not a package — and the `/order.js` widget only treated **package** groups as navigable `/ticket/<slug>` targets. A `data-add-listing` link to a regular public group was logged as "un-enhanceable" and never intercepted, even though clicking it should take the visitor to that group's page (exactly like a package bundle does).

A regular group and a package bundle both:
- are reached via their own `/ticket/<group>` page,
- never join the multi-listing cart,
- carry no price in the catalog.

So they belong in one navigable-group set rather than packages-only.

## How

- **`external-order.ts`** — renamed the catalog's `packages` field/type to `groups` (`CatalogGroup`), covering regular groups and package bundles alike.
- **`order-js.ts`** — include every public bookable group from `loadPublicGroups()` in the catalog instead of filtering to `is_package`. (`loadPublicGroups` already gates to non-hidden groups whose page can actually sell, so no dead links.)
- **`order.ts` (widget)** — renamed `resolvePackageSlug` → `resolveGroupSlug` (reads `CATALOG.groups`); the skip-reason message now ends "not a known listing or **group**".

This scope is limited to the external-order surface; the unrelated domain-wide `packages`/`is_package` concept is untouched.

## Testing

- New widget test: a link to a public regular group is enhanced and navigates straight to its `/ticket/<slug>` page without adding a cart line.
- New `order.js` test: a bookable regular (non-package) group's slug is advertised in the catalog `groups`.
- Updated existing catalog/handler tests for the `packages` → `groups` rename.
- `deno test` on the affected suites, `deno check`, and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnpzQorZq2CqAvBjgr8qSt)_