### PR TITLE
Detect duplicate type shapes; unify genuine duplicate types

### DIFF
--- a/src/features/admin/attendees-csv.ts
+++ b/src/features/admin/attendees-csv.ts
@@ -12,7 +12,7 @@ import { type Column, CSV } from "#shared/csv/index.ts";
 import { toMajorUnits } from "#shared/currency.ts";
 import { addDays } from "#shared/dates.ts";
 import { isServicing } from "#shared/db/attendees/kind.ts";
-import type { QuestionWithAnswers } from "#shared/db/questions.ts";
+import type { AttendeeQuestionData } from "#shared/db/questions.ts";
 import { DEFAULT_TIMEZONE, formatDatetimeShortInTz } from "#shared/timezone.ts";
 import type { Attendee } from "#shared/types.ts";
 
@@ -20,15 +20,6 @@ import type { Attendee } from "#shared/types.ts";
 export type CsvListingInfo = {
   listingDate: string;
   listingLocation: string;
-};
-
-/** Custom-question data optionally appended to an attendee export. */
-export type CsvQuestionData = {
-  questions: QuestionWithAnswers[];
-  attendeeAnswerMap: Map<number, number[]>;
-  /** attendeeId → (questionId → decrypted free-text answer), for free_text
-   * question columns. Absent when text answers were not loaded. */
-  textAnswerMap?: Map<number, Map<number, string>>;
 };
 
 /** Price in minor units as a decimal string in the configured currency. */
@@ -106,7 +97,7 @@ export const listingInfoColumns = <T>(
 
 /** One column per custom question, each cell the attendee's chosen answer (for
  * choice questions) or their decrypted free-text answer (for free_text). */
-const questionColumns = (data?: CsvQuestionData): Column<Attendee>[] => {
+const questionColumns = (data?: AttendeeQuestionData): Column<Attendee>[] => {
   const questions = data?.questions ?? [];
   const answerMap = data?.attendeeAnswerMap ?? new Map<number, number[]>();
   const textMap = data?.textAnswerMap;
@@ -138,7 +129,7 @@ type AttendeeCsvOptions = {
   /** Prepend fixed Listing Date / Listing Location columns. */
   listingInfo?: CsvListingInfo | undefined;
   /** Append one column per custom question. */
-  questionData?: CsvQuestionData | undefined;
+  questionData?: AttendeeQuestionData | undefined;
 };
 
 /** The ordered attendee columns for an export: an optional booking Date, then
@@ -183,7 +174,7 @@ export const generateAttendeesCsv = (
   attendees: Attendee[],
   includeDate = false,
   listingInfo?: CsvListingInfo,
-  questionData?: CsvQuestionData,
+  questionData?: AttendeeQuestionData,
   tz: string = DEFAULT_TIMEZONE,
 ): string =>
   CSV.generate(

--- a/src/features/admin/catalog-transfer/membership.ts
+++ b/src/features/admin/catalog-transfer/membership.ts
@@ -13,7 +13,11 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { queryAll, type TxScope } from "#shared/db/client.ts";
+import {
+  queryAll,
+  type SqlStatement,
+  type TxScope,
+} from "#shared/db/client.ts";
 import {
   PRICE_TYPE_GROUP,
   PRICE_TYPE_GROUP_DAY,
@@ -55,7 +59,6 @@ export type ImportedMembership = {
 };
 
 /** A prepared write statement. */
-type Statement = { sql: string; args: InValue[] };
 
 /** Build a multi-row INSERT for `table(columns)` from `rows`, or null when there
  * are no rows. Each row supplies one value per column, in order. */
@@ -63,7 +66,7 @@ const multiRowInsert = (
   table: string,
   columns: readonly string[],
   rows: readonly InValue[][],
-): Statement | null => {
+): SqlStatement | null => {
   if (rows.length === 0) return null;
   const placeholder = `(${columns.map(() => "?").join(", ")})`;
   return {
@@ -82,7 +85,7 @@ const multiRowInsert = (
  * already-populated package never disturbs its other members. */
 export const membershipStatements = (
   memberships: readonly ImportedMembership[],
-): Statement[] => {
+): SqlStatement[] => {
   const memberRows = memberships.map((m) => [
     m.groupId,
     m.listingId,
@@ -113,7 +116,7 @@ export const membershipStatements = (
       ["listing_id", "price_type", "price_id", "unit_price"],
       [...flatRows, ...dayRows],
     ),
-  ].filter((stmt): stmt is Statement => stmt !== null);
+  ].filter((stmt): stmt is SqlStatement => stmt !== null);
 };
 
 /** Write every membership (batched) inside an existing write transaction — the

--- a/src/features/admin/catalog-transfer/membership.ts
+++ b/src/features/admin/catalog-transfer/membership.ts
@@ -58,8 +58,6 @@ export type ImportedMembership = {
   dayPrices: DayPrices;
 };
 
-/** A prepared write statement. */
-
 /** Build a multi-row INSERT for `table(columns)` from `rows`, or null when there
  * are no rows. Each row supplies one value per column, in order. */
 const multiRowInsert = (

--- a/src/features/admin/listings-parents.ts
+++ b/src/features/admin/listings-parents.ts
@@ -38,16 +38,8 @@ import {
   edgeFieldError,
 } from "#shared/listing-parents-rules.ts";
 import type { ListingWithCount } from "#shared/types.ts";
+import type { ChildCandidate } from "#templates/admin/listings/types.ts";
 import { withEntityFromParam } from "./entity-handlers.ts";
-
-/** A selectable child candidate on the edit page's "required children" list: the
- * listing plus why it can't be a child of the one being edited (null when it
- * can). Ineligible candidates are pre-disabled (unless already ticked) so the
- * operator can't build an edge the save would only reject (usability #4). */
-export type ChildCandidate = {
-  listing: ListingWithCount;
-  ineligibleReason: string | null;
-};
 
 /** The data the edit page's "required children" section renders. `candidates`
  * excludes the listing itself (no self-edges) and carries each one's

--- a/src/shared/accounting/backfill.ts
+++ b/src/shared/accounting/backfill.ts
@@ -43,7 +43,12 @@ import {
 } from "#shared/accounting/mappers.ts";
 import { accountBalancesForIds } from "#shared/accounting/queries.ts";
 import { insertStatement, orIgnore } from "#shared/accounting/rows.ts";
-import { executeBatch, inPlaceholders, queryAll } from "#shared/db/client.ts";
+import {
+  executeBatch,
+  inPlaceholders,
+  queryAll,
+  type SqlStatement,
+} from "#shared/db/client.ts";
 import type { TransferInput } from "#shared/ledger/types.ts";
 import { nowIso } from "#shared/now.ts";
 import { toCanonicalIso } from "#shared/payment-helpers.ts";
@@ -58,7 +63,6 @@ type PaidRow = {
 };
 
 /** A leg INSERT or row-stamp UPDATE the backfill writes to the database. */
-type Statement = { sql: string; args: InValue[] };
 
 /**
  * Attendees are paged so a large booking history never loads all at once, and
@@ -180,7 +184,7 @@ const attendeeStatements = async (
   attendeeId: number,
   rows: PaidRow[],
   recordedAt: string,
-): Promise<Statement[]> => {
+): Promise<SqlStatement[]> => {
   const legs = await attendeeLegs(attendeeId, rows);
   return [
     ...legs.map((leg) => orIgnore(insertStatement(leg, recordedAt))),
@@ -207,7 +211,7 @@ export const backfillTransfers = async (
       Number(row.attendee_id),
     );
     const recordedAt = nowIso();
-    const statements: Statement[] = [];
+    const statements: SqlStatement[] = [];
     for (const [attendeeId, rows] of groups) {
       // Already ledgered by the live dual-write path: don't re-post, but still
       // stamp the row→event link from the existing booking's sale leg so the

--- a/src/shared/accounting/rows.ts
+++ b/src/shared/accounting/rows.ts
@@ -9,7 +9,12 @@
 
 import type { InValue } from "@libsql/client";
 import { ATTENDEE } from "#shared/accounting/accounts.ts";
-import { queryAll, resultRows, type TxScope } from "#shared/db/client.ts";
+import {
+  queryAll,
+  resultRows,
+  type SqlStatement,
+  type TxScope,
+} from "#shared/db/client.ts";
 import { account } from "#shared/ledger/account.ts";
 import type {
   AccountRef,
@@ -68,7 +73,6 @@ const rowToTransfer = (row: TransferRow): Transfer => ({
 type LegColumn = { col: string; expr: string; args: InValue[] };
 
 /** A built statement ready for `execute`/`executeBatch`. */
-type Statement = { sql: string; args: InValue[] };
 
 /** A plain bound-placeholder column. */
 const lit = (col: string, value: InValue): LegColumn => ({
@@ -122,7 +126,7 @@ const legColumns = (
 const renderInsert = (
   columns: LegColumn[],
   guard?: { sql: string; args: InValue[] },
-): Statement => {
+): SqlStatement => {
   const exprs = columns.map((column) => column.expr).join(", ");
   return {
     args: [...columns.flatMap((column) => column.args), ...(guard?.args ?? [])],
@@ -136,7 +140,7 @@ const renderInsert = (
 export const insertStatement = (
   t: TransferInput,
   recordedAt: string,
-): Statement => renderInsert(legColumns(t, recordedAt));
+): SqlStatement => renderInsert(legColumns(t, recordedAt));
 
 /**
  * Rewrite a built transfer INSERT as `INSERT OR IGNORE`, so a leg whose unique
@@ -166,7 +170,7 @@ export const guardedInsertStatement = (
   recordedAt: string,
   guardSql: string,
   guardArgs: InValue[],
-): Statement =>
+): SqlStatement =>
   renderInsert(legColumns(t, recordedAt), { args: guardArgs, sql: guardSql });
 
 /**
@@ -185,7 +189,7 @@ export const bookingLegBatchInsert = (
   attendeeIdSql: string,
   attendeeIdArg: InValue,
   guard: { sql: string; args: InValue[] },
-): Statement =>
+): SqlStatement =>
   orIgnore(
     renderInsert(
       legColumns(t, recordedAt, (col, acct) =>

--- a/src/shared/accounting/rows.ts
+++ b/src/shared/accounting/rows.ts
@@ -72,8 +72,6 @@ const rowToTransfer = (row: TransferRow): Transfer => ({
  *  for its value, and the args that expression binds. */
 type LegColumn = { col: string; expr: string; args: InValue[] };
 
-/** A built statement ready for `execute`/`executeBatch`. */
-
 /** A plain bound-placeholder column. */
 const lit = (col: string, value: InValue): LegColumn => ({
   args: [value],

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -42,8 +42,6 @@ import type { Transfer, TransferInput } from "#shared/ledger/types.ts";
 import { assertValidTransfer } from "#shared/ledger/validate.ts";
 import { nowIso } from "#shared/now.ts";
 
-/** A built INSERT statement ready for the batch writer. */
-
 /** Outcome of {@link postTransfers}: rows newly written vs idempotent replays. */
 export type PostResult = {
   readonly inserted: number;

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -35,6 +35,7 @@ import {
 import {
   executeBatch,
   inPlaceholders,
+  type SqlStatement,
   type TxScope,
 } from "#shared/db/client.ts";
 import type { Transfer, TransferInput } from "#shared/ledger/types.ts";
@@ -42,7 +43,6 @@ import { assertValidTransfer } from "#shared/ledger/validate.ts";
 import { nowIso } from "#shared/now.ts";
 
 /** A built INSERT statement ready for the batch writer. */
-type Statement = { sql: string; args: InValue[] };
 
 /** Outcome of {@link postTransfers}: rows newly written vs idempotent replays. */
 export type PostResult = {
@@ -194,8 +194,8 @@ const planGroup = (
   inputs: TransferInput[],
   snapshot: BatchSnapshot,
   recordedAt: string,
-  render: (statement: Statement) => Statement = (statement) => statement,
-): { inserts: Statement[]; result: PostResult } => {
+  render: (statement: SqlStatement) => SqlStatement = (statement) => statement,
+): { inserts: SqlStatement[]; result: PostResult } => {
   const eventGroup = inputs[0]!.eventGroup;
   const existing = snapshot.existingByGroup.get(eventGroup) ?? [];
   if (existing.length > 0) {
@@ -204,7 +204,7 @@ const planGroup = (
     assertEventMatches(eventGroup, existing, inputs);
     return { inserts: [], result: { inserted: 0, skipped: inputs.length } };
   }
-  const inserts: Statement[] = [];
+  const inserts: SqlStatement[] = [];
   for (const input of inputs) {
     // A stored leg holding our reference but belonging to a different event owns
     // that reference already — reject before inserting (naming the reference).
@@ -276,7 +276,7 @@ export const postTransferGroups = async (
   }
   const snapshot = await loadBatchSnapshot(nonEmpty, fromDb);
   const recordedAt = nowIso();
-  const inserts: Statement[] = [];
+  const inserts: SqlStatement[] = [];
   const planned = nonEmpty.map((inputs) => {
     // INSERT OR IGNORE so a leg a concurrent poster committed between the
     // snapshot read and this write is skipped rather than violating the unique

--- a/src/shared/db/attendees/create.ts
+++ b/src/shared/db/attendees/create.ts
@@ -25,6 +25,7 @@ import {
   executeBatchWithResults,
   inPlaceholders,
   insert,
+  type SqlStatement,
   type TxScope,
   withTransaction,
 } from "#shared/db/client.ts";
@@ -177,8 +178,6 @@ export const reverseOrderActivity = applyOrderActivity(
   unrecordBooking,
 );
 
-type Statement = { sql: string; args: InValue[] };
-
 /** Per-booking success flags and the new attendee row id (always set in
  *  practice — an INSERT returns its rowid). */
 type WriteOutcome = { flags: boolean[]; insertId: number | bigint | undefined };
@@ -194,7 +193,7 @@ class NoBookingsCreated extends Error {}
 
 /** Remove the just-inserted attendee when none of its capacity-checked booking
  *  inserts landed a row (the batch path's all-failed cleanup). */
-const cleanupDeleteStatement = (ticketTokenIndex: InValue): Statement => ({
+const cleanupDeleteStatement = (ticketTokenIndex: InValue): SqlStatement => ({
   args: [ticketTokenIndex, ticketTokenIndex],
   sql: `DELETE FROM attendees WHERE id = (
           SELECT MAX(id) FROM attendees WHERE ticket_token_index = ?
@@ -213,7 +212,7 @@ const cleanupDeleteStatement = (ticketTokenIndex: InValue): Statement => ({
  * when none landed (the attendee was cleaned up). The single place the attendee/
  * booking batch result decoding lives, shared by the plain and ledger batches. */
 const runAttendeeBatch = async (
-  statements: Statement[],
+  statements: SqlStatement[],
   bookingCount: number,
 ): Promise<WriteOutcome | null> => {
   const batchResults = await executeBatchWithResults(statements);
@@ -229,8 +228,8 @@ const runAttendeeBatch = async (
 /** The fast path: one ACID batch (attendee, bookings, all-failed cleanup).
  *  Returns null when no booking landed (the attendee was cleaned up). */
 const writeAsBatch = (
-  attendeeInsert: Statement,
-  bookingStatements: Statement[],
+  attendeeInsert: SqlStatement,
+  bookingStatements: SqlStatement[],
   ticketTokenIndex: InValue,
 ): Promise<WriteOutcome | null> =>
   runAttendeeBatch(
@@ -248,8 +247,8 @@ const writeAsBatch = (
  *  the transaction rolls back and null is returned (the caller refunds), rather
  *  than posting legs for listings that were not booked. */
 const writeWithLedger = (
-  attendeeInsert: Statement,
-  bookingStatements: Statement[],
+  attendeeInsert: SqlStatement,
+  bookingStatements: SqlStatement[],
   postLedger: LedgerPoster,
 ): Promise<WriteOutcome | null> =>
   withTransaction<WriteOutcome>(async (tx) => {
@@ -281,7 +280,7 @@ export const ATTENDEE_BY_TOKEN_SQL =
 const allBookingsLandedGuard = (
   ticketTokenIndex: InValue,
   expectedCount: number,
-): Statement => ({
+): SqlStatement => ({
   args: [ticketTokenIndex, expectedCount],
   sql: `(SELECT COUNT(*) FROM listing_attendees WHERE attendee_id = ${ATTENDEE_BY_TOKEN_SQL}) = ?`,
 });
@@ -289,16 +288,16 @@ const allBookingsLandedGuard = (
 /** What a prepared write needs in hand before touching the database. */
 type PreparedWrite = {
   enc: EncryptedAttendeeData;
-  attendeeInsert: Statement;
-  bookingStatements: Statement[];
+  attendeeInsert: SqlStatement;
+  bookingStatements: SqlStatement[];
 };
 
-const andConditions = (conditions: Statement[]): Statement => ({
+const andConditions = (conditions: SqlStatement[]): SqlStatement => ({
   args: conditions.flatMap((condition) => condition.args),
   sql: conditions.map((condition) => `(${condition.sql})`).join(" AND "),
 });
 
-const noExistingLedgerCondition = (legs: TransferInput[]): Statement => {
+const noExistingLedgerCondition = (legs: TransferInput[]): SqlStatement => {
   if (legs.length === 0) return { args: [], sql: "1 = 1" };
   const eventGroup = legs[0]!.eventGroup;
   const references = legs.map((leg) => leg.reference);
@@ -319,7 +318,7 @@ const noExistingLedgerCondition = (legs: TransferInput[]): Statement => {
  * Shared by every create strategy so validation/encryption lives in one place. */
 const prepareAttendeeWrite = async (
   input: AttendeeInput,
-  extraCondition?: Statement,
+  extraCondition?: SqlStatement,
 ): Promise<
   | { ok: true; prepared: PreparedWrite }
   | { ok: false; failure: Extract<CreateAttendeeResult, { success: false }> }
@@ -469,7 +468,7 @@ const finishAttendeeWrite = async (
  *  (interactive transaction or batch), and what "no booking landed" means for
  *  that path (plain capacity failure, or — for the batch — possibly sold-out). */
 type CreateStrategy<R extends CreateAttendeeResult | "sold-out"> = {
-  condition?: Statement;
+  condition?: SqlStatement;
   write: (prepared: PreparedWrite) => Promise<WriteOutcome | null>;
   noBooking: () => R | Promise<R>;
 };
@@ -560,7 +559,7 @@ const writeAsLedgerBatch = async (
   );
   // Stamp the order's event group onto the booking rows so each row's amount-paid
   // projection resolves exactly this booking's legs — only once all bookings landed.
-  const eventGroupUpdate: Statement[] =
+  const eventGroupUpdate: SqlStatement[] =
     plan.legs.length > 0
       ? [
           {
@@ -570,7 +569,7 @@ const writeAsLedgerBatch = async (
           },
         ]
       : [];
-  const finalizeStatements: Statement[] = plan.finalizeSessionId
+  const finalizeStatements: SqlStatement[] = plan.finalizeSessionId
     ? [
         batchFinalizeStatement(
           plan.finalizeSessionId,

--- a/src/shared/db/capacity.ts
+++ b/src/shared/db/capacity.ts
@@ -13,9 +13,9 @@
 
 import type { InValue } from "@libsql/client";
 import { addDays } from "#shared/dates.ts";
+import type { SqlStatement } from "#shared/db/client.ts";
 import { normalizeDurationDays } from "#shared/types.ts";
 
-export type SqlFragment = { sql: string; args: InValue[] };
 type DayRange = { startAt: string; endAt: string };
 
 /** Convert a date string ("YYYY-MM-DD") to a half-open [start, end) pair.
@@ -48,7 +48,7 @@ const buildDailyListingCountSql = (
   listingId: number,
   dayRange: DayRange,
   excludeAttendeeId?: number,
-): SqlFragment => ({
+): SqlStatement => ({
   args: [
     listingId,
     ...attendeeExclusionArgs(excludeAttendeeId),
@@ -74,7 +74,7 @@ const buildDailyListingCountSql = (
 const buildUndatedListingCountSql = (
   listingId: number,
   excludeAttendeeId?: number,
-): SqlFragment => {
+): SqlStatement => {
   if (excludeAttendeeId) {
     return {
       args: [listingId, listingId, excludeAttendeeId],
@@ -101,7 +101,7 @@ export const buildListingCountSql = (
   listingId: number,
   dayRange: DayRange | null,
   excludeAttendeeId?: number,
-): SqlFragment => {
+): SqlStatement => {
   if (dayRange) {
     return buildDailyListingCountSql(listingId, dayRange, excludeAttendeeId);
   }
@@ -155,7 +155,7 @@ const buildDailyGroupCountSql = (
   dayRange: DayRange,
   excludeAttendeeId?: number,
   groupRef = "groupRow.id",
-): SqlFragment => ({
+): SqlStatement => ({
   args: [
     ...attendeeExclusionArgs(excludeAttendeeId),
     ...attendeeExclusionArgs(excludeAttendeeId),
@@ -190,7 +190,7 @@ const buildDailyGroupCountSql = (
 const buildUndatedGroupCountSql = (
   excludeAttendeeId?: number,
   groupRef = "groupRow.id",
-): SqlFragment => ({
+): SqlStatement => ({
   args: attendeeExclusionArgs(excludeAttendeeId),
   sql: `(COALESCE((
           SELECT SUM(memberListing.booked_quantity)
@@ -206,7 +206,7 @@ const buildGroupCountSql = (
   dayRange: DayRange | null,
   excludeAttendeeId?: number,
   groupRef = "groupRow.id",
-): SqlFragment => {
+): SqlStatement => {
   if (dayRange) {
     return buildDailyGroupCountSql(dayRange, excludeAttendeeId, groupRef);
   }
@@ -224,7 +224,7 @@ const buildDayCapacitySql = (
   qty: number,
   dayRange: DayRange | null,
   excludeAttendeeId?: number,
-): SqlFragment => {
+): SqlStatement => {
   const listingCount = buildListingCountSql(
     listingId,
     dayRange,
@@ -275,7 +275,7 @@ export const buildCapacityCondition = (
   date: string | null,
   excludeAttendeeId?: number,
   durationDays = 1,
-): SqlFragment => {
+): SqlStatement => {
   if (!date) {
     return buildDayCapacitySql(listingId, qty, null, excludeAttendeeId);
   }
@@ -307,7 +307,7 @@ const listingCapClause = (
   listingId: number,
   dayRange: DayRange | null,
   demand: number,
-): SqlFragment => {
+): SqlStatement => {
   const count = buildListingCountSql(listingId, dayRange);
   return {
     args: count.args,
@@ -322,7 +322,7 @@ const groupCapClause = (
   groupId: number,
   dayRange: DayRange | null,
   demand: number,
-): SqlFragment => {
+): SqlStatement => {
   const count = buildGroupCountSql(dayRange, undefined, String(groupId));
   const cap = `(SELECT max_attendees FROM groups WHERE id = ${groupId})`;
   return {
@@ -338,8 +338,8 @@ const groupCapClause = (
 const bucketClauses = (
   bucket: CapacityBucket,
   extra: number,
-  clauseFor: (dayRange: DayRange | null, demand: number) => SqlFragment,
-): SqlFragment[] => {
+  clauseFor: (dayRange: DayRange | null, demand: number) => SqlStatement,
+): SqlStatement[] => {
   if (bucket.perDay.size > 0) {
     return [...bucket.perDay].map(([day, qty]) =>
       clauseFor(dateToRange(day), qty + extra),
@@ -358,8 +358,8 @@ const bucketClauses = (
 export const buildBatchCapacitySql = (
   listingDemand: Map<number, CapacityBucket>,
   groupDemand: Map<number, CapacityBucket>,
-): SqlFragment => {
-  const clauses: SqlFragment[] = [];
+): SqlStatement => {
+  const clauses: SqlStatement[] = [];
   for (const [listingId, bucket] of listingDemand) {
     clauses.push(
       ...bucketClauses(bucket, 0, (dayRange, demand) =>

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -319,13 +319,21 @@ export const resetAggregates = async <T extends string>(
 };
 
 /**
+ * A single SQL statement plus its bound arguments — the object form libsql's
+ * batch API accepts. This is the one shared shape for a `{ sql, args }` pair;
+ * callers that build statements to hand to {@link executeBatch} and friends
+ * import this rather than re-declaring the same object type locally.
+ */
+export type SqlStatement = { sql: string; args: InValue[] };
+
+/**
  * Execute a batch with optional query logging, then invalidate caches for every
  * table the batch mutated. Invalidation runs once the transaction has
  * committed; if the batch throws (rollback) it is skipped, so a cache is never
  * cleared for a write that did not land.
  */
 const trackedBatch = async (
-  statements: Array<{ sql: string; args: InValue[] }>,
+  statements: SqlStatement[],
   mode: TransactionMode,
 ): Promise<ResultSet[]> => {
   const start = performance.now();
@@ -351,7 +359,7 @@ const trackedBatch = async (
 /** Create a batch executor for a given transaction mode */
 const batchFor =
   (mode: TransactionMode) =>
-  (statements: Array<{ sql: string; args: InValue[] }>): Promise<ResultSet[]> =>
+  (statements: SqlStatement[]): Promise<ResultSet[]> =>
     trackedBatch(statements, mode);
 
 /** Execute multiple read queries in a single round-trip using Turso batch API. */
@@ -377,7 +385,7 @@ export const executeBatchWithResults = batchFor("write");
 
 /** Execute multiple write statements, discarding results. */
 export const executeBatch = async (
-  statements: Array<{ sql: string; args: InValue[] }>,
+  statements: SqlStatement[],
 ): Promise<void> => {
   await executeBatchWithResults(statements);
 };

--- a/src/shared/db/images.ts
+++ b/src/shared/db/images.ts
@@ -2,10 +2,13 @@
  * First-class uploaded images and their ordered item links.
  */
 
-import type { InValue } from "@libsql/client";
 import { mapParallel } from "#fp";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { executeBatch, queryAll } from "#shared/db/client.ts";
+import {
+  executeBatch,
+  queryAll,
+  type SqlStatement,
+} from "#shared/db/client.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
 import { type ColumnDef, col } from "#shared/db/table.ts";
 import type {
@@ -161,8 +164,6 @@ export const getImageUsesForImage = (imageId: number): Promise<ImageUse[]> =>
     [imageId],
   );
 
-type ImageUseStatement = { sql: string; args: InValue[] };
-
 const itemTable: Record<ImageUseItemType, string> = {
   group: "groups",
   listing: "listings",
@@ -173,7 +174,7 @@ const imageUseInsertStatement = (
   itemType: ImageUseItemType,
   itemId: number,
   sortOrder: number,
-): ImageUseStatement => ({
+): SqlStatement => ({
   args: [imageId, itemType, itemId, sortOrder, imageId],
   sql: `INSERT OR IGNORE INTO image_uses (image_id, item_type, item_id, sort_order)
         SELECT ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM images WHERE id = ?)`,
@@ -199,7 +200,7 @@ export const setImagesForItem = (
 const attachImageToExistingItemStatement = (
   imageId: number,
   target: ImageUseTarget,
-): ImageUseStatement => {
+): SqlStatement => {
   const table = itemTable[target.itemType];
   return {
     args: [
@@ -229,7 +230,7 @@ export const appendImageToItem = (
 const clearStaleImageUseTargetsStatement = (
   imageId: number,
   targets: readonly ImageUseTarget[],
-): ImageUseStatement => {
+): SqlStatement => {
   const targetPredicates = targets.map(() => "(item_type = ? AND item_id = ?)");
   return {
     args: [
@@ -264,7 +265,7 @@ export const setItemsForImage = (
 export const clearImageUsesForItemStatement = (
   itemType: ImageUseItemType,
   itemId: number,
-): ImageUseStatement => ({
+): SqlStatement => ({
   args: [itemType, itemId],
   sql: "DELETE FROM image_uses WHERE item_type = ? AND item_id = ?",
 });

--- a/src/shared/db/modifier-usage.ts
+++ b/src/shared/db/modifier-usage.ts
@@ -9,7 +9,11 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { inPlaceholders, queryAll } from "#shared/db/client.ts";
+import {
+  inPlaceholders,
+  queryAll,
+  type SqlStatement,
+} from "#shared/db/client.ts";
 import { mapByIds } from "#shared/db/query.ts";
 import { nowIso } from "#shared/now.ts";
 
@@ -22,7 +26,6 @@ export type ModifierUsage = {
 };
 
 /** A built SQL fragment: the text and its positional bind args. */
-type SqlFragment = { sql: string; args: InValue[] };
 
 /** Used quantity per modifier id, for remaining-stock checks at resolve time. */
 export const modifierUsedQuantities = (
@@ -44,7 +47,7 @@ export const modifierUsedQuantities = (
  * concurrency guard) and by the booking insert that must refuse to land when a
  * chosen modifier sold out mid-payment. Wrapped in parens so several can be
  * AND-ed safely. */
-export const modifierStockCondition = (usage: ModifierUsage): SqlFragment => ({
+export const modifierStockCondition = (usage: ModifierUsage): SqlStatement => ({
   args: [usage.modifierId, usage.modifierId, usage.modifierId, usage.quantity],
   sql: `((SELECT stock FROM modifiers WHERE id = ?) IS NULL
            OR (SELECT stock FROM modifiers WHERE id = ?)
@@ -61,7 +64,7 @@ export const modifierStockCondition = (usage: ModifierUsage): SqlFragment => ({
  * so the booking's capacity clause stands alone. */
 export const allModifiersInStockCondition = (
   usages: ModifierUsage[],
-): SqlFragment => {
+): SqlStatement => {
   if (usages.length === 0) return { args: [], sql: "1 = 1" };
   const parts = usages.map(modifierStockCondition);
   return {
@@ -84,8 +87,8 @@ export const usageInsert = (
   usage: ModifierUsage,
   attendeeIdExpr: string,
   attendeeIdArgs: InValue[],
-  guard: SqlFragment,
-): SqlFragment => ({
+  guard: SqlStatement,
+): SqlStatement => ({
   args: [
     usage.modifierId,
     ...attendeeIdArgs,

--- a/src/shared/db/modifier-usage.ts
+++ b/src/shared/db/modifier-usage.ts
@@ -25,8 +25,6 @@ export type ModifierUsage = {
   amountApplied: number;
 };
 
-/** A built SQL fragment: the text and its positional bind args. */
-
 /** Used quantity per modifier id, for remaining-stock checks at resolve time. */
 export const modifierUsedQuantities = (
   ids: number[],

--- a/src/shared/db/processed-payments.ts
+++ b/src/shared/db/processed-payments.ts
@@ -18,7 +18,12 @@
 import type { InValue } from "@libsql/client";
 import { attendeeOwedSubquery } from "#shared/accounting/projection-sql.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { execute, insert, queryOne } from "#shared/db/client.ts";
+import {
+  execute,
+  insert,
+  queryOne,
+  type SqlStatement,
+} from "#shared/db/client.ts";
 import { STALE_RESERVATION_MS } from "#shared/limits.ts";
 import { nowIso, nowMs } from "#shared/now.ts";
 
@@ -271,7 +276,6 @@ export const parseSessionFailure = async (
 };
 
 /** A built SQL statement: the text and its positional bind args. */
-type SqlStatement = { sql: string; args: InValue[] };
 
 /** Shared UPDATE shape for the finalize statement builders. */
 const buildFinalizeStatement = (

--- a/src/shared/db/processed-payments.ts
+++ b/src/shared/db/processed-payments.ts
@@ -275,8 +275,6 @@ export const parseSessionFailure = async (
   }
 };
 
-/** A built SQL statement: the text and its positional bind args. */
-
 /** Shared UPDATE shape for the finalize statement builders. */
 const buildFinalizeStatement = (
   attendeeId: number,

--- a/src/shared/db/site-page-items.ts
+++ b/src/shared/db/site-page-items.ts
@@ -9,13 +9,13 @@
  * transaction** — two concurrent adds of the same page can't both slip through.
  */
 
-import type { InValue } from "@libsql/client";
 import { registerTableInvalidation } from "#shared/cache-registry.ts";
 import {
   executeBatch,
   inPlaceholders,
   queryAll,
   resultRows,
+  type SqlStatement,
   withTransaction,
 } from "#shared/db/client.ts";
 import { requestCache } from "#shared/request-cache.ts";
@@ -26,7 +26,6 @@ import {
 import type { SitePageItem, SitePageItemType } from "#shared/types.ts";
 
 /** A parameterised statement for a batch / transaction. */
-type Stmt = { sql: string; args: InValue[] };
 
 const SELECT_COLS = "page_id, item_type, item_id, sort_order";
 
@@ -136,7 +135,7 @@ const itemDeleteStatement = (
   pageId: number,
   itemType: SitePageItemType,
   itemId: number,
-): Stmt => ({
+): SqlStatement => ({
   args: [pageId, itemType, itemId],
   sql: "DELETE FROM site_page_items WHERE page_id = ? AND item_type = ? AND item_id = ?",
 });
@@ -183,7 +182,7 @@ const setOrderStatement = (
   pageId: number,
   ref: ItemRef,
   order: number,
-): Stmt => ({
+): SqlStatement => ({
   args: [order, pageId, ref.type, ref.id],
   sql: "UPDATE site_page_items SET sort_order = ? WHERE page_id = ? AND item_type = ? AND item_id = ?",
 });
@@ -211,7 +210,7 @@ export const deleteSitePageWithEdges = (pageId: number): Promise<void> =>
 export const clearItemEdgesStatement = (
   itemType: "listing" | "group",
   itemId: number,
-): Stmt => ({
+): SqlStatement => ({
   args: [itemType, itemId],
   sql: "DELETE FROM site_page_items WHERE item_type = ? AND item_id = ?",
 });

--- a/src/shared/db/site-page-items.ts
+++ b/src/shared/db/site-page-items.ts
@@ -25,8 +25,6 @@ import {
 } from "#shared/site-pages/core.ts";
 import type { SitePageItem, SitePageItemType } from "#shared/types.ts";
 
-/** A parameterised statement for a batch / transaction. */
-
 const SELECT_COLS = "page_id, item_type, item_id, sort_order";
 
 const fetchAllItems = (): Promise<SitePageItem[]> =>

--- a/src/shared/db/site-pages.ts
+++ b/src/shared/db/site-pages.ts
@@ -52,13 +52,11 @@ const rawSitePagesTable = defineIdTable<SitePage, SitePageInput>("site_pages", {
   sort_order: col.simple<number>(),
 });
 
-/** Raw narrow projection row before decryption. */
-type RawNavRow = { id: number; name: string; slug: string; sort_order: number };
-
 /** Load the nav projection: only id/slug/name/sort_order, decrypting just slug
- * and name (never content/meta). Ordered by (sort_order, id). */
+ * and name (never content/meta). Ordered by (sort_order, id). The raw row (name
+ * and slug still encrypted) shares {@link SitePageNavRow}'s shape. */
 const fetchNavRows = async (): Promise<SitePageNavRow[]> => {
-  const rows = await queryAll<RawNavRow>(
+  const rows = await queryAll<SitePageNavRow>(
     "SELECT id, slug, name, sort_order FROM site_pages ORDER BY sort_order ASC, id ASC",
   );
   return Promise.all(

--- a/src/ui/templates/admin/listings/types.ts
+++ b/src/ui/templates/admin/listings/types.ts
@@ -59,6 +59,10 @@ export type ListingOverviewPanelOptions = ListingPanelSharedOptions & {
   noteNames: Map<number, string>;
 };
 
+/** A selectable child candidate on the edit page's "required children" list: the
+ * listing plus why it can't be a child of the one being edited (null when it
+ * can). Ineligible candidates are pre-disabled (unless already ticked) so the
+ * operator can't build an edge the save would only reject (usability #4). */
 export type ChildCandidate = {
   listing: ListingWithCount;
   ineligibleReason: string | null;

--- a/test/lib/code-quality.test.ts
+++ b/test/lib/code-quality.test.ts
@@ -7,11 +7,14 @@ import {
   detectModuleLevelLet,
   detectThenUsage,
   extractCallSites,
+  extractTypeShapes,
+  findDuplicateTypeShapes,
   findInMemoryStateViolations,
   findRawDbViolation,
   findRedundantArg,
   findTestOnlyExportViolations,
   getAllFilesWithExt,
+  type NamedTypeShape,
   type Site,
 } from "./code-quality/detectors.ts";
 
@@ -100,6 +103,57 @@ const AGGREGATION_MODULES = [
   "shared/db/index.ts",
   "shared/rest/index.ts",
   "templates/index.ts",
+];
+
+/**
+ * Object shapes that two or more differently-named types legitimately share.
+ * The duplicate-type-shape rule normally wants one reusable type instead of
+ * several identical ones (see the {@link findDuplicateTypeShapes} guard below),
+ * but these are *coincidental* structural matches across unrelated concepts —
+ * minimal `{ key, value }` / `{ label, value }` / `{ id, name }` pairs and
+ * role-specific context types that happen to carry the same fields. Unifying
+ * them would couple modules that have nothing to do with each other and hide
+ * their distinct intent, so each is allowed by its exact member signature (add
+ * or rename a field and it re-flags for review). Genuine duplicates — the
+ * `{ sql, args }` statement family, the twin `ChildCandidate`, the nav-row and
+ * question-data pairs — were unified instead of listed here.
+ */
+const ALLOWED_DUPLICATE_TYPE_SHAPES: { signature: string; reason: string }[] = [
+  {
+    reason:
+      "Distinct route params (attendee+listing vs listing+attendee) that coincide as two numeric ids.",
+    signature: "attendeeId: number; listingId: number",
+  },
+  {
+    reason:
+      "A generic {attendee, listing} pairing plus two role-named context types (payment refresh, ticket-token entry) that carry the same two fields for unrelated jobs.",
+    signature: "attendee: Attendee; listing: ListingWithCount",
+  },
+  {
+    reason:
+      "A server REST error result and a separate client-side QR-refresh wire type; two independent discriminated-union arms that share the failure shape.",
+    signature: "error: string; ok: false",
+  },
+  {
+    reason:
+      "The minimal {id, name} identity shape, shared coincidentally by a logistics agent, a listing row, and two unrelated select-option types.",
+    signature: "id: number; name: string",
+  },
+  {
+    reason:
+      "A stored settings key/value row and a rendered admin detail row; a DB shape and a presentation shape that happen to match.",
+    signature: "key: string; value: string",
+  },
+  {
+    reason:
+      "The generic {label, value} select-option shape, used independently by the date picker and the site-page picker.",
+    signature: "label: string; value: string",
+  },
+  {
+    reason:
+      "A selector's props and its edit-context, two local view-model types in one logistics component that currently carry the same two fields.",
+    signature: "selected: ReadonlySet<number>; users: AgentUserOption[]",
+  },
 ];
 
 /**
@@ -449,6 +503,34 @@ describe("code quality", () => {
         if (violation) violations.push(violation);
       }
       violations.sort();
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("no duplicate type shapes", () => {
+    /**
+     * Collect every object-shaped `type`/`interface` across production source
+     * (src + tsx), keyed by file. Prefer generic, reusable objects: two
+     * differently-named types with identical members should be one shared type.
+     * Coincidental cross-domain matches live in ALLOWED_DUPLICATE_TYPE_SHAPES.
+     */
+    const collectTypeShapes = (): NamedTypeShape[] => {
+      const defs: NamedTypeShape[] = [];
+      const record = (file: string, content: string): void => {
+        const relativePath = getRelativePath(file);
+        for (const shape of extractTypeShapes(content)) {
+          defs.push({ ...shape, file: relativePath });
+        }
+      };
+      for (const file of srcFiles) record(file, srcContents.get(file)!);
+      for (const file of tsxFiles) record(file, tsxContents.get(file)!);
+      return defs;
+    };
+
+    test("no two types should declare the same object shape", async () => {
+      await ensureLoaded();
+      const allowed = ALLOWED_DUPLICATE_TYPE_SHAPES.map((a) => a.signature);
+      const violations = findDuplicateTypeShapes(collectTypeShapes(), allowed);
       expect(violations).toEqual([]);
     });
   });

--- a/test/lib/code-quality/detectors.ts
+++ b/test/lib/code-quality/detectors.ts
@@ -626,3 +626,243 @@ export const findRedundantArg = (
   }
   return null;
 };
+
+/* -------------------------------------------------------------------------- *
+ * No duplicate type shapes                                                   *
+ *                                                                            *
+ * Two differently-named object types with the same members are a standing    *
+ * invitation to one shared, reusable type. This scanner extracts every        *
+ * object-shaped `type X = { … }` alias and `interface X { … }`, normalizes    *
+ * the member list, and groups declarations by that shape so identical ones    *
+ * under different names surface. It reuses the string/comment-aware           *
+ * tokenizer above so braces, semicolons and commas inside strings or          *
+ * comments never confuse the body-matching or member-splitting.               *
+ * -------------------------------------------------------------------------- */
+
+/** A single named object type discovered in a source file. `members` are the
+ * normalized (whitespace-collapsed) top-level members, in source order. */
+export type NamedTypeShape = {
+  file: string;
+  name: string;
+  kind: "type" | "interface";
+  members: string[];
+};
+
+/** Below this many members a shared shape isn't worth extracting: single-field
+ * objects like `{ id: number }` collide coincidentally across unrelated route
+ * params and rows, and forcing them to share a type hurts readability. */
+export const MIN_TYPE_SHAPE_MEMBERS = 2;
+
+/**
+ * Return a length-preserving copy of `content` with every comment — and, when
+ * `blankStrings` is set, every string/template literal — replaced by spaces
+ * (newlines kept, so offsets and line anchoring are unchanged). The all-blanked
+ * form is used for structural decisions (finding declarations, matching braces,
+ * splitting members) so a `{`, `}`, `;` or `,` inside a string or comment never
+ * leaks into them; the comments-only form supplies the real member text (string
+ * literal members like `kind: "listing"` stay intact, so distinct discriminated
+ * unions are never mistaken for one shape).
+ */
+export const blankSpans = (content: string, blankStrings: boolean): string => {
+  const out = content.split("");
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  let i = 0;
+  while (i < content.length) {
+    const pastComment = skipComment(content, i);
+    if (pastComment !== i) {
+      blank(i, pastComment);
+      i = pastComment;
+      continue;
+    }
+    const c = content[i];
+    if (c === '"' || c === "'" || c === "`") {
+      const end = skipString(content, i);
+      if (blankStrings) blank(i, end);
+      i = end;
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
+};
+
+/** Index of the `}` that closes the `{` at `open` in already-blanked `code`
+ * (no strings/comments to skip), or -1 if unbalanced. */
+const matchBrace = (code: string, open: number): number => {
+  let depth = 0;
+  for (let i = open; i < code.length; i++) {
+    if (code[i] === "{") depth++;
+    else if (code[i] === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+};
+
+/** The `{`/`}` offsets of an interface body starting after its name at `pos`,
+ * or null. Skips an optional `<…>` type-parameter/`extends` clause; a `=` or
+ * `;` before the body means this wasn't an interface declaration. */
+const parseInterfaceBody = (
+  code: string,
+  pos: number,
+): { open: number; close: number } | null => {
+  let depth = 0;
+  for (let i = pos; i < code.length; i++) {
+    const c = code[i];
+    if (c === "<") depth++;
+    else if (c === ">") {
+      if (code[i - 1] !== "=") depth--;
+    } else if (depth === 0 && c === "{") {
+      const close = matchBrace(code, i);
+      return close === -1 ? null : { close, open: i };
+    } else if (depth === 0 && (c === ";" || c === "=")) return null;
+  }
+  return null;
+};
+
+/** Advance past whitespace in `code` from `i`. */
+const skipSpace = (code: string, i: number): number => {
+  let j = i;
+  while (j < code.length && /\s/.test(code[j]!)) j++;
+  return j;
+};
+
+/**
+ * The `{`/`}` offsets of a `type X … = { … }` body starting after its name at
+ * `pos`, or null when the alias isn't a whole-object type (a union, a mapped
+ * type, `type X = Y`, etc.). Skips optional `<…>` type parameters, requires the
+ * `=`, and requires the object to be the entire right-hand side.
+ */
+const parseTypeAliasBody = (
+  code: string,
+  pos: number,
+): { open: number; close: number } | null => {
+  let i = skipSpace(code, pos);
+  if (code[i] === "<") {
+    let depth = 0;
+    for (; i < code.length; i++) {
+      if (code[i] === "<") depth++;
+      else if (code[i] === ">") {
+        depth--;
+        if (depth === 0) {
+          i++;
+          break;
+        }
+      }
+    }
+  }
+  i = skipSpace(code, i);
+  if (code[i] !== "=") return null;
+  i = skipSpace(code, i + 1);
+  if (code[i] !== "{") return null;
+  const close = matchBrace(code, i);
+  if (close === -1) return null;
+  let k = close + 1;
+  while (k < code.length && (code[k] === " " || code[k] === "\t")) k++;
+  const after = code[k];
+  if (after && after !== ";" && after !== "\n" && after !== "\r") return null;
+  return { close, open: i };
+};
+
+/**
+ * Split the interior of an object type into its normalized top-level members.
+ * `code` (fully blanked) drives the bracket-depth and delimiter detection;
+ * `text` (comments blanked, strings kept) supplies the member text. Angle
+ * brackets nest so a comma inside `Map<a, b>` doesn't split, while `=>` is not
+ * treated as a closing angle.
+ */
+export const splitTypeMembers = (
+  code: string,
+  text: string,
+  innerStart: number,
+  innerEnd: number,
+): string[] => {
+  const members: string[] = [];
+  let depth = 0;
+  let start = innerStart;
+  const push = (end: number): void => {
+    const raw = text.slice(start, end).replace(/\s+/g, " ").trim();
+    if (raw) members.push(raw);
+    start = end + 1;
+  };
+  for (let i = innerStart; i < innerEnd; i++) {
+    const c = code[i];
+    if (c === "{" || c === "(" || c === "[" || c === "<") depth++;
+    else if (c === "}" || c === ")" || c === "]") depth--;
+    else if (c === ">") {
+      if (code[i - 1] !== "=") depth--;
+    } else if (depth === 0 && (c === ";" || c === ",")) push(i);
+  }
+  push(innerEnd);
+  return members;
+};
+
+/** Every object-shaped `type`/`interface` declared in `content`, with its
+ * normalized member list. Non-object aliases (unions, `type X = Y`, mapped
+ * types) are skipped. */
+export const extractTypeShapes = (
+  content: string,
+): { name: string; kind: "type" | "interface"; members: string[] }[] => {
+  const code = blankSpans(content, true);
+  const text = blankSpans(content, false);
+  const shapes: {
+    name: string;
+    kind: "type" | "interface";
+    members: string[];
+  }[] = [];
+  const declaration =
+    /^[ \t]*(?:export[ \t]+)?(?:declare[ \t]+)?(type|interface)[ \t]+([A-Za-z_$][\w$]*)/gm;
+  for (const m of code.matchAll(declaration)) {
+    const kind = m[1] as "type" | "interface";
+    const nameEnd = m.index + m[0].length;
+    const body =
+      kind === "interface"
+        ? parseInterfaceBody(code, nameEnd)
+        : parseTypeAliasBody(code, nameEnd);
+    if (!body) continue;
+    const members = splitTypeMembers(code, text, body.open + 1, body.close);
+    shapes.push({ kind, members, name: m[2]!.trim() });
+  }
+  return shapes;
+};
+
+/** A stable signature for an object shape: its members, order-independent. */
+export const typeShapeSignature = (members: string[]): string =>
+  [...members].sort().join("; ");
+
+/**
+ * Group `defs` by shape and report each shape shared by two or more distinctly
+ * named types. Shapes with fewer than {@link MIN_TYPE_SHAPE_MEMBERS} members,
+ * and any signature on `allowedSignatures`, are ignored.
+ */
+export const findDuplicateTypeShapes = (
+  defs: NamedTypeShape[],
+  allowedSignatures: string[],
+): string[] => {
+  const groups = new Map<string, NamedTypeShape[]>();
+  for (const def of defs) {
+    if (def.members.length < MIN_TYPE_SHAPE_MEMBERS) continue;
+    const signature = typeShapeSignature(def.members);
+    if (allowedSignatures.includes(signature)) continue;
+    const group = groups.get(signature) ?? [];
+    group.push(def);
+    groups.set(signature, group);
+  }
+
+  const violations: string[] = [];
+  for (const [signature, group] of groups) {
+    const distinct = new Map<string, NamedTypeShape>();
+    for (const def of group) distinct.set(`${def.file}::${def.name}`, def);
+    if (distinct.size < 2) continue;
+    const where = [...distinct.values()]
+      .map((d) => `${d.kind} ${d.name} (${d.file})`)
+      .join(", ");
+    violations.push(
+      `duplicate type shape { ${signature} } — defined as ${where}; extract one shared type or add it to the allow-list`,
+    );
+  }
+  return violations.sort();
+};

--- a/test/lib/code-quality/duplicate-types.test.ts
+++ b/test/lib/code-quality/duplicate-types.test.ts
@@ -1,0 +1,357 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  blankSpans,
+  extractTypeShapes,
+  findDuplicateTypeShapes,
+  type NamedTypeShape,
+  splitTypeMembers,
+  typeShapeSignature,
+} from "./detectors.ts";
+
+/**
+ * Fixture-driven tests for the duplicate-type-shape detector. As with the other
+ * detectors, the integration guard (`../code-quality.test.ts`) only asserts the
+ * live tree is clean, so these examples feed each function known-bad and
+ * known-good inputs to pin the extraction, normalization and grouping logic.
+ */
+
+describe("blankSpans", () => {
+  test("blanks a line comment but keeps its length and newline", () => {
+    expect(blankSpans("a // c\nb", false)).toBe("a     \nb");
+  });
+
+  test("blanks a block comment across a newline", () => {
+    expect(blankSpans("a /* x\ny */ b", false)).toBe("a     \n     b");
+  });
+
+  test("keeps strings when blankStrings is false", () => {
+    expect(blankSpans('x = "a;b"', false)).toBe('x = "a;b"');
+  });
+
+  test("blanks strings when blankStrings is true", () => {
+    expect(blankSpans('x = "a;b"', true)).toBe("x =      ");
+  });
+
+  test("blanks a template literal, preserving embedded newlines", () => {
+    expect(blankSpans("`a\nb`", true)).toBe("  \n  ");
+  });
+});
+
+describe("splitTypeMembers", () => {
+  const split = (body: string): string[] =>
+    splitTypeMembers(body, body, 0, body.length);
+
+  test("splits top-level members on semicolons", () => {
+    expect(split("a: number; b: string")).toEqual(["a: number", "b: string"]);
+  });
+
+  test("does not split a comma inside a generic type argument", () => {
+    expect(split("m: Map<number, string>; n: number")).toEqual([
+      "m: Map<number, string>",
+      "n: number",
+    ]);
+  });
+
+  test("does not treat => as a closing angle bracket", () => {
+    expect(split("f: (x: number) => void; g: string")).toEqual([
+      "f: (x: number) => void",
+      "g: string",
+    ]);
+  });
+
+  test("collapses internal whitespace and drops empty members", () => {
+    expect(split("a:   number;\n  b: string;")).toEqual([
+      "a: number",
+      "b: string",
+    ]);
+  });
+
+  test("keeps a nested object as a single member", () => {
+    expect(split("a: { x: number; y: number }; b: string")).toEqual([
+      "a: { x: number; y: number }",
+      "b: string",
+    ]);
+  });
+
+  test("takes member text from `text`, structure from `code`", () => {
+    // A comma inside the string literal (blanked in `code`) must not split, and
+    // the real string text is preserved from `text`.
+    const text = 'kind: "a,b"; n: number';
+    const code = blankSpans(text, true);
+    expect(splitTypeMembers(code, text, 0, text.length)).toEqual([
+      'kind: "a,b"',
+      "n: number",
+    ]);
+  });
+});
+
+describe("extractTypeShapes", () => {
+  test("extracts an object type alias", () => {
+    expect(extractTypeShapes("type A = { a: number; b: string };")).toEqual([
+      { kind: "type", members: ["a: number", "b: string"], name: "A" },
+    ]);
+  });
+
+  test("extracts an interface, ignoring an extends clause", () => {
+    expect(
+      extractTypeShapes(
+        "interface A extends Base<number> { x: number; y: number }",
+      ),
+    ).toEqual([
+      { kind: "interface", members: ["x: number", "y: number"], name: "A" },
+    ]);
+  });
+
+  test("handles type parameters on the alias name", () => {
+    expect(
+      extractTypeShapes("type Box<T> = { value: T; label: string };"),
+    ).toEqual([
+      { kind: "type", members: ["value: T", "label: string"], name: "Box" },
+    ]);
+  });
+
+  test("ignores a non-object alias (union)", () => {
+    expect(extractTypeShapes('type A = "x" | "y";')).toEqual([]);
+  });
+
+  test("ignores a plain reference alias", () => {
+    expect(extractTypeShapes("type A = OtherType;")).toEqual([]);
+  });
+
+  test("ignores an alias whose object is only part of the RHS", () => {
+    expect(extractTypeShapes("type A = { a: number } | null;")).toEqual([]);
+  });
+
+  test("ignores import type and export-from re-exports", () => {
+    const src = [
+      'import type { A } from "./a.ts";',
+      'export type { B } from "./b.ts";',
+    ].join("\n");
+    expect(extractTypeShapes(src)).toEqual([]);
+  });
+
+  test("does not match `type` as an object property name", () => {
+    expect(extractTypeShapes("const o = { type: 1, name: 2 };")).toEqual([]);
+  });
+
+  test("keeps string-literal members distinct (not blanked away)", () => {
+    const a = extractTypeShapes('type A = { kind: "listing"; id: number };');
+    const b = extractTypeShapes('type B = { kind: "group"; id: number };');
+    expect(a[0]!.members).not.toEqual(b[0]!.members);
+  });
+
+  test("ignores a brace and semicolon inside a string-literal member", () => {
+    expect(extractTypeShapes('type A = { a: "{;}"; b: number };')).toEqual([
+      { kind: "type", members: ['a: "{;}"', "b: number"], name: "A" },
+    ]);
+  });
+
+  test("ignores a comment inside the body", () => {
+    const src = "type A = {\n  a: number; // note\n  b: string;\n};";
+    expect(extractTypeShapes(src)[0]!.members).toEqual([
+      "a: number",
+      "b: string",
+    ]);
+  });
+
+  test("extracts an exported type", () => {
+    expect(
+      extractTypeShapes("export type A = { a: number; b: number };")[0],
+    ).toEqual({ kind: "type", members: ["a: number", "b: number"], name: "A" });
+  });
+});
+
+describe("typeShapeSignature", () => {
+  test("is order-independent", () => {
+    expect(typeShapeSignature(["b: string", "a: number"])).toBe(
+      typeShapeSignature(["a: number", "b: string"]),
+    );
+  });
+
+  test("joins sorted members with a semicolon separator", () => {
+    expect(typeShapeSignature(["b: string", "a: number"])).toBe(
+      "a: number; b: string",
+    );
+  });
+});
+
+describe("findDuplicateTypeShapes", () => {
+  const def = (
+    file: string,
+    name: string,
+    members: string[],
+    kind: "type" | "interface" = "type",
+  ): NamedTypeShape => ({ file, kind, members, name });
+
+  test("flags two differently-named types with the same shape", () => {
+    const defs = [
+      def("a.ts", "A", ["x: number", "y: number"]),
+      def("b.ts", "B", ["y: number", "x: number"]),
+    ];
+    expect(findDuplicateTypeShapes(defs, [])).toEqual([
+      "duplicate type shape { x: number; y: number } — defined as type A (a.ts), type B (b.ts); extract one shared type or add it to the allow-list",
+    ]);
+  });
+
+  test("does not flag a single type", () => {
+    expect(
+      findDuplicateTypeShapes(
+        [def("a.ts", "A", ["x: number", "y: number"])],
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  test("ignores shapes below the member threshold", () => {
+    const defs = [
+      def("a.ts", "A", ["id: number"]),
+      def("b.ts", "B", ["id: number"]),
+    ];
+    expect(findDuplicateTypeShapes(defs, [])).toEqual([]);
+  });
+
+  test("respects the allow-list of accepted signatures", () => {
+    const defs = [
+      def("a.ts", "A", ["x: number", "y: number"]),
+      def("b.ts", "B", ["x: number", "y: number"]),
+    ];
+    expect(findDuplicateTypeShapes(defs, ["x: number; y: number"])).toEqual([]);
+  });
+
+  test("collapses re-encounters of the same qualified type", () => {
+    // The same file::name seen twice is not two distinct types.
+    const defs = [
+      def("a.ts", "A", ["x: number", "y: number"]),
+      def("a.ts", "A", ["x: number", "y: number"]),
+    ];
+    expect(findDuplicateTypeShapes(defs, [])).toEqual([]);
+  });
+
+  test("reports the interface kind in the message", () => {
+    const defs = [
+      def("a.ts", "A", ["x: number", "y: number"], "interface"),
+      def("b.ts", "B", ["x: number", "y: number"]),
+    ];
+    expect(findDuplicateTypeShapes(defs, [])[0]).toContain(
+      "interface A (a.ts)",
+    );
+  });
+});
+
+describe("blankSpans — span boundaries", () => {
+  test("blanks a single-quoted string", () => {
+    expect(blankSpans("'a'", true)).toBe("   ");
+  });
+
+  test("continues scanning after a comment (adjacent block comments)", () => {
+    // If the loop failed to resume at the comment's end, the second block
+    // comment would go unblanked.
+    expect(blankSpans("a/*x*//*y*/", false)).toBe("a          ");
+  });
+
+  test("blanks a comment then a following string (both, offset > 0)", () => {
+    expect(blankSpans('ab/**/"y"', true)).toBe("ab       ");
+  });
+
+  test("blanks a string then a following comment (both, offset > 0)", () => {
+    expect(blankSpans('a"y"/*z*/', true)).toBe("a        ");
+  });
+});
+
+describe("splitTypeMembers — delimiters and nesting", () => {
+  const split = (body: string): string[] =>
+    splitTypeMembers(body, body, 0, body.length);
+
+  test("splits on a top-level comma", () => {
+    expect(split("a: number, b: string")).toEqual(["a: number", "b: string"]);
+  });
+
+  test("does not split a comma inside a tuple/array member", () => {
+    expect(split("a: [number, string]; b: number")).toEqual([
+      "a: [number, string]",
+      "b: number",
+    ]);
+  });
+});
+
+describe("extractTypeShapes — parsing edge cases", () => {
+  test("splits comma-separated interface-style members", () => {
+    expect(
+      extractTypeShapes("type A = { a: number, b: number };")[0]!.members,
+    ).toEqual(["a: number", "b: number"]);
+  });
+
+  test("keeps a semicolon inside a string-literal member from splitting", () => {
+    // Only correct because the object body is scanned with strings blanked.
+    expect(
+      extractTypeShapes('type A = { a: ";"; b: number };')[0]!.members,
+    ).toEqual(['a: ";"', "b: number"]);
+  });
+
+  test("ignores a type alias with an unterminated object body", () => {
+    expect(extractTypeShapes("type A = { a: number; b: number")).toEqual([]);
+  });
+
+  test("ignores an interface with an unterminated body", () => {
+    expect(extractTypeShapes("interface A { a: number; b: number")).toEqual([]);
+  });
+
+  test("ignores an interface terminated by a semicolon before any body", () => {
+    expect(
+      extractTypeShapes(
+        "interface A;\ninterface C { x: number; y: number }",
+      ).map((s) => s.name),
+    ).toEqual(["C"]);
+  });
+
+  test("ignores an interface with an '=' before any body", () => {
+    expect(
+      extractTypeShapes(
+        "interface A = X;\ninterface C { x: number; y: number }",
+      ).map((s) => s.name),
+    ).toEqual(["C"]);
+  });
+
+  test("ignores an interface that never opens a body", () => {
+    expect(extractTypeShapes("interface A extends B")).toEqual([]);
+  });
+
+  test("skips an arrow inside an interface's extends generics", () => {
+    // The `>` of `=>` must not be treated as closing the `<…>`, or the body
+    // brace would be missed.
+    expect(
+      extractTypeShapes(
+        "interface A extends B<() => void> { x: number; y: number }",
+      )[0],
+    ).toEqual({
+      kind: "interface",
+      members: ["x: number", "y: number"],
+      name: "A",
+    });
+  });
+
+  test("accepts spaces between the object and the terminating semicolon", () => {
+    expect(
+      extractTypeShapes("type A = { a: number; b: number }  ;")[0]!.name,
+    ).toBe("A");
+  });
+
+  test("accepts a tab between the object and the terminating semicolon", () => {
+    expect(
+      extractTypeShapes("type A = { a: number; b: number }\t;")[0]!.name,
+    ).toBe("A");
+  });
+
+  test("accepts a newline immediately after the object (no semicolon)", () => {
+    expect(
+      extractTypeShapes("type A = { a: number; b: number }\n")[0]!.name,
+    ).toBe("A");
+  });
+
+  test("accepts a CRLF immediately after the object", () => {
+    expect(
+      extractTypeShapes("type A = { a: number; b: number }\r\n")[0]!.name,
+    ).toBe("A");
+  });
+});


### PR DESCRIPTION
## What & why

You asked for a test that flags when we've defined **multiple types with the same contents**, to push us toward generic, reusable objects. This adds that guard and cleans up the genuine duplicates it found.

## The detector

- New pure logic in `test/lib/code-quality/detectors.ts`: `extractTypeShapes` pulls every object-shaped `type X = { … }` alias and `interface X { … }`, and `findDuplicateTypeShapes` groups declarations by their normalized (order-independent) member list, reporting any shape declared under two or more different names.
- It reuses the file's existing string/comment-aware tokenizer, so a `{`, `}`, `;` or `,` inside a string literal or comment never confuses body matching or member splitting. String-literal members (e.g. `kind: "listing"` vs `kind: "group"`) stay distinct, so discriminated unions aren't mistaken for one shape.
- Fixtures in the new `test/lib/code-quality/duplicate-types.test.ts` pin the extraction/normalization/grouping logic (100% line + branch coverage of the detector); the integration guard in `test/lib/code-quality.test.ts` scans the live `src`+`tsx` tree and asserts it's clean.

## Policy choices

- **Single-field types are ignored** (2+ members required). Shapes like `{ id: number }` collide coincidentally across unrelated route params/rows, and forcing them to share a type hurts readability.
- **Coincidental cross-domain matches are allow-listed** with justifications (a DB `Settings` `{key,value}` row vs a UI `DetailRow`, the minimal `{id,name}` identity shape, etc.) — unifying those would couple unrelated modules. Add or rename a field and the shape re-flags for review.

## Genuine duplicates unified (not allow-listed)

- One shared `SqlStatement` type in `db/client.ts` replaces **ten** local `{ sql, args }` aliases (`Statement` / `SqlStatement` / `SqlFragment` / `Stmt` / `ImageUseStatement` across accounting, db and features).
- The twin `ChildCandidate` (defined identically in two files) collapses to the one in the listings template.
- `RawNavRow` reuses `SitePageNavRow`; `CsvQuestionData` reuses `AttendeeQuestionData`.

All unifications are type-only (no behaviour change).

## Verification

- `deno task lint:ci`, `deno task typecheck`, `deno task cpd` (0%), `deno task build:edge` — all pass.
- Detector fixtures + integration guard pass; detector has 100% line/branch coverage.
- Ran the tests covering every modified source file (accounting, db, csv, capacity, catalog-transfer, listing-parents, site-pages) — 292 passing, confirming the type-only dedup is runtime-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199wbpHWNYRPcpBDmZprHor

---
_Generated by [Claude Code](https://claude.ai/code/session_0199wbpHWNYRPcpBDmZprHor)_