### PR TITLE
Fix payment sandbox e2e for tabbed listing page, add ntfy failure alerts

### DIFF
--- a/.github/workflows/payment-sandbox-e2e.yml
+++ b/.github/workflows/payment-sandbox-e2e.yml
@@ -16,6 +16,8 @@
 #   SQUARE_LOCATION_ID         — Square sandbox location id
 #   SUMUP_API_KEY              — SumUp sandbox secret API key
 #   SUMUP_MERCHANT_CODE        — SumUp sandbox merchant code
+# Optional repository secret:
+#   NTFY_URL                   — ntfy topic URL pinged if a leg fails
 # The "free" leg needs no secrets — it is a harness/app self-test.
 
 name: Payment sandbox e2e
@@ -114,6 +116,7 @@ jobs:
           SQUARE_SANDBOX: "true"
           SUMUP_API_KEY: ${{ secrets.SUMUP_API_KEY }}
           SUMUP_MERCHANT_CODE: ${{ secrets.SUMUP_MERCHANT_CODE }}
+          NTFY_URL: ${{ secrets.NTFY_URL }}
         run: node --import tsx src/main.ts ${{ matrix.target }}
 
       - name: Upload run artifacts (screenshots, page HTML, server logs)

--- a/e2e-payments/README.md
+++ b/e2e-payments/README.md
@@ -32,8 +32,8 @@ For a target (`stripe` | `square` | `sumup` | `free`):
    - books, is redirected to the provider's hosted checkout, and pays with the
      provider's sandbox test card;
    - lands back on the app return URL and asserts the booking shows as paid
-     (customer success page, the booker on the admin listing, **and** the
-     captured amount in the listing's income ledger).
+     (customer success page, the captured amount in the listing's Overview
+     income ledger, **and** the booker on the listing's Attendees tab).
 
 ### What is (and isn't) exercised per provider
 
@@ -84,6 +84,10 @@ Watch it happen in a real window with `HEADLESS=false`.
 | `SUMUP_API_KEY`, `SUMUP_MERCHANT_CODE` | SumUp | Sandbox secret key + matching merchant code. |
 
 A target with missing secrets **skips** (exits 0) rather than failing.
+
+`NTFY_URL` (optional) — an ntfy topic URL (e.g. `https://ntfy.sh/your-topic`)
+pinged with the failed target and error message when a leg fails. Unset ⇒ no
+notification.
 
 Other knobs (all optional): `DENO_BIN`, `CLOUDFLARED_BIN`,
 `CHROMIUM_EXECUTABLE` (unset in CI so Playwright uses its own build),

--- a/e2e-payments/src/config.ts
+++ b/e2e-payments/src/config.ts
@@ -89,6 +89,9 @@ export const config = {
 
   /** Where to drop screenshots / server logs on failure. */
   artifactsDir: env("E2E_ARTIFACTS_DIR") ?? "artifacts",
+
+  /** Ntfy endpoint pinged on failure (e.g. `https://ntfy.sh/your-topic`). Unset ⇒ no notification. */
+  ntfyUrl: env("NTFY_URL"),
 };
 
 /** Whether a public tunnel is required for the given target. */

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -227,19 +227,15 @@ export const assertPaidBookingConfirmed = async (
   }
   log(`  ✔ customer saw the success page (${page.url()})`);
 
-  // 2. Cross-check in admin: the booker appears on the listing…
+  // 2. Cross-check in admin: the listing's Overview tab shows the captured
+  // income, and its Attendees tab shows the booker — the listing detail page
+  // was split into tabs (Overview / Attendees / …), so the roster no longer
+  // renders inline on the tab reached by clicking the listing name.
   await session.goto("/admin/");
   await login(session);
   await session.clickLink(LISTING_NAME);
-  const adminBody = await session.bodyText();
-  if (!adminBody.includes(BOOKER_EMAIL)) {
-    await session.screenshot("paid-admin-missing-booker");
-    throw new Error(
-      `paid booker ${BOOKER_EMAIL} not visible on the admin listing page`,
-    );
-  }
 
-  // …and, crucially, that the payment was actually captured. Assert against the
+  // …crucially, that the payment was actually captured. Assert against the
   // listing's INCOME LEDGER specifically — it projects from the payment ledger,
   // so a regression that creates the attendee but drops the payment
   // (price_paid = 0) records no income and the ledger section does not render.
@@ -275,6 +271,18 @@ export const assertPaidBookingConfirmed = async (
         `Income ledger:\n${paidRegion.slice(0, 600)}`,
     );
   }
+
+  // 3. The booker itself appears on the Attendees tab, not the Overview tab
+  // just checked above.
+  await session.clickLink("Attendees");
+  const attendeesBody = await session.bodyText();
+  if (!attendeesBody.includes(BOOKER_EMAIL)) {
+    await session.screenshot("paid-admin-missing-booker");
+    throw new Error(
+      `paid booker ${BOOKER_EMAIL} not visible on the admin listing's Attendees tab`,
+    );
+  }
+
   log(
     `  ✔ admin listing shows the paid booker (${BOOKER_EMAIL}) and captured amount (${withDecimals})`,
   );

--- a/e2e-payments/src/main.ts
+++ b/e2e-payments/src/main.ts
@@ -28,6 +28,7 @@ import {
 } from "./flow.ts";
 import { buildStaticAssets, startAppServer } from "./server.ts";
 import { noTunnel, startTunnel } from "./tunnel.ts";
+import { notifyFailure } from "./notify.ts";
 
 /**
  * Print the tail of the app server's log to stdout. On CI the server log is
@@ -120,9 +121,11 @@ const run = async (): Promise<void> => {
 
     step(`PASS — ${target} end-to-end booking completed`);
   } catch (err) {
-    fail(`FAIL — ${target}: ${err instanceof Error ? err.message : String(err)}`);
+    const message = err instanceof Error ? err.message : String(err);
+    fail(`FAIL — ${target}: ${message}`);
     if (session) await session.screenshot(`fail-${target}`);
     if (server) dumpServerLog(server.logPath);
+    await notifyFailure(target, message);
     throw err;
   } finally {
     if (session) await session.stop();

--- a/e2e-payments/src/notify.ts
+++ b/e2e-payments/src/notify.ts
@@ -1,0 +1,33 @@
+/**
+ * Ping a configured ntfy URL when a payment sandbox e2e run fails. Mirrors the
+ * app's own `src/shared/ntfy.ts` contract (POST the message, `Tags: warning`),
+ * but this harness has no request/domain to report — it identifies the failed
+ * target and error message instead.
+ */
+
+import { config } from "./config.ts";
+import { log, warn } from "./log.ts";
+
+export const notifyFailure = async (
+  target: string,
+  message: string,
+): Promise<void> => {
+  const ntfyUrl = config.ntfyUrl;
+  if (!ntfyUrl) return;
+
+  try {
+    await fetch(ntfyUrl, {
+      body: `payment sandbox e2e (${target}) failed: ${message}`.slice(0, 1000),
+      headers: {
+        Tags: "warning",
+        Title: `payment sandbox e2e: ${target} failed`,
+      },
+      method: "POST",
+    });
+    log(`  notified ${ntfyUrl}`);
+  } catch (err) {
+    warn(
+      `failed to notify ${ntfyUrl}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+};


### PR DESCRIPTION
## Summary

- The admin listing detail page was recently split into tabs (Overview / Attendees / Edit / …, see #1514). The payment sandbox e2e harness (`e2e-payments/`) still asserted the paid booker's email on the page reached by clicking the listing name, which is now the **Overview** tab and no longer renders the attendee roster. Updated `e2e-payments/src/flow.ts` to check the income ledger on Overview (unchanged location) and navigate to the **Attendees** tab to assert the booker is visible there.
- Added `NTFY_URL` support to the harness: a new `e2e-payments/src/notify.ts` pings the configured ntfy topic (mirroring the app's own `src/shared/ntfy.ts` contract) with the target and error message whenever a sandbox e2e leg fails. Wired the `NTFY_URL` secret through `.github/workflows/payment-sandbox-e2e.yml` and documented both changes in the harness README.

## Test plan

- [x] `npx tsc --noEmit` passes in `e2e-payments/` (isolated Node package outside the Deno lint/test/coverage gates by design).
- [ ] Nightly/manual run of `.github/workflows/payment-sandbox-e2e.yml` against real sandbox secrets to confirm the Attendees-tab assertion and ntfy ping behave as expected (not exercised in this sandbox — no Deno/provider secrets available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd8bqsvdZzwfXjFQ4Srqxg)_