### PR TITLE
Unify the aggregate-recalculate POST flow into runRecalculatePost

### DIFF
--- a/src/features/admin/aggregate-recalculation.ts
+++ b/src/features/admin/aggregate-recalculation.ts
@@ -1,4 +1,4 @@
-import { htmlResponse } from "#routes/response.ts";
+import { htmlResponse, redirect } from "#routes/response.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { Field } from "#shared/forms.tsx";
 import { type ValidationResult, validateForm } from "#shared/forms.tsx";
@@ -28,6 +28,31 @@ export const selectedRecalculationFields = <T extends string>(
 ): T[] => {
   const selected = new Set(form.getAll(RECALCULATE_FIELD_NAME));
   return allowed.filter((field) => selected.has(field));
+};
+
+/**
+ * The shared aggregate-recalculation POST flow, identical for listings,
+ * modifiers, and answers: read the selected fields, re-render the page with a
+ * "choose a field" message when none are ticked, otherwise reset those
+ * aggregates, log the action, and redirect to the entity's edit page. Each
+ * caller supplies the parts that differ as closures over its loaded entity, so
+ * the divergent auth/load wrappers stay at the call site.
+ */
+export const runRecalculatePost = async <T extends string>(config: {
+  form: FormParams;
+  fields: readonly T[];
+  /** Re-render the recalculate page with the "choose a field" error. */
+  renderChoose: () => Response | Promise<Response>;
+  reset: (selected: T[]) => Promise<unknown>;
+  log: () => Promise<unknown>;
+  successPath: string;
+  successMessage: string;
+}): Promise<Response> => {
+  const selected = selectedRecalculationFields(config.form, config.fields);
+  if (selected.length === 0) return config.renderChoose();
+  await config.reset(selected);
+  await config.log();
+  return redirect(config.successPath, config.successMessage, true);
 };
 
 type RecalculatePage<TEntity, TSnapshot, TSession> = (

--- a/src/features/admin/listings-recalculate.ts
+++ b/src/features/admin/listings-recalculate.ts
@@ -9,10 +9,9 @@
 import { t } from "#i18n";
 import {
   createRecalculatePageRenderer,
-  selectedRecalculationFields,
+  runRecalculatePost,
 } from "#routes/admin/aggregate-recalculation.ts";
 import { AUTH_FORM, requireSessionOr, withAuth } from "#routes/auth.ts";
-import { redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import {
@@ -51,27 +50,21 @@ export const handleListingRecalculatePost: TypedRouteHandler<
   "POST /admin/listings/recalculate/:listingId"
 > = (request, { listingId }) =>
   withAuth(request, AUTH_FORM, (session, form) =>
-    withEntityFromParam(listingId, getListingWithCount, async (listing) => {
-      const selected = selectedRecalculationFields(
+    withEntityFromParam(listingId, getListingWithCount, (listing) =>
+      runRecalculatePost({
+        fields: LISTING_AGGREGATE_FIELDS,
         form,
-        LISTING_AGGREGATE_FIELDS,
-      );
-      if (selected.length === 0) {
-        return renderListingRecalculatePage(
-          listing,
-          session,
-          t("listings_table.recalculate_choose"),
-        );
-      }
-      await resetListingAggregateFields(listing.id, selected);
-      await logActivity(
-        `Listing '${listing.name}' totals recalculated`,
-        listing,
-      );
-      return redirect(
-        `/admin/listing/${listing.id}/edit`,
-        t("listings_table.recalculate_success"),
-        true,
-      );
-    }),
+        log: () =>
+          logActivity(`Listing '${listing.name}' totals recalculated`, listing),
+        renderChoose: () =>
+          renderListingRecalculatePage(
+            listing,
+            session,
+            t("listings_table.recalculate_choose"),
+          ),
+        reset: (selected) => resetListingAggregateFields(listing.id, selected),
+        successMessage: t("listings_table.recalculate_success"),
+        successPath: `/admin/listing/${listing.id}/edit`,
+      }),
+    ),
   );

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -7,7 +7,7 @@ import { t } from "#i18n";
 import {
   createRecalculatePageRenderer,
   parseEditableAggregateForm,
-  selectedRecalculationFields,
+  runRecalculatePost,
 } from "#routes/admin/aggregate-recalculation.ts";
 import { loadAccountLedger } from "#routes/admin/ledger.ts";
 import { createCrudHandlers } from "#routes/admin/owner-crud.ts";
@@ -456,26 +456,24 @@ const handleModifierRecalculatePost: TypedRouteHandler<
   "POST /admin/modifiers/recalculate/:modifierId"
 > = (request, { modifierId }) =>
   withAuth(request, AUTH_FORM, (session, form) =>
-    withModifier(modifierId)(async (modifier) => {
-      const selected = selectedRecalculationFields(
+    withModifier(modifierId)((modifier) =>
+      runRecalculatePost({
+        fields: MODIFIER_AGGREGATE_FIELDS,
         form,
-        MODIFIER_AGGREGATE_FIELDS,
-      );
-      if (selected.length === 0) {
-        return renderModifierRecalculatePage(
-          modifier,
-          session,
-          t("modifiers.recalculate.choose"),
-        );
-      }
-      await resetModifierAggregateFields(modifier.id, selected);
-      await logActivity(`Modifier '${modifier.name}' totals recalculated`);
-      return redirect(
-        `/admin/modifiers/${modifier.id}/edit`,
-        t("modifiers.recalculate.success"),
-        true,
-      );
-    }),
+        log: () =>
+          logActivity(`Modifier '${modifier.name}' totals recalculated`),
+        renderChoose: () =>
+          renderModifierRecalculatePage(
+            modifier,
+            session,
+            t("modifiers.recalculate.choose"),
+          ),
+        reset: (selected) =>
+          resetModifierAggregateFields(modifier.id, selected),
+        successMessage: t("modifiers.recalculate.success"),
+        successPath: `/admin/modifiers/${modifier.id}/edit`,
+      }),
+    ),
   );
 
 /** Selected ids from a checkbox group, positive integers only. */

--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -6,7 +6,7 @@ import { mapNotNullish } from "#fp";
 import { t } from "#i18n";
 import {
   parseEditableAggregateForm,
-  selectedRecalculationFields,
+  runRecalculatePost,
 } from "#routes/admin/aggregate-recalculation.ts";
 import {
   createConfirmedHandlers,
@@ -487,26 +487,25 @@ const handleAnswerRecalculateGet = answerRoute((question, answer, session) => {
 
 /** Handle POST /admin/questions/:id/answers/:answerId/recalculate */
 const handleAnswerRecalculatePost = answerActionHandler(
-  async ({ context: { answer, question }, form, params, session }) => {
-    const selected = selectedRecalculationFields(form, ANSWER_AGGREGATE_FIELDS);
-    if (selected.length === 0) {
-      return renderAnswerRecalculatePage(
-        question,
-        answer,
-        session,
-        t("questions.recalculate.choose"),
-      );
-    }
-    await resetAnswerAggregateFields(answer.id, selected);
-    await logActivity(
-      `Answer '${answer.text}' selection total recalculated in question ${question.id}`,
-    );
-    return redirect(
-      editAnswerPath(params),
-      t("questions.recalculate.success"),
-      true,
-    );
-  },
+  ({ context: { answer, question }, form, params, session }) =>
+    runRecalculatePost({
+      fields: ANSWER_AGGREGATE_FIELDS,
+      form,
+      log: () =>
+        logActivity(
+          `Answer '${answer.text}' selection total recalculated in question ${question.id}`,
+        ),
+      renderChoose: () =>
+        renderAnswerRecalculatePage(
+          question,
+          answer,
+          session,
+          t("questions.recalculate.choose"),
+        ),
+      reset: (selected) => resetAnswerAggregateFields(answer.id, selected),
+      successMessage: t("questions.recalculate.success"),
+      successPath: editAnswerPath(params),
+    }),
 );
 
 /** Factory for move-up/move-down handlers */


### PR DESCRIPTION
The payoff after the three recalc-file mutation-hardening PRs (#1539/#1545/#1552): the listing, modifier, and answer recalculate POST handlers each spelled out the **same flow** —

```
read selected fields → if none, re-render with "choose a field"
→ else reset those aggregates → log → redirect to the edit page
```

— differing only in the fields, reset fn, log message, redirect target, and copy.

## Change
Collapse that flow into a single `runRecalculatePost` in `aggregate-recalculation.ts`. Each handler now passes the parts that differ as **closures over its loaded entity**:

```ts
runRecalculatePost({
  fields: LISTING_AGGREGATE_FIELDS,
  form,
  log: () => logActivity(`Listing '${listing.name}' totals recalculated`, listing),
  renderChoose: () => renderListingRecalculatePage(listing, session, t("…recalculate_choose")),
  reset: (selected) => resetListingAggregateFields(listing.id, selected),
  successMessage: t("…recalculate_success"),
  successPath: `/admin/listing/${listing.id}/edit`,
})
```

The three divergent auth/load wrappers (`withEntityFromParam` / `withModifier` / `answerActionHandler`, incl. the answer's compound question+answer entity) stay thin at each call site, while the flow itself lives once — so a future change to the recalculate flow (a new guard, an audit step, different redirect behaviour) happens in one place instead of three, and the three can't drift.

## Behaviour
Unchanged — a pure extraction. Each closure reproduces exactly what the inline body did (including the modifier's single-arg `logActivity` vs the listing's entity-tagged one).

## Verification
- `listings-recalculate.ts` baseline passes and stays **100% on mutation** after the extraction (its own mutant count drops as the flow moves to the shared helper).
- Typecheck / `lint:ci` / `cpd` (0 clones) clean.
- Src-only change, so `precommit:mutation` skips; the 100%-coverage gate and full suite (which exercise all three recalc paths) are the CI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNMEoUV7xXLU1F6gn2rxoW)_