### PR TITLE
Harden logistics-filter.ts test coverage (mutation score 89.2% → 100%)

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -529,3 +529,12 @@ src/shared/listing-parents-rules.ts:62:59  !== → !=   # dayPriceFor(): number|
 # by dedicated tests instead of being listed here.)
 src/shared/band-name-generator.ts:107:39  A $1 → ""   # no template/pool ever produces a literal "An" token for this correction to act on
 src/shared/band-name-generator.ts:107:39  A $1 → "A $1 mutated"   # same as above
+
+# logistics-filter.ts's parseAgentFilter/assignmentMatchesAgentFilter: a
+# non-numeric fallback string is unobservable through parsePositiveIntId's
+# strict decimal-digit schema, and the null-checks below have no undefined
+# case to disagree on.
+src/shared/logistics-filter.ts:22:39   → "mutated"   # parsePositiveIntId's schema rejects any non-digit string identically; the "" fallback and any mutated string both parse to null
+src/shared/logistics-filter.ts:23:11  !== → !=   # n: number|null (no undefined), so !== and != agree on null
+src/shared/logistics-filter.ts:41:45  === → ==   # startAgentId: number|null at every call site (no undefined), so === and == agree on null
+src/shared/logistics-filter.ts:41:68  === → ==   # endAgentId: number|null at every call site (no undefined), so === and == agree on null

--- a/test/lib/logistics-filter.test.ts
+++ b/test/lib/logistics-filter.test.ts
@@ -66,20 +66,60 @@ describe("logistics-filter assignmentMatchesAgentFilter", () => {
 describe("logistics-filter renderAgentFilter", () => {
   const href = (f: AgentFilter): string => `/x?agent=${agentFilterParam(f)}`;
 
-  test("renders All / None / each agent with the active one bold", () => {
+  test("renders All / None / each agent in order, with an agent id active", () => {
     const html = renderAgentFilter(1, agents, href);
-    expect(html).toContain("Agent:");
-    expect(html).toContain(">All<");
-    expect(html).toContain(">None<");
-    // The active agent (id 1) is bold + underlined, not a link.
-    expect(html).toContain("<strong><u>Van 1</u></strong>");
-    // The inactive agent is a link.
-    expect(html).toContain('<a href="/x?agent=2">Van 2</a>');
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        '<a href="/x?agent=">All</a>' +
+        ' / <a href="/x?agent=none">None</a>' +
+        " / <strong><u>Van 1</u></strong>" +
+        ' / <a href="/x?agent=2">Van 2</a>' +
+        "</div>",
+    );
+  });
+
+  test("bolds the All option when it is active", () => {
+    const html = renderAgentFilter("all", agents, href);
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        "<strong><u>All</u></strong>" +
+        ' / <a href="/x?agent=none">None</a>' +
+        ' / <a href="/x?agent=1">Van 1</a>' +
+        ' / <a href="/x?agent=2">Van 2</a>' +
+        "</div>",
+    );
+  });
+
+  test("bolds the None option when it is active", () => {
+    const html = renderAgentFilter("none", agents, href);
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        '<a href="/x?agent=">All</a>' +
+        " / <strong><u>None</u></strong>" +
+        ' / <a href="/x?agent=1">Van 1</a>' +
+        ' / <a href="/x?agent=2">Van 2</a>' +
+        "</div>",
+    );
+  });
+
+  test("renders just All / None when there are no agents", () => {
+    const html = renderAgentFilter("all", [], href);
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        "<strong><u>All</u></strong>" +
+        ' / <a href="/x?agent=none">None</a>' +
+        "</div>",
+    );
   });
 
   test("escapes agent names to prevent HTML injection", () => {
     const html = renderAgentFilter("all", [{ id: 9, name: "<b>x</b>" }], href);
-    expect(html).not.toContain("<b>x</b>");
-    expect(html).toContain("&lt;b&gt;x&lt;/b&gt;");
+    expect(html).toBe(
+      '<div class="table-actions">Agent: ' +
+        "<strong><u>All</u></strong>" +
+        ' / <a href="/x?agent=none">None</a>' +
+        ' / <a href="/x?agent=9">&lt;b&gt;x&lt;/b&gt;</a>' +
+        "</div>",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Mutation testing `src/shared/logistics-filter.ts` against its existing tests found **89.2%** of mutants killed (66/74, 1 pre-existing suppression), with 8 survivors:

- `renderAgentFilter`'s single test only checked loose `.toContain()` fragments, so mutating the `"all"`/`"none"` filter-value literals used to decide which option is active went undetected — no test ever rendered the bar with `active: "all"` or `active: "none"` to confirm the *matching* option (not just an agent id) bolds correctly.
- The remaining 4 survivors turned out to be genuine equivalent mutants once traced through the types (documented below), not real gaps.

### Changes

- Replaced `renderAgentFilter`'s loose `.toContain()` test with exact `.toBe()` assertions covering: an agent id active, `"all"` active, `"none"` active, the zero-agents case, and HTML-escaping — each checking the full rendered string (order, separators, and which option bolds).
- Documented four verified-equivalent mutants in `scripts/mutation/equivalent-mutants.txt`:
  - `parseAgentFilter`'s `raw ?? ""` fallback string: `parsePositiveIntId` requires strict decimal digits, so any non-numeric fallback (the original `""` or a mutated string) parses to `null` identically.
  - `parseAgentFilter`'s `n !== null` check: `n` is typed `number | null` with no `undefined` case, so `!==`/`!=` agree.
  - `assignmentMatchesAgentFilter`'s two `startAgentId`/`endAgentId === null` checks: both parameters are typed `number | null` at every call site in the codebase (no `undefined` case), so `===`/`==` agree.

Mutation score for `logistics-filter.ts` against the new tests: **100.0% (70/70 detected, 5 suppressed as known-equivalent)**, in `--exhaustive` mode.

## Test plan

- [x] `deno check` on the touched test file
- [x] `deno test --no-check --allow-all test/lib/logistics-filter.test.ts` — all pass
- [x] `deno task mutation src/shared/logistics-filter.ts test/lib/logistics-filter.test.ts --exhaustive` — 100.0% (70/70, 5 suppressed)
- [x] `deno task lint`
- [x] `deno task cpd` — 0 clones
- [x] `deno coverage` on the file — 100% line/branch
- [x] Broader regression pass (`logistics-filter.test.ts`, `filter-bar.test.ts`, `calendar.test.ts`) — 71 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_