### PR TITLE
Restore backups that predate a column-dropping migration

### DIFF
--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -21,6 +21,7 @@ import {
   SCHEMA_HASH,
   SCHEMA_TABLE_NAMES,
 } from "#shared/db/migrations.ts";
+import { legacyColumnRestores } from "#shared/db/restore-legacy-columns.ts";
 import { requireEnv } from "#shared/env.ts";
 import { MAX_BACKUPS, readLimit } from "#shared/limits.ts";
 import {
@@ -416,13 +417,20 @@ export const restoreFromSql = async (sql: string): Promise<void> => {
     // Roll the seed-data deletes into the same executeBatch transaction as the
     // import so that a failed import rolls the deletes back too, leaving the DB
     // in the clean post-initDb state rather than a mix of empty seed tables and
-    // partially applied backup rows.
-    await executeBatch([
-      { args: [], sql: "DELETE FROM settings" },
-      { args: [], sql: "DELETE FROM schema_migrations" },
-      { args: [], sql: "DELETE FROM attendee_statuses" },
-      ...splitStatements(sql).map((s) => ({ args: [], sql: s })),
-    ]);
+    // partially applied backup rows. Columns the dump writes that a migration
+    // the backup predates has since dropped are re-added first, so the replayed
+    // rows land intact for that pending migration to reshape on the next boot
+    // (see restore-legacy-columns.ts).
+    const statements = splitStatements(sql);
+    await executeBatch(
+      [
+        "DELETE FROM settings",
+        "DELETE FROM schema_migrations",
+        "DELETE FROM attendee_statuses",
+        ...legacyColumnRestores(statements),
+        ...statements,
+      ].map((s) => ({ args: [], sql: s })),
+    );
 
     // Clear all module-level caches — the backup may carry different data for
     // every table, so any warm cache is now stale. clearAllCaches() covers the

--- a/src/shared/db/restore-legacy-columns.ts
+++ b/src/shared/db/restore-legacy-columns.ts
@@ -1,0 +1,72 @@
+/**
+ * Reconcile an older backup's dump with the current schema before replaying it.
+ *
+ * A restore rebuilds the database at the CURRENT schema and then replays the
+ * backup's INSERT statements; the backup's own schema_migrations rows make the
+ * next boot replay whichever migrations the backup predates. That round-trips
+ * cleanly for tables and columns that were ADDED since the backup — but a
+ * column a later migration DROPPED breaks the replay, because the dump's
+ * INSERTs still write to it. Re-adding those columns before the replay
+ * reconstructs the backup-era table faithfully, and the pending migration then
+ * reshapes the data exactly as a live upgrade would (e.g.
+ * 2026-07-05_first_class_images backfills images from the re-added
+ * listings.image_url and drops the column again).
+ *
+ * This module is pure: dump statements in, ALTER statements out.
+ */
+
+import { SCHEMA } from "#shared/db/migrations/schema.ts";
+
+/** The `INSERT INTO "table" ("col", …) VALUES` prefix exportTable emits. */
+const INSERT_COLUMNS = /^INSERT INTO "(\w+)" \(([^)]+)\) VALUES /;
+
+/** A single double-quoted plain identifier, e.g. `"image_url"`. */
+const QUOTED_IDENTIFIER = /^"(\w+)"$/;
+
+/** Column names each declared table carries in the current schema. */
+const currentSchemaColumns = (): Map<string, Set<string>> =>
+  new Map(
+    SCHEMA.map(([name, table]) => [
+      name,
+      new Set(table.columns.map(([column]) => column)),
+    ]),
+  );
+
+/** Parse a dump statement's quoted column list into names — or null when any
+ *  token is not a plain quoted identifier (a hand-edited dump; leave it for
+ *  the INSERT itself to reject). */
+const parseColumnList = (list: string): string[] | null => {
+  const names: string[] = [];
+  for (const token of list.split(", ")) {
+    const match = token.match(QUOTED_IDENTIFIER);
+    if (!match) return null;
+    names.push(match[1]!);
+  }
+  return names;
+};
+
+/**
+ * ALTER statements re-adding every column the dump writes to a declared table
+ * but the current schema no longer carries. The column is added without a type:
+ * SQLite then gives it BLOB affinity, so replayed values are stored exactly as
+ * the dump's literals encode them, and the pending migration that dropped the
+ * column decides its fate on the next boot.
+ */
+export const legacyColumnRestores = (statements: string[]): string[] => {
+  const declaredColumns = currentSchemaColumns();
+  const restores: string[] = [];
+  const restored = new Set<string>();
+  for (const statement of statements) {
+    const insert = statement.match(INSERT_COLUMNS);
+    const declared = insert && declaredColumns.get(insert[1]!);
+    const columns = declared ? parseColumnList(insert[2]!) : null;
+    if (!declared || !columns) continue;
+    for (const column of columns) {
+      const key = `${insert[1]}.${column}`;
+      if (declared.has(column) || restored.has(key)) continue;
+      restored.add(key);
+      restores.push(`ALTER TABLE "${insert[1]}" ADD COLUMN "${column}"`);
+    }
+  }
+  return restores;
+};

--- a/test/lib/db/backup-restore.test.ts
+++ b/test/lib/db/backup-restore.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { createBackupZip, restoreFromZip } from "#shared/db/backup.ts";
+import { getDb, queryAll, queryOne } from "#shared/db/client.ts";
+import { initDb } from "#shared/db/migrations.ts";
+import { createTestListing, describeWithEnv } from "#test-utils";
+
+/**
+ * Regression tests for restoring a backup taken before a column-dropping
+ * migration. The restore rebuilds the database at the CURRENT schema and then
+ * replays the dump, so an INSERT that still writes a since-dropped column
+ * (e.g. listings.image_url, dropped by 2026-07-05_first_class_images) used to
+ * fail with "table listings has no column named image_url" — aborting the
+ * restore after the wipe. The dump's own schema_migrations rows record the
+ * drop migration as pending, so restoring the column lets the next boot
+ * replay it exactly as a live upgrade would.
+ */
+describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
+  const listingColumnNames = async (): Promise<string[]> => {
+    const rows = await queryAll<{ name: string }>(
+      "SELECT name FROM pragma_table_info('listings')",
+    );
+    return rows.map((row) => row.name);
+  };
+
+  describe("backups taken before a column-dropping migration", () => {
+    const FIRST_CLASS_IMAGES_ID = "2026-07-05_first_class_images";
+
+    /** Reshape the test database into its pre-first-class-images form: the
+     *  legacy encrypted image columns are back on listings and the migration
+     *  that drops them is not yet recorded. */
+    const downgradeToLegacyImageColumns = async (): Promise<void> => {
+      await getDb().executeMultiple(
+        "ALTER TABLE listings ADD COLUMN image_url TEXT NOT NULL DEFAULT '';" +
+          "ALTER TABLE listings ADD COLUMN image_thumb_url TEXT NOT NULL DEFAULT '';",
+      );
+      await getDb().execute({
+        args: [FIRST_CLASS_IMAGES_ID],
+        sql: "DELETE FROM schema_migrations WHERE id = ?",
+      });
+      await getDb().execute(
+        "UPDATE settings SET value = 'pre-images' WHERE key = 'db_schema_hash'",
+      );
+    };
+
+    test("restores the legacy column and replays the migration on next boot", async () => {
+      // Create the listing first: the admin route it posts through runs
+      // initDb, which would replay the un-recorded migration and drop the
+      // legacy columns again if the downgrade had already happened.
+      await createTestListing({ name: "Legacy Image Listing" });
+      await downgradeToLegacyImageColumns();
+      await getDb().execute(
+        "UPDATE listings SET image_url = 'legacy-image-cipher'",
+      );
+      const zip = await createBackupZip();
+
+      await restoreFromZip(zip);
+
+      // The replayed dump carried the since-dropped column; the restore must
+      // re-add it so the data survives for the pending migration to pick up.
+      const replayed = await queryOne<{ image_url: string }>(
+        "SELECT image_url FROM listings",
+      );
+      expect(replayed?.image_url).toBe("legacy-image-cipher");
+
+      // The next boot sees the restored (older) markers and replays the
+      // pending migration: the image is promoted to a first-class record and
+      // the legacy columns are dropped again.
+      await initDb();
+      const image = await queryOne<{
+        filename: string;
+        filename_thumb: string;
+      }>("SELECT filename, filename_thumb FROM images");
+      expect(image?.filename).toBe("legacy-image-cipher");
+      expect(image?.filename_thumb).toBe("legacy-image-cipher");
+      const use = await queryOne<{ item_type: string }>(
+        "SELECT item_type FROM image_uses",
+      );
+      expect(use?.item_type).toBe("listing");
+      expect(await listingColumnNames()).not.toContain("image_url");
+    });
+  });
+});

--- a/test/lib/db/restore-legacy-columns.test.ts
+++ b/test/lib/db/restore-legacy-columns.test.ts
@@ -1,0 +1,63 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { legacyColumnRestores } from "#shared/db/restore-legacy-columns.ts";
+
+describe("db > restore legacy columns", () => {
+  const legacyInsert = `INSERT INTO "listings" ("id", "name", "image_url") VALUES (1, 'cipher', 'img');`;
+
+  test("re-adds a column the current schema no longer declares", () => {
+    expect(legacyColumnRestores([legacyInsert])).toEqual([
+      `ALTER TABLE "listings" ADD COLUMN "image_url"`,
+    ]);
+  });
+
+  test("returns nothing when every dump column is still declared", () => {
+    expect(
+      legacyColumnRestores([
+        `INSERT INTO "settings" ("key", "value") VALUES ('a', 'b');`,
+      ]),
+    ).toEqual([]);
+  });
+
+  test("re-adds each legacy column once across repeated statements", () => {
+    expect(legacyColumnRestores([legacyInsert, legacyInsert])).toEqual([
+      `ALTER TABLE "listings" ADD COLUMN "image_url"`,
+    ]);
+  });
+
+  test("collects legacy columns per table across the whole dump", () => {
+    const statements = [
+      legacyInsert,
+      `INSERT INTO "holidays" ("id", "legacy_note") VALUES (1, 'x');`,
+    ];
+    expect(legacyColumnRestores(statements)).toEqual([
+      `ALTER TABLE "listings" ADD COLUMN "image_url"`,
+      `ALTER TABLE "holidays" ADD COLUMN "legacy_note"`,
+    ]);
+  });
+
+  test("ignores tables the current schema does not declare", () => {
+    expect(
+      legacyColumnRestores([
+        `INSERT INTO "events" ("id", "image_url") VALUES (1, 'img');`,
+      ]),
+    ).toEqual([]);
+  });
+
+  test("ignores statements that are not exportTable-shaped INSERTs", () => {
+    expect(
+      legacyColumnRestores([
+        "DELETE FROM listings;",
+        "INSERT INTO listings (id, image_url) VALUES (1, 'unquoted');",
+      ]),
+    ).toEqual([]);
+  });
+
+  test("leaves a column list with a non-identifier token for the INSERT to reject", () => {
+    expect(
+      legacyColumnRestores([
+        `INSERT INTO "listings" ("id", "bad""name") VALUES (1, 'x');`,
+      ]),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1575, purely additive to #1576 (no shared files with its final revision's rebuild changes beyond one adjacent hunk in `restoreFromSql`): a backup taken **before** a column-dropping migration could not be restored.

The restore rebuilds the database at the CURRENT schema and then replays the dump, so an INSERT that still writes a since-dropped column — e.g. `listings.image_url`, dropped by `2026-07-05_first_class_images` — failed with `table listings has no column named image_url`, wiping the database and aborting the restore. This bites any real pre-upgrade backup whose upgrade drops a column, which is exactly when the upgrade workflow takes one. Reproduced with a real production backup zip: its data was at schema `8qr676` (pre-images) while the current build is `suxi5o`.

## Fix

`restoreFromSql` now re-adds every column the dump writes but the current schema no longer declares, parsed from the dump's own `INSERT INTO "t" ("col", …)` headers by the new **pure** module `src/shared/db/restore-legacy-columns.ts`, in the same batch transaction as the replay (a failed import still rolls everything back). Columns are added typeless so SQLite stores the replayed literals verbatim. The dump's `schema_migrations` rows already record the dropping migration as pending, so the next boot replays it exactly as a live upgrade would.

Verified end-to-end with the production zip: restore succeeds, the next boot runs `2026-07-05_first_class_images`, all 12 listing images are promoted to first-class `images`/`image_uses` records, the legacy columns are dropped again, and the markers land on `suxi5o` with every user/attendee intact.

## Tests

- `test/lib/db/backup-restore.test.ts` — integration regression: downgrade a live DB to the pre-images shape, back it up, restore it, and prove the replayed `image_url` survives and the pending migration then promotes it and drops the column. Failed with the exact production error before the fix.
- `test/lib/db/restore-legacy-columns.test.ts` — unit tests for the pure parser/ALTER builder: legacy column re-added once across repeated statements, per-table collection, declared-column and unknown-table skips, non-exportTable-shaped statements and non-identifier tokens left for the INSERT itself to reject.

## Testing

- Full suite with coverage — green locally (the only failures are the two `stripe-mock.test.ts` binary-download tests this sandbox blocks by network policy; CI runs them normally)
- `deno task typecheck`, `deno task lint:ci`, `deno task cpd` — clean
- Mutation gate deliberately skipped at the operator's request (time-critical fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURNSMavYtB34dUQXsyKQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WURNSMavYtB34dUQXsyKQT)_