### PR TITLE
Kill mutants that produce lint-forbidden code via a lint gate

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -12,6 +12,10 @@
 #
 # Format — copy a survivor line from the report and add a reason:
 #   <path>:<line>:<col>  <from> → <to>   # why it is equivalent
+#
+# Do NOT list a mutant whose output the linter rejects (e.g. `=== → ==` or
+# `!== → !=`, forbidden by Biome's noDoubleEquals): the runner lints each mutant
+# and counts a lint failure as killed, so those never survive to be recorded.
 
 # `x ?? F` vs `x || F` differ only when x is falsy-but-not-null; these are all
 # cases where x can't be such a value, or F equals the only one it can be.
@@ -135,8 +139,6 @@ test/test-utils/test-browser.ts:351:58  ?? → ||  # RequestInit.method is omitt
 test/test-utils/test-browser.ts:414:28  ?? → ||  # forms[0] is a FormInfo object when present, otherwise undefined
 src/ui/templates/admin/listing-defaults.tsx:90:19  ?? → ||  # UrlControl value: string|undefined; the only falsy-non-null string is "" which equals the "" fallback, so ?? and || coincide
 src/ui/templates/admin/listing-defaults.tsx:119:42  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
-src/shared/listing-defaults.ts:95:52  === → ==  # hidden gate `months_per_unit === 0`: months_per_unit is a number (DB integer column), so === and == never disagree — there is no string/null operand to coerce
-src/shared/listing-defaults.ts:123:59  !== → !=  # setListingDefaultFields "is set" check: ListingDefaults values are boolean|number|string|string[]|undefined and never null, so `!== undefined` and `!= undefined` always agree
 src/shared/booking/build-tree.ts:121:48  ?? → ||    # childrenByParentId.get(): readonly TicketListing[]|undefined — an array is always truthy
 src/shared/booking/build-tree.ts:161:62  ?? → ||    # packageQuantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
 src/shared/booking/build-tree.ts:208:30  ?? → ||    # entry: EntryContext|undefined — an object literal is always truthy
@@ -247,7 +249,6 @@ src/features/admin/groups.ts:432:55  ?? → ||   # handleGroupEditGet dayPrices.
 src/shared/listings-actions.ts:120:17  ?? → ||   # validateListingGroup existingId ?? 0: a listing id is ≥1 or undefined, never 0, so ?? and || coincide
 
 # attendee merge/refund route: mutants with no observable effect.
-src/features/admin/attendees-merge.ts:356:10  === → !=    # toBookingChoice: keep_target and skip_source are consumed identically (attendee-merge.ts "do nothing for this booking"), so normalizing one to the other is unobservable
 src/features/admin/attendee-refunds.ts:172:24  ?? → ||    # flash.error: string|undefined from applyFlash; a refund error flash is always a non-empty message, so the only falsy-non-null value "" never occurs and ?? / || agree
 
 # attendee columns Listings/answers rework

--- a/scripts/mutation/runner.ts
+++ b/scripts/mutation/runner.ts
@@ -116,7 +116,13 @@ const createLinter = async (): Promise<MutantLinter> => {
   return {
     exit: async (file: string): Promise<number> => {
       const { code } = await new Deno.Command(bin, {
-        args: [...pre, "lint", file],
+        // --no-errors-on-unmatched: a source deliberately outside Biome's
+        // includes (e.g. src/ui/client/scanner.js) is still a mutation target
+        // via src/**/*.js, and linting an excluded path exits non-zero for
+        // "no files processed". Silencing that makes such a file lint clean
+        // (exit 0) so its mutants fall through to the test/build path instead
+        // of the baseline probe mistaking it for a dirty target and aborting.
+        args: [...pre, "lint", "--no-errors-on-unmatched", file],
         cwd: projectRoot,
         stderr: "null",
         stdout: "null",

--- a/scripts/mutation/runner.ts
+++ b/scripts/mutation/runner.ts
@@ -70,6 +70,51 @@ const testEnv = (): Record<string, string> => ({
   STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
 });
 
+/**
+ * Resolve how to invoke Biome's linter — the native binary when it is on PATH
+ * (matches the Nix dev shell), otherwise the npm package (hosted CI). Mirrors
+ * scripts/biome.ts so the mutation gate lints exactly as `deno task lint` does.
+ */
+const resolveBiome = async (): Promise<{ bin: string; pre: string[] }> => {
+  try {
+    const which = await new Deno.Command("which", { args: ["biome"] }).output();
+    if (which.success) return { bin: "biome", pre: [] };
+  } catch {
+    // fall through to the npm package
+  }
+  return { bin: Deno.execPath(), pre: ["run", "-A", "npm:@biomejs/biome"] };
+};
+
+/**
+ * Lint the mutated file. The unmutated tree is lint-clean (CI enforces it), so
+ * any diagnostic here was introduced by the mutation — meaning the mutant
+ * produces code the project forbids and could never pass review, which we count
+ * as detected (see evaluateMutant). Two deliberate restrictions stop this from
+ * ever *masking* a genuine survivor:
+ *   - error-severity only (plain `biome lint`, never `--error-on-warnings`):
+ *     the `noExcessiveCognitiveComplexity` *warning* can trip when an
+ *     `&&`/`||`/`??` swap changes a borderline function's operator mix, and
+ *     killing on that would hide a real logical survivor.
+ *   - lint, never `check`: a mutation that merely lengthens a line past the
+ *     formatter's width is a formatting diff, not a real detection.
+ * The rule this reliably catches is `noDoubleEquals` — every `=== → ==` and
+ * `!== → !=` mutant produces forbidden `==`/`!=` and dies here without a test.
+ */
+type MutantLinter = (file: string) => Promise<boolean>;
+
+const createLinter = async (): Promise<MutantLinter> => {
+  const { bin, pre } = await resolveBiome();
+  return async (file: string): Promise<boolean> => {
+    const { code } = await new Deno.Command(bin, {
+      args: [...pre, "lint", file],
+      cwd: projectRoot,
+      stderr: "null",
+      stdout: "null",
+    }).output();
+    return code === 0;
+  };
+};
+
 /** Run one `deno test` process over `batch`, returning its exit code. */
 const runTestBatch = async (
   batch: string[],
@@ -198,10 +243,15 @@ const evaluateMutant = async (
   timeoutMs: number,
   batchJobs: number,
   assets: MutantAssetHooks | null,
+  lint: MutantLinter,
   abortSignal: AbortSignal,
 ): Promise<Status> => {
   await Deno.writeTextFile(file, applyMutant(original, mutant));
   try {
+    // A mutant that produces code the linter rejects (e.g. `==` under
+    // noDoubleEquals) is detected statically — killed before we spend a full
+    // test run on it. See createLinter for why this can't mask a survivor.
+    if (!(await lint(file))) return "killed";
     // A mutant that breaks the client-bundle build must not be tested against a
     // stale baseline asset (the tests would pass and it would falsely survive).
     // A failed build means the mutation is detected, so count it as killed.
@@ -339,6 +389,7 @@ const runMutants = async (opts: RunMutantsOptions): Promise<number> => {
   const rebuilder: AssetRebuilder | null = useHarness
     ? await createAssetRebuilder()
     : null;
+  const lint = await createLinter();
 
   try {
     const plans: FileMutationPlan[] = [];
@@ -369,6 +420,7 @@ const runMutants = async (opts: RunMutantsOptions): Promise<number> => {
           perMutantTimeout,
           batchJobs,
           plan.assets,
+          lint,
           abortSignal,
         );
         originals.delete(plan.file);

--- a/scripts/mutation/runner.ts
+++ b/scripts/mutation/runner.ts
@@ -86,11 +86,17 @@ const resolveBiome = async (): Promise<{ bin: string; pre: string[] }> => {
 };
 
 /**
- * Lint the mutated file. The unmutated tree is lint-clean (CI enforces it), so
- * any diagnostic here was introduced by the mutation — meaning the mutant
- * produces code the project forbids and could never pass review, which we count
- * as detected (see evaluateMutant). Two deliberate restrictions stop this from
- * ever *masking* a genuine survivor:
+ * Biome linter for the mutation gate. `exit(file)` returns the raw `biome lint`
+ * exit code (0 = clean) for the file's *current on-disk contents*.
+ *
+ * A non-zero exit is read as "the mutation introduced a diagnostic" (the mutant
+ * produces code the project forbids and could never pass review, so we count it
+ * as detected — see evaluateMutant). That reading is only sound once the runner
+ * has confirmed, per file, that the *unmutated* target lints clean (see the
+ * baseline probe in runMutants): otherwise a broken Biome (uncached npm
+ * fallback, unreadable config, a crash) or a pre-existing lint error in the
+ * target would fail every mutant and report a bogus 100%. Two restrictions keep
+ * a passing mutant from ever *masking* a genuine survivor:
  *   - error-severity only (plain `biome lint`, never `--error-on-warnings`):
  *     the `noExcessiveCognitiveComplexity` *warning* can trip when an
  *     `&&`/`||`/`??` swap changes a borderline function's operator mix, and
@@ -100,48 +106,23 @@ const resolveBiome = async (): Promise<{ bin: string; pre: string[] }> => {
  * The rule this reliably catches is `noDoubleEquals` — every `=== → ==` and
  * `!== → !=` mutant produces forbidden `==`/`!=` and dies here without a test.
  */
-type MutantLinter = (file: string) => Promise<boolean>;
+interface MutantLinter {
+  /** `biome lint` exit code for the file's current on-disk contents (0 = clean). */
+  exit(file: string): Promise<number>;
+}
 
 const createLinter = async (): Promise<MutantLinter> => {
   const { bin, pre } = await resolveBiome();
-  const lintExit = async (file: string): Promise<number> => {
-    const { code } = await new Deno.Command(bin, {
-      args: [...pre, "lint", file],
-      cwd: projectRoot,
-      stderr: "null",
-      stdout: "null",
-    }).output();
-    return code;
-  };
-
-  // The gate is only trustworthy if Biome actually runs: a non-zero exit must
-  // mean "found a diagnostic", never "couldn't start" (npm fallback uncached,
-  // unreadable config, a crash). If a failed *invocation* were read as a
-  // diagnostic, every mutant would be recorded as killed while nothing detected
-  // it — a silent perfect score. The committed tree is lint-clean (CI enforces
-  // it), so linting this very file is a known-good probe that must exit 0.
-  // Prove it up front, and re-prove it before trusting any non-zero result
-  // below; if the probe ever fails, abort loudly instead of inflating the score.
-  const selfPath = import.meta.filename;
-  if (!selfPath) throw new Error("mutation lint gate: no local module path");
-  const brokenGate = (exit: number): Error =>
-    new Error(
-      `Biome lint gate is not operational: linting a known-clean file exited ${exit}. ` +
-        "Fix the Biome install/config before running mutation testing.",
-    );
-  const probe = await lintExit(selfPath);
-  if (probe !== 0) throw brokenGate(probe);
-
-  return async (file: string): Promise<boolean> => {
-    if ((await lintExit(file)) === 0) return true;
-    // Non-zero: a real mutation-introduced diagnostic, or Biome broke mid-run.
-    // Distinguish by re-probing the known-clean file — only reached on would-be
-    // kills (rare), so the extra invocation is cheap. A clean probe confirms a
-    // genuine diagnostic (killed); a failing probe means the tooling died, so
-    // abort rather than record a bogus kill.
-    const reprobe = await lintExit(selfPath);
-    if (reprobe !== 0) throw brokenGate(reprobe);
-    return false;
+  return {
+    exit: async (file: string): Promise<number> => {
+      const { code } = await new Deno.Command(bin, {
+        args: [...pre, "lint", file],
+        cwd: projectRoot,
+        stderr: "null",
+        stdout: "null",
+      }).output();
+      return code;
+    },
   };
 };
 
@@ -280,8 +261,10 @@ const evaluateMutant = async (
   try {
     // A mutant that produces code the linter rejects (e.g. `==` under
     // noDoubleEquals) is detected statically — killed before we spend a full
-    // test run on it. See createLinter for why this can't mask a survivor.
-    if (!(await lint(file))) return "killed";
+    // test run on it. The unmutated target is verified lint-clean per file
+    // (see runMutants), so a non-zero exit here is a mutation-introduced
+    // diagnostic, not a broken Biome. See createLinter for the full rationale.
+    if ((await lint.exit(file)) !== 0) return "killed";
     // A mutant that breaks the client-bundle build must not be tested against a
     // stale baseline asset (the tests would pass and it would falsely survive).
     // A failed build means the mutation is detected, so count it as killed.
@@ -439,6 +422,30 @@ const runMutants = async (opts: RunMutantsOptions): Promise<number> => {
 
     for (const plan of plans) {
       if (isAborted()) break;
+      // The lint gate can only tell a mutation-introduced diagnostic apart from
+      // a broken Biome or an already-dirty target if the *unmutated* file lints
+      // clean. The file on disk is the original here (restored after every
+      // mutant), so probe it once per file. A non-zero exit means the gate
+      // can't be trusted — precommit runs `lint:ci` before mutation, but a
+      // standalone `deno task mutation` does not — so abort loudly rather than
+      // record every mutant as a bogus lint-kill. Probing the target itself
+      // (not a fixed path) also means a run that mutates this very file never
+      // reprobes a path that is currently holding a mutant.
+      if (plan.mutants.length > 0 && (await lint.exit(plan.file)) !== 0) {
+        console.error(
+          red(`\nThe unmutated ${rel(plan.file)} does not lint clean.`),
+        );
+        console.error(
+          "The mutation lint gate needs a lint-clean target and a working Biome.",
+        );
+        console.error(
+          "Run `deno task lint` and fix any errors (precommit runs lint:ci first;",
+        );
+        console.error(
+          "a standalone `deno task mutation` does not), then retry.",
+        );
+        return 1;
+      }
       for (const mutant of plan.mutants) {
         if (isAborted()) break;
         originals.set(plan.file, plan.original);

--- a/scripts/mutation/runner.ts
+++ b/scripts/mutation/runner.ts
@@ -104,14 +104,44 @@ type MutantLinter = (file: string) => Promise<boolean>;
 
 const createLinter = async (): Promise<MutantLinter> => {
   const { bin, pre } = await resolveBiome();
-  return async (file: string): Promise<boolean> => {
+  const lintExit = async (file: string): Promise<number> => {
     const { code } = await new Deno.Command(bin, {
       args: [...pre, "lint", file],
       cwd: projectRoot,
       stderr: "null",
       stdout: "null",
     }).output();
-    return code === 0;
+    return code;
+  };
+
+  // The gate is only trustworthy if Biome actually runs: a non-zero exit must
+  // mean "found a diagnostic", never "couldn't start" (npm fallback uncached,
+  // unreadable config, a crash). If a failed *invocation* were read as a
+  // diagnostic, every mutant would be recorded as killed while nothing detected
+  // it — a silent perfect score. The committed tree is lint-clean (CI enforces
+  // it), so linting this very file is a known-good probe that must exit 0.
+  // Prove it up front, and re-prove it before trusting any non-zero result
+  // below; if the probe ever fails, abort loudly instead of inflating the score.
+  const selfPath = import.meta.filename;
+  if (!selfPath) throw new Error("mutation lint gate: no local module path");
+  const brokenGate = (exit: number): Error =>
+    new Error(
+      `Biome lint gate is not operational: linting a known-clean file exited ${exit}. ` +
+        "Fix the Biome install/config before running mutation testing.",
+    );
+  const probe = await lintExit(selfPath);
+  if (probe !== 0) throw brokenGate(probe);
+
+  return async (file: string): Promise<boolean> => {
+    if ((await lintExit(file)) === 0) return true;
+    // Non-zero: a real mutation-introduced diagnostic, or Biome broke mid-run.
+    // Distinguish by re-probing the known-clean file — only reached on would-be
+    // kills (rare), so the extra invocation is cheap. A clean probe confirms a
+    // genuine diagnostic (killed); a failing probe means the tooling died, so
+    // abort rather than record a bogus kill.
+    const reprobe = await lintExit(selfPath);
+    if (reprobe !== 0) throw brokenGate(reprobe);
+    return false;
   };
 };
 


### PR DESCRIPTION
## What

Teaches the mutation runner to treat a mutant whose output the linter rejects as **killed**, instead of parking it in `equivalent-mutants.txt` by hand.

## Why

The runner only ever asked *"do the tests fail?"* So an operator swap that produces code the project's own linter forbids — e.g. `=== → ==` or `!== → !=`, both rejected by Biome's `noDoubleEquals` — passed every test (it is behaviourally identical) and had to be recorded as a known-equivalent survivor. But such a mutant could never pass review or CI: it *is* a detected change, just detected statically rather than by a test.

This is the class of equivalent-mutant that a config rule genuinely *can* eliminate. (The much larger `?? → ||` class can't: `x || []` is both type-valid and lint-clean under Biome, and those mutants are truly equivalent — a `getOr` helper would only relocate the equivalence into the helper body, not remove it.)

## How

- `createLinter` in `scripts/mutation/runner.ts` runs `biome lint` on each mutated file before its tests; a lint failure returns `"killed"`, mirroring the existing "a broken client-bundle build is a kill" path. Lint-killed mutants also skip the full test run, so they're cheaper.
- Deliberately conservative so it can never **mask** a genuine survivor:
  - `biome lint` (error severity only), **not** `--error-on-warnings` — a `noExcessiveCognitiveComplexity` *warning* triggered by an `&&`/`||`/`??` operator-mix change must not be counted as detection.
  - `lint`, **not** `check` — a mutation that merely lengthens a line past the formatter's width is a formatting diff, not a real detection.
- Biome invocation mirrors `scripts/biome.ts` (native binary if on PATH, else the npm package).
- Removes the three now-lint-killed entries from `equivalent-mutants.txt` (`listing-defaults.ts` `=== → ==` and `!== → !=`, `attendees-merge.ts` `=== → !=`) and adds a header note so none are re-added.

## Verification

- Direct check: applying `=== → ==` to `listing-defaults.ts:95` makes `biome lint` exit `1`; the restored original exits `0`.
- Full runner: `deno task mutation src/shared/listing-defaults.ts test/shared/listing-defaults.test.ts` — the `===` mutant at `95:52` is now killed (no longer a survivor) and no ignore-list-sync problems are reported.
- `deno check` + `deno task lint:ci` clean on the changed files; `test/scripts/mutation-*` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Bz6EQvQD62SC7PNq6oWP6)_