### PR TITLE
Add mutation-hardened unit tests for SelectField

### DIFF
--- a/test/templates/components/select-field.test.tsx
+++ b/test/templates/components/select-field.test.tsx
@@ -1,0 +1,112 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  SelectField,
+  type SelectOption,
+} from "#templates/components/select-field.tsx";
+
+const opts = (...pairs: [value: string, label: string][]): SelectOption[] =>
+  pairs.map(([value, label]) => ({ label, value }));
+
+describe("SelectField", () => {
+  test("renders one <option> per choice, in order, selecting the matching value", () => {
+    const html = String(
+      SelectField({
+        name: "agent",
+        options: opts(["a", "Alpha"], ["b", "Bravo"], ["c", "Charlie"]),
+        value: "b",
+      }),
+    );
+    expect(html).toBe(
+      '<select name="agent">' +
+        '<option value="a">Alpha</option>' +
+        '<option selected value="b">Bravo</option>' +
+        '<option value="c">Charlie</option>' +
+        "</select>",
+    );
+  });
+
+  test("selects the empty-value option when the current value is ''", () => {
+    // The documented contract: pass value "" so the same === comparison marks
+    // the leading "none"/empty choice as selected.
+    const html = String(
+      SelectField({
+        name: "agent",
+        options: opts(["", "None"], ["a", "Alpha"]),
+        value: "",
+      }),
+    );
+    expect(html).toBe(
+      '<select name="agent">' +
+        '<option selected value="">None</option>' +
+        '<option value="a">Alpha</option>' +
+        "</select>",
+    );
+  });
+
+  test("marks no option selected when no value matches", () => {
+    const html = String(
+      SelectField({
+        name: "agent",
+        options: opts(["a", "Alpha"], ["b", "Bravo"]),
+        value: "zzz",
+      }),
+    );
+    expect(html).toBe(
+      '<select name="agent">' +
+        '<option value="a">Alpha</option>' +
+        '<option value="b">Bravo</option>' +
+        "</select>",
+    );
+    expect(html).not.toContain("selected");
+  });
+
+  test("selects exactly one option — the empty value does not match a non-empty one", () => {
+    // Guards the strict comparison: value "" must not select value "a".
+    const html = String(
+      SelectField({
+        name: "agent",
+        options: opts(["a", "Alpha"]),
+        value: "",
+      }),
+    );
+    expect(html).toBe(
+      '<select name="agent"><option value="a">Alpha</option></select>',
+    );
+  });
+
+  test("adds the id attribute (before name) when an id is given", () => {
+    const html = String(
+      SelectField({
+        id: "agent-sel",
+        name: "agent",
+        options: opts(["a", "Alpha"]),
+        value: "a",
+      }),
+    );
+    expect(html).toBe(
+      '<select id="agent-sel" name="agent">' +
+        '<option selected value="a">Alpha</option>' +
+        "</select>",
+    );
+  });
+
+  test("omits the id attribute when no id is given", () => {
+    const html = String(
+      SelectField({
+        name: "agent",
+        options: opts(["a", "Alpha"]),
+        value: "a",
+      }),
+    );
+    expect(html).toBe(
+      '<select name="agent"><option selected value="a">Alpha</option></select>',
+    );
+    expect(html).not.toContain("id=");
+  });
+
+  test("renders an empty <select> when there are no options", () => {
+    const html = String(SelectField({ name: "agent", options: [], value: "" }));
+    expect(html).toBe('<select name="agent"></select>');
+  });
+});


### PR DESCRIPTION
## What

Fourth in the mutation-hardening series (after #1531 listing-filter, #1533 filter-bar, #1534 projection-sql). `src/ui/templates/components/select-field.tsx` owns the shared `<select>` shape for admin forms — it maps declared options to `<option>`s and marks the one whose `value` equals the current value as `selected`. That selection comparison is the whole point of the component, and it had 100% incidental coverage but **no direct unit test**.

This PR adds `test/templates/components/select-field.test.tsx` with exact rendered-markup assertions.

## Coverage

- **One `<option>` per choice**, in order, with only the matching value `selected`.
- **`value=""` selects the leading empty/"none" option** — the documented contract for representing "nothing chosen".
- **No selection** when no option matches the current value.
- **Strict comparison** — `value=""` must not select a non-empty option.
- **Optional `id`** — rendered before `name` when given, omitted otherwise.
- **Empty `<select>`** when there are no options.

## Verification

```
deno task mutation src/ui/templates/components/select-field.tsx test/templates/components/select-field.test.tsx
# 100.0%  (1/1 killed) — the mode the precommit gate uses
```

Under `--exhaustive` a single survivor remains — `option.value === value` → `==` — which is a provably-equivalent mutant: both operands are typed `string`, so loose and strict equality can never diverge (no coercion). It is not generated in the default mode, so it correctly needs no `equivalent-mutants.txt` entry (an entry there would be flagged stale against the default run).

`lint:ci` and `typecheck` pass; all tests pass.

## Notes

Test-only change — no production source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC

---
_Generated by [Claude Code](https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC)_