### PR TITLE
Refuse restoring backups from newer builds; gate legacy-column re-adds

### DIFF
--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -16,12 +16,16 @@ import { executeBatch, queryAll } from "#shared/db/client.ts";
 import {
   clearAllCaches,
   LATEST_UPDATE,
+  MIGRATION_IDS,
   rebuildWipedSchema,
   resetDatabase,
   SCHEMA_HASH,
   SCHEMA_TABLE_NAMES,
 } from "#shared/db/migrations.ts";
-import { legacyColumnRestores } from "#shared/db/restore-legacy-columns.ts";
+import {
+  dumpMigrationState,
+  legacyColumnRestores,
+} from "#shared/db/restore-legacy-columns.ts";
 import { requireEnv } from "#shared/env.ts";
 import { MAX_BACKUPS, readLimit } from "#shared/limits.ts";
 import {
@@ -398,8 +402,22 @@ export const countZipStatements = (zipData: Uint8Array): number => {
  * Restore the database from SQL content.
  * Drops all tables, reinitializes the schema, then executes all SQL
  * statements in a single transaction via executeBatch.
+ *
+ * Refuses a dump from a newer build BEFORE wiping anything: replaying it here
+ * would silently discard newer-schema data (tables this build's schema lacks
+ * are skipped), making an accidental rollback look like a successful restore.
  */
 export const restoreFromSql = async (sql: string): Promise<void> => {
+  const statements = splitStatements(sql);
+  const migrations = dumpMigrationState(statements, MIGRATION_IDS);
+  if (migrations.fromNewerBuild.length > 0) {
+    throw new Error(
+      "Backup is from a newer version of the app: it records migration(s) " +
+        `newer than this build knows (${migrations.fromNewerBuild.join(", ")}). ` +
+        "Update the site to that version or newer, then restore this backup.",
+    );
+  }
+
   // Capture any failure and re-throw as PostResetError outside the catch to
   // avoid V8 coverage gaps on `throw` inside catch blocks for async functions.
   // resetDatabase() is inside the try so that partial-drop failures (e.g. the
@@ -423,14 +441,15 @@ export const restoreFromSql = async (sql: string): Promise<void> => {
     // partially applied backup rows. Columns the dump writes that a migration
     // the backup predates has since dropped are re-added first, so the replayed
     // rows land intact for that pending migration to reshape on the next boot
-    // (see restore-legacy-columns.ts).
-    const statements = splitStatements(sql);
+    // (see restore-legacy-columns.ts) — but only when the dump actually has
+    // pending migrations to consume them: with none pending, an unknown column
+    // is corruption, and the INSERT must fail loudly instead.
     await executeBatch(
       [
         "DELETE FROM settings",
         "DELETE FROM schema_migrations",
         "DELETE FROM attendee_statuses",
-        ...legacyColumnRestores(statements),
+        ...(migrations.hasPending ? legacyColumnRestores(statements) : []),
         ...statements,
       ].map((s) => ({ args: [], sql: s })),
     );

--- a/src/shared/db/restore-legacy-columns.ts
+++ b/src/shared/db/restore-legacy-columns.ts
@@ -12,13 +12,37 @@
  * 2026-07-05_first_class_images backfills images from the re-added
  * listings.image_url and drops the column again).
  *
- * This module is pure: dump statements in, ALTER statements out.
+ * Direction matters. Re-adding is only legitimate for a dump that is OLDER
+ * than this build — one whose recorded migrations are missing at least one of
+ * ours, so a pending migration exists to consume the re-added columns. A dump
+ * that records migrations dated after this build's newest is from a NEWER
+ * build: replaying it would silently discard newer-schema data
+ * (restoreFromZip skips tables the current schema lacks), so the restore must
+ * refuse it up front instead of making the rollback look successful. And when
+ * the recorded migrations leave nothing pending, an unknown column is
+ * corruption, not history — nothing may be re-added, and the INSERT fails
+ * loudly. dumpMigrationState answers both questions from the dump itself.
+ *
+ * This module is pure: dump statements in, ALTER statements / analysis out.
  */
 
+import { mapNotNullish } from "#fp";
 import { SCHEMA } from "#shared/db/migrations/schema.ts";
 
 /** The `INSERT INTO "table" ("col", …) VALUES` prefix exportTable emits. */
 const INSERT_COLUMNS = /^INSERT INTO "(\w+)" \(([^)]+)\) VALUES /;
+
+/** The exportTable-shaped INSERTs in a dump: each statement's target table
+ *  and raw quoted column list. Non-matching statements are skipped. */
+const dumpInserts = (
+  statements: string[],
+): { table: string; columnList: string; statement: string }[] =>
+  mapNotNullish((statement: string) => {
+    const insert = statement.match(INSERT_COLUMNS);
+    return insert
+      ? { columnList: insert[2]!, statement, table: insert[1]! }
+      : null;
+  })(statements);
 
 /** A single double-quoted plain identifier, e.g. `"image_url"`. */
 const QUOTED_IDENTIFIER = /^"(\w+)"$/;
@@ -45,6 +69,59 @@ const parseColumnList = (list: string): string[] | null => {
   return names;
 };
 
+/** A migration id as a quoted SQL literal, e.g. '2026-07-05_first_class_images'
+ *  — the date prefix keeps applied_at timestamps ('2026-07-05T14:45:07.397Z')
+ *  and prose descriptions from matching. */
+const MIGRATION_ID_LITERAL = /'(\d{4}-\d{2}-\d{2}_[\w-]+)'/g;
+
+/** A migration id's date part ("YYYY-MM-DD_name" → "YYYY-MM-DD"). */
+const migrationDate = (id: string): string => id.slice(0, 10);
+
+/** How the dump's recorded schema_migrations relate to this build's. */
+export type DumpMigrationState = {
+  /** Recorded ids dated after this build's newest migration — the dump can
+   *  only have come from a newer build and must not be replayed here.
+   *  Unrecognised ids dated within this build's history are tolerated: real
+   *  databases carry orphaned markers from historically renamed migrations
+   *  (e.g. 2026-06-18_answer_price_modifiers), which nothing cleans up. */
+  fromNewerBuild: string[];
+  /** True when the dump is missing at least one of this build's migrations —
+   *  the dump is older, and those migrations will replay on the next boot. */
+  hasPending: boolean;
+};
+
+/**
+ * Read the migration ids the dump's schema_migrations INSERTs record and
+ * relate them to this build's known ids. Ids are date-prefixed and a new
+ * migration is always dated on or after the newest one already shipped, so a
+ * recorded id with a later date than any known id can only come from a newer
+ * build. A dump with no schema_migrations statements (partial fixtures,
+ * plain SQL) reads as fully pending.
+ */
+export const dumpMigrationState = (
+  statements: string[],
+  knownIds: readonly string[],
+): DumpMigrationState => {
+  const recorded = new Set<string>();
+  for (const insert of dumpInserts(statements)) {
+    if (insert.table !== "schema_migrations") continue;
+    for (const match of insert.statement.matchAll(MIGRATION_ID_LITERAL)) {
+      recorded.add(match[1]!);
+    }
+  }
+  const known = new Set(knownIds);
+  const newestKnownDate = knownIds.reduce(
+    (newest, id) => (migrationDate(id) > newest ? migrationDate(id) : newest),
+    "",
+  );
+  return {
+    fromNewerBuild: [...recorded].filter(
+      (id) => !known.has(id) && migrationDate(id) > newestKnownDate,
+    ),
+    hasPending: knownIds.some((id) => !recorded.has(id)),
+  };
+};
+
 /**
  * ALTER statements re-adding every column the dump writes to a declared table
  * but the current schema no longer carries. The column is added without a type:
@@ -56,16 +133,15 @@ export const legacyColumnRestores = (statements: string[]): string[] => {
   const declaredColumns = currentSchemaColumns();
   const restores: string[] = [];
   const restored = new Set<string>();
-  for (const statement of statements) {
-    const insert = statement.match(INSERT_COLUMNS);
-    const declared = insert && declaredColumns.get(insert[1]!);
-    const columns = declared ? parseColumnList(insert[2]!) : null;
+  for (const insert of dumpInserts(statements)) {
+    const declared = declaredColumns.get(insert.table);
+    const columns = declared ? parseColumnList(insert.columnList) : null;
     if (!declared || !columns) continue;
     for (const column of columns) {
-      const key = `${insert[1]}.${column}`;
+      const key = `${insert.table}.${column}`;
       if (declared.has(column) || restored.has(key)) continue;
       restored.add(key);
-      restores.push(`ALTER TABLE "${insert[1]}" ADD COLUMN "${column}"`);
+      restores.push(`ALTER TABLE "${insert.table}" ADD COLUMN "${column}"`);
     }
   }
   return restores;

--- a/test/lib/db/backup-restore.test.ts
+++ b/test/lib/db/backup-restore.test.ts
@@ -1,6 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { createBackupZip, restoreFromZip } from "#shared/db/backup.ts";
+import {
+  createBackupZip,
+  exportTable,
+  PostResetError,
+  restoreFromSql,
+  restoreFromZip,
+} from "#shared/db/backup.ts";
 import { getDb, queryAll, queryOne } from "#shared/db/client.ts";
 import { initDb } from "#shared/db/migrations.ts";
 import { createTestListing, describeWithEnv } from "#test-utils";
@@ -16,6 +22,9 @@ import { createTestListing, describeWithEnv } from "#test-utils";
  * replay it exactly as a live upgrade would.
  */
 describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
+  const listingCount = async (): Promise<number> =>
+    (await queryOne<{ n: number }>("SELECT COUNT(*) AS n FROM listings"))!.n;
+
   const listingColumnNames = async (): Promise<string[]> => {
     const rows = await queryAll<{ name: string }>(
       "SELECT name FROM pragma_table_info('listings')",
@@ -78,6 +87,56 @@ describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
       );
       expect(use?.item_type).toBe("listing");
       expect(await listingColumnNames()).not.toContain("image_url");
+    });
+  });
+
+  describe("backups this build cannot replay", () => {
+    test("a backup from a newer build is refused before anything is wiped", async () => {
+      await createTestListing({ name: "Still Here" });
+      const recorded = await exportTable("schema_migrations");
+      const dump =
+        `${recorded.sql}\n` +
+        `INSERT INTO "schema_migrations" ("id", "description", "applied_at") ` +
+        `VALUES ('2099-01-01_from_the_future', 'Future change', '2099-01-01T00:00:00.000Z');\n`;
+
+      await expect(restoreFromSql(dump)).rejects.toThrow(
+        "2099-01-01_from_the_future",
+      );
+
+      // Refused up front: the database was never reset, so the data survives.
+      expect(await listingCount()).toBe(1);
+    });
+
+    test("an orphaned marker from a historically renamed migration is not refused", async () => {
+      // Real databases carry schema_migrations rows whose migration was later
+      // renamed (e.g. 2026-06-18_answer_price_modifiers); the old marker is
+      // never cleaned up, so its unrecognised id must not read as "newer".
+      await createTestListing({ name: "Orphan Marker Survivor" });
+      const recorded = await exportTable("schema_migrations");
+      const dump =
+        `${recorded.sql}\n` +
+        `INSERT INTO "schema_migrations" ("id", "description", "applied_at") ` +
+        `VALUES ('2026-06-18_answer_price_modifiers', 'Renamed since', '2026-06-18T00:00:00.000Z');\n` +
+        `${(await exportTable("listings")).sql}\n`;
+
+      await restoreFromSql(dump);
+
+      expect(await listingCount()).toBe(1);
+    });
+
+    test("an unknown column with no pending migration fails instead of being re-added", async () => {
+      // The dump records every known migration, so nothing pending could
+      // consume a stray column — it is corruption, and the INSERT must fail.
+      const recorded = await exportTable("schema_migrations");
+      const dump =
+        `${recorded.sql}\n` +
+        `INSERT INTO "holidays" ("id", "date", "stray_col") VALUES (1, '2026-01-01', 'x');\n`;
+
+      await expect(restoreFromSql(dump)).rejects.toThrow(PostResetError);
+      const holidayColumns = await queryAll<{ name: string }>(
+        "SELECT name FROM pragma_table_info('holidays')",
+      );
+      expect(holidayColumns.map((c) => c.name)).not.toContain("stray_col");
     });
   });
 });

--- a/test/lib/db/restore-legacy-columns.test.ts
+++ b/test/lib/db/restore-legacy-columns.test.ts
@@ -1,8 +1,75 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { legacyColumnRestores } from "#shared/db/restore-legacy-columns.ts";
+import {
+  dumpMigrationState,
+  legacyColumnRestores,
+} from "#shared/db/restore-legacy-columns.ts";
 
 describe("db > restore legacy columns", () => {
+  describe("dumpMigrationState", () => {
+    const KNOWN = ["2026-06-16_agent_users", "2026-07-05_first_class_images"];
+    const migrationRow = (id: string): string =>
+      `INSERT INTO "schema_migrations" ("id", "description", "applied_at") VALUES ('${id}', 'Adds things', '2026-07-03T10:32:24.047Z');`;
+
+    test("a dump missing a known migration reads as pending", () => {
+      expect(
+        dumpMigrationState([migrationRow("2026-06-16_agent_users")], KNOWN),
+      ).toEqual({ fromNewerBuild: [], hasPending: true });
+    });
+
+    test("an id dated after this build's newest migration reads as newer", () => {
+      const state = dumpMigrationState(
+        [migrationRow("2099-01-01_from_the_future")],
+        KNOWN,
+      );
+      expect(state.fromNewerBuild).toEqual(["2099-01-01_from_the_future"]);
+    });
+
+    test("an orphaned marker from a renamed migration is tolerated", () => {
+      // Real databases carry markers whose migration was later renamed (the
+      // old row is never deleted). Dated within this build's history, it must
+      // not read as a newer build.
+      const state = dumpMigrationState(
+        [...KNOWN, "2026-06-18_answer_price_modifiers"].map(migrationRow),
+        KNOWN,
+      );
+      expect(state).toEqual({ fromNewerBuild: [], hasPending: false });
+    });
+
+    test("a dump recording exactly the known migrations has nothing pending", () => {
+      expect(dumpMigrationState(KNOWN.map(migrationRow), KNOWN)).toEqual({
+        fromNewerBuild: [],
+        hasPending: false,
+      });
+    });
+
+    test("a dump with no schema_migrations statements reads as fully pending", () => {
+      expect(
+        dumpMigrationState(
+          [`INSERT INTO "settings" ("key", "value") VALUES ('a', 'b');`],
+          KNOWN,
+        ),
+      ).toEqual({ fromNewerBuild: [], hasPending: true });
+    });
+
+    test("applied_at timestamps are not mistaken for migration ids", () => {
+      // The row's only id-shaped literal is the id itself; the timestamp
+      // ('2026-07-03T…') and description must not register as recorded ids.
+      const state = dumpMigrationState(KNOWN.map(migrationRow), KNOWN);
+      expect(state.fromNewerBuild).toEqual([]);
+    });
+
+    test("id-shaped literals outside schema_migrations are ignored", () => {
+      const state = dumpMigrationState(
+        [
+          `INSERT INTO "listings" ("id", "name") VALUES (1, '2099-01-01_from_the_future');`,
+        ],
+        KNOWN,
+      );
+      expect(state.fromNewerBuild).toEqual([]);
+    });
+  });
+
   const legacyInsert = `INSERT INTO "listings" ("id", "name", "image_url") VALUES (1, 'cipher', 'img');`;
 
   test("re-adds a column the current schema no longer declares", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1577, addressing its [Codex P2 review comment](https://github.com/chobbledotcom/tickets/pull/1577#pullrequestreview-comment): with unconditional legacy-column re-adds, restoring a backup from a **newer** build could look successful while silently discarding newer-schema data — `restoreFromZip` skips tables the current schema lacks, and every unknown column was treated as droppable history.

## Changes

`restoreFromSql` now reads the dump's own `schema_migrations` rows first (`dumpMigrationState`, pure, in `restore-legacy-columns.ts`) and:

- **Refuses the restore before anything is wiped** when the dump records a migration dated after this build's newest — such an id can only come from a newer build. Failing before `resetDatabase()` leaves the database intact (previously any incompatibility only surfaced after the wipe), and the error tells the operator to update the site first.
- **Re-adds legacy columns only when the dump is missing one of this build's migrations**, so a pending migration exists to consume them. With nothing pending, an unknown column is corruption, not history: nothing is re-added and the INSERT fails loudly, as before #1577.

The newer-build comparison is by id **date**, not set membership, because real databases carry orphaned markers from historically renamed migrations — observed in a production backup: `2026-06-18_answer_price_modifiers` alongside the current `2026-06-18_answer_modifiers`. A membership test refuses those legitimate older backups (verified against the production zip before choosing the design); ids are date-prefixed and new migrations are always dated on or after the newest shipped one, so a later-dated id is the reliable newer-build signal.

## Tests

- `test/lib/db/restore-legacy-columns.test.ts` — `dumpMigrationState` unit tests: pending detection, future-dated id flagged, orphaned renamed-migration marker tolerated, exact-match dumps, dumps with no schema_migrations statements, timestamps/descriptions not mistaken for ids, ids outside schema_migrations ignored.
- `test/lib/db/backup-restore.test.ts` — integration: a future-dated dump is refused **with the database untouched**; an orphaned historical marker restores fine; an unknown column with nothing pending fails instead of being re-added.
- The production backup zip (older schema + orphaned marker) still restores end-to-end and replays its pending migration.

## Testing

- `deno task test:files test/lib/db/backup-restore.test.ts test/lib/db/restore-legacy-columns.test.ts test/lib/backup.test.ts` — 97 passed
- `deno task typecheck`, `deno task lint:ci`, `deno task cpd` — clean; full coverage suite running and green so far

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURNSMavYtB34dUQXsyKQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WURNSMavYtB34dUQXsyKQT)_