### PR TITLE
Harden square-validation.ts test coverage (mutation score 75.0% -> 100%)

### DIFF
--- a/test/lib/square-validation.test.ts
+++ b/test/lib/square-validation.test.ts
@@ -42,9 +42,16 @@ describe("validateSquareAccessToken", () => {
     expect(error).toContain("application ID or secret");
   });
 
-  test("rejects a value matching no known token format", () => {
-    const error = validateSquareAccessToken("not-a-real-token");
-    expect(error).toContain("EAAA");
+  test("rejects a sandbox application secret with the exact app-credential message", () => {
+    expect(validateSquareAccessToken("sandbox-sq0csb-EXAMPLE")).toBe(
+      `That looks like a Square application ID or secret (it starts with "sq0"), not an access token. Copy the Access Token from your Square application's Credentials page.`,
+    );
+  });
+
+  test("rejects a value matching no known token format with the exact message", () => {
+    expect(validateSquareAccessToken("not-a-real-token")).toBe(
+      `That doesn't look like a Square access token. Access tokens start with "EAAA" or "eyJ". Please check you pasted the Access Token, not the Application ID or a webhook signature key.`,
+    );
   });
 
   test("rejects a value with a valid prefix that is not anchored at the start", () => {
@@ -62,9 +69,10 @@ describe("validateSquareLocationId", () => {
     expect(validateSquareLocationId("L_test_456")).toBeNull();
   });
 
-  test("rejects an application ID pasted into the location field", () => {
-    const error = validateSquareLocationId("sq0idp-EXAMPLE");
-    expect(error).toContain("not a Location ID");
+  test("rejects an application ID pasted into the location field, with the example ID in the hint", () => {
+    expect(validateSquareLocationId("sq0idp-EXAMPLE")).toBe(
+      `That looks like a Square application ID or secret, not a Location ID. The Location ID is a short code like "LH182V1KBR6V2" found under Locations in your Square Dashboard.`,
+    );
   });
 });
 
@@ -73,8 +81,9 @@ describe("validateSquareWebhookSignatureKey", () => {
     expect(validateSquareWebhookSignatureKey("aZ9_-realLookingKey")).toBeNull();
   });
 
-  test("rejects an application ID pasted into the signature key field", () => {
-    const error = validateSquareWebhookSignatureKey("sq0idp-EXAMPLE");
-    expect(error).toContain("not a webhook signature key");
+  test("rejects an application ID pasted into the signature key field, with the exact message", () => {
+    expect(validateSquareWebhookSignatureKey("sq0idp-EXAMPLE")).toBe(
+      "That looks like a Square application ID or secret, not a webhook signature key. Copy the Signature Key shown on your webhook subscription page in the Square Developer Dashboard.",
+    );
   });
 });


### PR DESCRIPTION
## Summary

`deno task mutation src/shared/square-validation.ts test/lib/square-validation.test.ts --exhaustive` found a 75.0% mutation score with 6 survivors on the Square credential format validators (`validateSquareAccessToken`, `validateSquareLocationId`, `validateSquareWebhookSignatureKey`) shown in the admin Square settings page.

- The `sandbox-sq0csb-` (sandbox application secret) prefix in `APP_CREDENTIAL_PREFIXES` had no test at all, so mutating that string literal was invisible.
- The three user-facing hint/error messages, and the `EXAMPLE_LOCATION_ID` constant embedded in the location-ID hint, were only checked with `toContain` on a short substring (e.g. `"application ID or secret"`, `"not a Location ID"`), so wording or constant mutations elsewhere in the same string went undetected.

Added a test for the missing sandbox-secret prefix, and switched the message-bearing assertions to exact `toBe` checks against the full string so the whole message (including the embedded example ID) is verified.

Re-ran with `--exhaustive`: 24/24 mutants detected, **100.0%** score, no equivalents needed.

## Test plan

- [x] `deno task mutation src/shared/square-validation.ts test/lib/square-validation.test.ts --exhaustive` → 100.0% (0 survivors)
- [x] `deno test test/lib/square-validation.test.ts` → all passing
- [x] `deno run -A scripts/biome.ts check --error-on-warnings test/lib/square-validation.test.ts` → clean
- [x] `deno check` on the touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw


---
_Generated by [Claude Code](https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw)_