### PR TITLE
Collapse payment-provider settings routes onto one factory + a metadata registry

### DIFF
--- a/src/features/admin/settings-helpers.ts
+++ b/src/features/admin/settings-helpers.ts
@@ -18,8 +18,9 @@ import {
 import { errorRedirect, jsonResponse, redirect } from "#routes/response.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
-import { isMaskSentinel } from "#shared/db/settings.ts";
+import { isMaskSentinel, settings } from "#shared/db/settings.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import type { PaymentProviderType } from "#shared/types.ts";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -271,6 +272,113 @@ const settingsSecret = (
 ): ((request: Request) => Promise<Response>) =>
   asRoute(cfg, secretFieldHandler(cfg));
 
+// ── Payment-provider credential routes ──────────────────────────────
+
+/**
+ * Config for a payment provider's credential-save route. Collapses the shape
+ * shared by Stripe/Square/SumUp: extract a masked secret (+ optional text
+ * fields) → validate → "secret required unless already stored" → persist
+ * credentials → select the provider → sibling test route.
+ */
+type ProviderCredentialsConfig<T> = {
+  /** Provider selected on a successful save. */
+  provider: PaymentProviderType;
+  /** Form ID for flash-message targeting. */
+  formId: string;
+  /** Form field name of the masked secret. */
+  secretField: string;
+  /** Whether a secret is already stored (drives the "required" guard). */
+  hasSecret: () => boolean;
+  /** Error shown when the secret is cleared and none is stored. */
+  secretRequiredError: string;
+  /** Flash message + activity-log entry on a successful save. */
+  successMessage: string;
+  logMessage: string;
+  /** Flash for a secret-only provider (no extra fields) when the submission
+   * carries no new secret — a genuine no-op. Set only by such providers;
+   * providers with extra fields always persist and never go "unchanged". */
+  unchangedMessage?: string;
+  /** Extract the non-secret fields (location, merchant code, …). */
+  extraFields?: (form: FormParams) => T;
+  /** Provider-specific validation (demo-mode guard, field/format checks).
+   * Receives the extra fields and the classified secret. Every provider has at
+   * least a demo-mode guard, so this is required. */
+  validate: (
+    fields: T,
+    secret: SecretFieldResult,
+  ) => string | null | Promise<string | null>;
+  /** Persist the secret (only called when a new value was provided). */
+  saveSecret: (value: string) => Promise<void> | void;
+  /** Persist the non-secret fields (called on every successful save). */
+  saveFields?: (fields: T) => Promise<void> | void;
+  /** Side effects for a newly provided secret — e.g. Stripe provisions its
+   * webhook and persists the returned config. Runs before the secret is saved,
+   * so returning an error string aborts the save with nothing persisted. */
+  afterSave?: (value: string) => Promise<string | null> | string | null;
+  /** Connection-test function behind the sibling `/test` route. */
+  testFn: () => Promise<unknown>;
+};
+
+/** Persist a validated submission: run `afterSave` + save the secret when a new
+ * value was provided, then save the extra fields and select the provider.
+ * Returns an `afterSave` error string (nothing persisted) or null on success. */
+const persistProviderCredentials = async <T>(
+  cfg: ProviderCredentialsConfig<T>,
+  fields: T,
+  secret: SecretFieldResult,
+): Promise<string | null> => {
+  if (secret.action === "provided") {
+    const error = cfg.afterSave ? await cfg.afterSave(secret.value) : null;
+    if (error) return error;
+    await cfg.saveSecret(secret.value);
+  }
+  if (cfg.saveFields) await cfg.saveFields(fields);
+  await settings.update.paymentProvider(cfg.provider);
+  return null;
+};
+
+/**
+ * Build the `{ save, test }` route pair for a payment provider's credentials.
+ * Stripe passes its webhook provisioning as `afterSave`; the rest differ only
+ * in their fields, validation, and persistence.
+ */
+const defineProviderCredentialsRoute = <T>(
+  cfg: ProviderCredentialsConfig<T>,
+): {
+  save: (request: Request) => Promise<Response>;
+  test: (request: Request) => Promise<Response>;
+} => {
+  const save = settingsRoute(async (form, errorPage) => {
+    const secret = processSecretField(form, cfg.secretField);
+    const fields = cfg.extraFields
+      ? cfg.extraFields(form)
+      : (undefined as unknown as T);
+
+    const settingsFlash = (message: string): Response =>
+      redirect(SETTINGS_PATH, message, true, { formId: cfg.formId });
+
+    // Provider validation + the "secret required unless already stored" guard.
+    const invalid = await cfg.validate(fields, secret);
+    if (invalid) return errorPage(invalid, 400, cfg.formId);
+    if (secret.action === "cleared" && !cfg.hasSecret()) {
+      return errorPage(cfg.secretRequiredError, 400, cfg.formId);
+    }
+
+    // A secret-only provider with no new secret is a genuine no-op.
+    if (cfg.unchangedMessage && secret.action !== "provided") {
+      return settingsFlash(cfg.unchangedMessage);
+    }
+
+    const saveError = await persistProviderCredentials(cfg, fields, secret);
+    if (saveError) return errorPage(saveError, 400, cfg.formId);
+
+    await logActivity(cfg.logMessage);
+    return settingsFlash(cfg.successMessage);
+  });
+
+  return { save, test: testRoute(cfg.testFn) };
+};
+
 // ── Exports ─────────────────────────────────────────────────────────
 
 export type {
@@ -286,6 +394,7 @@ export {
   advancedSettingsRoute,
   clearableFieldHandler,
   createSettingsHandler,
+  defineProviderCredentialsRoute,
   getWebhookUrl,
   processSecretField,
   secretFieldHandler,

--- a/src/features/admin/settings-square.ts
+++ b/src/features/admin/settings-square.ts
@@ -1,17 +1,13 @@
 /**
  * Admin Square settings routes - credentials, webhook signature key and
- * connection test. Owner-only access enforced via settingsHandler /
- * settingsSecret / testRoute.
+ * connection test. Owner-only access enforced via
+ * defineProviderCredentialsRoute / settingsSecret.
  */
 
-/* jscpd:ignore-start */
 import { t } from "#i18n";
 import {
-  processSecretField,
-  type SecretFieldResult,
-  settingsHandler,
+  defineProviderCredentialsRoute,
   settingsSecret,
-  testRoute,
 } from "#routes/admin/settings-helpers.ts";
 import { settings } from "#shared/db/settings.ts";
 import { isDemoMode } from "#shared/demo.ts";
@@ -22,48 +18,43 @@ import {
   validateSquareWebhookSignatureKey,
 } from "#shared/square-validation.ts";
 
-/* jscpd:ignore-end */
-
-/**
- * Handle POST /admin/settings/square - owner only
- */
-type SquareFormData = {
-  token: SecretFieldResult;
+type SquareFields = {
   locationId: string;
   sandbox: boolean;
 };
 
-export const handleAdminSquarePost = settingsHandler<SquareFormData>({
-  extract: (form) => ({
+const squareRoutes = defineProviderCredentialsRoute<SquareFields>({
+  extraFields: (form) => ({
     locationId: form.getString("square_location_id"),
     sandbox: form.get("square_sandbox") === "on",
-    token: processSecretField(form, "square_access_token"),
   }),
   formId: "settings-square",
-  label: "Square credentials",
-  save: async ({ token, locationId, sandbox }) => {
-    if (token.action === "provided") {
-      await settings.update.square.accessToken(token.value);
-    }
+  hasSecret: () => settings.square.hasToken,
+  logMessage: "Square credentials updated",
+  provider: "square",
+  saveFields: async ({ locationId, sandbox }) => {
     await settings.update.square.locationId(locationId);
     await settings.update.square.sandbox(sandbox);
-    await settings.update.paymentProvider("square");
   },
-  validate: ({ token, locationId }) => {
+  saveSecret: (value) => settings.update.square.accessToken(value),
+  secretField: "square_access_token",
+  secretRequiredError: t("error.square_token_required"),
+  successMessage: "Square credentials updated",
+  testFn: testSquareConnection,
+  validate: ({ locationId }, secret) => {
     if (isDemoMode()) return t("error.square_demo_mode");
     if (!locationId) return t("error.square_location_required");
     const locationError = validateSquareLocationId(locationId);
     if (locationError) return locationError;
-    if (token.action === "cleared" && !settings.square.hasToken) {
-      return t("error.square_token_required");
-    }
-    if (token.action === "provided") {
-      const tokenError = validateSquareAccessToken(token.value);
-      if (tokenError) return tokenError;
+    if (secret.action === "provided") {
+      return validateSquareAccessToken(secret.value);
     }
     return null;
   },
 });
+
+/** Handle POST /admin/settings/square - owner only */
+export const handleAdminSquarePost = squareRoutes.save;
 
 /**
  * Handle POST /admin/settings/square-webhook - owner only
@@ -78,4 +69,4 @@ export const handleAdminSquareWebhookPost = settingsSecret({
 });
 
 /** Handle POST /admin/settings/square/test - owner only */
-export const handleSquareTestPost = testRoute(testSquareConnection);
+export const handleSquareTestPost = squareRoutes.test;

--- a/src/features/admin/settings-stripe.ts
+++ b/src/features/admin/settings-stripe.ts
@@ -1,78 +1,57 @@
 /**
  * Admin Stripe settings routes - credential configuration, webhook setup and
- * connection test. Owner-only access enforced via settingsRoute / testRoute.
+ * connection test. Owner-only access enforced via defineProviderCredentialsRoute.
  */
 
 import { t } from "#i18n";
 import {
+  defineProviderCredentialsRoute,
   getWebhookUrl,
-  processSecretField,
-  settingsRoute,
-  testRoute,
 } from "#routes/admin/settings-helpers.ts";
-import { logActivity } from "#shared/db/activityLog.ts";
 import { settings } from "#shared/db/settings.ts";
 import { isDemoMode } from "#shared/demo.ts";
-import { ok } from "#shared/response.ts";
 import {
   detectStripeKeyMode,
   setupWebhookEndpoint,
   testStripeConnection,
 } from "#shared/stripe.ts";
 
-/**
- * Handle POST /admin/settings/stripe - owner only
- */
-export const handleAdminStripePost = settingsRoute(async (form, errorPage) => {
-  if (isDemoMode()) {
-    return errorPage(t("error.stripe_demo_mode"), 400, "settings-stripe");
-  }
-
-  const field = processSecretField(form, "stripe_secret_key");
-
-  if (field.action === "unchanged") {
-    return ok("/admin/settings", t("success.stripe_unchanged"), {
-      formId: "settings-stripe",
-    });
-  }
-
-  if (field.action === "cleared") {
-    if (!settings.stripe.hasKey) {
-      return errorPage(t("error.stripe_key_required"), 400, "settings-stripe");
-    }
-    return ok("/admin/settings", t("success.stripe_unchanged"), {
-      formId: "settings-stripe",
-    });
-  }
-
-  if (!detectStripeKeyMode(field.value)) {
-    return errorPage(t("error.stripe_key_format"), 400, "settings-stripe");
-  }
-
-  const webhookUrl = getWebhookUrl();
-  const webhookResult = await setupWebhookEndpoint(
-    field.value,
-    webhookUrl,
-    settings.stripe.webhookEndpointId,
-  );
-
-  if (!webhookResult.success) {
-    return errorPage(
-      `Failed to set up Stripe webhook: ${webhookResult.error}`,
-      400,
-      "settings-stripe",
+const stripeRoutes = defineProviderCredentialsRoute<undefined>({
+  // Provision the Stripe webhook before the key is persisted, so a setup
+  // failure aborts the save leaving nothing configured.
+  afterSave: async (value) => {
+    const result = await setupWebhookEndpoint(
+      value,
+      getWebhookUrl(),
+      settings.stripe.webhookEndpointId,
     );
-  }
-
-  await settings.update.stripe.secretKey(field.value);
-  await settings.update.stripe.webhookConfig(webhookResult);
-  await settings.update.paymentProvider("stripe");
-
-  await logActivity("Stripe key configured");
-  return ok("/admin/settings", t("success.stripe_updated"), {
-    formId: "settings-stripe",
-  });
+    if (!result.success) {
+      return `Failed to set up Stripe webhook: ${result.error}`;
+    }
+    await settings.update.stripe.webhookConfig(result);
+    return null;
+  },
+  formId: "settings-stripe",
+  hasSecret: () => settings.stripe.hasKey,
+  logMessage: "Stripe key configured",
+  provider: "stripe",
+  saveSecret: (value) => settings.update.stripe.secretKey(value),
+  secretField: "stripe_secret_key",
+  secretRequiredError: t("error.stripe_key_required"),
+  successMessage: t("success.stripe_updated"),
+  testFn: testStripeConnection,
+  unchangedMessage: t("success.stripe_unchanged"),
+  validate: (_fields, secret) => {
+    if (isDemoMode()) return t("error.stripe_demo_mode");
+    if (secret.action === "provided" && !detectStripeKeyMode(secret.value)) {
+      return t("error.stripe_key_format");
+    }
+    return null;
+  },
 });
 
+/** Handle POST /admin/settings/stripe - owner only */
+export const handleAdminStripePost = stripeRoutes.save;
+
 /** Handle POST /admin/settings/stripe/test - owner only */
-export const handleStripeTestPost = testRoute(testStripeConnection);
+export const handleStripeTestPost = stripeRoutes.test;

--- a/src/features/admin/settings-sumup.ts
+++ b/src/features/admin/settings-sumup.ts
@@ -1,52 +1,44 @@
 /**
  * Admin SumUp settings routes - credential configuration and connection test
- * Owner-only access enforced via settingsHandler / testRoute
+ * Owner-only access enforced via defineProviderCredentialsRoute
  */
 
-import {
-  processSecretField,
-  type SecretFieldResult,
-  settingsHandler,
-  testRoute,
-} from "#routes/admin/settings-helpers.ts";
+import { defineProviderCredentialsRoute } from "#routes/admin/settings-helpers.ts";
 import { settings } from "#shared/db/settings.ts";
 import { isDemoMode } from "#shared/demo.ts";
 import { isSumupCurrency, testSumupConnection } from "#shared/sumup.ts";
 
-/**
- * Handle POST /admin/settings/sumup - owner only
- */
-type SumupFormData = {
-  apiKey: SecretFieldResult;
+type SumupFields = {
   merchantCode: string;
 };
 
-export const handleAdminSumupPost = settingsHandler<SumupFormData>({
-  extract: (form) => ({
-    apiKey: processSecretField(form, "sumup_api_key"),
+const sumupRoutes = defineProviderCredentialsRoute<SumupFields>({
+  extraFields: (form) => ({
     merchantCode: form.getString("sumup_merchant_code"),
   }),
   formId: "settings-sumup",
-  label: "SumUp credentials",
-  save: async ({ apiKey, merchantCode }) => {
-    if (apiKey.action === "provided") {
-      await settings.update.sumup.apiKey(apiKey.value);
-    }
-    await settings.update.sumup.merchantCode(merchantCode);
-    await settings.update.paymentProvider("sumup");
-  },
-  validate: ({ apiKey, merchantCode }) => {
+  hasSecret: () => settings.sumup.hasKey,
+  logMessage: "SumUp credentials updated",
+  provider: "sumup",
+  saveFields: ({ merchantCode }) =>
+    settings.update.sumup.merchantCode(merchantCode),
+  saveSecret: (value) => settings.update.sumup.apiKey(value),
+  secretField: "sumup_api_key",
+  secretRequiredError: "SumUp API Key is required",
+  successMessage: "SumUp credentials updated",
+  testFn: testSumupConnection,
+  validate: ({ merchantCode }) => {
     if (isDemoMode()) return "Cannot configure SumUp in demo mode";
     if (!isSumupCurrency(settings.currency)) {
       return `SumUp does not support your site currency (${settings.currency}). Choose a different payment provider.`;
     }
     if (!merchantCode) return "Merchant code is required";
-    if (apiKey.action === "cleared" && !settings.sumup.hasKey) {
-      return "SumUp API Key is required";
-    }
     return null;
   },
 });
 
+/** Handle POST /admin/settings/sumup - owner only */
+export const handleAdminSumupPost = sumupRoutes.save;
+
 /** Handle POST /admin/settings/sumup/test - owner only */
-export const handleSumupTestPost = testRoute(testSumupConnection);
+export const handleSumupTestPost = sumupRoutes.test;

--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -43,6 +43,7 @@ import { getHiddenPackageMemberIds } from "#shared/db/groups.ts";
 import { getListing } from "#shared/db/listings.ts";
 import { clearSessionTokens } from "#shared/db/processed-payments.ts";
 import { ErrorCode, logDebug, logError } from "#shared/logger.ts";
+import { WEBHOOK_SIGNATURE_HEADERS } from "#shared/payment-providers.ts";
 import {
   getActivePaymentProvider,
   type ValidatedPaymentSession,
@@ -287,11 +288,13 @@ const webhookResultResponse = (
   return webhookAckResponse({ error: result.error, processed: false });
 };
 
-/** Detect which provider sent the webhook based on request headers */
+/** Detect which provider sent the webhook based on request headers. Reads the
+ * signature header of each provider that signs its webhooks (per the shared
+ * registry) and returns the first one present. */
 const getWebhookSignatureHeader = (request: Request): string | null =>
-  request.headers.get("stripe-signature") ??
-  request.headers.get("x-square-hmacsha256-signature") ??
-  null;
+  WEBHOOK_SIGNATURE_HEADERS.map((header) => request.headers.get(header)).find(
+    Boolean,
+  ) ?? null;
 
 /**
  * Authenticate an incoming webhook: resolve the provider, require the signature

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -12,8 +12,6 @@
   "settings.payment_provider": "Payment Provider",
   "settings.payment_provider_hint": "Choose which payment provider to use for paid listings.",
   "settings.payment_none": "None (payments disabled)",
-  "settings.payment_stripe": "Stripe",
-  "settings.payment_square": "Square",
   "settings.save_payment_provider": "Save Payment Provider",
   "settings.stripe.heading": "Stripe Settings",
   "settings.stripe.configured_hint": "A Stripe secret key is currently configured. Enter a new key below to replace it.",

--- a/src/shared/payment-providers.ts
+++ b/src/shared/payment-providers.ts
@@ -1,0 +1,47 @@
+/**
+ * Payment-provider metadata registry.
+ *
+ * Provider *behaviour* already lives behind the `PaymentProvider` interface and
+ * its per-type loader `Record`. This registry does the same for provider
+ * *metadata* — the display label, the radio value, and the webhook signature
+ * header — that used to be re-spelled by hand in the settings radio list, the
+ * webhook header chain, and each settings route.
+ *
+ * One exhaustive `Record<PaymentProviderType, …>` means adding a provider is a
+ * single compile error here rather than a hunt through scattered literals.
+ */
+
+import type { PaymentProviderType } from "#shared/types.ts";
+
+export type PaymentProviderMeta = {
+  /** Human-readable display name — radio label and prose. */
+  readonly label: string;
+  /** Request header carrying the webhook signature, or null for providers whose
+   * webhooks are unsigned (authenticity is re-established via the provider API
+   * instead — see `PaymentProvider.requiresWebhookSignature`). */
+  readonly webhookSignatureHeader: string | null;
+};
+
+/** Provider metadata keyed by identifier. Declaration order drives the settings
+ * radio list, so keep it in the order operators should see. */
+export const PAYMENT_PROVIDERS: Record<
+  PaymentProviderType,
+  PaymentProviderMeta
+> = {
+  square: {
+    label: "Square",
+    webhookSignatureHeader: "x-square-hmacsha256-signature",
+  },
+  stripe: { label: "Stripe", webhookSignatureHeader: "stripe-signature" },
+  sumup: { label: "SumUp", webhookSignatureHeader: null },
+};
+
+/** Provider ids in declared order. */
+export const PAYMENT_PROVIDER_IDS = Object.keys(
+  PAYMENT_PROVIDERS,
+) as PaymentProviderType[];
+
+/** Webhook signature headers of every provider that signs its webhooks. */
+export const WEBHOOK_SIGNATURE_HEADERS = PAYMENT_PROVIDER_IDS.map(
+  (id) => PAYMENT_PROVIDERS[id].webhookSignatureHeader,
+).filter((header): header is string => header !== null);

--- a/src/ui/templates/admin/settings/payment.tsx
+++ b/src/ui/templates/admin/settings/payment.tsx
@@ -6,6 +6,10 @@ import { t } from "#i18n";
 import { MASK_SENTINEL } from "#shared/db/settings.ts";
 import { CsrfForm, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
+import {
+  PAYMENT_PROVIDER_IDS,
+  PAYMENT_PROVIDERS,
+} from "#shared/payment-providers.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
 import { RadioOption } from "#templates/components/radio-option.tsx";
@@ -33,27 +37,15 @@ export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
       >
         {t("settings.payment_none")}
       </RadioOption>
-      <RadioOption
-        checked={s.paymentProvider === "stripe"}
-        name="payment_provider"
-        value="stripe"
-      >
-        {t("settings.payment_stripe")}
-      </RadioOption>
-      <RadioOption
-        checked={s.paymentProvider === "square"}
-        name="payment_provider"
-        value="square"
-      >
-        {t("settings.payment_square")}
-      </RadioOption>
-      <RadioOption
-        checked={s.paymentProvider === "sumup"}
-        name="payment_provider"
-        value="sumup"
-      >
-        SumUp
-      </RadioOption>
+      {PAYMENT_PROVIDER_IDS.map((id) => (
+        <RadioOption
+          checked={s.paymentProvider === id}
+          name="payment_provider"
+          value={id}
+        >
+          {PAYMENT_PROVIDERS[id].label}
+        </RadioOption>
+      ))}
     </fieldset>
     <SubmitButton icon="save">
       {t("settings.save_payment_provider")}


### PR DESCRIPTION
## What & why

Two related clean-ups for the payment-provider settings surface.

### 1. One factory for the three near-twin credential routes

`settings-stripe.ts`, `settings-square.ts`, and `settings-sumup.ts` all implemented the identical shape: extract a masked secret (+ text fields) → demo-mode guard → "secret required unless already stored" → save credentials → `settings.update.paymentProvider(…)` → sibling test route. `settings-square.ts` even carried a `jscpd:ignore-start` block — the duplication had been *suppressed*, not fixed.

New `defineProviderCredentialsRoute({provider, secretField, extraFields, validate, testFn, afterSave?, …})` in `settings-helpers.ts` builds the `{ save, test }` route pair from that shared shape. Each provider now supplies only what actually differs (its fields, validation, and persistence):

- **Stripe** is the sole real variant — it passes its webhook provisioning as `afterSave` (run *before* the key is persisted, so a setup failure aborts with nothing saved) and sets `unchangedMessage` for its secret-only no-op path.
- **Square/SumUp** collapse to a handful of config lines each.

The `jscpd:ignore` suppression is removed and duplication is back to **0%**.

### 2. A `PAYMENT_PROVIDERS` registry for scattered provider metadata

Provider *behaviour* was already a `Record`, but provider *metadata* (display label, radio value, webhook signature header) was re-spelled by hand in the settings radio list and the webhook header chain. New `src/shared/payment-providers.ts` holds one exhaustive `Record<PaymentProviderType, …>`, so adding a provider is a single-map compile error:

- the settings radio list now maps over `PAYMENT_PROVIDER_IDS`;
- webhook authentication reads `WEBHOOK_SIGNATURE_HEADERS` from the registry instead of a hard-coded `stripe-signature` / `x-square-hmacsha256-signature` chain.

## Behaviour

Behaviour is preserved. The masking, Stripe/Square/SumUp route, payment-provider, webhook-auth, and i18n-coverage suites all pass; Stripe's "unchanged" no-op flash and its webhook-fail-persists-nothing contract are retained.

## Checks

- `deno task typecheck`, `deno task lint`, `deno task cpd` (0 clones) — all green.
- Full test suite green except two `stripe-mock.test.ts` cases that require a GitHub release download blocked in this sandbox (environmental; pass with network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016J2kmkNxuvD6ewkfinqBTR)_