### PR TITLE
Document the == null exception to the equivalent-mutants no-=== rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -649,6 +649,18 @@ mutates each changed `src/` file against the changed `test/` files and demands a
 100% kill rate, so the cost stays bounded to what you actually changed.
 Known-equivalent survivors recorded in
 `scripts/mutation/equivalent-mutants.txt` are suppressed, as with a manual run.
+That file's header warns against recording `=== → ==`/`!== → !=` mutants
+because Biome's `noDoubleEquals` normally rejects `==`/`!=` and the runner
+counts a lint failure as killed before tests even run — **but this does not
+apply to comparisons against the `null` literal**: Biome's `noDoubleEquals`
+allows `== null`/`!= null` as the idiomatic null-or-undefined check, so a
+`=== null` → `== null` mutant on a value typed to exclude `undefined` is a
+real, lint-surviving equivalent and belongs in the file (there are several
+already, e.g. `logistics-filter.ts:41:45`, `sort-listings.ts:44:12`,
+`package-privacy.ts:44:10`). Verify either way by mutating the line by hand
+and running `deno run -A scripts/biome.ts check --error-on-warnings <file>` —
+exit 0 means the lint gate does not kill it, so a real survivor needs a test
+or a documented equivalent, not removal on the assumption that lint caught it.
 It is a deliberately mapping-free, best-effort check with three documented blind
 spots (see the header of `scripts/precommit/mutation-step.ts`): it scopes to the
 *committed* diff, so uncommitted work isn't checked until committed; it trusts

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -14,8 +14,18 @@
 #   <path>:<line>:<col>  <from> → <to>   # why it is equivalent
 #
 # Do NOT list a mutant whose output the linter rejects (e.g. `=== → ==` or
-# `!== → !=`, forbidden by Biome's noDoubleEquals): the runner lints each mutant
-# and counts a lint failure as killed, so those never survive to be recorded.
+# `!== → !=` comparing two non-null-literal operands, forbidden by Biome's
+# noDoubleEquals): the runner lints each mutant and counts a lint failure as
+# killed, so those never survive to be recorded.
+#
+# Exception: `x === null` → `x == null` (and `!==`/`!=`) is NOT rejected —
+# Biome's noDoubleEquals allows `== null`/`!= null` as the idiomatic
+# null-or-undefined check. So when `x` is typed to exclude `undefined`, this
+# mutant genuinely reaches the test stage and can be a real equivalent (===
+# and == agree on every value `x` can hold); it belongs here like any other
+# equivalent, not excluded by the rule above. Verify by hand if in doubt:
+# mutate the line, then `deno run -A scripts/biome.ts check --error-on-warnings
+# <file>` — exit 0 means lint did not kill it.
 
 # `x ?? F` vs `x || F` differ only when x is falsy-but-not-null; these are all
 # cases where x can't be such a value, or F equals the only one it can be.


### PR DESCRIPTION
## Summary

Codex's automated review flagged the same false positive twice across PRs #1591 and #1594: a `=== → ==` mutant comparing a nullable-typed value against the `null` literal, on the assumption that `scripts/mutation/equivalent-mutants.txt`'s header rule ("don't record `=== → ==`/`!== → !=` — Biome's `noDoubleEquals` kills them via lint before tests run") applied to it.

It doesn't. Biome's `noDoubleEquals` allows `== null`/`!= null` as the idiomatic null-or-undefined check — confirmed empirically by mutating a real `=== null` comparison to `== null` and running `deno run -A scripts/biome.ts check --error-on-warnings` (exit 0, no diagnostics). So when a value's type excludes `undefined`, a `=== null` → `== null` mutant genuinely reaches the test stage and can be a real equivalent (there are already several such entries in the file, e.g. `logistics-filter.ts:41:45`, `sort-listings.ts:44:12`, `package-privacy.ts:44:10`).

This documents the exception in both places so it stops needing re-litigating on every PR:
- `scripts/mutation/equivalent-mutants.txt`'s header, right next to the rule it carves an exception out of.
- `AGENTS.md`'s Mutation Testing section, with a one-line recipe to verify either way by hand.

No code or test changes — documentation only.

## Test plan

- [x] Re-ran `deno task mutation src/shared/package-privacy.ts test/lib/package-privacy.test.ts --exhaustive` after the header edit → still 100.0% (1 suppressed as known-equivalent), confirming the doc change doesn't affect parsing/behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw


---
_Generated by [Claude Code](https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw)_