### PR TITLE
Harden url-safety.ts test coverage (mutation score 64.0% -> 100%)

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -588,3 +588,56 @@ src/shared/package-privacy.ts:44:10  === → ==   # display: PackageDisplay|null
 # consecutive separators — produces the identical issues[0].message under
 # both true and false.
 src/shared/slug.ts:64:63  true → false   # abortPipeEarly: SlugSchema's issues[0] message is identical either way for every input category the pipe can fail on
+
+# url-safety.ts: isInternalHostname and isIpLiteral are private helpers only
+# ever called (via isSafeServerFetchUrl) with `url.hostname` from an already
+# `new URL()`-parsed, `URL.canParse()`-gated string — never with an arbitrary
+# string. That constrains the reachable input space enough to make two
+# clusters of mutants unobservable through the exported functions, confirmed
+# empirically (see scripts/mutation.ts run history / PR for the isSafeServer-
+# FetchUrl-level checks that back these):
+#
+# 1. isInternalHostname's exact-match arms (`h === "localhost"`, `h ===
+#    "local"`): both target strings contain no ".", and isDomainHostname
+#    requires `host.includes(".")` — so any host these arms would ever match
+#    is *already* rejected by the separate, independent isDomainHostname
+#    dot-check. Mutating the literal (even to "" or a nonsense string) cannot
+#    change isSafeServerFetchUrl's output for any reachable host.
+src/shared/url-safety.ts:13:9  localhost → ""   # bare "localhost" has no dot; isDomainHostname's dot-check rejects it independently either way
+src/shared/url-safety.ts:13:9  localhost → "localhost mutated"   # same as above
+src/shared/url-safety.ts:15:9  local → ""   # bare "local" has no dot; isDomainHostname's dot-check rejects it independently either way
+src/shared/url-safety.ts:15:9  local → "local mutated"   # same as above
+#
+# 2. isIpLiteral's bracket-stripping ternary and its `h.includes(":")` check:
+#    the WHATWG URL spec only accepts a bracketed host if it's a syntactically
+#    valid IPv6 address (confirmed empirically: any asymmetric-bracket or
+#    non-IPv6 bracketed string fails URL.canParse entirely, so isIpLiteral
+#    never sees it), and every valid IPv6 address contains a colon — with or
+#    without the surrounding brackets stripped. So whichever way the ternary
+#    or the slice bounds are mutated, `h.includes(":")` still finds a colon
+#    for every reachable bracketed host, and `return true`/`return undefined`/
+#    `return false` from that branch don't matter either, because any dotless
+#    host (which every such host is — Deno's URL parser normalizes embedded
+#    IPv4-in-IPv6 notation to hex, e.g. "[::ffff:1.2.3.4]" → "[::ffff:102:
+#    304]", so no bracketed host ever keeps a literal "."} is *also*
+#    independently rejected by isDomainHostname's dot-check. Verified directly
+#    against isSafeServerFetchUrl (not just isIpLiteral in isolation) across
+#    every bracketed test case already in this suite plus IPv4-mapped and
+#    malformed-bracket variants — all agree with the unmutated function.
+src/shared/url-safety.ts:22:5  ?: → alternate only   # bracket-stripping is unobservable; see block comment above
+src/shared/url-safety.ts:22:25  && → ||   # host can never start with "[" without also ending with "]" (URL.canParse rejects the asymmetric case), so && and || agree
+src/shared/url-safety.ts:22:25  && → ??   # startsWith("["): plain boolean, never nullish, so ?? reduces to the left operand alone — which agrees with && given the bracket-symmetry invariant above
+src/shared/url-safety.ts:22:21  [ → ""   # startsWith("") is always true; combined with the bracket-symmetry invariant this doesn't change which hosts get stripped
+src/shared/url-safety.ts:22:21  [ → "[ mutated"   # no reachable host starts with this literal, so stripping never happens — but unobservable either way, see block comment above
+src/shared/url-safety.ts:22:43  ] → ""   # endsWith("") is always true; see block comment above
+src/shared/url-safety.ts:22:43  ] → "] mutated"   # no reachable host ends with this literal, so stripping never happens — but unobservable either way, see block comment above
+src/shared/url-safety.ts:22:61  1 → 0   # slice(0,-1) vs slice(1,-1): still leaves a colon in every reachable bracketed (IPv6) host
+src/shared/url-safety.ts:22:61  1 → 2   # slice(2,-1) vs slice(1,-1): still leaves a colon in every reachable bracketed (IPv6) host
+src/shared/url-safety.ts:22:61  1 → -1   # slice(-1,-1) empties h, but the resulting dotless "" is caught by isDomainHostname's dot-check regardless
+src/shared/url-safety.ts:22:64  - → +   # slice(1,+1) empties h; same isDomainHostname fallback as above
+src/shared/url-safety.ts:22:65  1 → 0   # slice(1,-0)=slice(1,0) empties h; same isDomainHostname fallback as above
+src/shared/url-safety.ts:22:65  1 → 2   # slice(1,-2) vs slice(1,-1): still leaves a colon in every reachable bracketed (IPv6) host
+src/shared/url-safety.ts:22:65  1 → -1   # slice(1,1) empties h; same isDomainHostname fallback as above
+src/shared/url-safety.ts:23:18  : → ": mutated"   # h never contains this literal, so the colon-detection branch is skipped — falls to the regex, but the dotless-host isDomainHostname fallback still catches it
+src/shared/url-safety.ts:23:31  return true → return undefined   # !undefined behaves like !false downstream; same isDomainHostname fallback as above
+src/shared/url-safety.ts:23:31  true → false   # isIpLiteral wrongly says "not an IP literal", but the dotless-host isDomainHostname fallback still rejects it

--- a/test/lib/url-safety.test.ts
+++ b/test/lib/url-safety.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { isSafeServerFetchUrl } from "#shared/url-safety.ts";
+import {
+  isSafeServerFetchUrl,
+  validateSafeServerFetchUrl,
+} from "#shared/url-safety.ts";
 
 describe("url-safety", () => {
   describe("isSafeServerFetchUrl accepts public https domains", () => {
@@ -43,6 +46,7 @@ describe("url-safety", () => {
       "https://[fe80::1]/", // IPv6 link-local
       "https://[fc00::1]/", // IPv6 unique-local
       "https://[fd12::1]/", // IPv6 unique-local
+      "https://example.com./hook", // trailing dot: not a real public domain shape
     ];
     for (const url of unsafe) {
       test(url, () => expect(isSafeServerFetchUrl(url)).toBe(false));
@@ -62,5 +66,29 @@ describe("url-safety", () => {
     for (const [url, expected] of variants) {
       expect(isSafeServerFetchUrl(url)).toBe(expected);
     }
+  });
+
+  describe("validateSafeServerFetchUrl", () => {
+    const MESSAGE = "Webhook URL is not safe to fetch";
+
+    test("returns null when no URL was provided", () => {
+      expect(validateSafeServerFetchUrl(undefined, MESSAGE)).toBeNull();
+    });
+
+    test("returns null for a blank URL", () => {
+      expect(validateSafeServerFetchUrl("", MESSAGE)).toBeNull();
+    });
+
+    test("returns null for a safe URL", () => {
+      expect(
+        validateSafeServerFetchUrl("https://example.com/hook", MESSAGE),
+      ).toBeNull();
+    });
+
+    test("returns the given message for an unsafe URL", () => {
+      expect(
+        validateSafeServerFetchUrl("https://localhost/hook", MESSAGE),
+      ).toBe(MESSAGE);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`deno task mutation src/shared/url-safety.ts test/lib/url-safety.test.ts --exhaustive` found a 64.0% mutation score with 27 survivors on this SSRF guard (`isSafeServerFetchUrl`/`validateSafeServerFetchUrl`), which decides whether an admin-supplied URL is safe for the server to fetch itself.

Two real gaps:

- **`validateSafeServerFetchUrl` had no tests at all.** Added cases for undefined, blank, safe, and unsafe input. This killed a security-relevant mutant that removed the `!` on `isSafeServerFetchUrl(raw)` (which would have inverted safe/unsafe entirely) and one that swapped the ternary's arms (same effect), plus two others.
- **`isDomainHostname`'s trailing-dot check was untested.** `host.includes(".") && !host.endsWith(".")` had no test for a trailing-dot hostname like `example.com.`, so weakening the `&&` to `??` (which reduces to just the `includes()` check, since a boolean result is never nullish) or mutating the `"."` literal both went uncaught. Added `https://example.com./hook` to the rejected-URL list.

The other 21 survivors are genuinely equivalent, recorded in `scripts/mutation/equivalent-mutants.txt` with reasoning — this took real verification, not just a type argument, since I'd already made one wrong equivalence call earlier in this session (caught by Codex review) and wanted to avoid repeating it:

- `isInternalHostname`'s bare `"localhost"`/`"local"` exact-match checks only ever match dotless hosts — and `isDomainHostname`'s independent dot requirement already rejects any dotless host regardless of what these checks do.
- `isIpLiteral`'s bracket-stripping ternary, its slice bounds, and its colon-detection are all unobservable because the WHATWG URL spec only accepts a bracketed host if it's a syntactically valid IPv6 address (confirmed empirically: malformed/asymmetric-bracket strings fail `URL.canParse` entirely, never reaching this code), every valid IPv6 address contains a colon whether or not the brackets get stripped, and Deno's URL parser normalizes embedded IPv4-in-IPv6 notation to hex (`[::ffff:1.2.3.4]` → `[::ffff:102:304]`) so no bracketed host ever retains a literal dot — meaning `isDomainHostname`'s dot requirement independently rejects the result no matter what these mutants do to the stripped string.

I verified this against the **full exported `isSafeServerFetchUrl`** (not just the private helpers in isolation) across every existing test case plus IPv4-mapped and malformed-bracket inputs, to make sure a redundant guard elsewhere wasn't masking something.

Re-ran with `--exhaustive`: 54/54 mutants detected, **100.0%** score, 21 known-equivalent suppressed.

## Test plan

- [x] `deno task mutation src/shared/url-safety.ts test/lib/url-safety.test.ts --exhaustive` → 100.0% (0 survivors, 21 suppressed as equivalent)
- [x] `deno test test/lib/url-safety.test.ts` → all passing
- [x] `deno run -A scripts/biome.ts check --error-on-warnings test/lib/url-safety.test.ts` → clean
- [x] `deno check` on the touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw


---
_Generated by [Claude Code](https://claude.ai/code/session_016nVBQrwCYrD79a6CNdvDrw)_