### PR TITLE
Harden band-name-generator.ts test coverage (mutation score 58.2% → 100%)

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -518,3 +518,14 @@ src/shared/cache-registry.ts:115:63  insert → "insert mutated"   # same as abo
 # durationsCompatible: `dayPriceFor(child, ...) !== null` — dayPriceFor
 # returns number|null (no undefined case), so !== and != agree on null.
 src/shared/listing-parents-rules.ts:62:59  !== → !=   # dayPriceFor(): number|null (no undefined), so !== and != agree on null
+
+# band-name-generator.ts's fixArticles: the "An <consonant> → A <consonant>"
+# correction has no template or pool word that ever produces a literal "An"
+# token to correct — confirmed empirically over 20,000 generated descriptions
+# with zero matches for /\bAn [^aeiouAEIOU]/ — so this replacement's argument
+# is unobservable via any input the public API can produce. (The mirrored
+# "A <vowel> → An <vowel>" correction on the next line IS exercised — several
+# BUILDING_STATES/BAND_ADJECTIVES entries start with a vowel — and is covered
+# by dedicated tests instead of being listed here.)
+src/shared/band-name-generator.ts:107:39  A $1 → ""   # no template/pool ever produces a literal "An" token for this correction to act on
+src/shared/band-name-generator.ts:107:39  A $1 → "A $1 mutated"   # same as above

--- a/test/lib/band-name-generator.test.ts
+++ b/test/lib/band-name-generator.test.ts
@@ -1,20 +1,40 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  AGE_NOTES,
+  AUDIENCE_OUTCOMES,
   BAND_ADJECTIVES,
+  BAND_DESCRIPTORS,
   BAND_NOUNS,
   BAND_PERSON_NAMES,
   BAND_SUFFIXES,
+  BAND_VERBS,
+  BUILDING_STATES,
+  CONNECTORS,
+  CROSSOVERS,
   createRand,
   DEFAULT_BAND_SEED,
   DEFAULT_DESCRIPTION_SEED,
   DEFAULT_VENUE_SEED,
   FESTIVAL_TYPES,
+  GENRES,
   generateBandNames,
   generateDescriptions,
   generateVenueNames,
+  INTENSITIES,
+  LISTING_TYPES,
+  NOISE_VERBS,
+  NUMBER_WORDS,
+  ODD_INSTRUMENTS,
+  PRIZES,
+  PROHIBITIONS,
   pickFrom,
+  REQUIREMENTS,
+  SHOW_ITEMS,
+  TIMES,
+  TOUR_ADJECTIVES,
   VENUE_TYPES,
+  WEIRD_VENUES,
 } from "#shared/band-name-generator.ts";
 
 describe("createRand", () => {
@@ -126,5 +146,208 @@ describe("generateDescriptions", () => {
       expect(d).not.toMatch(/\bAn [^aeiouAEIOU]/);
       expect(d).not.toMatch(/\bA [aeiouAEIOU]/);
     }
+  });
+});
+
+// Pinned outputs for the default seeds. These double as a regression check on
+// the seed constants themselves (a changed seed renders different text) and
+// on renderTemplate's capitalisation (a botched charAt/slice index would
+// produce different text at the same position).
+describe("golden outputs for the default seeds", () => {
+  test("first band name", () => {
+    expect(generateBandNames(1, DEFAULT_BAND_SEED)[0]).toBe(
+      "Insatiable Rabid Hydra",
+    );
+  });
+
+  test("first venue name", () => {
+    expect(generateVenueNames(1, DEFAULT_VENUE_SEED)[0]).toBe(
+      "The Boiler Room of Caboose",
+    );
+  });
+
+  test("first description (capitalises a lowercase pool word)", () => {
+    expect(generateDescriptions(1, DEFAULT_DESCRIPTION_SEED)[0]).toBe(
+      "Approximately-original-lineup reckoning supported by blackgaze eternal underdogs",
+    );
+  });
+
+  test("fixes 'A' to 'An' before a vowel-starting building state", () => {
+    expect(generateDescriptions(120, DEFAULT_DESCRIPTION_SEED)[119]).toBe(
+      "An informally-occupied former HMV hosts emo-violence warriors",
+    );
+  });
+
+  test("leaves 'A' as-is before a consonant-starting building state", () => {
+    expect(generateDescriptions(24, DEFAULT_DESCRIPTION_SEED)[23]).toBe(
+      "A derelict padlocked snooker hall hosts crust-punk diehards",
+    );
+  });
+});
+
+// Every pattern template, copied from band-name-generator.ts (the arrays
+// themselves aren't exported — only reachable through the generate*
+// functions). Mutating any template's literal text must make it stop
+// matching its regex here, for every sample that used it.
+const BAND_PATTERNS = [
+  "The {adj} {noun}",
+  "The {adj} {noun} {suffix}",
+  "{adj} {noun}",
+  "{adj} {noun} {suffix}",
+  "{noun}'s {adj} {noun}",
+  "{adj} {person} {suffix}",
+  "{person} {suffix}",
+  "{adj} {adj} {noun}",
+  "The {adj} {adj} {noun}",
+  "A {adj} {noun}",
+  "{noun} of {noun}",
+  "The {noun} of {noun}",
+  "{noun} {suffix}",
+  "{person} and the {adj} {noun}",
+];
+
+const VENUE_PATTERNS = [
+  "The {noun} {venue}",
+  "The {adj} {noun} {venue}",
+  "{noun} {venue}",
+  "{adj} {noun} {festival}",
+  "The {noun} {festival}",
+  "{noun}'s {venue}",
+  "The {venue} of {noun}",
+  "The {adj} {venue}",
+  "{noun} {festival}",
+  "{person}'s {venue}",
+];
+
+const DESCRIPTION_PATTERNS = [
+  "{intensity} {listingType} of {showItem}, {showItem}, and {showItem}",
+  "{intensity} {genre} {listingType} — {ageNote}, no {prohibition}",
+  "{tourAdj} {listingType} {connector} {genre} {bandDescriptor}",
+  "{genre} {bandDescriptor} {noiseVerb} the {venue}",
+  "{genre} {listingType} {connector} {number} {oddInstrument}",
+  "{number} bands, {number} {oddInstrument}s, one {buildingState} {weirdVenue}",
+  "{bandDescriptor} of {genre} {noiseVerb} the {venue} on a {listingType} of {showItem}",
+  "{intensity} {listingType} of {genre}, {genre}, and {showItem}",
+  "{genre} {listingType}, {ageNote}, no {prohibition}",
+  "{crossover} {genre} {listingType} {connector} {oddInstrument}",
+  "A {buildingState} {weirdVenue} hosts {genre} {bandDescriptor}",
+  "{genre} {listingType} — {requirement} compulsory, {requirement} optional",
+  "{genre} karaoke {listingType}, prizes for {prize}",
+  "{tourAdj} tour {connector} {outcome} and {outcome}",
+  "Doors at {time}, {genre} on at {time}, {outcome} by midnight",
+  "{genre} collective inside a {buildingState} {weirdVenue}",
+  "{bandDescriptor} {bandVerb} for one {tourAdj} {listingType}",
+  "{intensity} {genre} {listingType} {connector} {oddInstrument} solos",
+  "{genre} {bandDescriptor} {bandVerb} from the {weirdVenue}",
+  "{intensity} {showItem}, {intensity} {showItem}, one {oddInstrument}",
+  "{crossover} crossover {connector} {oddInstrument} and {showItem}",
+  "{tourAdj} {listingType} ending in {outcome}",
+  "{intensity} {genre} {connector} {requirement} and {requirement}",
+  "{number} {genre} acts {connector} {number} {oddInstrument}",
+  "{bandDescriptor} of {genre} return for one {tourAdj} {listingType}",
+];
+
+// Mirrors the private SLOT_POOLS map in band-name-generator.ts, so each
+// slot's regex only accepts its actual pool words — not any string. A loose
+// `.+` per slot would let a mutated template's corrupted tail get absorbed
+// by some other (also loose) pattern's slot, hiding the mutation.
+const SLOT_POOLS: Record<string, readonly string[]> = {
+  adj: BAND_ADJECTIVES,
+  ageNote: AGE_NOTES,
+  bandDescriptor: BAND_DESCRIPTORS,
+  bandVerb: BAND_VERBS,
+  buildingState: BUILDING_STATES,
+  connector: CONNECTORS,
+  crossover: CROSSOVERS,
+  festival: FESTIVAL_TYPES,
+  genre: GENRES,
+  intensity: INTENSITIES,
+  listingType: LISTING_TYPES,
+  noiseVerb: NOISE_VERBS,
+  noun: BAND_NOUNS,
+  number: NUMBER_WORDS,
+  oddInstrument: ODD_INSTRUMENTS,
+  outcome: AUDIENCE_OUTCOMES,
+  person: BAND_PERSON_NAMES,
+  prize: PRIZES,
+  prohibition: PROHIBITIONS,
+  requirement: REQUIREMENTS,
+  showItem: SHOW_ITEMS,
+  suffix: BAND_SUFFIXES,
+  time: TIMES,
+  tourAdj: TOUR_ADJECTIVES,
+  venue: VENUE_TYPES,
+  weirdVenue: WEIRD_VENUES,
+};
+
+const escapeRegex = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** Alternation of a slot's pool words. The first slot in a template also
+ * accepts each word with its first letter capitalised, since renderTemplate
+ * capitalises the whole string's first character. */
+const slotAlternation = (key: string, isFirstSlot: boolean): string => {
+  const words = SLOT_POOLS[key]!;
+  const variants = isFirstSlot
+    ? words.flatMap((w) => [w, w.charAt(0).toUpperCase() + w.slice(1)])
+    : words;
+  return `(?:${[...new Set(variants)].map(escapeRegex).join("|")})`;
+};
+
+/** Build a regex matching a rendered template: literal text stays literal,
+ * `{slot}` becomes an alternation of that slot's real pool words, and a
+ * leading "A " tolerates the "An" correction (the only place any template
+ * needs it — see fixArticles). */
+const templateRegex = (template: string): RegExp => {
+  const segments = template.split(/(\{\w+\})/g);
+  const firstSlotIndex = segments.findIndex((part) => /^\{\w+\}$/.test(part));
+  const body = segments
+    .map((part, index) => {
+      const slotMatch = /^\{(\w+)\}$/.exec(part);
+      return slotMatch
+        ? slotAlternation(slotMatch[1]!, index === firstSlotIndex)
+        : escapeRegex(part);
+    })
+    .join("")
+    .replace(/^A /, "(?:A|An) ");
+  return new RegExp(`^${body}$`);
+};
+
+/** Every sample matches one known pattern, and every pattern matches at
+ * least one sample — so mutating any pattern's literal text is caught
+ * whether the mutant renders as blank output or a corrupted string. */
+const expectFullPatternCoverage = (
+  patterns: readonly string[],
+  samples: readonly string[],
+): void => {
+  const regexes = patterns.map(templateRegex);
+  for (const sample of samples) {
+    expect(regexes.some((re) => re.test(sample))).toBe(true);
+  }
+  for (const re of regexes) {
+    expect(samples.some((s) => re.test(s))).toBe(true);
+  }
+};
+
+describe("pattern template coverage", () => {
+  test("every band pattern is used, and every band name matches a known pattern", () => {
+    expectFullPatternCoverage(
+      BAND_PATTERNS,
+      generateBandNames(120, DEFAULT_BAND_SEED),
+    );
+  });
+
+  test("every venue pattern is used, and every venue name matches a known pattern", () => {
+    expectFullPatternCoverage(
+      VENUE_PATTERNS,
+      generateVenueNames(150, DEFAULT_VENUE_SEED),
+    );
+  });
+
+  test("every description pattern is used, and every description matches a known pattern", () => {
+    expectFullPatternCoverage(
+      DESCRIPTION_PATTERNS,
+      generateDescriptions(250, DEFAULT_DESCRIPTION_SEED),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Mutation testing `src/shared/band-name-generator.ts` against its existing tests found only **58.2%** of mutants killed (103/177), with 74 survivors falling into three categories:

- **48 pattern templates** (14 band, 10 venue, 24 description) — the existing tests only check length, uniqueness, "contains a pool word", and generic capital-letter properties, none of which notice a template's literal text changing (e.g. `"The {adj} {noun}"` mutated to `"The {adj} {noun} mutated"`).
- **`renderTemplate`'s capitalisation** (`charAt(0)`/`slice(1)`) — swapping the index wasn't caught by the existing `d[0] === d[0].toUpperCase()` check, since that's still true if the capitalisation lands on the wrong character in some cases.
- **The three `DEFAULT_*_SEED` constants** — every existing test calls the generators with the seed *symbolically*, so a mutated seed value still produces valid, deterministic, duplicate-free output and passes every existing assertion.

### Changes

- Added a **pattern-coverage test** per template family (band/venue/description): builds a regex for each template where every `{slot}` is an alternation of that slot's *real pool words* (not a generic wildcard — a wildcard would let a mutated template's corrupted tail get silently absorbed by another pattern's equally generic slot, which is why an earlier wildcard-based version of this test still let all 48 template mutants through). Asserts every generated sample matches a known pattern, and every known pattern is exercised by at least one sample.
- Added a handful of **golden exact-output assertions** tied to the default seeds — these double as regression pins for the seed constants themselves and for the capitalisation logic (a swapped index produces different text at the same position), and cover both directions of the "A"/"An" article-agreement fix.
- Documented one verified-equivalent mutant in `scripts/mutation/equivalent-mutants.txt`: the `fixArticles` "An \<consonant\> → A \<consonant\>" correction has no template or pool word that ever produces a literal "An" token to correct — confirmed empirically over 20,000 generated descriptions with zero matches. (The mirrored "A \<vowel\> → An \<vowel\>" direction *is* exercised — several `BUILDING_STATES`/`BAND_ADJECTIVES` entries start with a vowel — and is covered by the golden tests instead.)

Mutation score for `band-name-generator.ts` against the new tests: **100.0% (175/175 detected, 2 suppressed as known-equivalent)**, in `--exhaustive` mode.

## Test plan

- [x] `deno check` on the touched test file
- [x] `deno test --no-check --allow-all test/lib/band-name-generator.test.ts` — all pass
- [x] `deno task mutation src/shared/band-name-generator.ts test/lib/band-name-generator.test.ts --exhaustive` — 100.0% (175/175, 2 suppressed)
- [x] `deno task lint`
- [x] `deno task cpd` — 0 clones
- [x] `deno coverage` on the file — 100% line/branch
- [x] Broader regression pass (`band-name-generator.test.ts`, `demo.test.ts`) — 51 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_019uEELqbGqNwQGAgFA6WGmS)_