### PR TITLE
Add mutation-hardened unit tests for ticket-url

### DIFF
--- a/test/lib/ticket-url.test.ts
+++ b/test/lib/ticket-url.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import {
+  resetEffectiveDomain,
+  setEffectiveDomainForTest,
+} from "#shared/config.ts";
+import { buildCheckinUrl, buildTicketUrl } from "#shared/ticket-url.ts";
+
+const DOMAIN = "tickets.example.com";
+const entry = (ticket_token: string) => ({ attendee: { ticket_token } });
+
+describe("buildTicketUrl", () => {
+  beforeEach(() => setEffectiveDomainForTest(DOMAIN));
+  afterEach(() => resetEffectiveDomain());
+
+  test("joins each attendee's token with '+' under the /t path", () => {
+    expect(buildTicketUrl([entry("aaa"), entry("bbb"), entry("ccc")])).toBe(
+      `https://${DOMAIN}/t/aaa+bbb+ccc`,
+    );
+  });
+
+  test("renders a single token without any separator", () => {
+    expect(buildTicketUrl([entry("solo")])).toBe(`https://${DOMAIN}/t/solo`);
+  });
+
+  test("de-duplicates repeated tokens, preserving first-seen order", () => {
+    expect(
+      buildTicketUrl([
+        entry("a"),
+        entry("b"),
+        entry("a"),
+        entry("c"),
+        entry("b"),
+      ]),
+    ).toBe(`https://${DOMAIN}/t/a+b+c`);
+  });
+
+  test("produces a trailing /t/ with no tokens for an empty selection", () => {
+    expect(buildTicketUrl([])).toBe(`https://${DOMAIN}/t/`);
+  });
+
+  test("uses the effective domain (falling back to localhost when unset)", () => {
+    resetEffectiveDomain();
+    expect(buildTicketUrl([entry("x")])).toBe("https://localhost/t/x");
+  });
+});
+
+describe("buildCheckinUrl", () => {
+  beforeEach(() => setEffectiveDomainForTest(DOMAIN));
+  afterEach(() => resetEffectiveDomain());
+
+  test("builds the single-token check-in URL under /checkin", () => {
+    expect(buildCheckinUrl("tok123")).toBe(`https://${DOMAIN}/checkin/tok123`);
+  });
+
+  test("uses the effective domain (falling back to localhost when unset)", () => {
+    resetEffectiveDomain();
+    expect(buildCheckinUrl("tok123")).toBe("https://localhost/checkin/tok123");
+  });
+});


### PR DESCRIPTION
## What

Sixth in the mutation-hardening series (after #1531 listing-filter, #1533 filter-bar, #1534 projection-sql, #1536 select-field, #1538 request-schemas). `src/shared/ticket-url.ts` builds the combined ticket URL (`/t/<tokens>`) and the single-token check-in URL (`/checkin/<token>`) from attendee tokens — de-duplicating repeated tokens and joining them with `+`. It had 100% incidental coverage but **no direct unit test**, so the dedup, the join separator, and the path/domain assembly were unguarded.

This PR adds `test/lib/ticket-url.test.ts`.

## Coverage

- **`buildTicketUrl`** — `+`-joins each attendee's token under `/t`; a single token has no separator; repeated tokens de-duplicate preserving first-seen order; an empty selection yields a trailing `/t/`.
- **`buildCheckinUrl`** — builds `/checkin/<token>`.
- **Both** — use the effective domain, falling back to `localhost` when unset (via `setEffectiveDomainForTest` / `resetEffectiveDomain`).

## Verification

```
deno task mutation src/shared/ticket-url.ts test/lib/ticket-url.test.ts
# 100.0%  (2/2 killed) — the mode the precommit gate uses

deno task mutation src/shared/ticket-url.ts test/lib/ticket-url.test.ts --exhaustive
# 100.0%  (3/3 detected)
```

No equivalent-mutant suppression needed. `lint:ci` and `typecheck` pass; all tests pass.

## Notes

Test-only change — no production source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC

---
_Generated by [Claude Code](https://claude.ai/code/session_013TRJVr3RmJN2LoPvira5hC)_