### PR TITLE
Harden renewal-helpers.ts test coverage (mutation score 82.9% -> 100%)

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -538,3 +538,19 @@ src/shared/logistics-filter.ts:22:39   → "mutated"   # parsePositiveIntId's sc
 src/shared/logistics-filter.ts:23:11  !== → !=   # n: number|null (no undefined), so !== and != agree on null
 src/shared/logistics-filter.ts:41:45  === → ==   # startAgentId: number|null at every call site (no undefined), so === and == agree on null
 src/shared/logistics-filter.ts:41:68  === → ==   # endAgentId: number|null at every call site (no undefined), so === and == agree on null
+
+# renewal-helpers.ts's isProvisioned: BuiltSite.renewalTokenIndex is typed
+# string|null (no undefined case), so !== and != agree on null.
+src/shared/renewal-helpers.ts:10:25  !== → !=   # renewalTokenIndex: string|null (no undefined), so !== and != agree on null
+
+# renewal-helpers.ts's formatDeadlineLabel: `diffMs < 0` is only reached when
+# diffDays !== 0 (the line above already returns "today" otherwise), and
+# diffDays = Math.round(Math.abs(diffMs) / 86_400_000) is nonzero only when
+# Math.abs(diffMs) >= 43_200_000 (half a day — Math.round rounds a .5 up, so
+# anything below that rounds to 0 and returns earlier). So every diffMs that
+# reaches this line is already <= -43_200_000 or >= 43_200_000, nowhere near
+# 0, 1, or -1 — comparing it with `<` vs `<=`, or against 0 vs ±1, always
+# picks the same branch.
+src/shared/renewal-helpers.ts:20:13  < → <=   # diffMs here is always <= -43_200_000 or >= 43_200_000 (see block comment above); < and <= agree everywhere in that range
+src/shared/renewal-helpers.ts:20:16  0 → 1   # same reachability guarantee; diffMs is never in [0, 1)
+src/shared/renewal-helpers.ts:20:16  0 → -1   # same reachability guarantee; diffMs is never in [-1, 0)

--- a/test/lib/renewal-helpers.test.ts
+++ b/test/lib/renewal-helpers.test.ts
@@ -40,4 +40,14 @@ describe("formatDeadlineLabel", () => {
     const past = new Date(NOW - 3 * DAY_MS).toISOString();
     expect(formatDeadlineLabel(past, NOW)).toBe("expired 3 day(s) ago");
   });
+
+  test("rounds a hair under the 1.5-day mark down to 1 day, not 2", () => {
+    const future = new Date(NOW + 1.5 * DAY_MS - 1).toISOString();
+    expect(formatDeadlineLabel(future, NOW)).toBe("in 1 day(s)");
+  });
+
+  test("rounds a hair over the 1.5-day mark up to 2 days, not 1", () => {
+    const future = new Date(NOW + 1.5 * DAY_MS + 1).toISOString();
+    expect(formatDeadlineLabel(future, NOW)).toBe("in 2 day(s)");
+  });
 });


### PR DESCRIPTION
## Summary

`deno task mutation src/shared/renewal-helpers.ts test/lib/renewal-helpers.test.ts --exhaustive` found an 82.9% mutation score with 6 survivors on `formatDeadlineLabel`/`isProvisioned`, the renewal-deadline label formatter used by admin templates and routes.

Two were real gaps: the day-length divisor (`86_400_000`) had no test anywhere near a rounding boundary, so nudging it by ±1ms was invisible — every existing test used exact-day offsets far from any half-day boundary. Added two boundary cases:
- a diff just **under** 1.5 days → must round to `"in 1 day(s)"` (kills the divisor being nudged down, which would round it up to 2)
- a diff just **over** 1.5 days → must round to `"in 2 day(s)"` (kills the divisor being nudged up, which would round it down to 1)

The other four survivors are genuinely equivalent, recorded in `scripts/mutation/equivalent-mutants.txt` with reasoning:
- `renewalTokenIndex` is typed `string | null` (no `undefined` case), so `!==`/`!=` always agree on the null check.
- `diffMs < 0` is only reached once `diffDays !== 0`, and `diffDays = Math.round(Math.abs(diffMs) / 86_400_000)` is nonzero only when `Math.abs(diffMs) >= 43_200_000` (half a day — `Math.round` rounds `.5` up). So every `diffMs` reaching that line is already far from 0, 1, or -1, making `<` vs `<=` and the `0`→`±1` literal swaps unobservable.

Re-ran with `--exhaustive`: 31/31 mutants detected, **100.0%** score, 4 known-equivalent suppressed.

## Test plan

- [x] `deno task mutation src/shared/renewal-helpers.ts test/lib/renewal-helpers.test.ts --exhaustive` → 100.0% (0 survivors, 4 suppressed as equivalent)
- [x] `deno test test/lib/renewal-helpers.test.ts` → all passing
- [x] `deno run -A scripts/biome.ts check --error-on-warnings test/lib/renewal-helpers.test.ts` → clean
- [x] `deno check` on the touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw


---
_Generated by [Claude Code](https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw)_