### PR TITLE
Add mutation-hardened unit tests for listing-filter

### DIFF
--- a/test/lib/listing-filter.test.ts
+++ b/test/lib/listing-filter.test.ts
@@ -1,0 +1,210 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  filterListingsByType,
+  isListingFilter,
+  LISTING_FILTERS,
+  type ListingFilter,
+  listingCategory,
+  listingFilterLabel,
+  listingTypeFromRequest,
+  renderTypeFilter,
+} from "#shared/listing-filter.ts";
+import type { ListingType } from "#shared/types.ts";
+
+/** A minimal listing shape carrying only the two fields the categoriser reads. */
+const listing = (
+  purchase_only: boolean,
+  listing_type: ListingType,
+): { purchase_only: boolean; listing_type: ListingType } => ({
+  listing_type,
+  purchase_only,
+});
+
+const requestForType = (type: string | null): Request =>
+  new Request(
+    type === null
+      ? "http://localhost/admin/listings"
+      : `http://localhost/admin/listings?type=${encodeURIComponent(type)}`,
+  );
+
+describe("LISTING_FILTERS", () => {
+  test("lists all four filter values in canonical order", () => {
+    expect(LISTING_FILTERS).toEqual([
+      "all",
+      "standard",
+      "daily",
+      "purchase-only",
+    ]);
+  });
+});
+
+describe("listingFilterLabel", () => {
+  test("maps each filter value to its exact human label", () => {
+    expect(listingFilterLabel("all")).toBe("All");
+    expect(listingFilterLabel("standard")).toBe("Standard");
+    expect(listingFilterLabel("daily")).toBe("Daily");
+    expect(listingFilterLabel("purchase-only")).toBe("No Check-In");
+  });
+});
+
+describe("isListingFilter", () => {
+  test("accepts each valid filter value", () => {
+    for (const f of LISTING_FILTERS) {
+      expect(isListingFilter(f)).toBe(true);
+    }
+  });
+
+  test("rejects a non-filter string", () => {
+    expect(isListingFilter("weekly")).toBe(false);
+    expect(isListingFilter("")).toBe(false);
+    expect(isListingFilter("ALL")).toBe(false);
+  });
+
+  test("rejects null", () => {
+    expect(isListingFilter(null)).toBe(false);
+  });
+});
+
+describe("listingTypeFromRequest", () => {
+  test("returns the ?type= value when it is a valid filter", () => {
+    expect(listingTypeFromRequest(requestForType("daily"))).toBe("daily");
+    expect(listingTypeFromRequest(requestForType("standard"))).toBe("standard");
+    expect(listingTypeFromRequest(requestForType("purchase-only"))).toBe(
+      "purchase-only",
+    );
+    expect(listingTypeFromRequest(requestForType("all"))).toBe("all");
+  });
+
+  test("defaults to 'all' when ?type= is an unknown value", () => {
+    expect(listingTypeFromRequest(requestForType("weekly"))).toBe("all");
+  });
+
+  test("defaults to 'all' when ?type= is absent", () => {
+    expect(listingTypeFromRequest(requestForType(null))).toBe("all");
+  });
+});
+
+describe("listingCategory", () => {
+  test("is 'purchase-only' whenever purchase_only is set, regardless of type", () => {
+    expect(listingCategory(listing(true, "standard"))).toBe("purchase-only");
+    expect(listingCategory(listing(true, "daily"))).toBe("purchase-only");
+  });
+
+  test("is 'daily' for a non-purchase daily listing", () => {
+    expect(listingCategory(listing(false, "daily"))).toBe("daily");
+  });
+
+  test("is 'standard' for a non-purchase standard listing", () => {
+    expect(listingCategory(listing(false, "standard"))).toBe("standard");
+  });
+});
+
+describe("filterListingsByType", () => {
+  const listings = [
+    listing(false, "standard"),
+    listing(false, "daily"),
+    listing(true, "standard"),
+  ];
+
+  test("'all' passes every listing through", () => {
+    expect(filterListingsByType("all")(listings)).toEqual(listings);
+  });
+
+  test("'all' returns a fresh array, not the input reference", () => {
+    const result = filterListingsByType("all")(listings);
+    expect(result).not.toBe(listings);
+  });
+
+  test("'standard' keeps only non-purchase standard listings", () => {
+    expect(filterListingsByType("standard")(listings)).toEqual([
+      listing(false, "standard"),
+    ]);
+  });
+
+  test("'daily' keeps only non-purchase daily listings", () => {
+    expect(filterListingsByType("daily")(listings)).toEqual([
+      listing(false, "daily"),
+    ]);
+  });
+
+  test("'purchase-only' keeps only purchase-only listings", () => {
+    expect(filterListingsByType("purchase-only")(listings)).toEqual([
+      listing(true, "standard"),
+    ]);
+  });
+});
+
+describe("renderTypeFilter", () => {
+  const href = (f: ListingFilter): string => `/admin/listings?type=${f}`;
+
+  test("renders 'all' plus only the present categories, in canonical order", () => {
+    const html = renderTypeFilter("all", ["daily", "standard"], href);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: ' +
+        "<strong><u>All</u></strong>" +
+        ' / <a href="/admin/listings?type=standard">Standard</a>' +
+        ' / <a href="/admin/listings?type=daily">Daily</a>' +
+        "</div>",
+    );
+  });
+
+  test("bolds the active option and links the rest via hrefFor", () => {
+    const html = renderTypeFilter("daily", ["standard", "daily"], href);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: ' +
+        '<a href="/admin/listings?type=all">All</a>' +
+        ' / <a href="/admin/listings?type=standard">Standard</a>' +
+        " / <strong><u>Daily</u></strong>" +
+        "</div>",
+    );
+  });
+
+  test("omits categories that are not present", () => {
+    const html = renderTypeFilter("all", ["standard"], href);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: ' +
+        "<strong><u>All</u></strong>" +
+        ' / <a href="/admin/listings?type=standard">Standard</a>' +
+        "</div>",
+    );
+    expect(html).not.toContain("Daily");
+    expect(html).not.toContain("No Check-In");
+  });
+
+  test("does not duplicate 'All' when 'all' is itself passed in categories", () => {
+    const html = renderTypeFilter("standard", ["all", "standard"], href);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: ' +
+        '<a href="/admin/listings?type=all">All</a>' +
+        " / <strong><u>Standard</u></strong>" +
+        "</div>",
+    );
+    // The leading "all" option must appear exactly once, never echoed by the
+    // categories list — this is what the `f !== "all"` guard protects.
+    expect(html.match(/type=all/g)).toHaveLength(1);
+  });
+
+  test("offers only 'All' when no categories are present", () => {
+    const html = renderTypeFilter("all", [], href);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: <strong><u>All</u></strong></div>',
+    );
+  });
+
+  test("renders all four options with 'purchase-only' labelled 'No Check-In'", () => {
+    const html = renderTypeFilter(
+      "purchase-only",
+      ["standard", "daily", "purchase-only"],
+      href,
+    );
+    expect(html).toBe(
+      '<div class="table-actions">Showing: ' +
+        '<a href="/admin/listings?type=all">All</a>' +
+        ' / <a href="/admin/listings?type=standard">Standard</a>' +
+        ' / <a href="/admin/listings?type=daily">Daily</a>' +
+        " / <strong><u>No Check-In</u></strong>" +
+        "</div>",
+    );
+  });
+});


### PR DESCRIPTION
## What

`src/shared/listing-filter.ts` had 100% incidental coverage from integration tests but **no direct unit test**, leaving its logic unguarded against regressions. Running the mutation tester against it confirmed the gap — many operators/branches survived because no test asserted the module's behaviour directly.

This PR adds `test/lib/listing-filter.test.ts`, a pure unit test covering every export with mutation-resistant assertions.

## Coverage

- **`LISTING_FILTERS` / `listingFilterLabel`** — exact filter values, order, and human labels (incl. `purchase-only` → `"No Check-In"`).
- **`isListingFilter`** — accepts each valid value; rejects unknown strings, `""`, wrong-case, and `null`.
- **`listingTypeFromRequest`** — returns the `?type=` value when valid; defaults to `"all"` for unknown and absent params.
- **`listingCategory`** — `purchase_only` takes precedence over `daily`/`standard`; correct category for each non-purchase type.
- **`filterListingsByType`** — per-category filtering; `"all"` passes everything through as a fresh array (not the input reference).
- **`renderTypeFilter`** — exact rendered markup for active bolding, `hrefFor` links, category presence/absence, the empty-categories case, and the `f !== "all"` dedup guard (verified by passing `"all"` inside `categories` and asserting it appears exactly once).

## Verification

```
deno task mutation src/shared/listing-filter.ts test/lib/listing-filter.test.ts
# 100.0%  (33/33 killed) — the mode the precommit gate uses

deno task mutation src/shared/listing-filter.ts test/lib/listing-filter.test.ts --exhaustive
# 100.0%  (68/68 detected)
```

Under `--exhaustive` the only 6 survivors are provably-equivalent mutants (`===`↔`==` / `!==`↔`!=` over operands that are always the same string type — `ListingFilter`/`ListingType`/`string|null`), which no test can kill; they are not generated in the default (precommit) mode.

`lint:ci`, `typecheck`, `cpd`, and `build:edge` all pass. The full `test:coverage` step could not run in this environment because the test harness downloads `stripe-mock` from `github.com/stripe/stripe-mock`, which is outside this session's GitHub egress scope (403) — unrelated to this change; the new test is a pure unit test needing neither the app nor Stripe and passes standalone.

## Notes

Test-only change — no production source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC

---
_Generated by [Claude Code](https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC)_