### PR TITLE
Fix Attendees-tab click scoping and harden ntfy notification in e2e-payments

### DIFF
--- a/e2e-payments/README.md
+++ b/e2e-payments/README.md
@@ -86,8 +86,9 @@ Watch it happen in a real window with `HEADLESS=false`.
 A target with missing secrets **skips** (exits 0) rather than failing.
 
 `NTFY_URL` (optional) — an ntfy topic URL (e.g. `https://ntfy.sh/your-topic`)
-pinged with the failed target and error message when a leg fails. Unset ⇒ no
-notification.
+pinged when a leg fails. Only the failed target is reported (no error detail,
+which can include booker emails or scraped page text) — full diagnostics stay
+in the CI job log/artifacts. Unset ⇒ no notification.
 
 Other knobs (all optional): `DENO_BIN`, `CLOUDFLARED_BIN`,
 `CHROMIUM_EXECUTABLE` (unset in CI so Playwright uses its own build),

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -273,8 +273,21 @@ export const assertPaidBookingConfirmed = async (
   }
 
   // 3. The booker itself appears on the Attendees tab, not the Overview tab
-  // just checked above.
-  await session.clickLink("Attendees");
+  // just checked above. Scoped to the tab strip (`nav.entity-tabs`): the
+  // global admin nav also has an "Attendees" link (the site-wide
+  // `/admin/attendees` index), and clickLink's unscoped `.first()` would match
+  // that link — landing on the wrong page and passing without ever exercising
+  // this listing's tab.
+  const attendeesTabLink = session.page
+    .locator("nav.entity-tabs a", { hasText: "Attendees" })
+    .first();
+  const attendeesHref = await attendeesTabLink.getAttribute("href", {
+    timeout: config.navTimeoutMs,
+  });
+  if (!attendeesHref) {
+    throw new Error("no Attendees tab link found on the listing page");
+  }
+  await session.goto(attendeesHref);
   const attendeesBody = await session.bodyText();
   if (!attendeesBody.includes(BOOKER_EMAIL)) {
     await session.screenshot("paid-admin-missing-booker");

--- a/e2e-payments/src/main.ts
+++ b/e2e-payments/src/main.ts
@@ -125,7 +125,7 @@ const run = async (): Promise<void> => {
     fail(`FAIL — ${target}: ${message}`);
     if (session) await session.screenshot(`fail-${target}`);
     if (server) dumpServerLog(server.logPath);
-    await notifyFailure(target, message);
+    await notifyFailure(target);
     throw err;
   } finally {
     if (session) await session.stop();

--- a/e2e-payments/src/notify.ts
+++ b/e2e-payments/src/notify.ts
@@ -1,33 +1,39 @@
 /**
  * Ping a configured ntfy URL when a payment sandbox e2e run fails. Mirrors the
- * app's own `src/shared/ntfy.ts` contract (POST the message, `Tags: warning`),
- * but this harness has no request/domain to report — it identifies the failed
- * target and error message instead.
+ * app's own `src/shared/ntfy.ts` contract: report just enough to identify the
+ * failure (which target broke), not the failure detail itself — harness error
+ * messages routinely echo exact booker emails or scraped page text, and unlike
+ * the app's fixed error-code enum there is no safe way to sanitize free-form
+ * failure text. Full diagnostics stay in the CI job log/artifacts. Never logs
+ * the configured URL itself: for a public ntfy topic, the URL is the
+ * publish/subscribe handle.
  */
 
 import { config } from "./config.ts";
 import { log, warn } from "./log.ts";
 
-export const notifyFailure = async (
-  target: string,
-  message: string,
-): Promise<void> => {
+const NOTIFY_TIMEOUT_MS = 5_000;
+
+export const notifyFailure = async (target: string): Promise<void> => {
   const ntfyUrl = config.ntfyUrl;
   if (!ntfyUrl) return;
 
   try {
-    await fetch(ntfyUrl, {
-      body: `payment sandbox e2e (${target}) failed: ${message}`.slice(0, 1000),
+    const res = await fetch(ntfyUrl, {
+      body: `payment sandbox e2e (${target}) failed — see the CI job log/artifacts for details.`,
       headers: {
         Tags: "warning",
         Title: `payment sandbox e2e: ${target} failed`,
       },
       method: "POST",
+      signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS),
     });
-    log(`  notified ${ntfyUrl}`);
+    if (!res.ok) {
+      warn(`ntfy publish rejected: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`);
+      return;
+    }
+    log("  notified ntfy of the failure");
   } catch (err) {
-    warn(
-      `failed to notify ${ntfyUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    warn(`failed to notify ntfy: ${err instanceof Error ? err.message : String(err)}`);
   }
 };


### PR DESCRIPTION
## Summary

Follow-up to #1553 (already merged), addressing the automated Codex review comments left on that PR after merge:

- **Scope the Attendees click to the listing's tab strip.** `e2e-payments/src/flow.ts` previously used the generic `clickLink("Attendees")`, but the global admin nav also has an unscoped `/admin/attendees` link with the same text — `clickLink`'s `.first()` matched that instead of the listing's own tab, so the assertion could pass without ever exercising the tab this fix was meant to cover. Now locates the link inside `nav.entity-tabs` specifically and navigates to its `href` directly.
- **Bound and validate the ntfy publish.** `e2e-payments/src/notify.ts` now sends the request with a 5s `AbortSignal.timeout` (so a slow/hanging ntfy endpoint can't stall teardown), checks `res.ok` instead of assuming success, and no longer logs the configured ntfy URL (a public topic's URL is its publish/subscribe handle).
- **Stop forwarding raw failure text to ntfy.** The alert now reports only the failed target and points at the CI job log/artifacts for detail — harness error messages can include the test booker's email or scraped page text, and the app's own ntfy contract (`src/shared/ntfy.ts`) deliberately never sends failure specifics off-box either.

## Test plan

- [x] `npx tsc --noEmit` passes in `e2e-payments/` (isolated Node package outside the Deno lint/test/coverage gates by design).
- [ ] Nightly/manual run of `.github/workflows/payment-sandbox-e2e.yml` against real sandbox secrets to confirm the scoped Attendees-tab click and the ntfy failure path behave as expected (not exercised in this sandbox — no Deno/provider secrets available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd8bqsvdZzwfXjFQ4Srqxg)_