### PR TITLE
Fix restore failing with "missing table settings" after the wipe

### DIFF
--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -15,7 +15,7 @@ import { chunk, compact } from "#fp";
 import { executeBatch, queryAll } from "#shared/db/client.ts";
 import {
   clearAllCaches,
-  initDb,
+  initializeFreshSchema,
   LATEST_UPDATE,
   resetDatabase,
   SCHEMA_HASH,
@@ -406,7 +406,12 @@ export const restoreFromSql = async (sql: string): Promise<void> => {
   let postResetErr: string | undefined;
   try {
     await resetDatabase();
-    await initDb({ allowMissingSettings: true });
+    // The database was just wiped, so rebuild the schema directly. Never go
+    // through initDb here: its state check reads the settings markers, and a
+    // lagging read replica can still serve the pre-wipe rows — a stale "up to
+    // date" answer routes boot into schema verification against the wiped
+    // primary and fails the restore with "missing table settings".
+    await initializeFreshSchema();
 
     // Roll the seed-data deletes into the same executeBatch transaction as the
     // import so that a failed import rolls the deletes back too, leaving the DB

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -315,8 +315,16 @@ export const MIGRATION_IDS: string[] = MIGRATIONS.map(
  * there is no legacy data to backfill or reshape. Creating the latest schema in
  * one pass keeps first boot fast while still recording every migration marker so
  * future boots use the normal up-to-date path.
+ *
+ * Exported for the restore path: after resetDatabase() wipes every table,
+ * restoreFromSql rebuilds the schema by calling this directly instead of going
+ * through initDb. initDb's state check reads the settings markers, and a
+ * lagging read replica can still serve the pre-wipe rows — a stale "up to
+ * date" answer routes boot into schema verification against the wiped primary
+ * and fails the whole restore with "missing table settings". Here we already
+ * know the database was just wiped, so there is no state to check.
  */
-const initializeFreshSchema = async (): Promise<void> => {
+export const initializeFreshSchema = async (): Promise<void> => {
   logDebug("Migration", "Initializing fresh database from current schema");
   await applySchemaChanges();
   await syncIndexes();

--- a/test/lib/backup.test.ts
+++ b/test/lib/backup.test.ts
@@ -1,5 +1,7 @@
+import type { ResultSet } from "@libsql/client";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import { unzipSync, zipSync } from "fflate";
 import {
   BACKUP_REQUIRED_WITHIN_MS,
@@ -28,6 +30,7 @@ import { getDb, queryAll } from "#shared/db/client.ts";
 import { listingsTable } from "#shared/db/listings.ts";
 import {
   initDb,
+  LATEST_UPDATE,
   SCHEMA_HASH,
   SCHEMA_TABLE_NAMES,
 } from "#shared/db/migrations.ts";
@@ -594,6 +597,47 @@ describeWithEnv("backup", { db: true }, () => {
         "SELECT value FROM settings WHERE key = 'k'",
       );
       expect(rows[0]!.value).toBe("v");
+    });
+
+    test("succeeds even when a stale read says the wiped database is up to date", async () => {
+      // After the restore wipes every table, a lagging read replica can still
+      // serve the old settings rows. The restore must never consult that state:
+      // when it did (via initDb's state check), the stale "up to date" answer
+      // routed it into schema verification against the wiped primary, and the
+      // whole restore died with "missing table settings" — leaving the
+      // operator's database empty.
+      await createTestListing({ name: "Stale Read Survivor" });
+      const zip = await createBackupZip();
+
+      const client = getDb();
+      const originalExecute = client.execute.bind(client);
+      const sqlOf = (stmt: string | { sql: string }): string =>
+        typeof stmt === "string" ? stmt : stmt.sql;
+      // The exact read initDb's state check issues; nothing else matches it.
+      const isMarkerRead = (sql: string): boolean =>
+        sql.includes("IN ('latest_db_update', 'db_schema_hash')");
+      const staleMarkers = {
+        rows: [
+          { key: "latest_db_update", value: LATEST_UPDATE },
+          { key: "db_schema_hash", value: SCHEMA_HASH },
+        ],
+      } as unknown as ResultSet;
+      const executeStub = stub(client, "execute", ((
+        stmt: string | { sql: string },
+      ) =>
+        isMarkerRead(sqlOf(stmt))
+          ? Promise.resolve(staleMarkers)
+          : originalExecute(stmt as never)) as never);
+
+      try {
+        await restoreFromZip(zip);
+      } finally {
+        executeStub.restore();
+      }
+
+      const listings = await listingsTable.findAll();
+      expect(listings.length).toBe(1);
+      expect(listings[0]!.name).toBe("Stale Read Survivor");
     });
   });
 

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -1,9 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { getDb } from "#shared/db/client.ts";
+import { verifyCurrentAppSchema } from "#shared/db/migrations/schema-sync.ts";
 import {
   applyMigrationWithRetry,
   initDb,
+  initializeFreshSchema,
   invalidateInitDbCache,
   MIGRATION_LOCK_TTL_MS,
   type Migration,
@@ -347,6 +349,27 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
 
       expect(listing.id).toBe(1);
       expect(listing.name).toBe("New Listing");
+    });
+
+    test("initializeFreshSchema rebuilds a wiped database directly", async () => {
+      // The restore path calls this straight after resetDatabase() — with no
+      // initDb state check in between — so it must produce a complete,
+      // bootable schema purely from the declarative SCHEMA.
+      await resetDatabase();
+      invalidateTestDbCache();
+      resetTestSession();
+
+      await initializeFreshSchema();
+
+      // Every app-schema table, index, and trigger is present...
+      await verifyCurrentAppSchema();
+      // ...and the schema markers were written, so a normal boot treats the
+      // database as fully migrated rather than throwing MissingSettingsTable.
+      await initDb();
+
+      await settings.setup.complete("testadmin", TEST_ADMIN_PASSWORD, "USD");
+      const listing = await createTestListing({ name: "Fresh Schema Listing" });
+      expect(listing.name).toBe("Fresh Schema Listing");
     });
   });
 });


### PR DESCRIPTION
## Summary

Restoring a backup could fail with:

```
Error: Error: Database schema verification failed: missing table settings
```

leaving the database wiped and the operator stranded on `/setup/`.

### Cause

`restoreFromSql` runs `resetDatabase()` (drops every table) and then called `initDb({ allowMissingSettings: true })` to rebuild the schema. `initDb`'s state check reads the `settings` markers with a plain read, which libsql can serve from a **read replica that still lags behind the drops**. The stale rows answer "up to date", so boot routes into `baselineCurrentSchemaIfNeeded` → `verifyCurrentAppSchema`, which snapshots the live schema from the (correctly wiped) primary — and fails on the first app-schema table: `settings`. The restore then dies as a `PostResetError` with the database already empty.

(The same read-your-writes lag is already documented on `VERIFY_RETRY_BACKOFF_MS` and `queryBatchPrimary`; this was the one restore-critical path still consulting a laggable read.)

### Fix

After the wipe there is no state worth checking — the database is by definition empty. `restoreFromSql` now calls `initializeFreshSchema()` directly (newly exported; the exact function `initDb` itself uses for a brand-new database), so the restore path never consults the settings markers at all. Everything downstream is unchanged: the seed-data deletes and the backup import still run in one batch transaction, and post-reset failures still surface as `PostResetError`.

## Regression tests

- `test/lib/backup.test.ts` — *"succeeds even when a stale read says the wiped database is up to date"*: stubs the client's `execute` so the exact marker read `initDb` issues returns the pre-wipe "up to date" rows (emulating the lagging replica), then round-trips a real backup. Before the fix this failed with the production error verbatim (`Error: Error: Database schema verification failed: missing table settings`); with the fix the restore completes and the data is back.
- `test/lib/db/migration-runtime.test.ts` — *"initializeFreshSchema rebuilds a wiped database directly"*: locks in the newly-exported function's contract — after `resetDatabase()` it produces a complete schema (`verifyCurrentAppSchema` passes: every table, index, and trigger present) that a normal `initDb()` boot then accepts as fully migrated.

## Testing

- Full suite: 14,211 passed; the only 2 failures are `test/lib/stripe-mock.test.ts` binary-download tests, which this sandbox blocks by policy (GitHub release downloads) — unrelated to the diff and expected to pass in CI
- `src/shared/db/backup.ts` at 100% line + branch coverage (`migrations.ts` is coverage-exempt by config)
- `deno task typecheck`, `deno task lint:ci`, `deno task cpd`, `deno task build:edge` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JmvXDDbQ3dSDHJN5qND16

---
_Generated by [Claude Code](https://claude.ai/code/session_019JmvXDDbQ3dSDHJN5qND16)_