### PR TITLE
Add unit-tests-report task to track per-file test coverage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,6 +20,7 @@
     "precommit:mutation": "deno run -A scripts/precommit-mutation.ts",
     "find-unused-src": "deno run --allow-read scripts/find-unused-src.ts",
     "line-counts": "deno run --allow-read=src,test scripts/line-counts.ts",
+    "unit-tests-report": "deno run --allow-read=src,test scripts/unit-tests-report.ts",
     "upgrade": "deno run --allow-read --allow-write --allow-net scripts/safe-upgrade.ts",
     "backup": "deno run --env-file --allow-env --allow-read --allow-write --allow-net --allow-sys --allow-ffi scripts/backup.ts",
     "cli:tui": "deno run --allow-env --allow-read --allow-run cli/tui.ts",

--- a/scripts/unit-tests-report-lib.ts
+++ b/scripts/unit-tests-report-lib.ts
@@ -1,0 +1,318 @@
+/**
+ * Unit-test coverage report — the pure core.
+ *
+ * The project is working towards a unit test (with 100% mutation coverage) for
+ * every source file, on top of the integration/e2e tests that already exercise
+ * the app end-to-end. This report measures progress towards that goal by a
+ * simple, mechanical convention: a source file at `src/<path>.ts` is considered
+ * to have a unit test when a test file lives at the *mirror* location under
+ * `test/`, either as a single file or — when one source needs several test
+ * files — inside a directory named after the source:
+ *
+ *   src/shared/accounting/store.ts   ->  test/shared/accounting/store.test.ts
+ *                                    or  test/shared/accounting/store/*.test.ts
+ *
+ * From that one rule the report derives three things a human (or a future
+ * agent) can act on directly:
+ *
+ *   1. Source files with no mirrored test at all — the untested list.
+ *   2. Source files that *have* tests but a high source-lines-to-test-lines
+ *      ratio — the thinly-tested list, a good place to add cases.
+ *   3. Test files that don't sit at any source's mirror location — either a
+ *      test for something that isn't a single source file, or a test that
+ *      belongs somewhere else and should be moved.
+ *
+ * Everything here is a pure function of the file lists (path + line count) it is
+ * handed; the walking and line-counting live in the thin shell
+ * `scripts/unit-tests-report.ts`, so every rule below is unit-testable with
+ * crafted inputs.
+ */
+
+import { filter, map, pipe, sort, sumOf } from "#fp";
+
+/** A source or test file paired with its line count. */
+export type FileLines = {
+  path: string;
+  lines: number;
+};
+
+/** How to read the tree and which files are exempt from the "needs a test"
+ *  rule. Roots are configurable so the logic can be tested against a temp
+ *  tree, and default to the real `src`/`test` roots. */
+export type ReportOptions = {
+  srcRoot: string;
+  testRoot: string;
+  /** Path prefixes under `src` that are not expected to have their own unit
+   *  test (e.g. generated data, translation tables). */
+  exemptSourcePrefixes: string[];
+  /** Path prefixes under `test` that are not expected to mirror a source file
+   *  (e.g. end-to-end suites, script tests, shared test helpers). */
+  exemptTestPrefixes: string[];
+};
+
+/** A single source file enriched with the tests that cover it. */
+export type SourceReport = {
+  path: string;
+  lines: number;
+  /** Mirror-located test files covering this source, in path order. */
+  testFiles: string[];
+  /** Combined line count of `testFiles`. */
+  testLines: number;
+  tested: boolean;
+  /** Source lines per test line — how thin the tests are. `Infinity` when the
+   *  source has no test at all, so untested files always sort to the top. */
+  ratio: number;
+};
+
+/** The whole report, ready to format or serialise. */
+export type Report = {
+  totalSources: number;
+  testedCount: number;
+  /** Untested source files, biggest first (the largest gap is the best
+   *  target). */
+  untested: SourceReport[];
+  /** Tested source files, thinnest coverage first. */
+  ranked: SourceReport[];
+  /** Test files that don't sit at any source's mirror location. */
+  orphanTests: string[];
+};
+
+/** Default roots and exemptions for a real run against this repo. */
+export const DEFAULT_OPTIONS: ReportOptions = {
+  // Translation tables are data, not logic, so they carry no unit test.
+  exemptSourcePrefixes: ["src/locales/"],
+  // These test trees exercise the app as a whole or test the tooling itself,
+  // so they deliberately don't mirror a single source file.
+  exemptTestPrefixes: [
+    "test/e2e/",
+    "test/integration/",
+    "test/scripts/",
+    "test/test-utils/",
+    "test/setup.ts",
+    "test/test-utils.ts",
+  ],
+  srcRoot: "src",
+  testRoot: "test",
+};
+
+const hasExemptPrefix = (path: string, prefixes: string[]): boolean =>
+  prefixes.some((prefix) => path === prefix || path.startsWith(prefix));
+
+/** Count non-blank lines, so whitespace padding doesn't inflate the ratio. */
+export const countLines = (text: string): number =>
+  text.split("\n").filter((line) => line.trim() !== "").length;
+
+/** A `.ts`/`.tsx` file that isn't a type-declaration file. */
+export const isSourcePath = (path: string): boolean =>
+  (path.endsWith(".ts") || path.endsWith(".tsx")) && !path.endsWith(".d.ts");
+
+/** A `.test.ts`/`.test.tsx` test file. */
+export const isTestPath = (path: string): boolean =>
+  path.endsWith(".test.ts") || path.endsWith(".test.tsx");
+
+/** Whether a source file is one we expect to carry its own unit test. Type
+ *  declaration files and anything on an exempt prefix are left out. */
+export const isTestableSource = (
+  path: string,
+  options: ReportOptions,
+): boolean =>
+  !path.endsWith(".d.ts") &&
+  !hasExemptPrefix(path, options.exemptSourcePrefixes);
+
+/**
+ * The mirror location a source file's test(s) must live at, with the source
+ * root swapped for the test root and the extension dropped. A `src/a/b/name.ts`
+ * maps to the prefix `test/a/b/name`, matched either as `<prefix>.test.ts(x)`
+ * or as any file inside `<prefix>/`.
+ */
+export const mirrorPrefix = (
+  srcPath: string,
+  options: ReportOptions,
+): string => {
+  const withoutRoot = srcPath.slice(options.srcRoot.length + 1);
+  const withoutExt = withoutRoot.replace(/\.(?:ts|tsx)$/, "");
+  return `${options.testRoot}/${withoutExt}`;
+};
+
+/** Whether a test file covers the source with this mirror prefix — either the
+ *  single mirrored file, or one of several inside the source's directory. */
+export const testCoversPrefix = (prefix: string, testPath: string): boolean =>
+  testPath === `${prefix}.test.ts` ||
+  testPath === `${prefix}.test.tsx` ||
+  testPath.startsWith(`${prefix}/`);
+
+/** Build the per-source view: the tests covering it and how thin they are. */
+const describeSource = (
+  source: FileLines,
+  tests: FileLines[],
+  options: ReportOptions,
+): SourceReport => {
+  const prefix = mirrorPrefix(source.path, options);
+  const covering = filter((test: FileLines) =>
+    testCoversPrefix(prefix, test.path),
+  )(tests);
+  const testLines = sumOf((test: FileLines) => test.lines)(covering);
+  return {
+    lines: source.lines,
+    path: source.path,
+    ratio:
+      testLines === 0 ? Number.POSITIVE_INFINITY : source.lines / testLines,
+    tested: covering.length > 0,
+    testFiles: pipe(
+      map((test: FileLines) => test.path),
+      sort((a: string, b: string) => a.localeCompare(b)),
+    )(covering),
+    testLines,
+  };
+};
+
+/** Biggest source file first — the largest untested file is the best target. */
+const byLinesDesc = (a: SourceReport, b: SourceReport): number =>
+  b.lines - a.lines || a.path.localeCompare(b.path);
+
+/** Thinnest coverage first, then biggest source as a tie-breaker. */
+const byRatioDesc = (a: SourceReport, b: SourceReport): number =>
+  b.ratio - a.ratio || b.lines - a.lines || a.path.localeCompare(b.path);
+
+/**
+ * Fold the raw source and test file lists into the full report: which sources
+ * are (un)tested, how thin the tested ones are, and which test files don't
+ * mirror any source.
+ */
+export const buildReport = (
+  allSources: FileLines[],
+  allTests: FileLines[],
+  options: ReportOptions,
+): Report => {
+  const sources = filter((s: FileLines) => isTestableSource(s.path, options))(
+    allSources,
+  );
+  const described = map((s: FileLines) => describeSource(s, allTests, options))(
+    sources,
+  );
+
+  const covered = new Set(described.flatMap((s) => s.testFiles));
+  const orphanTests = pipe(
+    filter(
+      (test: FileLines) =>
+        !covered.has(test.path) &&
+        !hasExemptPrefix(test.path, options.exemptTestPrefixes),
+    ),
+    map((test: FileLines) => test.path),
+    sort((a: string, b: string) => a.localeCompare(b)),
+  )(allTests);
+
+  return {
+    orphanTests,
+    ranked: pipe(
+      filter((s: SourceReport) => s.tested),
+      sort(byRatioDesc),
+    )(described),
+    testedCount: filter((s: SourceReport) => s.tested)(described).length,
+    totalSources: described.length,
+    untested: pipe(
+      filter((s: SourceReport) => !s.tested),
+      sort(byLinesDesc),
+    )(described),
+  };
+};
+
+/** The single best file to write tests for next: the largest untested file if
+ *  any remain, otherwise the thinnest-tested one. `null` only when every source
+ *  is exempt (an empty tree). */
+export const suggestedTarget = (report: Report): SourceReport | null =>
+  report.untested[0] ?? report.ranked[0] ?? null;
+
+/* -------------------------------------------------------------------------- *
+ * Formatting                                                                 *
+ * -------------------------------------------------------------------------- */
+
+/** How many rows each list shows before it is truncated, unless `--all`. */
+export const DEFAULT_LIMIT = 25;
+
+const pct = (part: number, whole: number): string =>
+  whole === 0 ? "0.0" : ((part / whole) * 100).toFixed(1);
+
+/** A ratio for display: `∞` for untested, else two decimals. */
+export const formatRatio = (ratio: number): string =>
+  ratio === Number.POSITIVE_INFINITY ? "∞" : ratio.toFixed(2);
+
+const limitRows = <T>(rows: T[], limit: number | null): T[] =>
+  limit === null ? rows : rows.slice(0, limit);
+
+const truncationNote = (shown: number, total: number): string[] =>
+  shown < total ? [`  … and ${total - shown} more (use --all to list)`] : [];
+
+const untestedLines = (report: Report, limit: number | null): string[] => {
+  if (report.untested.length === 0)
+    return ["  (none — every source has a test)"];
+  const shown = limitRows(report.untested, limit);
+  return [
+    ...shown.map((s) => `  ${String(s.lines).padStart(5)}  ${s.path}`),
+    ...truncationNote(shown.length, report.untested.length),
+  ];
+};
+
+const rankedLines = (report: Report, limit: number | null): string[] => {
+  if (report.ranked.length === 0) return ["  (none)"];
+  const shown = limitRows(report.ranked, limit);
+  return [
+    `  ${"ratio".padStart(6)}  ${"src".padStart(5)}  ${"test".padStart(5)}  file`,
+    ...shown.map(
+      (s) =>
+        `  ${formatRatio(s.ratio).padStart(6)}  ${String(s.lines).padStart(
+          5,
+        )}  ${String(s.testLines).padStart(5)}  ${s.path}`,
+    ),
+    ...truncationNote(shown.length, report.ranked.length),
+  ];
+};
+
+const orphanLines = (report: Report, limit: number | null): string[] => {
+  if (report.orphanTests.length === 0) return ["  (none)"];
+  const shown = limitRows(report.orphanTests, limit);
+  return [
+    ...shown.map((path) => `  ${path}`),
+    ...truncationNote(shown.length, report.orphanTests.length),
+  ];
+};
+
+/**
+ * Render the report as plain text lines. `limit` caps each list (null shows
+ * everything); the thinnest-tested and largest-untested files come first so the
+ * top of each list is the best place to spend effort next.
+ */
+export const formatReport = (
+  report: Report,
+  limit: number | null,
+): string[] => {
+  const target = suggestedTarget(report);
+  return [
+    "Unit-test coverage report",
+    "=========================",
+    `Source files needing a test: ${report.totalSources}`,
+    `  with a mirrored test:      ${report.testedCount} (${pct(
+      report.testedCount,
+      report.totalSources,
+    )}%)`,
+    `  untested:                  ${report.untested.length}`,
+    `Orphan test files (mirror no source): ${report.orphanTests.length}`,
+    "",
+    target
+      ? `👉 Suggested next target: ${target.path} (${
+          target.tested
+            ? `ratio ${formatRatio(target.ratio)}, ${target.lines} src / ${target.testLines} test lines`
+            : `untested, ${target.lines} lines`
+        })`
+      : "👉 Nothing to do — no testable sources found.",
+    "",
+    "Untested source files (largest first):",
+    ...untestedLines(report, limit),
+    "",
+    "Thinnest-tested source files (highest src:test ratio first):",
+    ...rankedLines(report, limit),
+    "",
+    `Orphan test files (not at any source's mirror path):`,
+    ...orphanLines(report, limit),
+  ];
+};

--- a/scripts/unit-tests-report.ts
+++ b/scripts/unit-tests-report.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S deno run --allow-read=src,test
+/**
+ * Unit-test coverage report — the thin shell.
+ *
+ * Walks `src/` and `test/`, counts lines, and prints which source files still
+ * need a mirrored unit test, which existing tests are thinnest, and which test
+ * files don't line up to a source file. See `unit-tests-report-lib.ts` for the
+ * mirror convention and the pure logic; this file is just the filesystem and
+ * argument wiring, so it is never imported by tests.
+ *
+ * Usage:
+ *   deno task unit-tests-report            # top 25 of each list
+ *   deno task unit-tests-report --all      # every entry
+ *   deno task unit-tests-report --json     # machine-readable report
+ */
+
+import {
+  buildReport,
+  countLines,
+  DEFAULT_LIMIT,
+  DEFAULT_OPTIONS,
+  type FileLines,
+  formatReport,
+  isSourcePath,
+  isTestPath,
+} from "./unit-tests-report-lib.ts";
+
+async function* walkFiles(directory: string): AsyncGenerator<string> {
+  for await (const entry of Deno.readDir(directory)) {
+    const path = `${directory}/${entry.name}`;
+    if (entry.isDirectory) {
+      yield* walkFiles(path);
+      continue;
+    }
+    yield path;
+  }
+}
+
+const collect = async (
+  root: string,
+  keep: (path: string) => boolean,
+): Promise<FileLines[]> => {
+  const files: FileLines[] = [];
+  for await (const path of walkFiles(root)) {
+    if (!keep(path)) continue;
+    files.push({ lines: countLines(await Deno.readTextFile(path)), path });
+  }
+  return files;
+};
+
+if (import.meta.main) {
+  const args = new Set(Deno.args);
+  const options = DEFAULT_OPTIONS;
+  const sources = await collect(options.srcRoot, isSourcePath);
+  const tests = await collect(options.testRoot, isTestPath);
+  const report = buildReport(sources, tests, options);
+
+  if (args.has("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    const limit = args.has("--all") ? null : DEFAULT_LIMIT;
+    console.log(formatReport(report, limit).join("\n"));
+  }
+}

--- a/test/scripts/unit-tests-report.test.ts
+++ b/test/scripts/unit-tests-report.test.ts
@@ -1,0 +1,401 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  buildReport,
+  countLines,
+  DEFAULT_LIMIT,
+  DEFAULT_OPTIONS,
+  type FileLines,
+  formatRatio,
+  formatReport,
+  isSourcePath,
+  isTestableSource,
+  isTestPath,
+  mirrorPrefix,
+  type ReportOptions,
+  suggestedTarget,
+  testCoversPrefix,
+} from "../../scripts/unit-tests-report-lib.ts";
+
+const options: ReportOptions = {
+  exemptSourcePrefixes: ["src/locales/"],
+  exemptTestPrefixes: ["test/e2e/", "test/setup.ts"],
+  srcRoot: "src",
+  testRoot: "test",
+};
+
+const src = (path: string, lines: number): FileLines => ({ lines, path });
+const tst = (path: string, lines: number): FileLines => ({ lines, path });
+
+describe("countLines", () => {
+  test("counts non-blank lines only", () => {
+    // Multi-character lines distinguish a real newline split from a per-char one.
+    expect(countLines("ab\n\n  \ncd\n")).toBe(2);
+    expect(countLines("")).toBe(0);
+  });
+});
+
+describe("isSourcePath", () => {
+  test("accepts .ts and .tsx but not declaration or other files", () => {
+    expect(isSourcePath("src/a.ts")).toBe(true);
+    expect(isSourcePath("src/a.tsx")).toBe(true);
+    expect(isSourcePath("src/a.d.ts")).toBe(false);
+    expect(isSourcePath("src/a.json")).toBe(false);
+  });
+});
+
+describe("isTestPath", () => {
+  test("accepts only .test.ts and .test.tsx files", () => {
+    expect(isTestPath("test/a.test.ts")).toBe(true);
+    expect(isTestPath("test/a.test.tsx")).toBe(true);
+    expect(isTestPath("test/a.ts")).toBe(false);
+    expect(isTestPath("test/helpers.ts")).toBe(false);
+  });
+});
+
+describe("isTestableSource", () => {
+  test("skips declaration files and exempt prefixes, keeps the rest", () => {
+    expect(isTestableSource("src/shared/a.ts", options)).toBe(true);
+    expect(isTestableSource("src/static.d.ts", options)).toBe(false);
+    expect(isTestableSource("src/locales/en/index.ts", options)).toBe(false);
+  });
+});
+
+describe("mirrorPrefix", () => {
+  test("swaps the src root for the test root and drops the extension", () => {
+    expect(mirrorPrefix("src/shared/accounting/store.ts", options)).toBe(
+      "test/shared/accounting/store",
+    );
+    expect(mirrorPrefix("src/ui/templates/nav.tsx", options)).toBe(
+      "test/ui/templates/nav",
+    );
+  });
+});
+
+describe("testCoversPrefix", () => {
+  const prefix = "test/shared/store";
+  test("matches the single .test.ts or .test.tsx mirror", () => {
+    expect(testCoversPrefix(prefix, "test/shared/store.test.ts")).toBe(true);
+    expect(testCoversPrefix(prefix, "test/shared/store.test.tsx")).toBe(true);
+  });
+  test("matches any file inside a directory named after the source", () => {
+    expect(testCoversPrefix(prefix, "test/shared/store/reads.test.ts")).toBe(
+      true,
+    );
+  });
+  test("rejects unrelated or sibling-prefixed paths", () => {
+    expect(testCoversPrefix(prefix, "test/shared/store-helpers.test.ts")).toBe(
+      false,
+    );
+    expect(testCoversPrefix(prefix, "test/shared/other.test.ts")).toBe(false);
+  });
+});
+
+describe("buildReport", () => {
+  test("pairs sources with mirrored tests and sums their lines", () => {
+    const report = buildReport(
+      [src("src/shared/a.ts", 100)],
+      [tst("test/shared/a.test.ts", 40)],
+      options,
+    );
+    expect(report.totalSources).toBe(1);
+    expect(report.testedCount).toBe(1);
+    expect(report.untested).toEqual([]);
+    expect(report.ranked[0]).toMatchObject({
+      path: "src/shared/a.ts",
+      ratio: 2.5,
+      tested: true,
+      testFiles: ["test/shared/a.test.ts"],
+      testLines: 40,
+    });
+  });
+
+  test("gives a source with a single one-line test a finite ratio", () => {
+    const report = buildReport(
+      [src("src/a.ts", 7)],
+      [tst("test/a.test.ts", 1)],
+      options,
+    );
+    expect(report.ranked[0]).toMatchObject({ ratio: 7, tested: true });
+  });
+
+  test("groups several test files under a source's directory", () => {
+    const report = buildReport(
+      [src("src/shared/a.ts", 90)],
+      [
+        tst("test/shared/a/one.test.ts", 20),
+        tst("test/shared/a/two.test.ts", 10),
+      ],
+      options,
+    );
+    expect(report.ranked[0]).toMatchObject({
+      ratio: 3,
+      testFiles: ["test/shared/a/one.test.ts", "test/shared/a/two.test.ts"],
+      testLines: 30,
+    });
+  });
+
+  test("marks a source with no mirror as untested with an infinite ratio", () => {
+    const report = buildReport([src("src/shared/a.ts", 50)], [], options);
+    expect(report.testedCount).toBe(0);
+    expect(report.untested[0]).toMatchObject({
+      ratio: Number.POSITIVE_INFINITY,
+      tested: false,
+      testLines: 0,
+    });
+    expect(report.ranked).toEqual([]);
+  });
+
+  test("drops exempt sources before counting", () => {
+    const report = buildReport(
+      [src("src/locales/en/index.ts", 10), src("src/static.d.ts", 3)],
+      [],
+      options,
+    );
+    expect(report.totalSources).toBe(0);
+  });
+
+  test("orders untested biggest-first and ranked thinnest-first", () => {
+    const report = buildReport(
+      [
+        src("src/small.ts", 10),
+        src("src/big.ts", 200),
+        src("src/thin.ts", 100),
+        src("src/thick.ts", 100),
+      ],
+      [tst("test/thin.test.ts", 5), tst("test/thick.test.ts", 90)],
+      options,
+    );
+    expect(report.untested.map((s) => s.path)).toEqual([
+      "src/big.ts",
+      "src/small.ts",
+    ]);
+    expect(report.ranked.map((s) => s.path)).toEqual([
+      "src/thin.ts",
+      "src/thick.ts",
+    ]);
+  });
+
+  test("breaks an untested tie on file path, and a ratio tie on size then path", () => {
+    const report = buildReport(
+      [
+        // Same size, both untested -> tie broken by path (b before z).
+        src("src/z.ts", 100),
+        src("src/b.ts", 100),
+        // Same ratio (4.0); bigger source ranks first.
+        src("src/big-ratio.ts", 200),
+        src("src/small-ratio.ts", 20),
+        // Identical ratio (2.0) and size -> tie broken by path (m before n).
+        src("src/n.ts", 40),
+        src("src/m.ts", 40),
+      ],
+      [
+        tst("test/big-ratio.test.ts", 50),
+        tst("test/small-ratio.test.ts", 5),
+        tst("test/n.test.ts", 20),
+        tst("test/m.test.ts", 20),
+      ],
+      options,
+    );
+    expect(report.untested.map((s) => s.path)).toEqual([
+      "src/b.ts",
+      "src/z.ts",
+    ]);
+    expect(report.ranked.map((s) => s.path)).toEqual([
+      "src/big-ratio.ts",
+      "src/small-ratio.ts",
+      "src/m.ts",
+      "src/n.ts",
+    ]);
+  });
+
+  test("reports test files that mirror no source, sorted, minus exempt trees", () => {
+    const report = buildReport(
+      [src("src/shared/a.ts", 10)],
+      [
+        tst("test/shared/a.test.ts", 5),
+        // Two orphans, given out of order, so the sort is exercised.
+        tst("test/shared/zeta.test.ts", 5),
+        tst("test/shared/ghost.test.ts", 5),
+        tst("test/e2e/flow.test.ts", 5),
+        tst("test/setup.ts", 5),
+      ],
+      options,
+    );
+    expect(report.orphanTests).toEqual([
+      "test/shared/ghost.test.ts",
+      "test/shared/zeta.test.ts",
+    ]);
+  });
+});
+
+describe("suggestedTarget", () => {
+  test("prefers the largest untested source", () => {
+    const report = buildReport(
+      [src("src/big.ts", 200), src("src/tested.ts", 100)],
+      [tst("test/tested.test.ts", 10)],
+      options,
+    );
+    expect(suggestedTarget(report)?.path).toBe("src/big.ts");
+  });
+
+  test("falls back to the thinnest-tested source when none are untested", () => {
+    const report = buildReport(
+      [src("src/thin.ts", 100), src("src/thick.ts", 100)],
+      [tst("test/thin.test.ts", 5), tst("test/thick.test.ts", 90)],
+      options,
+    );
+    expect(suggestedTarget(report)?.path).toBe("src/thin.ts");
+  });
+
+  test("returns null when there are no testable sources", () => {
+    expect(suggestedTarget(buildReport([], [], options))).toBeNull();
+  });
+});
+
+describe("formatRatio", () => {
+  test("shows infinity as a symbol and finite ratios to two decimals", () => {
+    expect(formatRatio(Number.POSITIVE_INFINITY)).toBe("∞");
+    expect(formatRatio(2.5)).toBe("2.50");
+  });
+});
+
+describe("formatReport", () => {
+  // Exact-output assertions: the aligned columns, padding and labels are part
+  // of the report's contract, so every character is pinned down here.
+  test("renders the full report with an untested target, a ranked row and an orphan", () => {
+    const report = buildReport(
+      [src("src/big.ts", 200), src("src/thin.ts", 100)],
+      [tst("test/thin.test.ts", 5), tst("test/ghost.test.ts", 5)],
+      options,
+    );
+    expect(formatReport(report, null)).toEqual([
+      "Unit-test coverage report",
+      "=========================",
+      "Source files needing a test: 2",
+      "  with a mirrored test:      1 (50.0%)",
+      "  untested:                  1",
+      "Orphan test files (mirror no source): 1",
+      "",
+      "👉 Suggested next target: src/big.ts (untested, 200 lines)",
+      "",
+      "Untested source files (largest first):",
+      "    200  src/big.ts",
+      "",
+      "Thinnest-tested source files (highest src:test ratio first):",
+      "   ratio    src   test  file",
+      "   20.00    100      5  src/thin.ts",
+      "",
+      "Orphan test files (not at any source's mirror path):",
+      "  test/ghost.test.ts",
+    ]);
+  });
+
+  test("caps each list at the limit and notes how many rows were hidden", () => {
+    const report = buildReport(
+      [
+        src("src/u1.ts", 200),
+        src("src/u2.ts", 100),
+        src("src/t1.ts", 60),
+        src("src/t2.ts", 30),
+      ],
+      [
+        tst("test/t1.test.ts", 5),
+        tst("test/t2.test.ts", 5),
+        tst("test/o1.test.ts", 5),
+        tst("test/o2.test.ts", 5),
+      ],
+      options,
+    );
+    expect(formatReport(report, 1)).toEqual([
+      "Unit-test coverage report",
+      "=========================",
+      "Source files needing a test: 4",
+      "  with a mirrored test:      2 (50.0%)",
+      "  untested:                  2",
+      "Orphan test files (mirror no source): 2",
+      "",
+      "👉 Suggested next target: src/u1.ts (untested, 200 lines)",
+      "",
+      "Untested source files (largest first):",
+      "    200  src/u1.ts",
+      "  … and 1 more (use --all to list)",
+      "",
+      "Thinnest-tested source files (highest src:test ratio first):",
+      "   ratio    src   test  file",
+      "   12.00     60      5  src/t1.ts",
+      "  … and 1 more (use --all to list)",
+      "",
+      "Orphan test files (not at any source's mirror path):",
+      "  test/o1.test.ts",
+      "  … and 1 more (use --all to list)",
+    ]);
+  });
+
+  test("shows placeholders and a do-nothing target for an empty tree", () => {
+    expect(formatReport(buildReport([], [], options), null)).toEqual([
+      "Unit-test coverage report",
+      "=========================",
+      "Source files needing a test: 0",
+      "  with a mirrored test:      0 (0.0%)",
+      "  untested:                  0",
+      "Orphan test files (mirror no source): 0",
+      "",
+      "👉 Nothing to do — no testable sources found.",
+      "",
+      "Untested source files (largest first):",
+      "  (none — every source has a test)",
+      "",
+      "Thinnest-tested source files (highest src:test ratio first):",
+      "  (none)",
+      "",
+      "Orphan test files (not at any source's mirror path):",
+      "  (none)",
+    ]);
+  });
+
+  test("names a tested target with its ratio when nothing is untested", () => {
+    const report = buildReport(
+      [src("src/a.ts", 10)],
+      [tst("test/a.test.ts", 10)],
+      options,
+    );
+    expect(formatReport(report, null)).toEqual([
+      "Unit-test coverage report",
+      "=========================",
+      "Source files needing a test: 1",
+      "  with a mirrored test:      1 (100.0%)",
+      "  untested:                  0",
+      "Orphan test files (mirror no source): 0",
+      "",
+      "👉 Suggested next target: src/a.ts (ratio 1.00, 10 src / 10 test lines)",
+      "",
+      "Untested source files (largest first):",
+      "  (none — every source has a test)",
+      "",
+      "Thinnest-tested source files (highest src:test ratio first):",
+      "   ratio    src   test  file",
+      "    1.00     10     10  src/a.ts",
+      "",
+      "Orphan test files (not at any source's mirror path):",
+      "  (none)",
+    ]);
+  });
+});
+
+describe("DEFAULT_OPTIONS and DEFAULT_LIMIT", () => {
+  test("target the real roots, exempt lists, and default row cap", () => {
+    expect(DEFAULT_LIMIT).toBe(25);
+    expect(DEFAULT_OPTIONS.srcRoot).toBe("src");
+    expect(DEFAULT_OPTIONS.testRoot).toBe("test");
+    expect(DEFAULT_OPTIONS.exemptSourcePrefixes).toEqual(["src/locales/"]);
+    expect(DEFAULT_OPTIONS.exemptTestPrefixes).toEqual([
+      "test/e2e/",
+      "test/integration/",
+      "test/scripts/",
+      "test/test-utils/",
+      "test/setup.ts",
+      "test/test-utils.ts",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Adds `deno task unit-tests-report` — a report (not a hard gate) that measures progress toward a mutation-covered unit test for every source file, layered on top of the integration/e2e tests we already have.

It applies a **mirror-path convention**:

```
src/shared/accounting/store.ts  ->  test/shared/accounting/store.test.ts
                                or  test/shared/accounting/store/*.test.ts   (when one source needs several test files)
```

and prints three actionable lists:

1. **Untested source files** — no mirrored test, largest first (biggest gap = best target).
2. **Thinnest-tested source files** — ranked by source-lines-to-test-lines ratio, worst first, to find good places to add cases.
3. **Orphan test files** — tests that don't sit at any source's mirror path (i.e. tests that need moving, or that legitimately cover something other than one source file).

It also names a single **suggested next target**, so a run can drive an incremental "improve the least-well-tested file" loop:

```
👉 Suggested next target: src/features/api/payment-processing.ts (untested, 1744 lines)
```

Flags: `--all` (show every entry, not just the top 25) and `--json` (machine-readable).

## How

- Pure logic in `scripts/unit-tests-report-lib.ts` — mirror matching, exemptions, ranking, and formatting — behind a thin filesystem shell (`scripts/unit-tests-report.ts`) that is never imported by tests, matching the existing `line-counts` / `precommit` split.
- Exemptions: `.d.ts` and `src/locales/` sources (translation data); the `test/e2e`, `test/integration`, `test/scripts`, and `test/test-utils` trees (which deliberately don't mirror a single source file).
- `test/scripts/unit-tests-report.test.ts` covers the lib at **100% line, branch, and mutation coverage** (`deno task mutation scripts/unit-tests-report-lib.ts test/scripts/unit-tests-report.test.ts` → 113/113).

## Note on the test-tree reorganization

This is deliberately the *report* half of the discussion, not the file moves. Running it against the current tree shows the reorg is bigger than a `test/lib` → `test/shared` rename: of 674 test files, only ~243 have an unambiguous mirror target, ~400 (`server-*` route tests, `templates/*`, integration) legitimately cover whole feature areas rather than one source file, and there's real coupling to untangle (a `biome.json` grandfathered-big-file list pinned to `test/lib/...` paths, cross-dir test helpers, and `test/lib/db` colliding with the existing `test/shared/db`). The report makes that backlog trackable so the moves can be done as a focused, verifiable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwFPraZDAxxSc2ffbY9iCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwFPraZDAxxSc2ffbY9iCY)_