### PR TITLE
Unify listingInfoColumns across the two CSV exporters

### DIFF
--- a/src/features/admin/attendees-csv.ts
+++ b/src/features/admin/attendees-csv.ts
@@ -87,27 +87,20 @@ export const standardAttendeeColumns = (domain: string): Column<Attendee>[] => [
   },
 ];
 
-/** Optional Listing Date / Listing Location columns (fixed for every row). The
- * listing date is a UTC ISO datetime, shown as a date + time in `tz`. */
-const listingInfoColumns = (
-  tz: string,
-  info?: CsvListingInfo,
-): Column<Attendee>[] => [
-  ...(info?.listingDate
-    ? [
-        {
-          header: t("csv.col.listing_date"),
-          value: () => formatDatetimeShortInTz(info.listingDate, tz),
-        },
-      ]
+/** Optional Listing Date / Listing Location columns, shared by the attendee and
+ * calendar exports. Each column is emitted only when its `show` flag is set; its
+ * `value` reads the cell from the row (a per-row listing for the calendar, a
+ * fixed listing for a single-listing attendee export). The listing date is a UTC
+ * ISO datetime, which the supplied `value` is expected to render in the site tz. */
+export const listingInfoColumns = <T>(
+  date: { show: boolean; value: Column<T>["value"] },
+  location: { show: boolean; value: Column<T>["value"] },
+): Column<T>[] => [
+  ...(date.show
+    ? [{ header: t("csv.col.listing_date"), value: date.value }]
     : []),
-  ...(info?.listingLocation
-    ? [
-        {
-          header: t("csv.col.listing_location"),
-          value: () => info.listingLocation,
-        },
-      ]
+  ...(location.show
+    ? [{ header: t("csv.col.listing_location"), value: location.value }]
     : []),
 ];
 
@@ -166,7 +159,16 @@ const attendeeColumns = ({
         },
       ]
     : []),
-  ...listingInfoColumns(tz, listingInfo),
+  ...listingInfoColumns<Attendee>(
+    {
+      show: Boolean(listingInfo?.listingDate),
+      value: () => formatDatetimeShortInTz(listingInfo!.listingDate, tz),
+    },
+    {
+      show: Boolean(listingInfo?.listingLocation),
+      value: () => listingInfo!.listingLocation,
+    },
+  ),
   ...standardAttendeeColumns(domain),
   ...questionColumns(questionData),
 ];

--- a/src/features/admin/calendar-csv.ts
+++ b/src/features/admin/calendar-csv.ts
@@ -9,6 +9,7 @@
 import { t } from "#i18n";
 import {
   csvDateRange,
+  listingInfoColumns,
   standardAttendeeColumns,
 } from "#routes/admin/attendees-csv.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
@@ -65,32 +66,6 @@ export const toCalendarAttendees = <
     };
   });
 };
-
-/** Optional Listing Date / Listing Location columns (per booking's listing).
- * The listing date is a UTC ISO datetime, shown as a date + time in `tz`. */
-const listingInfoColumns = (
-  tz: string,
-  showDate: boolean,
-  showLocation: boolean,
-): Column<CalendarAttendee>[] => [
-  ...(showDate
-    ? [
-        {
-          header: t("csv.col.listing_date"),
-          value: (a: CalendarAttendee) =>
-            a.listingDate ? formatDatetimeShortInTz(a.listingDate, tz) : "",
-        },
-      ]
-    : []),
-  ...(showLocation
-    ? [
-        {
-          header: t("csv.col.listing_location"),
-          value: (a: CalendarAttendee) => a.listingLocation,
-        },
-      ]
-    : []),
-];
 
 /** The six logistics columns; each is blank for non-logistics bookings. */
 const logisticsColumns = (
@@ -160,10 +135,16 @@ const calendarColumns = ({
   return [
     { header: t("terms.listing"), value: (a) => a.listingName },
     { header: "Type", value: typeLabel },
-    ...listingInfoColumns(
-      tz,
-      attendees.some((a) => a.listingDate !== ""),
-      attendees.some((a) => a.listingLocation !== ""),
+    ...listingInfoColumns<CalendarAttendee>(
+      {
+        show: attendees.some((a) => a.listingDate !== ""),
+        value: (a) =>
+          a.listingDate ? formatDatetimeShortInTz(a.listingDate, tz) : "",
+      },
+      {
+        show: attendees.some((a) => a.listingLocation !== ""),
+        value: (a) => a.listingLocation,
+      },
     ),
     {
       header: t("common.date"),


### PR DESCRIPTION
## What

`attendees-csv.ts` and `calendar-csv.ts` each privately defined a same-named `listingInfoColumns` emitting the same **Listing Date** / **Listing Location** columns, differing only in the show condition and the per-cell row accessor (a fixed single-listing value vs a per-row `a.listing*`).

This extracts one generic `listingInfoColumns<T>` and calls it from both exporters, killing the duplication.

## How

- The shared helper takes a `{ show, value }` pair per column and folds them into the optional Listing Date / Listing Location columns. Callers supply the `show` flag (info-presence for the attendee export, per-row `.some(...)` for the calendar) and the cell accessor.
- It lives in `attendees-csv.ts`, already the shared home for `standardAttendeeColumns` / `csvDateRange` that `calendar-csv.ts` imports. The pure `#shared/csv` module deliberately knows nothing about i18n/listings, so the helper stays out of it.
- `calendar-csv.ts` drops its private copy and imports the shared one.

## Verification

- `deno check` on both files — passes.
- `test/lib/attendees-csv.test.ts`, `test/lib/calendar-csv.test.ts`, `test/lib/csv-questions.test.ts` — all green (45 steps).
- `deno task lint:ci` — clean; `deno task cpd` — 0 clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125bYYmXY7TWA6wqXBtSLMM

---
_Generated by [Claude Code](https://claude.ai/code/session_0125bYYmXY7TWA6wqXBtSLMM)_