### PR TITLE
Drop dead applyFlash from listing recalculate; test its activity log

### DIFF
--- a/src/features/admin/listings-recalculate.ts
+++ b/src/features/admin/listings-recalculate.ts
@@ -12,7 +12,6 @@ import {
   selectedRecalculationFields,
 } from "#routes/admin/aggregate-recalculation.ts";
 import { AUTH_FORM, requireSessionOr, withAuth } from "#routes/auth.ts";
-import { applyFlash } from "#routes/csrf.ts";
 import { redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
@@ -38,7 +37,6 @@ export const handleListingRecalculateGet: TypedRouteHandler<
 > = (request, { listingId }) =>
   requireSessionOr(request, (session) =>
     withEntityFromParam(listingId, getListingWithCount, (listing) => {
-      applyFlash(request);
       const flash = getFlash();
       return renderListingRecalculatePage(
         listing,

--- a/test/lib/server-listings.test.ts
+++ b/test/lib/server-listings.test.ts
@@ -1468,6 +1468,23 @@ describeWithEnv("server (admin listings)", { db: true }, () => {
       expect(updated?.tickets_count).toBe(5);
     });
 
+    test("records an activity-log entry when totals are recalculated", async () => {
+      const { listing } = await setupListingAndLogin({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+
+      await adminFormPost(`/admin/listings/recalculate/${listing.id}`, {
+        recalculate_fields: "booked_quantity",
+      });
+
+      const log = await getAllActivityLog(10);
+      const entry = log.find((e) => e.message.includes("totals recalculated"));
+      expect(entry?.message).toBe(
+        `Listing '${listing.name}' totals recalculated`,
+      );
+    });
+
     test("shows recalculation success on the redirected edit page", async () => {
       const { listing } = await setupListingAndLogin({
         maxAttendees: 100,


### PR DESCRIPTION
First step of paying down the mutation-test debt in the aggregate-recalculate handlers so the planned `createRecalculateHandlers` unification can later land as a small diff on gate-clean files.

## What & why

`src/features/admin/listings-recalculate.ts` had two latent mutation survivors under `server-listings.test.ts`:

1. **`applyFlash(request)` in the GET handler was dead code.** `applyFlash`'s only effect is `setFlashFormId(?form)` — recording the form a redirect targeted so a matching `CsrfForm` renders the flash inline. But the recalculate page is built by `adminFormPage`, whose `CsrfForm` carries **no `id`**, and `CsrfForm` only auto-renders a flash when `rest.id === getFlashFormId()`. So the `formId` this call sets is never read; the flash message renders solely from the explicit `<Flash error success/>` the handler already passes (populated by middleware, not by `applyFlash`). Removing the call changes nothing observable — verified by the suite still passing.

2. **The POST handler's `logActivity` call had no covering assertion.** Added one: a recalculation now asserts the `Listing '<name>' totals recalculated` entry lands in the activity log (mirroring the existing modifier-revenue log test), so dropping that line fails a test.

## Verification

- `deno task mutation src/features/admin/listings-recalculate.ts test/lib/server-listings.test.ts` → **100% (10/10 killed)**, baseline green.
- `deno task lint` / `cpd` clean; typecheck clean.

No behaviour change — dead-code removal plus one new assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW)_