### PR TITLE
Mutation-harden src/shared/cache-registry.ts

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -486,3 +486,24 @@ src/shared/booking/package-cap.ts:163:22  === → ==   # limitedGroup: {groupId,
 # early return gives for a genuinely empty `shared`, so no input can ever
 # distinguish the two paths' output.
 src/shared/booking/package-cap.ts:170:25  0 → -1   # shared.length is never negative; the empty-array fallback path already returns 0 too
+
+# cache-registry.ts's setsIntersect is private and only ever consumed
+# negated (`!setsIntersect(...)`) inside invalidateCachesForWrite — `!false`
+# and `!undefined` both coerce to `true`, so no caller (internal or through
+# the public API) can ever observe the difference between the two return
+# values.
+src/shared/cache-registry.ts:69:10  return false → return undefined   # only ever consumed via `!setsIntersect(...)`; !false and !undefined agree
+
+# registerTableInvalidation: `invalidatorsByTable.get(table) ?? new Set()`
+# — Map#get() is undefined or a Set object, and a Set is always truthy
+# (even when empty), so ?? and || agree.
+src/shared/cache-registry.ts:87:47  ?? → ||   # invalidatorsByTable.get(): Set<Registration>|undefined — a Set is always truthy, even when empty
+
+# invalidateCachesForTable passes a literal `verb: "insert"` through to
+# invalidateCachesForWrite, whose only branch on verb is `=== "update"`.
+# Any string that isn't literally "update" takes the same (ungated) path,
+# and the verb is never otherwise observable (invalidators are called with
+# no arguments), so mutating this literal to any other non-"update" string
+# is unobservable.
+src/shared/cache-registry.ts:115:63  insert → ""   # invalidateCachesForWrite only branches on === "update"; any other literal behaves identically and is never otherwise observable
+src/shared/cache-registry.ts:115:63  insert → "insert mutated"   # same as above

--- a/test/lib/cache-registry.test.ts
+++ b/test/lib/cache-registry.test.ts
@@ -144,9 +144,7 @@ describe("cache-registry", () => {
 
       test("a gated dependency fires on update only when an assigned column is listed", () => {
         expect(callsForGatedUpdate(["price", "name"], ["name"])).toBe(1);
-        expect(callsForGatedUpdate(["price", "name"], ["description"])).toBe(
-          0,
-        );
+        expect(callsForGatedUpdate(["price", "name"], ["description"])).toBe(0);
       });
 
       test("an empty whenColumns list gates out every update, since no column can ever match", () => {

--- a/test/lib/cache-registry.test.ts
+++ b/test/lib/cache-registry.test.ts
@@ -1,0 +1,279 @@
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import {
+  getAllCacheStats,
+  invalidateCachesForTable,
+  invalidateCachesForWrite,
+  registerCache,
+  registerDependencies,
+  registerTableInvalidation,
+  resetCacheRegistry,
+} from "#shared/cache-registry.ts";
+
+describe("cache-registry", () => {
+  afterEach(() => resetCacheRegistry());
+
+  describe("registerCache / getAllCacheStats", () => {
+    test("returns an empty array when no caches are registered", () => {
+      expect(getAllCacheStats()).toEqual([]);
+    });
+
+    test("collects a single registered cache's stat", () => {
+      registerCache(() => ({ entries: 3, name: "widgets" }));
+      expect(getAllCacheStats()).toEqual([{ entries: 3, name: "widgets" }]);
+    });
+
+    test("collects every registered cache's stat, in registration order", () => {
+      registerCache(() => ({ entries: 1, name: "a" }));
+      registerCache(() => ({ entries: 2, name: "b" }));
+      expect(getAllCacheStats()).toEqual([
+        { entries: 1, name: "a" },
+        { entries: 2, name: "b" },
+      ]);
+    });
+
+    test("calls each provider fresh on every call, not a cached snapshot", () => {
+      let entries = 1;
+      registerCache(() => ({ entries, name: "widgets" }));
+      expect(getAllCacheStats()).toEqual([{ entries: 1, name: "widgets" }]);
+      entries = 2;
+      expect(getAllCacheStats()).toEqual([{ entries: 2, name: "widgets" }]);
+    });
+  });
+
+  describe("registerTableInvalidation / invalidateCachesForWrite", () => {
+    test("does not fire for a table with no registrations", () => {
+      expect(() =>
+        invalidateCachesForWrite("untouched", {
+          columns: new Set(),
+          verb: "insert",
+        }),
+      ).not.toThrow();
+    });
+
+    test("fires the invalidator when its exact table is written", () => {
+      let calls = 0;
+      registerTableInvalidation(["listings"], () => {
+        calls++;
+      });
+      invalidateCachesForWrite("listings", {
+        columns: new Set(),
+        verb: "insert",
+      });
+      expect(calls).toBe(1);
+    });
+
+    test("does not fire for a different table", () => {
+      let calls = 0;
+      registerTableInvalidation(["listings"], () => {
+        calls++;
+      });
+      invalidateCachesForWrite("attendees", {
+        columns: new Set(),
+        verb: "insert",
+      });
+      expect(calls).toBe(0);
+    });
+
+    test("registers the same invalidator against every listed table", () => {
+      let calls = 0;
+      registerTableInvalidation(["listings", "attendees"], () => {
+        calls++;
+      });
+      invalidateCachesForWrite("listings", {
+        columns: new Set(),
+        verb: "insert",
+      });
+      invalidateCachesForWrite("attendees", {
+        columns: new Set(),
+        verb: "insert",
+      });
+      expect(calls).toBe(2);
+    });
+
+    test("fires every independently-registered invalidator for the same table", () => {
+      let firstCalls = 0;
+      let secondCalls = 0;
+      registerTableInvalidation(["listings"], () => {
+        firstCalls++;
+      });
+      registerTableInvalidation(["listings"], () => {
+        secondCalls++;
+      });
+      invalidateCachesForWrite("listings", {
+        columns: new Set(),
+        verb: "insert",
+      });
+      expect(firstCalls).toBe(1);
+      expect(secondCalls).toBe(1);
+    });
+
+    describe("whenColumns gating", () => {
+      /** Registers a gated invalidator on "listings" and returns how many
+       * times it fired for a single update touching `updatedColumns`. */
+      const callsForGatedUpdate = (
+        whenColumns: readonly string[],
+        updatedColumns: readonly string[],
+      ): number => {
+        let calls = 0;
+        registerTableInvalidation(
+          ["listings"],
+          () => {
+            calls++;
+          },
+          { whenColumns },
+        );
+        invalidateCachesForWrite("listings", {
+          columns: new Set(updatedColumns),
+          verb: "update",
+        });
+        return calls;
+      };
+
+      test("an ungated dependency fires on update regardless of assigned columns", () => {
+        let calls = 0;
+        registerTableInvalidation(["listings"], () => {
+          calls++;
+        });
+        invalidateCachesForWrite("listings", {
+          columns: new Set(["unrelated_column"]),
+          verb: "update",
+        });
+        expect(calls).toBe(1);
+      });
+
+      test("a gated dependency fires on update only when an assigned column is listed", () => {
+        expect(callsForGatedUpdate(["price", "name"], ["name"])).toBe(1);
+        expect(callsForGatedUpdate(["price", "name"], ["description"])).toBe(
+          0,
+        );
+      });
+
+      test("an empty whenColumns list gates out every update, since no column can ever match", () => {
+        expect(callsForGatedUpdate([], ["name"])).toBe(0);
+      });
+
+      for (const verb of ["insert", "delete", "replace"] as const) {
+        test(`a gated dependency always fires on ${verb}, regardless of columns`, () => {
+          let calls = 0;
+          registerTableInvalidation(
+            ["listings"],
+            () => {
+              calls++;
+            },
+            { whenColumns: ["price"] },
+          );
+          invalidateCachesForWrite("listings", { columns: new Set(), verb });
+          expect(calls).toBe(1);
+        });
+      }
+    });
+  });
+
+  describe("invalidateCachesForTable", () => {
+    test("fires an ungated invalidator", () => {
+      let calls = 0;
+      registerTableInvalidation(["listings"], () => {
+        calls++;
+      });
+      invalidateCachesForTable("listings");
+      expect(calls).toBe(1);
+    });
+
+    test("fires a column-gated invalidator too, treating the write as unconditional (INSERT semantics)", () => {
+      let calls = 0;
+      registerTableInvalidation(
+        ["listings"],
+        () => {
+          calls++;
+        },
+        { whenColumns: ["price"] },
+      );
+      invalidateCachesForTable("listings");
+      expect(calls).toBe(1);
+    });
+
+    test("is a no-op for a table with no registrations", () => {
+      expect(() => invalidateCachesForTable("untouched")).not.toThrow();
+    });
+  });
+
+  describe("registerDependencies", () => {
+    test("registers the own table unconditionally, even for an update touching unrelated columns", () => {
+      let calls = 0;
+      registerDependencies("listings", [], () => {
+        calls++;
+      });
+      invalidateCachesForWrite("listings", {
+        columns: new Set(["unrelated"]),
+        verb: "update",
+      });
+      expect(calls).toBe(1);
+    });
+
+    test("registers a plain string dependency unconditionally", () => {
+      let calls = 0;
+      registerDependencies("listings", ["listing_attendees"], () => {
+        calls++;
+      });
+      invalidateCachesForWrite("listing_attendees", {
+        columns: new Set(["unrelated"]),
+        verb: "update",
+      });
+      expect(calls).toBe(1);
+    });
+
+    test("gates an object dependency's whenColumns on update", () => {
+      let calls = 0;
+      registerDependencies(
+        "listings",
+        [{ table: "listing_prices", whenColumns: ["amount"] }],
+        () => {
+          calls++;
+        },
+      );
+      invalidateCachesForWrite("listing_prices", {
+        columns: new Set(["unrelated"]),
+        verb: "update",
+      });
+      expect(calls).toBe(0);
+
+      invalidateCachesForWrite("listing_prices", {
+        columns: new Set(["amount"]),
+        verb: "update",
+      });
+      expect(calls).toBe(1);
+    });
+
+    test("fires once per independently-written table, not once overall", () => {
+      let calls = 0;
+      registerDependencies("listings", ["listing_attendees"], () => {
+        calls++;
+      });
+      invalidateCachesForTable("listings");
+      invalidateCachesForTable("listing_attendees");
+      expect(calls).toBe(2);
+    });
+  });
+
+  describe("resetCacheRegistry", () => {
+    test("clears registered cache-stat providers", () => {
+      registerCache(() => ({ entries: 1, name: "widgets" }));
+      resetCacheRegistry();
+      expect(getAllCacheStats()).toEqual([]);
+    });
+
+    test("clears registered table invalidators", () => {
+      let calls = 0;
+      registerTableInvalidation(["listings"], () => {
+        calls++;
+      });
+      resetCacheRegistry();
+      invalidateCachesForWrite("listings", {
+        columns: new Set(),
+        verb: "insert",
+      });
+      expect(calls).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`src/shared/cache-registry.ts` is the global cache-invalidation registry: cache modules register per-table invalidators (optionally gated to specific UPDATE columns) at load time, and the DB write path fires them by table + verb. Structurally important — every cached table's invalidation correctness routes through here — but had no dedicated test file at all.

- Added `test/lib/cache-registry.test.ts` covering every exported function: `registerCache`/`getAllCacheStats`, `registerTableInvalidation` combined with `invalidateCachesForWrite` (including the `whenColumns` column-gating logic and its edge case — an explicit empty `whenColumns` list gates out every update, since no column can ever match it), `invalidateCachesForTable`'s INSERT-semantics bypass of the gate, `registerDependencies`' own-table vs. string vs. object-with-`whenColumns` dependency handling, and `resetCacheRegistry`.
- 4 remaining survivors are genuine equivalents (documented in `equivalent-mutants.txt`): `setsIntersect` is private and only ever consumed negated, so `false` vs `undefined` are unobservable; a `Map#get() ?? new Set()` fallback where a `Set` is always truthy; and `invalidateCachesForTable`'s literal `"insert"` verb string, which only matters via a single `=== "update"` branch — any other literal string is indistinguishable and never otherwise observable.

Exhaustive: **100%** (38/38 detected, 4 suppressed). Default: **100%** (24/24 detected, 3 suppressed).

## Test plan

- [x] `deno test --no-check --allow-all test/lib/cache-registry.test.ts` — all pass
- [x] `deno task mutation src/shared/cache-registry.ts test/lib/cache-registry.test.ts --exhaustive` — 100%
- [x] Also 100% in default (non-exhaustive) mode
- [x] `deno task lint` — clean
- [x] `deno task typecheck` — clean
- [x] `deno task cpd` — 0 clones
- [x] Sibling caches that build on this registry (`request-cache`, `page-cache`, `form-stash`) and the codebase-wide `code-quality.test.ts` convention checks still pass unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_