### PR TITLE
Style the badge variants and document building stripe-mock with Go

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,23 @@ mise exec -- deno --version
 
 The `.tool-versions` file is kept in sync for asdf-compatible tooling.
 
+## stripe-mock
+
+The test harness needs the `stripe-mock` binary at `.bin/stripe-mock` (any test
+that imports the app boots the harness, which starts it on port 12111). The
+harness normally downloads a prebuilt release from GitHub, but in sandboxes
+where GitHub release downloads are blocked you can build it from source with Go
+instead — the Go module proxy is usually reachable when GitHub isn't:
+
+```bash
+GOBIN="$PWD/.bin" go install github.com/stripe/stripe-mock@v0.188.0
+```
+
+Pin the same version the harness expects (`STRIPE_MOCK_VERSION` in
+`scripts/test-harness.ts`). Once `.bin/stripe-mock` exists the harness uses it
+as-is and skips the download, so `deno task test`, `deno task test:files`, and
+`--harness` mutation runs all work offline from GitHub.
+
 ## Preferences
 
 - **Use FP methods**: Prefer curried functional utilities from `#fp` over imperative loops

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1446,16 +1446,36 @@ input[type="submit"].danger:hover,
   font-weight: bold;
 }
 
+/* Pill/label badges shared across admin & public pages. All share one shape;
+   the variant sets the colour. `.badge-alert` additionally carries the inline
+   margins it needs when it sits mid-sentence. */
+.badge,
+.badge-ok,
+.badge-missing,
 .badge-alert {
+  display: inline-block;
   font-size: 0.6rem;
   font-weight: bold;
   color: #fff;
-  background-color: #cc0000;
-  margin-left: 1rem;
-  margin-right: 1rem;
   padding: 0.2rem 0.5rem;
   border-radius: 999px;
   white-space: nowrap;
+}
+
+.badge,
+.badge-missing {
+  background-color: #6b6b6b;
+}
+.badge-ok {
+  background-color: #006600;
+}
+.badge.danger,
+.badge-alert {
+  background-color: #cc0000;
+}
+.badge-alert {
+  margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 [data-theme="dark"] .password-warning {
@@ -1467,6 +1487,14 @@ input[type="submit"].danger:hover,
 [data-theme="dark"] .success-text {
   color: #50fa7b;
 }
+[data-theme="dark"] .badge,
+[data-theme="dark"] .badge-missing {
+  background-color: #44475a;
+}
+[data-theme="dark"] .badge-ok {
+  background-color: #1a7a1a;
+}
+[data-theme="dark"] .badge.danger,
 [data-theme="dark"] .badge-alert {
   background-color: #991919;
 }


### PR DESCRIPTION
## What & why

Two small, independent improvements spotted while surveying badge usage across the templates.

### 1. Style the unstyled badge variants

The pill classes `.badge`, `.badge-ok`, `.badge-missing`, and `.badge.danger` are emitted by admin and public templates (checked-in / refunded flags, attendee-status flags, the debug config-status page) but had **no CSS at all** — only `.badge-alert` was styled, so the rest rendered as unstyled inline text.

This gives every variant one shared pill shape (the same shape `.badge-alert` already used — `inline-block`, `0.6rem` bold, rounded `999px`, `nowrap`) with a per-variant background colour:

| variant | colour |
|---|---|
| `.badge` / `.badge-missing` | neutral grey |
| `.badge-ok` | green |
| `.badge.danger` / `.badge-alert` | red |

`.badge-alert` keeps its mid-sentence horizontal margins; dark-theme colours mirror the existing `.badge-alert` dark override. Only `style.scss` changes (the source); `style.css` is regenerated by the build.

### 2. Document building stripe-mock with Go

The test harness needs `.bin/stripe-mock`, normally downloaded from a GitHub release. In sandboxes where GitHub release downloads are blocked, the Go module proxy is still reachable, so `go install github.com/stripe/stripe-mock@<version>` builds an equivalent binary and the harness uses it as-is. AGENTS.md now records this so the full suite and `--harness` mutation runs work offline from GitHub.

## Verification

- `deno task build:static` compiles the SCSS; all five badge classes are present in the generated `style.css`.
- `deno task lint:ci` clean.
- No `src/` `.ts`/`.tsx` behaviour changes — pure CSS + docs, so rendered markup (and every existing badge test) is unaffected.

## Note on follow-ups

While surveying, the natural next step — a shared `<Badge>` component to replace the hand-written spans, and a `createRecalculateHandlers` factory to unify the three aggregate-recalculate GET/POST handlers — turned out to require touching files carrying pre-existing mutation-test debt (measured: debug.tsx 52, settings-statuses 28, attendee-detail 17, modifiers 13 latent survivors). Those are being paid down first in separate test-only PRs so the refactors can land as small, clean diffs on gate-clean files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW)_