### PR TITLE
Mutation-harden src/shared/booking/build-tree.ts

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -139,9 +139,9 @@ test/test-utils/test-browser.ts:351:58  ?? → ||  # RequestInit.method is omitt
 test/test-utils/test-browser.ts:414:28  ?? → ||  # forms[0] is a FormInfo object when present, otherwise undefined
 src/ui/templates/admin/listing-defaults.tsx:90:19  ?? → ||  # UrlControl value: string|undefined; the only falsy-non-null string is "" which equals the "" fallback, so ?? and || coincide
 src/ui/templates/admin/listing-defaults.tsx:119:42  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
-src/shared/booking/build-tree.ts:121:48  ?? → ||    # childrenByParentId.get(): readonly TicketListing[]|undefined — an array is always truthy
-src/shared/booking/build-tree.ts:161:62  ?? → ||    # packageQuantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
-src/shared/booking/build-tree.ts:208:30  ?? → ||    # entry: EntryContext|undefined — an object literal is always truthy
+src/shared/booking/build-tree.ts:132:48  ?? → ||    # childrenByParentId.get(): readonly TicketListing[]|undefined — an array is always truthy
+src/shared/booking/build-tree.ts:172:62  ?? → ||    # packageQuantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
+src/shared/booking/build-tree.ts:205:38  ?? → ||    # input.root: RootRef-minus-listing|undefined — an object literal is always truthy, so ?? and || coincide
 src/shared/booking/fold-tree.ts:157:4  ?? → ||    # childQtyField: parseNonNegativeInt returns a non-negative int or null; its only falsy result (0) already maps to 0, so ?? and || coincide
 src/shared/booking/fold-tree.ts:280:48  ?? → ||    # foldChild summed: state.quantities.get(childId) is undefined (first fold) or a positive running total, never 0, so ?? and || coincide
 src/shared/booking/fold-tree.ts:424:58  ?? → ||    # foldBookingTree parentQty: base.quantities.get() is undefined or ≥0, and a 0 takes the same `<= 0` skip, so ?? and || coincide

--- a/test/lib/build-tree-children.test.ts
+++ b/test/lib/build-tree-children.test.ts
@@ -1,0 +1,173 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { BuildTreeInput } from "#shared/booking/build-tree.ts";
+import { buildBookingTree } from "#shared/booking/build-tree.ts";
+import type { ListingWithCount } from "#shared/types.ts";
+import { resolved } from "./booking-model-fixtures.ts";
+
+/** A parent (id 1) with one required child (id 9), for tests that only need
+ * to vary the child's own listing fields or the surrounding tree input. */
+const treeWithChild = (
+  childOverrides: Partial<ListingWithCount> = {},
+  treeOverrides: Partial<BuildTreeInput> = {},
+) =>
+  buildBookingTree({
+    childrenByParentId: new Map([
+      [1, [resolved({ id: 9, ...childOverrides })]],
+    ]),
+    listings: [resolved({ id: 1 })],
+    slugs: ["ab12c"],
+    ...treeOverrides,
+  });
+
+describe("buildBookingTree — price rule", () => {
+  test("a standard listing uses BASE by default", () => {
+    const tree = buildBookingTree({
+      listings: [
+        resolved({ can_pay_more: false, customisable_days: false, id: 1 }),
+      ],
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.priceRule).toEqual({ kind: "BASE" });
+  });
+
+  test("a pay-what-you-want listing uses PAY_MORE with its min/max", () => {
+    const tree = buildBookingTree({
+      listings: [
+        resolved({
+          can_pay_more: true,
+          id: 1,
+          max_price: 5000,
+          unit_price: 1000,
+        }),
+      ],
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.priceRule).toEqual({
+      kind: "PAY_MORE",
+      maxMinor: 5000,
+      minMinor: 1000,
+    });
+  });
+
+  test("a customisable listing uses DAY_PRICE with no overrides outside a package", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ customisable_days: true, id: 1 })],
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.priceRule).toEqual({
+      kind: "DAY_PRICE",
+      overrides: undefined,
+    });
+  });
+
+  test("a package member's flat price override wins over pay-what-you-want", () => {
+    const tree = buildBookingTree({
+      listings: [
+        resolved({
+          can_pay_more: true,
+          id: 1,
+          max_price: 5000,
+          unit_price: 1000,
+        }),
+      ],
+      packagePrices: new Map([[1, 2500]]),
+      root: { groupId: 3, kind: "package" },
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.priceRule).toEqual({
+      amountMinor: 2500,
+      kind: "OVERRIDE",
+    });
+  });
+
+  test("a package member's per-day overrides ride the DAY_PRICE rule", () => {
+    const dayOverrides = new Map([[3, 900]]);
+    const tree = buildBookingTree({
+      listings: [resolved({ customisable_days: true, id: 1 })],
+      packageDayPrices: new Map([[1, dayOverrides]]),
+      root: { groupId: 3, kind: "package" },
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.priceRule).toEqual({
+      kind: "DAY_PRICE",
+      overrides: dayOverrides,
+    });
+  });
+});
+
+describe("buildBookingTree — child date span", () => {
+  test("a daily child inherits the parent's span", () => {
+    const tree = treeWithChild({ listing_type: "daily" });
+    expect(tree.nodes[0]!.children[0]!.dateSpan).toEqual({ kind: "INHERIT" });
+  });
+
+  test("a customisable-days child inherits the parent's span", () => {
+    const tree = treeWithChild({ customisable_days: true });
+    expect(tree.nodes[0]!.children[0]!.dateSpan).toEqual({ kind: "INHERIT" });
+  });
+
+  test("a standard (non-daily, non-customisable) child has no date span", () => {
+    const tree = treeWithChild({
+      customisable_days: false,
+      listing_type: "standard",
+    });
+    expect(tree.nodes[0]!.children[0]!.dateSpan).toEqual({ kind: "NONE" });
+  });
+});
+
+describe("buildBookingTree — child nodes", () => {
+  test("builds a child node addressed by the parent's full nodeKey", () => {
+    const tree = treeWithChild();
+    const childNode = tree.nodes[0]!.children[0]!;
+    expect(childNode.nodeKey).toBe("listing:1/child:9");
+    expect(childNode.edgeRef).toEqual({ kind: "parent_child", parentId: 1 });
+    expect(childNode.quantityRule).toEqual({ kind: "BUYER_CHOICE" });
+  });
+
+  test("has no children when the parent has no children entry", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 1 })],
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.children).toEqual([]);
+  });
+
+  test("builds every child for a parent with multiple children, in order", () => {
+    const tree = buildBookingTree({
+      childrenByParentId: new Map([
+        [1, [resolved({ id: 9 }), resolved({ id: 10 })]],
+      ]),
+      listings: [resolved({ id: 1 })],
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes[0]!.children.map((c) => c.listingId)).toEqual([9, 10]);
+  });
+
+  test("a package member's own children use the package-member ancestor path", () => {
+    const tree = treeWithChild({}, { root: { groupId: 3, kind: "package" } });
+    expect(tree.nodes[0]!.children[0]!.nodeKey).toBe(
+      "package:3/member:1/child:9",
+    );
+  });
+
+  describe("visibility", () => {
+    test("a child is shown when neither it nor its parent is hidden", () => {
+      const tree = treeWithChild();
+      expect(tree.nodes[0]!.children[0]!.visibility).toBe("SHOWN");
+    });
+
+    test("a child is hidden when its own listing is hidden", () => {
+      const tree = treeWithChild({ hidden: true });
+      expect(tree.nodes[0]!.children[0]!.visibility).toBe("HIDDEN");
+    });
+
+    test("a child is hidden when its hidden package-member parent is hidden, even if the child itself isn't", () => {
+      const tree = treeWithChild(
+        {},
+        { hidePackageListings: true, root: { groupId: 3, kind: "package" } },
+      );
+      expect(tree.nodes[0]!.children[0]!.visibility).toBe("HIDDEN");
+    });
+  });
+});

--- a/test/lib/build-tree.test.ts
+++ b/test/lib/build-tree.test.ts
@@ -1,0 +1,118 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { buildBookingTree } from "#shared/booking/build-tree.ts";
+import { resolved } from "./booking-model-fixtures.ts";
+
+describe("buildBookingTree — root ref", () => {
+  test("defaults to a listing root using the given slugs when no root is given", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 1 })],
+      slugs: ["ab12c"],
+    });
+    expect(tree.rootRef).toEqual({ kind: "listing", slugs: ["ab12c"] });
+  });
+
+  test("uses the given group root", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 1 })],
+      root: { groupId: 7, kind: "group" },
+      slugs: ["ab12c"],
+    });
+    expect(tree.rootRef).toEqual({ groupId: 7, kind: "group" });
+  });
+
+  test("uses the given package root", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 1 })],
+      root: { groupId: 7, kind: "package" },
+      slugs: ["ab12c"],
+    });
+    expect(tree.rootRef).toEqual({ groupId: 7, kind: "package" });
+  });
+});
+
+describe("buildBookingTree — standalone listing nodes (no root)", () => {
+  test("builds a top-level node addressed by its own listing id", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 5 })],
+      slugs: ["ab12c"],
+    });
+    const node = tree.nodes[0]!;
+    expect(node.nodeKey).toBe("listing:5");
+    expect(node.edgeRef).toEqual({ kind: "none" });
+    expect(node.listingId).toBe(5);
+    expect(node.dateSpan).toEqual({ kind: "NONE" });
+    expect(node.visibility).toBe("SHOWN");
+    expect(node.quantityRule).toEqual({ kind: "BUYER_CHOICE" });
+  });
+
+  test("multiple listings each become their own top-level node, in order", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 1 }), resolved({ id: 2 })],
+      slugs: ["ab12c"],
+    });
+    expect(tree.nodes.map((n) => n.nodeKey)).toEqual([
+      "listing:1",
+      "listing:2",
+    ]);
+  });
+});
+
+describe("buildBookingTree — group member nodes", () => {
+  test("builds a node addressed by group and listing id", () => {
+    const tree = buildBookingTree({
+      listings: [resolved({ id: 5 })],
+      root: { groupId: 3, kind: "group" },
+      slugs: ["ab12c"],
+    });
+    const node = tree.nodes[0]!;
+    expect(node.nodeKey).toBe("group:3/member:5");
+    expect(node.edgeRef).toEqual({ groupId: 3, kind: "group_member" });
+    expect(node.quantityRule).toEqual({ kind: "BUYER_CHOICE" });
+  });
+});
+
+describe("buildBookingTree — package member nodes", () => {
+  const packageMemberTree = (
+    overrides: {
+      hidePackageListings?: boolean;
+      packageQuantities?: ReadonlyMap<number, number>;
+    } = {},
+  ) =>
+    buildBookingTree({
+      listings: [resolved({ id: 5 })],
+      root: { groupId: 3, kind: "package" },
+      slugs: ["ab12c"],
+      ...overrides,
+    });
+
+  test("builds a node addressed by the package group and listing id", () => {
+    const node = packageMemberTree().nodes[0]!;
+    expect(node.nodeKey).toBe("package:3/member:5");
+    expect(node.edgeRef).toEqual({ groupId: 3, kind: "group_member" });
+    expect(node.dateSpan).toEqual({ kind: "NONE" });
+  });
+
+  test("defaults the fixed quantity to 1 when none is given", () => {
+    expect(packageMemberTree().nodes[0]!.quantityRule).toEqual({
+      kind: "FIXED",
+      qty: 1,
+    });
+  });
+
+  test("uses the given fixed quantity for a member", () => {
+    const tree = packageMemberTree({
+      packageQuantities: new Map([[5, 3]]),
+    });
+    expect(tree.nodes[0]!.quantityRule).toEqual({ kind: "FIXED", qty: 3 });
+  });
+
+  test("is shown by default", () => {
+    expect(packageMemberTree().nodes[0]!.visibility).toBe("SHOWN");
+  });
+
+  test("is hidden when the package hides its listings", () => {
+    const tree = packageMemberTree({ hidePackageListings: true });
+    expect(tree.nodes[0]!.visibility).toBe("HIDDEN");
+  });
+});


### PR DESCRIPTION
## Summary

`src/shared/booking/build-tree.ts` is the pure, DB-free booking-tree builder that every sibling booking module (`fold-tree`, `capacity-tree`, `price-tree`, `package-cap`) relies on to construct test fixtures via `buildBookingTree`, but it had no dedicated unit test file of its own — only indirect exercise through those other suites, which already put it at 93% purely from that incidental coverage.

- Added two focused test files: `build-tree.test.ts` for root-ref resolution and node construction (standalone/group/package member nodes, fixed quantity, visibility), and `build-tree-children.test.ts` for price-rule derivation, child date-span inheritance, and required-child node construction (nodeKey/edgeRef/visibility inheritance).
- Closed the 4 real gaps the indirect coverage missed: the `BUYER_CHOICE` quantity-rule string literal on required-child nodes, and the `NONE` date-span / `OVERRIDE`-vs-`PAY_MORE` price-rule / hidden-visibility facts specific to package-member nodes weren't asserted directly anywhere.
- Also fixed 3 already-stale `equivalent-mutants.txt` entries for this file (line numbers no longer matched the current source, one with an unrelated leftover justification from a prior refactor) while re-deriving and re-verifying all 3 equivalences against the current code.

Exhaustive: **100%** (96/96 detected, 3 suppressed). Default: **100%** (43/43 detected, 3 suppressed).

## Test plan

- [x] `deno test --no-check --allow-all test/lib/build-tree{,-children}.test.ts` — all pass
- [x] `deno task mutation src/shared/booking/build-tree.ts 'test/lib/build-tree{,-children}.test.ts' --exhaustive` — 100%, no stale ignore-list warnings
- [x] Also 100% in default (non-exhaustive) mode
- [x] `deno task lint` — clean
- [x] `deno task typecheck` — clean
- [x] `deno task cpd` — 0 clones
- [x] Sibling test files that already build fixtures via `buildBookingTree` (`fold-tree`, `capacity-tree`, `booking-tree`, `price-tree`, `package-cap*`) still pass unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_