### PR TITLE
Fail closed on unknown same-date migration ids in restored dumps

### DIFF
--- a/src/shared/db/restore-legacy-columns.ts
+++ b/src/shared/db/restore-legacy-columns.ts
@@ -79,8 +79,9 @@ const migrationDate = (id: string): string => id.slice(0, 10);
 
 /** How the dump's recorded schema_migrations relate to this build's. */
 export type DumpMigrationState = {
-  /** Recorded ids dated after this build's newest migration — the dump can
-   *  only have come from a newer build and must not be replayed here.
+  /** Recorded ids that can only have come from a newer build — dated after
+   *  this build's newest migration, or dated the same but with nothing
+   *  pending (see dumpMigrationState). The dump must not be replayed here.
    *  Unrecognised ids dated within this build's history are tolerated: real
    *  databases carry orphaned markers from historically renamed migrations
    *  (e.g. 2026-06-18_answer_price_modifiers), which nothing cleans up. */
@@ -95,8 +96,12 @@ export type DumpMigrationState = {
  * relate them to this build's known ids. Ids are date-prefixed and a new
  * migration is always dated on or after the newest one already shipped, so a
  * recorded id with a later date than any known id can only come from a newer
- * build. A dump with no schema_migrations statements (partial fixtures,
- * plain SQL) reads as fully pending.
+ * build. An unrecognised id sharing the newest date is ambiguous — a same-day
+ * migration from a newer build, or an orphaned marker from a same-day rename
+ * — so it fails closed as "newer" unless the dump is missing one of this
+ * build's migrations, which proves the dump predates it. A dump with no
+ * schema_migrations statements (partial fixtures, plain SQL) reads as fully
+ * pending.
  */
 export const dumpMigrationState = (
   statements: string[],
@@ -114,11 +119,15 @@ export const dumpMigrationState = (
     (newest, id) => (migrationDate(id) > newest ? migrationDate(id) : newest),
     "",
   );
+  const hasPending = knownIds.some((id) => !recorded.has(id));
+  const isFromNewerBuild = (id: string): boolean => {
+    if (known.has(id)) return false;
+    const date = migrationDate(id);
+    return date > newestKnownDate || (date === newestKnownDate && !hasPending);
+  };
   return {
-    fromNewerBuild: [...recorded].filter(
-      (id) => !known.has(id) && migrationDate(id) > newestKnownDate,
-    ),
-    hasPending: knownIds.some((id) => !recorded.has(id)),
+    fromNewerBuild: [...recorded].filter(isFromNewerBuild),
+    hasPending,
   };
 };
 

--- a/test/lib/db/restore-legacy-columns.test.ts
+++ b/test/lib/db/restore-legacy-columns.test.ts
@@ -25,6 +25,30 @@ describe("db > restore legacy columns", () => {
       expect(state.fromNewerBuild).toEqual(["2099-01-01_from_the_future"]);
     });
 
+    test("an unknown id sharing the newest date fails closed when nothing is pending", () => {
+      // A complete dump plus an unrecognised same-day id: a same-day
+      // migration from a newer build looks exactly like this, so it must be
+      // refused rather than silently dropping that migration's table data.
+      const state = dumpMigrationState(
+        [...KNOWN, "2026-07-05_same_day_addition"].map(migrationRow),
+        KNOWN,
+      );
+      expect(state.fromNewerBuild).toEqual(["2026-07-05_same_day_addition"]);
+    });
+
+    test("an unknown same-date id is tolerated when the dump has pending migrations", () => {
+      // Pending migrations prove the dump predates this build, so a same-day
+      // unrecognised id can only be an orphaned marker from a same-day
+      // rename — refusing it would block a legitimate older backup.
+      const state = dumpMigrationState(
+        ["2026-06-16_agent_users", "2026-07-05_renamed_since"].map(
+          migrationRow,
+        ),
+        KNOWN,
+      );
+      expect(state).toEqual({ fromNewerBuild: [], hasPending: true });
+    });
+
     test("an orphaned marker from a renamed migration is tolerated", () => {
       // Real databases carry markers whose migration was later renamed (the
       // old row is never deleted). Dated within this build's history, it must


### PR DESCRIPTION
## Summary

Follow-up to #1581, addressing its Codex P1 review comment (that PR merged before the fix could land on it): the newer-build guard used a strict `>` date comparison, so a backup from a newer build whose extra migration shares the **same date** as this build's newest slipped through — `restoreFromZip` would then silently skip that migration's new table data while reporting success. Same-day migrations are common in this repo, so the window is real.

## Changes

A same-date unrecognised id is genuinely ambiguous — it is either a same-day migration from a newer build or an orphaned marker from a same-day rename (the repo has a real rename precedent: `2026-06-18_answer_price_modifiers` → `2026-06-18_answer_modifiers`). `dumpMigrationState` now fails closed on it as "newer" **unless the dump is missing one of this build's migrations**: pending migrations prove the dump predates this build, so its same-date stray can only be an orphan, and a legitimate older backup is not refused. Strictly older unknown ids stay tolerated; strictly newer ones stay refused. Membership alone cannot distinguish the two same-date cases, so failing closed exactly when the dump otherwise claims to be complete — the dangerous "rollback looks successful" shape — is the safe resolution.

## Tests

- `dumpMigrationState` units: a complete dump plus an unknown same-date id is refused; an unknown same-date id alongside pending migrations is tolerated (the same-day-rename orphan case). Existing tests for strictly-newer refusal and strictly-older orphan tolerance unchanged.
- The production backup zip (older schema + orphaned marker) still restores end-to-end and replays its pending migration.

## Testing

- `deno task test:files test/lib/db/restore-legacy-columns.test.ts test/lib/db/backup-restore.test.ts test/lib/backup.test.ts` — 99 passed
- `deno task typecheck`, `deno task lint:ci`, `deno task cpd` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURNSMavYtB34dUQXsyKQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WURNSMavYtB34dUQXsyKQT)_