### PR TITLE
Mutation-harden src/shared/booking/package-cap.ts

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -463,3 +463,26 @@ src/shared/booking/model.ts:226:22  - → /   # same as above
 # truthy in JS even when empty, so ?? and || agree for every possible
 # return value.
 src/shared/booking/model.ts:255:49  ?? → ||   # dayCountsChildSupports(): number[]|null, and an array is truthy even when empty
+
+# package-cap.ts's groupIdsFor: `ctx.groupIdsByListingId.get(...) ?? []` — a
+# Map#get() on a ReadonlyMap<number, number[]> is either undefined or a
+# truthy array (even an empty array is truthy), so ?? and || agree.
+src/shared/booking/package-cap.ts:60:63  ?? → ||   # groupIdsByListingId.get(): number[]|undefined, and an array is truthy even when empty
+
+# smallestLimitedGroupFor: `limitedGroupsFor(...).toSorted(...)[0] ?? null`
+# — array-index access yields the element (an object, always truthy) or
+# undefined for an empty array, so ?? and || agree.
+src/shared/booking/package-cap.ts:150:7  ?? → ||   # array[0]: object|undefined — an object is always truthy, never falsy-but-defined
+
+# childLimitPart: `limitedGroup === null` — smallestLimitedGroupFor returns
+# `{groupId,remaining} | null` (no undefined case), so === and == agree.
+src/shared/booking/package-cap.ts:163:22  === → ==   # limitedGroup: {groupId,remaining}|null (no undefined), so === and == agree on null
+
+# parentGroupChildLimit: `shared.length === 0`, mutated to `=== -1` — array
+# length is never negative, so this condition is always false either way;
+# the fallback computation (Math.min() over an empty spread is +Infinity,
+# ticketsThatFitInPool(Infinity,2) is Infinity, sumOf of [] is 0, and
+# Math.min(Infinity,0) is 0) coincidentally reproduces the same `0` the
+# early return gives for a genuinely empty `shared`, so no input can ever
+# distinguish the two paths' output.
+src/shared/booking/package-cap.ts:170:25  0 → -1   # shared.length is never negative; the empty-array fallback path already returns 0 too

--- a/test/lib/package-cap-fixtures.ts
+++ b/test/lib/package-cap-fixtures.ts
@@ -1,0 +1,29 @@
+import { buildBookingTree } from "#shared/booking/build-tree.ts";
+import type { TicketListing } from "#shared/booking/model.ts";
+import type { BookingTree } from "#shared/booking/tree.ts";
+import type { ListingWithCount } from "#shared/types.ts";
+import { resolved } from "./booking-model-fixtures.ts";
+
+/** Shared fixtures for the package-cap*.test.ts suite. Not itself a test file. */
+
+/** A resolved listing carrying only the ticket limit this test needs. */
+export const tl = (
+  id: number,
+  maxPurchasable: number,
+  over: Partial<ListingWithCount> = {},
+): TicketListing => ({
+  ...resolved({ id, ...over }),
+  maxPurchasable,
+});
+
+/** A package tree over the given member ids, each with its per-package qty. */
+export const packageTree = (
+  qtyById: ReadonlyMap<number, number>,
+  groupId = 5,
+): BookingTree =>
+  buildBookingTree({
+    listings: [...qtyById.keys()].map((id) => tl(id, 0)),
+    packageQuantities: qtyById,
+    root: { groupId, kind: "package" },
+    slugs: ["pkg"],
+  });

--- a/test/lib/package-cap-limits.test.ts
+++ b/test/lib/package-cap-limits.test.ts
@@ -1,0 +1,251 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { TicketListing } from "#shared/booking/model.ts";
+import {
+  packageBundleLimit,
+  packageChildTicketLimits,
+  packageLimitInfo,
+} from "#shared/booking/package-cap.ts";
+import { packageTree, tl } from "./package-cap-fixtures.ts";
+
+// PARENT_CHILD_GROUP_UNITS is 2, so a pool of 5 spots fits floor(5/2)=2
+// tickets — used across the group-sharing tests below.
+const withGroup9Pool5 = (
+  groupIdsByListingId: ReadonlyMap<number, number[]>,
+  children: readonly TicketListing[],
+) =>
+  packageLimitInfo(
+    [tl(1, 100)],
+    new Map([[1, children]]),
+    new Map([[9, 5]]),
+    groupIdsByListingId,
+  );
+
+describe("packageChildTicketLimits", () => {
+  test("omits members that have no children entry", () => {
+    const ctx = packageLimitInfo([tl(1, 10)], new Map(), new Map(), new Map());
+    expect(packageChildTicketLimits(ctx)).toEqual(new Map());
+  });
+
+  test("omits members whose children array is empty", () => {
+    const ctx = packageLimitInfo(
+      [tl(1, 10)],
+      new Map([[1, []]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageChildTicketLimits(ctx)).toEqual(new Map());
+  });
+
+  test("sums each bookable child's own limit when there's no group sharing", () => {
+    const ctx = packageLimitInfo(
+      [tl(1, 100)],
+      new Map([[1, [tl(2, 3), tl(3, 4)]]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageChildTicketLimits(ctx)).toEqual(new Map([[1, 7]]));
+  });
+
+  test("excludes a non-bookable child from the sum", () => {
+    const closedChild = { ...tl(3, 4), isClosed: true };
+    const ctx = packageLimitInfo(
+      [tl(1, 100)],
+      new Map([[1, [tl(2, 3), closedChild]]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageChildTicketLimits(ctx)).toEqual(new Map([[1, 3]]));
+  });
+
+  test("caps children sharing a capped group, whether or not the parent shares it too", () => {
+    const children = [tl(2, 100), tl(3, 100)];
+    for (const [label, groupIdsByListingId, expected] of [
+      [
+        "parent shares the group: a parentGroup pool, divided by PARENT_CHILD_GROUP_UNITS",
+        new Map([
+          [1, [9]],
+          [2, [9]],
+          [3, [9]],
+        ]),
+        2,
+      ],
+      [
+        "parent doesn't share the group: a childGroup pool, not divided",
+        new Map([
+          [2, [9]],
+          [3, [9]],
+        ]),
+        5,
+      ],
+    ] as const) {
+      const ctx = withGroup9Pool5(groupIdsByListingId, children);
+      expect(packageChildTicketLimits(ctx), label).toEqual(
+        new Map([[1, expected]]),
+      );
+    }
+  });
+
+  test("caps by the pooled limit even with only one parent-group child", () => {
+    // Regression: the "no parent-group children" short-circuit checks
+    // shared.length === 0, not just falsiness — with exactly one such
+    // child, the real pooled computation must still run.
+    const ctx = withGroup9Pool5(
+      new Map([
+        [1, [9]],
+        [2, [9]],
+      ]),
+      [tl(2, 100)],
+    );
+    expect(packageChildTicketLimits(ctx)).toEqual(new Map([[1, 2]]));
+  });
+
+  test("picks the smallest-remaining group when a child belongs to several, regardless of iteration order", () => {
+    const groupRemainingByGroupIdAscending = new Map([
+      [9, 3],
+      [10, 50],
+    ]);
+    const groupRemainingByGroupIdDescending = new Map([
+      [10, 50],
+      [9, 3],
+    ]);
+    for (const [groupRemainingByGroupId, groupIdsByListingId] of [
+      [groupRemainingByGroupIdAscending, new Map([[2, [9, 10]]])],
+      [groupRemainingByGroupIdDescending, new Map([[2, [10, 9]]])],
+    ] as const) {
+      const ctx = packageLimitInfo(
+        [tl(1, 100)],
+        new Map([[1, [tl(2, 100)]]]),
+        groupRemainingByGroupId,
+        groupIdsByListingId,
+      );
+      // Group 9 (remaining 3) is smaller than group 10 (remaining 50), so
+      // it's the binding pool regardless of which order the maps list them in.
+      expect(packageChildTicketLimits(ctx)).toEqual(new Map([[1, 3]]));
+    }
+  });
+
+  test("is empty when childrenByParentId is undefined", () => {
+    const ctx = packageLimitInfo([tl(1, 100)], undefined, new Map(), new Map());
+    expect(packageChildTicketLimits(ctx)).toEqual(new Map());
+  });
+});
+
+describe("packageBundleLimit", () => {
+  test("is limited by the package's own quantity when there are no children", () => {
+    const tree = packageTree(new Map([[1, 1]]));
+    const ctx = packageLimitInfo([tl(1, 10)], new Map(), new Map(), new Map());
+    expect(packageBundleLimit(tree, ctx)).toBe(10);
+  });
+
+  test("a sole non-daily child constrains the bundle limit via its own ticket pool", () => {
+    // Each package needs 2 of this member, and its sole child can only
+    // supply 5 tickets total, so floor(5/2)=2 packages — tighter than the
+    // package's own quantity limit (floor(100/2)=50).
+    const tree = packageTree(new Map([[1, 2]]));
+    const ctx = packageLimitInfo(
+      [tl(1, 100)],
+      new Map([[1, [tl(2, 5)]]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageBundleLimit(tree, ctx)).toBe(2);
+  });
+
+  test("a sole daily child is not constrained by the per-package ticket pool", () => {
+    // Same fixture as the non-daily case above (child limit 5, packageQty
+    // 2, which would floor to 2), but a daily child's own limit is already
+    // governed by the parent's capacity elsewhere — it must not also be
+    // pooled here, so the bundle limit falls back to the package's own
+    // quantity limit (floor(100/2)=50).
+    const tree = packageTree(new Map([[1, 2]]));
+    const ctx = packageLimitInfo(
+      [tl(1, 100)],
+      new Map([[1, [tl(2, 5, { listing_type: "daily" })]]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageBundleLimit(tree, ctx)).toBe(50);
+  });
+
+  test("does not apply single-child ticket pooling when a member has more than one child", () => {
+    // Two children (not a sole child) with no group sharing: the package's
+    // own quantity limit already incorporates their summed own-limits via
+    // packageChildTicketLimits, so the additional single-child pool must
+    // not also apply (which would wrongly treat the first child as sole).
+    const tree = packageTree(new Map([[1, 2]]));
+    const ctx = packageLimitInfo(
+      [tl(1, 100)],
+      new Map([[1, [tl(2, 3), tl(3, 3)]]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageBundleLimit(tree, ctx)).toBe(3);
+  });
+
+  test("pools a shared capped group's capacity across different package members, not per-member", () => {
+    // Two separate package members each have a sole child in the SAME
+    // capped group (pool of 3). Computed per-member, each would see the
+    // full pool of 3 in isolation — but together they draw from one
+    // shared pool of 3, one package-set each, so only 1 bundle fits.
+    const tree = packageTree(
+      new Map([
+        [1, 1],
+        [4, 1],
+      ]),
+    );
+    const ctx = packageLimitInfo(
+      [tl(1, 100), tl(4, 100)],
+      new Map([
+        [1, [tl(10, 100)]],
+        [4, [tl(11, 100)]],
+      ]),
+      new Map([[9, 3]]),
+      new Map([
+        [10, [9]],
+        [11, [9]],
+      ]),
+    );
+    expect(packageBundleLimit(tree, ctx)).toBe(1);
+  });
+
+  test("pools a shared child's own stock across different package members needing the same child", () => {
+    // Two separate package members each require the SAME sole child
+    // listing (id 20, stock of 3). Computed per-member, each would see the
+    // full stock of 3 in isolation — but together each package-set from
+    // either member consumes one of the same 3 physical tickets, so only
+    // floor(3/2)=1 combined round fits.
+    const tree = packageTree(
+      new Map([
+        [1, 1],
+        [4, 1],
+      ]),
+    );
+    const sharedChild = tl(20, 3);
+    const ctx = packageLimitInfo(
+      [tl(1, 100), tl(4, 100)],
+      new Map([
+        [1, [sharedChild]],
+        [4, [sharedChild]],
+      ]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageBundleLimit(tree, ctx)).toBe(1);
+  });
+
+  test("blocks a member whose only child is non-bookable, unlike a member with no children at all", () => {
+    // A required child that's entirely unavailable right now (inactive)
+    // is NOT the same as no child requirement — it must block the package
+    // (0 available), not silently fall back to the member's own capacity.
+    const tree = packageTree(new Map([[1, 1]]));
+    const inactiveChild = tl(2, 100, { active: false });
+    const ctx = packageLimitInfo(
+      [tl(1, 10)],
+      new Map([[1, [inactiveChild]]]),
+      new Map(),
+      new Map(),
+    );
+    expect(packageBundleLimit(tree, ctx)).toBe(0);
+  });
+});

--- a/test/lib/package-cap.test.ts
+++ b/test/lib/package-cap.test.ts
@@ -1,0 +1,98 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  childCanBeBooked,
+  childTicketLimit,
+  groupCapacityInfo,
+  packageLimitInfo,
+} from "#shared/booking/package-cap.ts";
+import { resolved } from "./booking-model-fixtures.ts";
+import { tl } from "./package-cap-fixtures.ts";
+
+describe("groupCapacityInfo", () => {
+  test("wraps the remaining and group-id maps together", () => {
+    const remaining = new Map([[1, 5]]);
+    const groupIds = new Map([[10, [1]]]);
+    expect(groupCapacityInfo(remaining, groupIds)).toEqual({
+      groupIdsByListingId: groupIds,
+      groupRemainingByGroupId: remaining,
+    });
+  });
+});
+
+describe("packageLimitInfo", () => {
+  test("combines listings, children, and group capacity into one context", () => {
+    const listings = [resolved({ id: 1 })];
+    const childrenByParentId = new Map([[1, [resolved({ id: 2 })]]]);
+    const remaining = new Map([[5, 3]]);
+    const groupIds = new Map([[1, [5]]]);
+    expect(
+      packageLimitInfo(listings, childrenByParentId, remaining, groupIds),
+    ).toEqual({
+      childrenByParentId,
+      groupIdsByListingId: groupIds,
+      groupRemainingByGroupId: remaining,
+      listings,
+    });
+  });
+});
+
+describe("childCanBeBooked", () => {
+  test("true for an active, open, in-stock child", () => {
+    expect(
+      childCanBeBooked(
+        resolved({ active: true, attendee_count: 0, max_attendees: 10 }),
+      ),
+    ).toBe(true);
+  });
+
+  test("false when inactive", () => {
+    expect(childCanBeBooked(resolved({ active: false }))).toBe(false);
+  });
+
+  test("false when closed", () => {
+    expect(childCanBeBooked(resolved({}, true))).toBe(false);
+  });
+
+  test("false when sold out", () => {
+    expect(
+      childCanBeBooked(resolved({ attendee_count: 1, max_attendees: 1 })),
+    ).toBe(false);
+  });
+});
+
+describe("childTicketLimit", () => {
+  const noGroups = groupCapacityInfo(new Map(), new Map());
+
+  test("uses the child's own limit when parent and child share no capped group", () => {
+    expect(childTicketLimit(tl(1, 10), tl(2, 4), noGroups)).toBe(4);
+  });
+
+  test("uses the parent's own limit for a daily child, regardless of the child's own limit", () => {
+    const dailyChild = tl(2, 4, { listing_type: "daily" });
+    expect(childTicketLimit(tl(1, 10), dailyChild, noGroups)).toBe(10);
+  });
+
+  test("uses the shared group's ticket-pool limit when it's tighter than the child's own limit", () => {
+    // PARENT_CHILD_GROUP_UNITS is 2, so a pool of 3 spots fits floor(3/2)=1 ticket.
+    const ctx = groupCapacityInfo(
+      new Map([[7, 3]]),
+      new Map([
+        [1, [7]],
+        [2, [7]],
+      ]),
+    );
+    expect(childTicketLimit(tl(1, 100), tl(2, 100), ctx)).toBe(1);
+  });
+
+  test("uses the child's own limit when it's tighter than the shared group's ticket-pool limit", () => {
+    const ctx = groupCapacityInfo(
+      new Map([[7, 20]]),
+      new Map([
+        [1, [7]],
+        [2, [7]],
+      ]),
+    );
+    expect(childTicketLimit(tl(1, 100), tl(2, 3), ctx)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

`src/shared/booking/package-cap.ts` is a pure functional module (package/group capacity calculations for the booking system) with no dedicated unit test file — like `model.ts` before it, only exercised indirectly through booking-flow integration tests.

- Split coverage across two focused suites (`package-cap.test.ts` for the simpler constructors + per-child limit functions, `package-cap-limits.test.ts` for the more involved per-package/cross-member limit functions), plus a shared `package-cap-fixtures.ts` module — each file well under the ~400-line guideline.
- Iterating against exhaustive mutation testing found and closed 15 real gaps, most notably:
  - `childTicketLimit`/`packageChildTicketLimits`: a member with exactly one parent-shared-group child wasn't distinguished from zero such children, and a child belonging to multiple capped groups wasn't proven to pick the smallest-remaining one (tested both iteration orders).
  - `packageChildTicketLimits`: `childrenByParentId: undefined` was never exercised, and a member whose only child is entirely non-bookable wasn't proven to behave differently from a member with no children at all (the former correctly blocks the package at 0; the latter is unconstrained).
  - `packageBundleLimit`: a sole daily child wasn't proven exempt from per-package ticket pooling (its limit is already governed by the parent's own capacity), a member with 2+ children wasn't proven exempt from the sole-child pooling path, and — the most significant gap — nothing proved that group capacity and a literal shared child's stock are pooled *across* different package members, not computed independently per member (two new tests confirm the naive per-member view would wrongly allow 3x the real combined capacity).
- 4 remaining survivors are genuine equivalents (documented in `equivalent-mutants.txt`): `??`/`||` swaps where the operand can only be undefined or a truthy array/object, an `===`/`==` null comparison with no undefined case, and an unreachable `array.length === -1` whose fallback path coincidentally reproduces the same output (confirmed empirically).

Exhaustive: **100%** (117/117 detected, 4 suppressed). Default: **100%** (53/53 detected, 2 suppressed).

## Test plan

- [x] `deno test --no-check --allow-all test/lib/package-cap*.test.ts` — all pass
- [x] `deno task mutation src/shared/booking/package-cap.ts 'test/lib/package-cap{,-limits}.test.ts' --exhaustive` — 100%
- [x] Also 100% in default (non-exhaustive) mode
- [x] `deno task lint` — clean
- [x] `deno task typecheck` — clean
- [x] `deno task cpd` — 0 clones
- [x] Sibling booking test files (`fold-tree`, `capacity-tree`, `booking-tree`, `price-tree`, `booking-model-*`) still pass unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_