### PR TITLE
Fix column-order.ts's premature date conversion in filter pipelines

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -332,14 +332,3 @@ src/features/admin/questions.ts:559:24  return notFoundResponse() → return und
 # string literal, so === and == never disagree — no null/undefined/number
 # operand exists to coerce.
 scripts/edge-bundle-modules.ts:40:36  === → ==
-
-# renderFilteredValue's pre-conversion of a date-parseable string to a Date
-# object before handing it to LiquidJS's `date` filter is provably redundant:
-# probing every input shape (ISO timestamps, date-only, offset/Z timezones,
-# RFC 1123, slash format, %A/%z/%H specifiers) shows LiquidJS's built-in
-# strftime date filter parses a raw date-parseable string identically to
-# passing the equivalent Date object. So whenever the real literal `"| date"`
-# match would fire (i.e. the raw value is genuinely a date being formatted by
-# a date filter), converting or not converting renders the same string — no
-# input can tell the two apart.
-src/shared/column-order.ts:174:59  | date → "| date mutated"

--- a/src/shared/column-order.ts
+++ b/src/shared/column-order.ts
@@ -156,6 +156,9 @@ export const resolveColumnLayout = (
     : { columnKeys: [...defaultOrder], filters: new Map() };
 };
 
+/** Matches only when `date` is the first filter applied to the raw value */
+const FIRST_FILTER_IS_DATE_RE = /^[^|]*\|\s*date\b/;
+
 /**
  * Render a single column value through a Liquid filter expression.
  *
@@ -169,9 +172,15 @@ export const renderFilteredValue = (
   key: string,
 ): string => {
   // For date filters, convert ISO strings to Date objects so LiquidJS's
-  // built-in strftime works correctly.
+  // built-in strftime works correctly. Only convert when `date` is the first
+  // filter in the chain — converting for a later `| date` (e.g. a filter
+  // that transforms the raw string before a date filter downstream) would
+  // feed that earlier filter a Date instead of the raw string.
   let contextValue = rawValue;
-  if (typeof rawValue === "string" && expression.includes("| date")) {
+  if (
+    typeof rawValue === "string" &&
+    FIRST_FILTER_IS_DATE_RE.test(expression)
+  ) {
     const d = new Date(rawValue);
     if (!Number.isNaN(d.getTime())) contextValue = d;
   }

--- a/test/lib/column-order/template.test.ts
+++ b/test/lib/column-order/template.test.ts
@@ -211,6 +211,20 @@ describe("renderFilteredValue", () => {
       "2026-01-01",
     );
   });
+
+  test("does not convert to a Date when a filter runs before the date filter", () => {
+    // Regression: converting whenever the expression merely *contains*
+    // "| date" (rather than checking `date` is the first filter) fed a Date
+    // object into `append`, breaking the pipeline — the appended string
+    // "T00:00:00Z" landed on the Date's toString() instead of the raw string.
+    expect(
+      renderFilteredValue(
+        'created | append: "T00:00:00Z" | date: "%Y"',
+        "2026-04-10",
+        "created",
+      ),
+    ).toBe("2026");
+  });
 });
 
 describe("renderCells", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1555. Codex's review on that PR ([comment](https://github.com/chobbledotcom/tickets/pull/1555#discussion_r3523864255)) correctly flagged that the "equivalent mutant" suppression added for `src/shared/column-order.ts:174` was wrong — it was a real, distinguishable behavior gap, not an equivalent mutant.

`renderFilteredValue`'s guard converted the raw value to a `Date` whenever the filter expression merely *contained* `"| date"` **anywhere** in the pipe chain, not only when `date` was the filter actually applied directly to the raw string. For a template like:

```
{{created | append: "T00:00:00Z" | date: "%Y"}}
```

the conversion fires (since the expression contains `"| date"`), feeding a `Date` object into `append` *before* the date filter runs — `append` then operates on the Date's `toString()` instead of the raw string, producing garbage instead of the intended `"2026"`.

- Narrowed the guard to a `FIRST_FILTER_IS_DATE_RE` regex that only converts when `date` is the *first* filter in the chain, so a preceding filter (like `append`) still receives the raw string.
- Added a regression test reproducing the exact append-then-date case from the review comment (fails on the old code, passes with the fix).
- Removed the now-invalid equivalent-mutant entry — the mutation is now killed by a real test, not suppressed.

Exhaustive mutation score for `src/shared/column-order.ts` is **100% (80/80)** with **zero suppressions**.

## Test plan

- [x] `deno task test:files test/lib/column-order/template.test.ts` — all 40 tests pass
- [x] `deno task mutation src/shared/column-order.ts 'test/lib/column-order/**/*.test.ts' --exhaustive` — 100% (80/80), no suppressions
- [x] `deno task precommit:mutation` — 100% (48/48) on the changed-file gate
- [x] `deno task lint` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_