### PR TITLE
Rely on shared types to cut duplicated shape definitions

### DIFF
--- a/src/features/admin/attendee-form-model.ts
+++ b/src/features/admin/attendee-form-model.ts
@@ -23,7 +23,11 @@ import type {
 } from "#shared/db/attendee-types.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { START_DATE_FIELD } from "#shared/order-select.ts";
-import { type ListingWithCount, normalizeDurationDays } from "#shared/types.ts";
+import {
+  type ContactInfo,
+  type ListingWithCount,
+  normalizeDurationDays,
+} from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import {
   parseNonNegativeInt,
@@ -108,12 +112,7 @@ export type AttendeeBooking = {
 };
 
 /** The full parsed form — attendee fields, the shared range, and line items. */
-export type ParsedAttendeeForm = {
-  name: string;
-  email: string;
-  phone: string;
-  address: string;
-  special_instructions: string;
+export type ParsedAttendeeForm = ContactInfo & {
   /** Selected attendee status id, or null for "no status". */
   statusId: number | null;
   /** Outstanding balance in minor units (order-level, plaintext). */
@@ -128,7 +127,7 @@ export type ParsedAttendeeForm = {
 
 /** Attendee-level validation error. */
 export type AttendeeFieldError = {
-  field: "name" | "email" | "phone" | "address" | "special_instructions";
+  field: keyof ContactInfo;
   message: string;
 };
 
@@ -457,14 +456,9 @@ const lineDate = (line: AttendeeFormLine, parsed: ParsedAttendeeForm) =>
 
 export const toCreateInput = (
   parsed: ParsedAttendeeForm,
-): {
-  address: string;
+): ContactInfo & {
   bookings: ListingBooking[];
-  email: string;
-  name: string;
-  phone: string;
   remainingBalance: number;
-  special_instructions: string;
   statusId: number | null;
 } => ({
   address: parsed.address,

--- a/src/features/admin/attendees-merge.ts
+++ b/src/features/admin/attendees-merge.ts
@@ -36,7 +36,7 @@ import type {
   MergeValueChoice,
 } from "#shared/merge/attendee-merge-types.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
-import type { Attendee } from "#shared/types.ts";
+import type { Attendee, ContactInfo } from "#shared/types.ts";
 import { AttendeeMergePanel } from "#templates/admin/attendees.tsx";
 
 /* jscpd:ignore-end */
@@ -59,16 +59,14 @@ const loadMergeTarget = async (
 /** Look up and decrypt a source attendee by ticket token */
 const loadMergeSource = async (
   token: string,
-): Promise<{
-  id: number;
-  name: string;
-  email: string;
-  phone: string;
-  address: string;
-  special_instructions: string;
-  ticket_token: string;
-  bookings: ListingAttendeeRow[];
-} | null> => {
+): Promise<
+  | (ContactInfo & {
+      id: number;
+      ticket_token: string;
+      bookings: ListingAttendeeRow[];
+    })
+  | null
+> => {
   const pk = await requireRequestPrivateKey();
   const results = await getAttendeesByTokens([token]);
   const raw = results[0];

--- a/src/features/admin/settings-general.ts
+++ b/src/features/admin/settings-general.ts
@@ -24,14 +24,13 @@ import { settings } from "#shared/db/settings.ts";
 import { applyDemoOverrides, TERMS_DEMO_FIELDS } from "#shared/demo.ts";
 import { parseEmbedHosts, validateEmbedHosts } from "#shared/embed-hosts.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
-import type { PaymentProviderType } from "#shared/payments.ts";
 import { ok } from "#shared/response.ts";
-import type { Theme } from "#shared/types.ts";
+import {
+  isPaymentProvider,
+  type PaymentProviderType,
+  type Theme,
+} from "#shared/types.ts";
 import { isValidEmail, updateBusinessEmail } from "#shared/validation/email.ts";
-
-/** Type guard: check if a string is a valid payment provider */
-const isPaymentProvider = (s: string): s is PaymentProviderType =>
-  s === "stripe" || s === "square" || s === "sumup";
 
 /**
  * Handle POST /admin/settings/payment-provider - owner only

--- a/src/shared/db/attendee-types.ts
+++ b/src/shared/db/attendee-types.ts
@@ -163,18 +163,18 @@ export type BatchAvailabilityItem = {
   durationDays?: number;
 };
 
-/** Input for updating attendee PII (shared across listings) */
-export type UpdateAttendeePIIInput = {
-  name: string;
-  email: string;
-  phone: string;
-  address: string;
-  special_instructions: string;
+/** Contact PII plus the decrypted identifiers needed to rebuild a PII blob:
+ * the {@link ContactInfo} fields alongside the attendee's `payment_id` and
+ * `ticket_token`. The single shape used to (re)build an encrypted PII blob. */
+export type AttendeePii = ContactInfo & {
   /** Decrypted payment_id for PII blob rebuild (from existing attendee) */
   payment_id: string;
   /** Decrypted ticket_token for PII blob rebuild (from existing attendee) */
   ticket_token: string;
 };
+
+/** Input for updating attendee PII (shared across listings) */
+export type UpdateAttendeePIIInput = AttendeePii;
 
 /**
  * A desired final-state listing line for the atomic attendee edit path.

--- a/src/shared/db/attendees/pii.ts
+++ b/src/shared/db/attendees/pii.ts
@@ -14,6 +14,7 @@ import {
 } from "#shared/crypto/keys.ts";
 import { generateTicketToken } from "#shared/crypto/utils.ts";
 import type {
+  AttendeePii,
   EncryptedAttendeeData,
   EncryptInput,
   UpdateAttendeePIIInput,
@@ -26,9 +27,7 @@ import type { Attendee, ContactInfo, PiiBlob } from "#shared/types.ts";
 export const PII_BLOB_VERSION = 1;
 
 /** Build a PII blob JSON from contact fields */
-export const buildPiiBlob = (
-  info: ContactInfo & { payment_id: string; ticket_token: string },
-): string =>
+export const buildPiiBlob = (info: AttendeePii): string =>
   JSON.stringify({
     a: info.address,
     e: info.email,

--- a/src/shared/db/common-schema.ts
+++ b/src/shared/db/common-schema.ts
@@ -43,6 +43,16 @@ export const cachedEntityTable = <Row, Input, Cached = Row>(
   return { cache, table };
 };
 
+/** Stored values of the trigger-maintained aggregate columns `F`, keyed by column. */
+export type AggregateValues<F extends string> = Record<F, number>;
+
+/** Per-column comparison of each aggregate `F`'s stored value against its
+ * rebuilt-from-source value — what the "recalculate aggregates" tools return. */
+export type AggregateRecalculation<F extends string> = Record<
+  F,
+  { current: number; recalculated: number }
+>;
+
 type EncryptFn = (v: string) => Promise<string>;
 type DecryptFn = (v: string) => Promise<string>;
 

--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -38,6 +38,8 @@ import {
   resultRows,
 } from "#shared/db/client.ts";
 import {
+  type AggregateRecalculation,
+  type AggregateValues,
   cachedEntityTable,
   defineIdTable,
   encryptedNameSchema,
@@ -869,12 +871,10 @@ export const LISTING_AGGREGATE_FIELDS = [
 
 export type ListingAggregateField = (typeof LISTING_AGGREGATE_FIELDS)[number];
 
-export type ListingAggregateValues = Record<ListingAggregateField, number>;
+export type ListingAggregateValues = AggregateValues<ListingAggregateField>;
 
-export type ListingAggregateRecalculation = Record<
-  ListingAggregateField,
-  { current: number; recalculated: number }
->;
+export type ListingAggregateRecalculation =
+  AggregateRecalculation<ListingAggregateField>;
 
 /**
  * Recalculate every listing aggregate in one pass. tickets_count counts only

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -20,6 +20,8 @@ import {
   resetAggregates,
 } from "#shared/db/client.ts";
 import {
+  type AggregateRecalculation,
+  type AggregateValues,
   defineIdTable,
   encryptedNameSchema,
 } from "#shared/db/common-schema.ts";
@@ -141,12 +143,10 @@ export const MODIFIER_AGGREGATE_FIELDS = ["total_uses", "usage_count"] as const;
 
 export type ModifierAggregateField = (typeof MODIFIER_AGGREGATE_FIELDS)[number];
 
-export type ModifierAggregateValues = Record<ModifierAggregateField, number>;
+export type ModifierAggregateValues = AggregateValues<ModifierAggregateField>;
 
-export type ModifierAggregateRecalculation = Record<
-  ModifierAggregateField,
-  { current: number; recalculated: number }
->;
+export type ModifierAggregateRecalculation =
+  AggregateRecalculation<ModifierAggregateField>;
 
 /** The modifier count aggregates as they would be if rebuilt from usage rows.
  * Takes the stored {@link ModifierRow} — total_revenue is no longer a

--- a/src/shared/db/questions.ts
+++ b/src/shared/db/questions.ts
@@ -27,6 +27,10 @@ import {
   resultRows,
 } from "#shared/db/client.ts";
 /* jscpd:ignore-end */
+import type {
+  AggregateRecalculation,
+  AggregateValues,
+} from "#shared/db/common-schema.ts";
 import { columnMapByIds, swapSortOrder } from "#shared/db/query.ts";
 import { settings } from "#shared/db/settings.ts";
 import { col, defineTable } from "#shared/db/table.ts";
@@ -1098,12 +1102,10 @@ export const ANSWER_AGGREGATE_FIELDS = ["times_selected"] as const;
 
 export type AnswerAggregateField = (typeof ANSWER_AGGREGATE_FIELDS)[number];
 
-export type AnswerAggregateValues = Record<AnswerAggregateField, number>;
+export type AnswerAggregateValues = AggregateValues<AnswerAggregateField>;
 
-export type AnswerAggregateRecalculation = Record<
-  AnswerAggregateField,
-  { current: number; recalculated: number }
->;
+export type AnswerAggregateRecalculation =
+  AggregateRecalculation<AnswerAggregateField>;
 
 /** The stored selection total (times_selected) for every answer of a question,
  * keyed by answer id. Reads the trigger-maintained column directly rather than

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -46,66 +46,6 @@ export type TableSchema<Row> = {
   [K in keyof Row]: ColumnDef<Row[K]>;
 };
 
-/** Derive column metadata: whether it's an input column and whether it has a default */
-type ColumnMeta<K, Row, Schema extends TableSchema<Row>> = K extends keyof Row
-  ? {
-      isInput: Schema[K]["generated"] extends true ? false : true;
-      hasDefault: Schema[K]["default"] extends () => Row[K] ? true : false;
-    }
-  : { isInput: false; hasDefault: false };
-
-/** Check if column is input-eligible (not generated) */
-type IsInputColumn<K, Row, Schema extends TableSchema<Row>> = ColumnMeta<
-  K,
-  Row,
-  Schema
->["isInput"];
-
-/** Check if column has a default value */
-type ColumnHasDefault<K, Row, Schema extends TableSchema<Row>> = ColumnMeta<
-  K,
-  Row,
-  Schema
->["hasDefault"];
-
-/** Extract input keys based on whether they have defaults */
-type InputKeysWith<
-  Row,
-  Schema extends TableSchema<Row>,
-  WithDefault extends boolean,
-> = {
-  [K in keyof Row]: IsInputColumn<K, Row, Schema> extends true
-    ? ColumnHasDefault<K, Row, Schema> extends WithDefault
-      ? K
-      : never
-    : never;
-}[keyof Row];
-
-/** Required input keys (non-generated, no default) */
-type RequiredInputKeys<Row, Schema extends TableSchema<Row>> = InputKeysWith<
-  Row,
-  Schema,
-  false
->;
-
-/** Optional input keys (has default) */
-type OptionalInputKeys<Row, Schema extends TableSchema<Row>> = InputKeysWith<
-  Row,
-  Schema,
-  true
->;
-
-/**
- * Derive Input type from Row type and Schema
- * - Excludes generated columns
- * - Makes columns with defaults optional
- */
-export type InputFor<Row, Schema extends TableSchema<Row>> = {
-  [K in RequiredInputKeys<Row, Schema>]: Row[K];
-} & {
-  [K in OptionalInputKeys<Row, Schema>]?: Row[K];
-};
-
 // Case conversion is delegated to valibot's `toCamelCase`/`toSnakeCase` actions
 // rather than bespoke regexes. The schemas are built once at module load and
 // reused on every call. valibot's word-splitting is more robust than a plain

--- a/src/shared/email-renderer.ts
+++ b/src/shared/email-renderer.ts
@@ -22,7 +22,11 @@ import { settings } from "#shared/db/settings.ts";
 import type { EmailEntry } from "#shared/email.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
 import { packagePrivacyOfDisplay } from "#shared/package-privacy.ts";
-import { isPaidListing, normalizeDurationDays } from "#shared/types.ts";
+import {
+  type ContactInfo,
+  isPaidListing,
+  normalizeDurationDays,
+} from "#shared/types.ts";
 import { DEFAULT_TEMPLATES } from "#templates/email/defaults.ts";
 import type { EmailContent } from "#templates/email/shared.ts";
 import { listingNames } from "#templates/email/shared.ts";
@@ -55,12 +59,7 @@ type TemplateEntry = {
     slug: string;
     is_paid: boolean;
   };
-  attendee: {
-    name: string;
-    email: string;
-    phone: string;
-    address: string;
-    special_instructions: string;
+  attendee: ContactInfo & {
     quantity: number;
     price_paid: string;
     date: string | null;

--- a/src/shared/merge/attendee-merge-types.ts
+++ b/src/shared/merge/attendee-merge-types.ts
@@ -6,7 +6,10 @@
  * 2. Apply: the admin submits explicit decisions for each conflict.
  */
 
-import type { ListingAttendeeRow } from "#shared/db/attendee-types.ts";
+import type {
+  AttendeePii,
+  ListingAttendeeRow,
+} from "#shared/db/attendee-types.ts";
 import type { ContactInfo } from "#shared/types.ts";
 
 // ---------------------------------------------------------------------------
@@ -169,7 +172,7 @@ export type BuildAttendeeMergeDiffInput = {
 export type ApplyAttendeeMergeInput = {
   targetId: number;
   sourceId: number;
-  targetPii: ContactInfo & { payment_id: string; ticket_token: string };
+  targetPii: AttendeePii;
   sourcePii: ContactInfo;
   diff: AttendeeMergeDiff;
   decision: AttendeeMergeDecisionInput;

--- a/src/shared/square.ts
+++ b/src/shared/square.ts
@@ -420,23 +420,20 @@ type SquareOrder = {
   createdAt?: string | undefined;
 };
 
+/** A Square Money object with both fields optional, as returned on a payment's
+ * `amountMoney` / `refundedMoney`. */
+type SquareMoney = {
+  amount?: bigint | undefined;
+  currency?: string | undefined;
+};
+
 /** Square payment response shape (subset we use) */
 type SquarePayment = {
   id?: string | undefined;
   status?: string | undefined;
   orderId?: string | undefined;
-  amountMoney?:
-    | {
-        amount?: bigint | undefined;
-        currency?: string | undefined;
-      }
-    | undefined;
-  refundedMoney?:
-    | {
-        amount?: bigint | undefined;
-        currency?: string | undefined;
-      }
-    | undefined;
+  amountMoney?: SquareMoney | undefined;
+  refundedMoney?: SquareMoney | undefined;
 };
 
 /** Result of creating a payment link */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,9 +100,7 @@ export const isPaymentProvider = (s: string): s is PaymentProviderType =>
 /** Persisted payment-provider setting: an explicit provider, "none" (admin saved
  *  payments-disabled), or absent (never saved — drives the settings nag). */
 export const PaymentProviderSettingSchema = v.picklist([
-  "stripe",
-  "square",
-  "sumup",
+  ...PaymentProviderSchema.options,
   "none",
 ]);
 

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -7,6 +7,9 @@ import { t } from "#i18n";
 import { formatCurrency, getDecimalPlaces } from "#shared/currency.ts";
 import { DAY_NAMES } from "#shared/dates.ts";
 import { isUpdateTier } from "#shared/db/built-sites.ts";
+import type { ListingAggregateValues } from "#shared/db/listings.ts";
+import type { ModifierAggregateValues } from "#shared/db/modifiers.ts";
+import type { AnswerAggregateValues } from "#shared/db/questions.ts";
 import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { type Field, validateForm } from "#shared/forms.tsx";
@@ -88,10 +91,7 @@ export type ListingEditFormValues = ListingFormValues & {
   slug: string;
 };
 
-export type ListingAggregateFormValues = {
-  booked_quantity: number;
-  tickets_count: number;
-};
+export type ListingAggregateFormValues = ListingAggregateValues;
 
 /** Typed values from group create form validation (no slug - auto-generated) */
 export type GroupCreateFormValues = {
@@ -858,10 +858,7 @@ export type ModifierFormValues = {
   active: string;
 };
 
-export type ModifierAggregateFormValues = {
-  total_uses: number;
-  usage_count: number;
-};
+export type ModifierAggregateFormValues = ModifierAggregateValues;
 
 const aggregateIntegerField = (name: string, label: string): Field => ({
   label,
@@ -883,9 +880,7 @@ export const modifierAggregateFields: Field[] = [
   aggregateIntegerField("usage_count", t("fields.modifier.usage_count")),
 ];
 
-export type AnswerAggregateFormValues = {
-  times_selected: number;
-};
+export type AnswerAggregateFormValues = AnswerAggregateValues;
 
 export const answerAggregateFields: Field[] = [
   aggregateIntegerField("times_selected", t("fields.answer.times_selected")),


### PR DESCRIPTION
Cleans up several places where types were restated by hand instead of derived from an existing single source of truth. Net **−70 lines** in `/src`; `deno task typecheck` and `deno task lint` both pass.

## Changes

- **Delete dead `InputFor` type machinery** (`src/shared/db/table.ts`). `InputFor` and its six helper types (`ColumnMeta`, `IsInputColumn`, `ColumnHasDefault`, `InputKeysWith`, `RequiredInputKeys`, `OptionalInputKeys`) were never referenced anywhere in `src`, `test`, or `cli`. They were also non-functional for their intended purpose: they produced snake_case keys, whereas the actual table `Input` types are camelCase, so they could never have replaced the hand-written ones. ~60 lines removed.
- **Introduce `AttendeePii`** = `ContactInfo & { payment_id; ticket_token }` (`src/shared/db/attendee-types.ts`) and reuse it for `UpdateAttendeePIIInput`, `buildPiiBlob` (`attendees/pii.ts`), and `ApplyAttendeeMergeInput.targetPii` (`merge/attendee-merge-types.ts`) — the same intersection was previously written out in each spot.
- **Derive `PaymentProviderSettingSchema`** from `PaymentProviderSchema.options` (`src/shared/types.ts`) so the `stripe`/`square`/`sumup` list has one source of truth (produces the identical picklist).
- **Drop the duplicate local `isPaymentProvider`** guard in `settings-general.ts` (which re-hardcoded the provider list a third time) in favour of the shared guard from `#shared/types`.
- **Replace hand-written `ContactInfo` field lists** with `ContactInfo` / `keyof ContactInfo` in `attendee-form-model.ts` (`ParsedAttendeeForm`, `AttendeeFieldError`, `toCreateInput`), `attendees-merge.ts` (`loadMergeSource` return type), and `email-renderer.ts` (inline `attendee` shape).

The payoff beyond LOC: adding a PII field or a payment provider now updates one definition instead of many.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAPC66Zfw2Br6idcqtR1rW)_