### PR TITLE
Unify QR and balance signed tokens onto a defineSignedToken factory

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -18,6 +18,8 @@
 src/shared/checkout-pricing.ts:85:35  ?? → ||    # Map<number,number> sum: 0 ?? 0 === 0 || 0
 src/shared/checkout-pricing.ts:334:41  ?? → ||   # intent.modifiers: an array is always truthy
 src/shared/logistics-filter.ts:22:35  ?? → ||    # raw: string|null, only falsy string "" === fallback ""
+src/shared/qr-token.ts:60:18  ?? → ||    # input.date?: string, only falsy string "" === fallback ""
+src/shared/qr-token.ts:62:18  ?? → ||    # input.name?: string, only falsy string "" === fallback ""
 src/shared/site-assignment.ts:192:57  ?? → ||    # parseReadOnlyFromMs(): number|null, 0 ?? 0 === 0 || 0
 src/shared/site-assignment.ts:370:34  ?? → ||    # available[idx]: object|undefined, never falsy non-null
 src/shared/site-assignment.ts:392:34  ?? → ||    # getEmailConfig(): EmailConfig|null

--- a/src/shared/balance-link.ts
+++ b/src/shared/balance-link.ts
@@ -9,21 +9,8 @@
  * Format: bal1.{payloadB64url}.{hmacB64url}  ·  HMAC input: "balance:{payload}"
  */
 
-// jscpd:ignore-start
-import {
-  buildSignedToken,
-  decodeTokenPayload,
-  encodeTokenPayload,
-  isExpiredNow,
-  isTokenObject,
-  verifySignedToken,
-} from "#shared/crypto/signed-token.ts";
+import { defineSignedToken } from "#shared/crypto/define-signed-token.ts";
 import { nowMs } from "#shared/now.ts";
-
-// jscpd:ignore-end
-
-const PREFIX = "bal1.";
-const DOMAIN = "balance:";
 
 /** Balance links last 90 days — long enough to be a "pay when you can" link. */
 export const BALANCE_LINK_MAX_AGE_S = 90 * 24 * 60 * 60;
@@ -36,7 +23,16 @@ export type BalancePayload = {
   e: number;
 };
 
-const buildMessage = (encoded: string): string => `${DOMAIN}${encoded}`;
+/** The balance scheme: the HMAC message is bound to the payload alone. */
+const balanceToken = defineSignedToken<BalancePayload, void>({
+  maxAgeS: BALANCE_LINK_MAX_AGE_S,
+  message: (_context, encoded) => `balance:${encoded}`,
+  parse: (parsed) =>
+    typeof parsed.a === "number" && typeof parsed.e === "number"
+      ? (parsed as unknown as BalancePayload)
+      : null,
+  prefix: "bal1.",
+});
 
 /**
  * Sign a balance-payment token for an attendee. Returns "bal1.{payload}.{hmac}".
@@ -44,36 +40,16 @@ const buildMessage = (encoded: string): string => `${DOMAIN}${encoded}`;
 export const signBalanceToken = (
   attendeeId: number,
   maxAgeSeconds: number = BALANCE_LINK_MAX_AGE_S,
-): Promise<string> => {
-  const payload: BalancePayload = {
+): Promise<string> =>
+  balanceToken.sign(undefined, {
     a: attendeeId,
     e: Math.floor(nowMs() / 1000) + maxAgeSeconds,
-  };
-  const encoded = encodeTokenPayload(payload);
-  return buildSignedToken(PREFIX, encoded, buildMessage(encoded));
-};
+  });
 
 /**
  * Verify a balance-payment token: prefix, HMAC signature, expiry and
  * clock-skew bounds. Returns the payload on success, or null on any failure.
  */
-export const verifyBalanceToken = async (
+export const verifyBalanceToken = (
   token: string,
-): Promise<BalancePayload | null> => {
-  const encoded = await verifySignedToken(PREFIX, token, buildMessage);
-  if (encoded === null) return null;
-
-  const parsed = decodeTokenPayload(encoded);
-  if (
-    !isTokenObject(parsed) ||
-    typeof parsed.a !== "number" ||
-    typeof parsed.e !== "number"
-  ) {
-    return null;
-  }
-  const payload = parsed as unknown as BalancePayload;
-
-  if (isExpiredNow(payload.e, BALANCE_LINK_MAX_AGE_S)) return null;
-
-  return payload;
-};
+): Promise<BalancePayload | null> => balanceToken.verify(undefined, token);

--- a/src/shared/crypto/define-signed-token.ts
+++ b/src/shared/crypto/define-signed-token.ts
@@ -1,0 +1,89 @@
+/**
+ * Factory for the app's signed-token schemes. A scheme is `{ sign, verify }`
+ * over the primitives in `signed-token.ts`: the QR booking links and the
+ * balance-payment links are both instances of it. The factory owns the shared
+ * skeleton — encode → HMAC → prefix on the way out, and prefix → HMAC →
+ * decode → structural-check → expiry on the way back — so a scheme only
+ * declares what actually differs: its prefix, lifetime, HMAC message, and the
+ * structural guard for its payload.
+ */
+
+import {
+  buildSignedToken,
+  decodeTokenPayload,
+  encodeTokenPayload,
+  isExpiredNow,
+  isTokenObject,
+  verifySignedToken,
+} from "#shared/crypto/signed-token.ts";
+
+/** Every signed-token payload carries its expiry as unix seconds. */
+export type ExpiringPayload = { e: number };
+
+/**
+ * The parts of a signed-token scheme that differ between token types.
+ *
+ * `Context` is any extra key the HMAC message is bound to beyond the payload
+ * itself — a listing slug for QR tokens, nothing (`void`) for balance tokens.
+ */
+export type SignedTokenScheme<Payload extends ExpiringPayload, Context> = {
+  /** Token prefix, e.g. `"qr1."`. Namespaces one scheme's signatures from the
+   * next so a token from one type can never verify as another. */
+  prefix: string;
+  /** Maximum token lifetime in seconds; bounds the accepted expiry on verify. */
+  maxAgeS: number;
+  /** Domain-separated HMAC input derived from the caller's context and the
+   * base64url-encoded payload. */
+  message: (context: Context, encoded: string) => string;
+  /** Structural guard: narrow a decoded object to `Payload`, or `null` when it
+   * does not match the expected shape. */
+  parse: (raw: Record<string, unknown>) => Payload | null;
+};
+
+/** A `{ sign, verify }` pair produced by {@link defineSignedToken}. */
+export type SignedToken<Payload extends ExpiringPayload, Context> = {
+  sign: (context: Context, payload: Payload) => Promise<string>;
+  verify: (context: Context, token: string) => Promise<Payload | null>;
+};
+
+/**
+ * Build the `{ sign, verify }` pair for one signed-token scheme.
+ *
+ * `sign` encodes the payload and appends an HMAC over the scheme's message.
+ * `verify` checks the prefix and HMAC, decodes the payload, runs the scheme's
+ * structural guard, and enforces the expiry/clock-skew bounds — returning the
+ * typed payload on success or `null` on any failure.
+ */
+export const defineSignedToken = <Payload extends ExpiringPayload, Context>(
+  scheme: SignedTokenScheme<Payload, Context>,
+): SignedToken<Payload, Context> => {
+  const sign = (context: Context, payload: Payload): Promise<string> => {
+    const encoded = encodeTokenPayload(payload);
+    return buildSignedToken(
+      scheme.prefix,
+      encoded,
+      scheme.message(context, encoded),
+    );
+  };
+
+  const verify = async (
+    context: Context,
+    token: string,
+  ): Promise<Payload | null> => {
+    const encoded = await verifySignedToken(scheme.prefix, token, (e) =>
+      scheme.message(context, e),
+    );
+    if (encoded === null) return null;
+
+    const parsed = decodeTokenPayload(encoded);
+    if (!isTokenObject(parsed)) return null;
+
+    const payload = scheme.parse(parsed);
+    if (!payload) return null;
+
+    if (isExpiredNow(payload.e, scheme.maxAgeS)) return null;
+    return payload;
+  };
+
+  return { sign, verify };
+};

--- a/src/shared/qr-token.ts
+++ b/src/shared/qr-token.ts
@@ -9,21 +9,8 @@
  * HMAC input: "qr-book:{slug}:{payloadB64url}"
  */
 
-// jscpd:ignore-start
-import {
-  buildSignedToken,
-  decodeTokenPayload,
-  encodeTokenPayload,
-  isExpiredNow,
-  isTokenObject,
-  verifySignedToken,
-} from "#shared/crypto/signed-token.ts";
+import { defineSignedToken } from "#shared/crypto/define-signed-token.ts";
 import { nowMs } from "#shared/now.ts";
-
-// jscpd:ignore-end
-
-const PREFIX = "qr1.";
-const DOMAIN = "qr-book:";
 
 /** QR token expiry in seconds from generation */
 export const QR_TOKEN_MAX_AGE_S = 300;
@@ -42,25 +29,20 @@ export type QrBookPayload = {
   e: number;
 };
 
-/** Decode payload JSON from base64url. Returns null on any decode failure. */
-const decodePayload = (encoded: string): QrBookPayload | null => {
-  const parsed = decodeTokenPayload(encoded);
-  if (
-    !isTokenObject(parsed) ||
-    typeof parsed.n !== "string" ||
-    typeof parsed.v !== "number" ||
-    typeof parsed.q !== "number" ||
-    typeof parsed.d !== "string" ||
-    typeof parsed.e !== "number"
-  ) {
-    return null;
-  }
-  return parsed as unknown as QrBookPayload;
-};
-
-/** Build the domain-separated HMAC input for a token */
-const buildMessage = (slug: string, encodedPayload: string): string =>
-  `${DOMAIN}${slug}:${encodedPayload}`;
+/** The QR scheme: HMAC message is keyed by the listing slug. */
+const qrToken = defineSignedToken<QrBookPayload, string>({
+  maxAgeS: QR_TOKEN_MAX_AGE_S,
+  message: (slug, encoded) => `qr-book:${slug}:${encoded}`,
+  parse: (parsed) =>
+    typeof parsed.n === "string" &&
+    typeof parsed.v === "number" &&
+    typeof parsed.q === "number" &&
+    typeof parsed.d === "string" &&
+    typeof parsed.e === "number"
+      ? (parsed as unknown as QrBookPayload)
+      : null,
+  prefix: "qr1.",
+});
 
 /**
  * Build a payload ready for signing.
@@ -90,29 +72,14 @@ export const buildQrBookPayload = (input: {
 export const signQrBookToken = (
   slug: string,
   payload: QrBookPayload,
-): Promise<string> => {
-  const encoded = encodeTokenPayload(payload);
-  return buildSignedToken(PREFIX, encoded, buildMessage(slug, encoded));
-};
+): Promise<string> => qrToken.sign(slug, payload);
 
 /**
  * Verify a QR booking token for the given listing slug.
  * Checks the prefix, HMAC signature, expiry, and clock-skew bounds.
  * Returns the decoded payload on success, or null on any failure.
  */
-export const verifyQrBookToken = async (
+export const verifyQrBookToken = (
   slug: string,
   token: string,
-): Promise<QrBookPayload | null> => {
-  const encoded = await verifySignedToken(PREFIX, token, (e) =>
-    buildMessage(slug, e),
-  );
-  if (encoded === null) return null;
-
-  const payload = decodePayload(encoded);
-  if (!payload) return null;
-
-  if (isExpiredNow(payload.e, QR_TOKEN_MAX_AGE_S)) return null;
-
-  return payload;
-};
+): Promise<QrBookPayload | null> => qrToken.verify(slug, token);

--- a/test/lib/balance-link.test.ts
+++ b/test/lib/balance-link.test.ts
@@ -96,4 +96,18 @@ describe("balance-link", () => {
     const token = await signBalanceToken(42, BALANCE_LINK_MAX_AGE_S + 1000);
     expect(await verifyBalanceToken(token)).toBeNull();
   });
+
+  test("does not verify a token minted by a different scheme", async () => {
+    // Balance and QR tokens are built on the same signed-token factory; the
+    // distinct prefix and HMAC domain keep them isolated, so a QR token must
+    // never pass as a balance token even though the signing machinery is shared.
+    const { buildQrBookPayload, signQrBookToken } = await import(
+      "#shared/qr-token.ts"
+    );
+    const qrToken = await signQrBookToken(
+      "listing",
+      buildQrBookPayload({ name: "Ada" }),
+    );
+    expect(await verifyBalanceToken(qrToken)).toBeNull();
+  });
 });

--- a/test/lib/define-signed-token.test.ts
+++ b/test/lib/define-signed-token.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import {
+  defineSignedToken,
+  type ExpiringPayload,
+} from "#shared/crypto/define-signed-token.ts";
+import {
+  buildSignedToken,
+  encodeTokenPayload,
+} from "#shared/crypto/signed-token.ts";
+import { setupTestEncryptionKey } from "#test-utils";
+
+// A minimal scheme exercising the factory directly: the payload has one extra
+// field beyond the expiry, and the HMAC message is keyed by a string context so
+// the context-binding branch is covered independently of the real token types.
+type ToyPayload = ExpiringPayload & { x: number };
+
+const MAX_AGE_S = 100;
+
+const toy = defineSignedToken<ToyPayload, string>({
+  maxAgeS: MAX_AGE_S,
+  message: (context, encoded) => `toy:${context}:${encoded}`,
+  parse: (parsed) =>
+    typeof parsed.x === "number" && typeof parsed.e === "number"
+      ? (parsed as unknown as ToyPayload)
+      : null,
+  prefix: "toy1.",
+});
+
+const nowS = (): number => Math.floor(Date.now() / 1000);
+
+// Forge a correctly-signed token wrapping an arbitrary payload for the toy
+// scheme's context, so shape/expiry checks run with a passing signature.
+const forge = (context: string, payload: unknown): Promise<string> => {
+  const encoded = encodeTokenPayload(payload);
+  return buildSignedToken("toy1.", encoded, `toy:${context}:${encoded}`);
+};
+
+describe("defineSignedToken", () => {
+  beforeAll(() => {
+    setupTestEncryptionKey();
+  });
+
+  test("signs a token with the scheme prefix", async () => {
+    const token = await toy.sign("ctx", { e: nowS() + 50, x: 7 });
+    expect(token.startsWith("toy1.")).toBe(true);
+  });
+
+  test("verifies a token it signed, returning the typed payload", async () => {
+    const token = await toy.sign("ctx", { e: nowS() + 50, x: 7 });
+    const payload = await toy.verify("ctx", token);
+    expect(payload).toEqual({ e: expect.any(Number), x: 7 });
+  });
+
+  test("rejects a token verified under a different context", async () => {
+    // The context is bound into the HMAC message, so a token minted for one
+    // context must not verify for another even with an untouched signature.
+    const token = await toy.sign("ctx-a", { e: nowS() + 50, x: 7 });
+    expect(await toy.verify("ctx-b", token)).toBeNull();
+  });
+
+  test("rejects a token without the scheme prefix", async () => {
+    expect(await toy.verify("ctx", "other1.abc.def")).toBeNull();
+  });
+
+  test("rejects a token with a tampered signature", async () => {
+    const token = await toy.sign("ctx", { e: nowS() + 50, x: 7 });
+    const [, encoded] = token.split(".");
+    expect(await toy.verify("ctx", `toy1.${encoded}.deadbeef`)).toBeNull();
+  });
+
+  test("rejects a correctly-signed payload that is not an object", async () => {
+    const token = await forge("ctx", 42);
+    expect(await toy.verify("ctx", token)).toBeNull();
+  });
+
+  test("rejects a correctly-signed payload of the wrong shape", async () => {
+    // Valid HMAC and a valid expiry, but the required `x` field is missing, so
+    // the scheme's structural guard must reject before the expiry check.
+    const token = await forge("ctx", { e: nowS() + 50 });
+    expect(await toy.verify("ctx", token)).toBeNull();
+  });
+
+  test("rejects an expired token", async () => {
+    // Signature and shape are valid; only the expiry is in the past.
+    const token = await toy.sign("ctx", { e: nowS() - 10, x: 7 });
+    expect(await toy.verify("ctx", token)).toBeNull();
+  });
+
+  test("rejects a token dated implausibly far in the future", async () => {
+    const token = await toy.sign("ctx", { e: nowS() + MAX_AGE_S + 1000, x: 7 });
+    expect(await toy.verify("ctx", token)).toBeNull();
+  });
+});

--- a/test/lib/qr-token.test.ts
+++ b/test/lib/qr-token.test.ts
@@ -54,6 +54,26 @@ describe("qr-token", () => {
       expect(payload.q).toBe(3);
       expect(payload.d).toBe("2026-05-01");
     });
+
+    test("keeps an explicit zero price instead of the not-provided sentinel", () => {
+      // A free QR booking passes value 0; the ?? default must not treat that
+      // falsy-but-provided price as "not supplied" and overwrite it with -1.
+      expect(buildQrBookPayload({ value: 0 }).v).toBe(0);
+    });
+
+    test("keeps an explicit zero quantity instead of defaulting to 1", () => {
+      // Quantity 0 is falsy but supplied; it must survive rather than snap to 1.
+      expect(buildQrBookPayload({ quantity: 0 }).q).toBe(0);
+    });
+
+    test("honours an explicit zero max age when computing the expiry", () => {
+      // maxAgeSeconds 0 is falsy but supplied, so the expiry is exactly now —
+      // it must not fall back to the 300s default.
+      const nowS = Math.floor(Date.now() / 1000);
+      const payload = buildQrBookPayload({ maxAgeSeconds: 0 });
+      expect(payload.e).toBeGreaterThanOrEqual(nowS - 2);
+      expect(payload.e).toBeLessThanOrEqual(nowS + 2);
+    });
   });
 
   describe("signQrBookToken", () => {
@@ -207,6 +227,70 @@ describe("qr-token", () => {
       expect(await verifyQrBookToken("listing", `qr1.${encoded}.${hmac}`)).toBe(
         null,
       );
+    });
+
+    // Forge a correctly-signed "qr1." token wrapping an arbitrary payload, so
+    // the shape guard runs with a signature that already passes. Each field is
+    // validated independently: a token valid in every field but one must still
+    // be rejected, so no single field's type check can be dropped.
+    const forgeQrToken = async (
+      slug: string,
+      payload: unknown,
+    ): Promise<string> => {
+      const encoded = base64ToBase64Url(
+        toBase64(new TextEncoder().encode(JSON.stringify(payload))),
+      );
+      const hmac = base64ToBase64Url(
+        await hmacHash(`qr-book:${slug}:${encoded}`),
+      );
+      return `qr1.${encoded}.${hmac}`;
+    };
+
+    const validExpiry = (): number =>
+      Math.floor(Date.now() / 1000) + QR_TOKEN_MAX_AGE_S - 10;
+
+    test("rejects a signed payload whose name is not a string", async () => {
+      const token = await forgeQrToken("listing", {
+        d: "",
+        e: validExpiry(),
+        n: 1,
+        q: 1,
+        v: 1,
+      });
+      expect(await verifyQrBookToken("listing", token)).toBeNull();
+    });
+
+    test("rejects a signed payload whose value is not a number", async () => {
+      const token = await forgeQrToken("listing", {
+        d: "",
+        e: validExpiry(),
+        n: "",
+        q: 1,
+        v: "1",
+      });
+      expect(await verifyQrBookToken("listing", token)).toBeNull();
+    });
+
+    test("rejects a signed payload whose quantity is not a number", async () => {
+      const token = await forgeQrToken("listing", {
+        d: "",
+        e: validExpiry(),
+        n: "",
+        q: "1",
+        v: 1,
+      });
+      expect(await verifyQrBookToken("listing", token)).toBeNull();
+    });
+
+    test("rejects a signed payload whose date is not a string", async () => {
+      const token = await forgeQrToken("listing", {
+        d: 5,
+        e: validExpiry(),
+        n: "",
+        q: 1,
+        v: 1,
+      });
+      expect(await verifyQrBookToken("listing", token)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## What & why

`qr-token.ts` and `balance-link.ts` were two parallel implementations of the **same signed-token skeleton** over the `crypto/signed-token.ts` primitives:

- **sign:** encode payload → HMAC over a domain-separated message → prefix
- **verify:** check prefix + HMAC → decode → structural type-guard → expiry/clock-skew bound

The two `verify` functions were line-for-line the same control flow, and both files even carried `jscpd:ignore` blocks around an *identical* six-line import list — an explicit acknowledgement that they duplicated each other.

This collapses the shared skeleton into a single **`defineSignedToken(scheme)`** factory (the house "config in, `{ sign, verify }` out" idiom, alongside `defineTable`/`defineForm`/`defineResource`). A scheme now declares only what actually differs:

| | QR booking token | Balance-payment token |
|---|---|---|
| prefix | `qr1.` | `bal1.` |
| HMAC message | keyed by the listing **slug** | bound to the payload alone |
| payload guard | 5-field shape | 2-field shape |
| lifetime | 300 s | 90 days |

Both modules keep every public export and signature unchanged (thin wrappers delegate to the factory), so no caller changes. Both `jscpd:ignore` import blocks are gone.

## Changes

- **`src/shared/crypto/define-signed-token.ts`** (new) — the `defineSignedToken` factory + `ExpiringPayload`/`SignedTokenScheme`/`SignedToken` types.
- **`src/shared/qr-token.ts`** / **`src/shared/balance-link.ts`** — re-expressed as thin scheme declarations + wrappers over the factory (net −91 lines across the two + factory).
- **`test/lib/define-signed-token.test.ts`** (new) — exercises the factory directly with a toy scheme (100% mutant kill).
- **`test/lib/qr-token.test.ts`** — strengthened to lock the per-field shape guard (each field wrong in isolation) and the falsy-value payload defaults (`value`/`quantity`/`maxAge` of `0`).
- **`test/lib/balance-link.test.ts`** — added a cross-scheme isolation test: a QR token must never verify as a balance token despite sharing the factory.
- **`scripts/mutation/equivalent-mutants.txt`** — recorded the two provably-equivalent `?? "" ≡ || ""` string-default mutants (same pattern as the existing `logistics-filter.ts` entry).

## Verification

- `deno task lint`, `typecheck`, `cpd` (0% — both `jscpd:ignore` blocks removed), `build:edge` — all green.
- The three affected test files pass.
- `deno task mutation` over all three changed src files against all three changed tests: **100%** (58 mutants, 56 killed, 2 known-equivalent suppressed) — matching what the precommit mutation gate runs.
- The full `test:coverage` suite could not run in this sandbox (the `stripe-mock` binary download is blocked by the environment's network policy); it exercises no code on this change's path and runs normally in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW)_