### PR TITLE
Add mutation-hardened unit tests for filter-bar

### DIFF
--- a/test/lib/filter-bar.test.ts
+++ b/test/lib/filter-bar.test.ts
@@ -1,0 +1,93 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { type FilterBarOption, renderFilterBar } from "#shared/filter-bar.ts";
+
+const option = (
+  label: string,
+  href: string,
+  active: boolean,
+): FilterBarOption => ({ active, href, label });
+
+describe("renderFilterBar", () => {
+  test("renders an active option as bold + underlined text, not a link", () => {
+    const html = renderFilterBar("Showing", [option("All", "/all", true)]);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: <strong><u>All</u></strong></div>',
+    );
+  });
+
+  test("renders an inactive option as a link to its href", () => {
+    const html = renderFilterBar("Showing", [option("All", "/all", false)]);
+    expect(html).toBe(
+      '<div class="table-actions">Showing: <a href="/all">All</a></div>',
+    );
+  });
+
+  test("joins multiple options with ' / ' in the given order", () => {
+    const html = renderFilterBar("Agent", [
+      option("All", "/agent/all", true),
+      option("None", "/agent/none", false),
+      option("Van 1", "/agent/van-1", false),
+    ]);
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        "<strong><u>All</u></strong>" +
+        ' / <a href="/agent/none">None</a>' +
+        ' / <a href="/agent/van-1">Van 1</a>' +
+        "</div>",
+    );
+  });
+
+  test("marks only the active option as bold, linking every other", () => {
+    const html = renderFilterBar("Agent", [
+      option("All", "/agent/all", false),
+      option("Van 1", "/agent/van-1", true),
+    ]);
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        '<a href="/agent/all">All</a>' +
+        " / <strong><u>Van 1</u></strong>" +
+        "</div>",
+    );
+  });
+
+  test("renders the label and an empty body when there are no options", () => {
+    const html = renderFilterBar("Showing", []);
+    expect(html).toBe('<div class="table-actions">Showing: </div>');
+  });
+
+  test("uses the supplied label verbatim in the heading", () => {
+    const html = renderFilterBar("Filter by status", [
+      option("Open", "/s/open", true),
+    ]);
+    expect(html).toBe(
+      '<div class="table-actions">Filter by status: <strong><u>Open</u></strong></div>',
+    );
+  });
+
+  test("emits labels verbatim — callers pre-escape user-supplied text", () => {
+    // The contract (see module header) is that labels are not escaped here, so
+    // an already-escaped agent name round-trips unchanged rather than being
+    // double-escaped.
+    const escaped = "Tom &amp; Jerry&#39;s Van";
+    const html = renderFilterBar("Agent", [option(escaped, "/a/1", false)]);
+    expect(html).toBe(
+      `<div class="table-actions">Agent: <a href="/a/1">${escaped}</a></div>`,
+    );
+  });
+
+  test("keeps two adjacent active options separated by ' / '", () => {
+    // Two active options in a row would run together if the separator were
+    // dropped; asserts the join survives even without an intervening link.
+    const html = renderFilterBar("X", [
+      option("A", "/a", true),
+      option("B", "/b", true),
+    ]);
+    expect(html).toBe(
+      '<div class="table-actions">X: ' +
+        "<strong><u>A</u></strong>" +
+        " / <strong><u>B</u></strong>" +
+        "</div>",
+    );
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #1531 (listing-filter). `src/shared/filter-bar.ts` renders the labelled filter bar — `"Showing: All / Standard / Daily"`, `"Agent: All / None / Van 1"` — shared by the listing-type and logistics-agent filters. It's the module `renderTypeFilter` (now tested) delegates to, but it had **no direct unit test**, so its rendering logic was unguarded against regressions. A mutation run confirmed the gap.

This PR adds `test/lib/filter-bar.test.ts`, a pure unit test (the module has zero imports) covering `renderFilterBar` with exact-markup assertions.

## Coverage

- **Active option** → bold + underlined text (`<strong><u>…</u></strong>`), not a link.
- **Inactive option** → a link to its `href`.
- **Multiple options** → joined by `' / '` in the given order, with only the active one bold.
- **Empty options** → the label heading with an empty body.
- **Label** → used verbatim in the heading.
- **Verbatim label emission** → an already-escaped agent name round-trips unchanged (the module's documented "callers pre-escape" contract; guards against double-escaping).
- **Two adjacent active options** → still separated by `' / '` (guards the separator even with no intervening link).

## Verification

```
deno task mutation src/shared/filter-bar.ts test/lib/filter-bar.test.ts
# 100.0%  (3/3 killed) — the mode the precommit gate uses

deno task mutation src/shared/filter-bar.ts test/lib/filter-bar.test.ts --exhaustive
# 100.0%  (6/6 detected)
```

No equivalent-mutant suppression needed. `lint:ci` and `typecheck` pass. The new test is a pure unit test (no app/Stripe/DB dependency) and passes standalone.

## Notes

Test-only change — no production source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC

---
_Generated by [Claude Code](https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC)_