### PR TITLE
Mutation-harden column-order.ts's template tests

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -320,3 +320,14 @@ src/features/admin/group-page-data.ts:182:49  ?? → ||   # dayPrices.get(): Day
 # string literal, so === and == never disagree — no null/undefined/number
 # operand exists to coerce.
 scripts/edge-bundle-modules.ts:40:36  === → ==
+
+# renderFilteredValue's pre-conversion of a date-parseable string to a Date
+# object before handing it to LiquidJS's `date` filter is provably redundant:
+# probing every input shape (ISO timestamps, date-only, offset/Z timezones,
+# RFC 1123, slash format, %A/%z/%H specifiers) shows LiquidJS's built-in
+# strftime date filter parses a raw date-parseable string identically to
+# passing the equivalent Date object. So whenever the real literal `"| date"`
+# match would fire (i.e. the raw value is genuinely a date being formatted by
+# a date filter), converting or not converting renders the same string — no
+# input can tell the two apart.
+src/shared/column-order.ts:174:59  | date → "| date mutated"

--- a/test/lib/column-order/template.test.ts
+++ b/test/lib/column-order/template.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import type { ColumnGenerators } from "#shared/column-order.ts";
+import type { ColumnDef, ColumnGenerators } from "#shared/column-order.ts";
 import {
   buildDefaultTemplate,
   getHeaderText,
@@ -50,9 +50,20 @@ describe("validateColumnTemplate", () => {
     expect(error).toContain("Available columns");
   });
 
+  test("lists available columns comma-separated in the error message", () => {
+    const error = validateColumnTemplate("{{bogus}}", [
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+    expect(error).toBe(
+      'Unknown column "bogus". Available columns: alpha, beta, gamma',
+    );
+  });
+
   test("rejects empty template", () => {
     const error = validateColumnTemplate("", VALID_LISTING_KEYS);
-    expect(error).toContain("at least one column");
+    expect(error).toBe("Template must include at least one column");
   });
 
   test("accepts templates with date filter", () => {
@@ -141,6 +152,12 @@ describe("resolveColumnLayout", () => {
   });
 });
 
+describe("buildDefaultTemplate", () => {
+  test("joins column tags with a comma and space", () => {
+    expect(buildDefaultTemplate(["a", "b", "c"])).toBe("{{a}}, {{b}}, {{c}}");
+  });
+});
+
 describe("renderFilteredValue", () => {
   test("applies date filter with strftime format", () => {
     const result = renderFilteredValue(
@@ -178,6 +195,21 @@ describe("renderFilteredValue", () => {
 
   test("renders value without filter when no pipe", () => {
     expect(renderFilteredValue("name", "Alice", "name")).toBe("Alice");
+  });
+
+  test("does not attempt Date conversion for a non-string raw value", () => {
+    // A null rawValue is falsy-but-non-null, so it must skip conversion and
+    // render as empty — converting null via `new Date(null)` would render
+    // the 1970 epoch date instead.
+    expect(renderFilteredValue('date | date: "%B"', null, "date")).toBe("");
+  });
+
+  test("only converts to a Date when the filter expression is a date filter", () => {
+    // "2026-01-01" is Date-parseable, but the filter here is `upcase`, not a
+    // date filter, so the raw string must pass through unconverted.
+    expect(renderFilteredValue("date | upcase", "2026-01-01", "date")).toBe(
+      "2026-01-01",
+    );
   });
 });
 
@@ -251,6 +283,65 @@ describe("renderCells", () => {
     expect(html).toContain("&lt;script&gt;");
   });
 
+  test("joins rendered cells with no separator", () => {
+    const generators: ColumnGenerators<{ a: string; b: string }> = {
+      colA: { cell: (r) => r.a, description: "test", label: "A" },
+      colB: { cell: (r) => r.b, description: "test", label: "B" },
+    };
+    const html = renderCells(
+      { a: "1", b: "2" },
+      ["colA", "colB"],
+      generators,
+      undefined,
+      new Map(),
+      escapeHtml,
+    );
+    expect(html).toBe("<td>1</td><td>2</td>");
+  });
+
+  test("escapes filtered output even when the column is marked isHtml", () => {
+    // Filtered values are always plain text (per renderCells' contract), so
+    // a filter must still be escaped even on an isHtml column.
+    const generators: ColumnGenerators<{ raw: string }> = {
+      val: {
+        cell: (r) => r.raw,
+        description: "test",
+        isHtml: true,
+        label: "Val",
+        rawValue: (r) => r.raw,
+      },
+    };
+    const html = renderCells(
+      { raw: "<b>bold</b>" },
+      ["val"],
+      generators,
+      undefined,
+      new Map([["val", "val | upcase"]]),
+      escapeHtml,
+    );
+    expect(html).toBe("<td>&lt;B&gt;BOLD&lt;/B&gt;</td>");
+  });
+
+  test("does not escape isHtml column content when no filter is applied", () => {
+    const generators: ColumnGenerators<{ raw: string }> = {
+      val: {
+        cell: (r) => r.raw,
+        description: "test",
+        isHtml: true,
+        label: "Val",
+      },
+    };
+    const html = renderCells(
+      { raw: "<b>bold</b>" },
+      ["val"],
+      generators,
+      undefined,
+      new Map(),
+      escapeHtml,
+    );
+    expect(html).toBe("<td><b>bold</b></td>");
+  });
+
   test("applies CSS class from column definition", () => {
     const generators: ColumnGenerators<{ val: string }> = {
       val: {
@@ -279,5 +370,15 @@ describe("getHeaderText", () => {
 
   test("falls back to label when headerText is not set", () => {
     expect(getHeaderText(LISTING_TABLE_COLUMNS.location!)).toBe("Location");
+  });
+
+  test("keeps an explicit empty-string headerText instead of falling back to label", () => {
+    const col: ColumnDef<unknown> = {
+      cell: () => "",
+      description: "test",
+      headerText: "",
+      label: "Fallback Label",
+    };
+    expect(getHeaderText(col)).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

`deno task mutation src/shared/column-order.ts` (the configurable admin-table column-order template parser/renderer) scored only **80.5%** (16 survivors) against its existing tests — a real gap for a file with several branches that had never been mutation-tested.

- Locked down exact text for the "unknown column" error message (column list join separator) and the "must include at least one column" error, instead of loose `.toContain()` checks.
- Added a direct format test for `buildDefaultTemplate`'s `", "` join separator.
- Added tests for `renderFilteredValue`'s date-conversion guard (`typeof rawValue === "string" && expression.includes("| date")`): a `null` raw value to prove non-strings are never converted, and a non-date filter (`upcase`) applied to a date-parseable string to prove conversion only happens for date filters.
- Added tests covering both `useFilter`/`isHtml` combinations in `renderCells`, so the escaping ternary can't silently invert or hard-code a branch.
- Added a test proving `renderCells` joins cells with no separator.
- Added a test proving `getHeaderText` keeps an explicit empty-string `headerText` rather than falling back to `label` (`??` vs `||`).

One survivor (`174:59`, the `"| date"` substring literal) is a genuine equivalent mutant: probing several date string shapes (ISO, date-only, offset/Z timezones, RFC 1123, slash format, various strftime specifiers) shows LiquidJS's `date` filter parses a raw date-parseable string identically to the pre-converted `Date` object, so no input can ever distinguish the two. Documented in `scripts/mutation/equivalent-mutants.txt` with the reasoning.

Full exhaustive mutation score for `src/shared/column-order.ts` is now **100%** (81/81 detected, 1 suppressed as known-equivalent).

## Test plan

- [x] `deno task test:files test/lib/column-order/template.test.ts` — all 39 tests pass
- [x] `deno task mutation src/shared/column-order.ts 'test/lib/column-order/**/*.test.ts' --exhaustive` — 100% (81/81 detected, 1 suppressed)
- [x] `deno task lint` — clean
- [x] `deno task precommit` — passes except two pre-existing `stripe-mock` download tests that require live GitHub release access unavailable in this sandbox (confirmed to fail identically without this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_