### PR TITLE
Make booking address field always editable

### DIFF
--- a/src/locales/en/address-lookup.json
+++ b/src/locales/en/address-lookup.json
@@ -11,7 +11,6 @@
   "address_lookup.find": "Find address",
   "address_lookup.choose": "Choose your address",
   "address_lookup.choose_placeholder": "Select an address…",
-  "address_lookup.edit": "Edit address",
   "address_lookup.searching": "Searching…",
   "address_lookup.no_results": "No addresses found — please type your address below.",
   "address_lookup.invalid_search": "That doesn't look like a valid postcode",

--- a/src/ui/client/admin/address-lookup.ts
+++ b/src/ui/client/admin/address-lookup.ts
@@ -9,9 +9,8 @@
  * reaches the browser. Searching fills a select with the returned address
  * lines and choosing one fills the textarea.
  *
- * Modes ("data-address-lookup"): "locked" (public booking form) makes the
- * textarea read-only until the Edit button — or a submit with no address —
- * unlocks it; "editable" (admin attendee forms) leaves it always editable.
+ * The textarea always stays editable: a search fills it in, but the customer
+ * can type or correct the address at any point.
  */
 
 const ENDPOINT = "/address-lookup";
@@ -25,7 +24,6 @@ type PanelParts = {
   resultsLabel: HTMLElement;
   select: HTMLSelectElement;
   status: HTMLElement;
-  editButton: HTMLButtonElement | null;
   textarea: HTMLTextAreaElement;
 };
 
@@ -93,29 +91,15 @@ const search = async (parts: PanelParts): Promise<void> => {
   }
 };
 
-/** Lock the textarea behind the Edit button (public booking form). */
-const lockTextarea = (parts: PanelParts): void => {
-  const { editButton, textarea } = parts;
-  if (!editButton) return;
-  textarea.readOnly = true;
-  editButton.hidden = false;
-  const unlock = (): void => {
-    textarea.readOnly = false;
-    editButton.hidden = true;
-  };
-  editButton.addEventListener("click", () => {
-    unlock();
-    textarea.focus();
-  });
-  // A read-only textarea skips native required validation, so an untouched
-  // form could submit an empty address. Unlock and resubmit instead: the
-  // second pass runs native validation against the now-editable textarea.
-  textarea.form?.addEventListener("submit", (event) => {
-    if (!textarea.readOnly || textarea.value.trim() !== "") return;
-    event.preventDefault();
-    unlock();
-    textarea.form?.requestSubmit();
-  });
+/** Copy the chosen address into the textarea, hide the dropdown again, and
+ *  fire an input event so dependent enhancements (e.g. the char counter)
+ *  react to the prefilled value straight away. */
+const chooseAddress = (parts: PanelParts): void => {
+  const { resultsLabel, select, textarea } = parts;
+  if (!select.value) return;
+  textarea.value = select.value;
+  resultsLabel.hidden = true;
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
 };
 
 /** Find the panel's controls and its form's address textarea. */
@@ -141,7 +125,6 @@ const collectParts = (panel: HTMLElement): PanelParts | null => {
   }
   if (!textarea) return null;
   return {
-    editButton: panel.querySelector<HTMLButtonElement>("[data-address-edit]"),
     findButton,
     panel,
     resultsLabel,
@@ -152,23 +135,19 @@ const collectParts = (panel: HTMLElement): PanelParts | null => {
   };
 };
 
-/** Reveal one panel and wire its search, selection, and edit behaviors. */
+/** Reveal one panel and wire its search and selection behaviors. */
 const setupPanel = (panel: HTMLElement): void => {
   const parts = collectParts(panel);
   if (!parts) return;
-  const { findButton, searchInput, select, textarea } = parts;
+  const { findButton, searchInput, select } = parts;
   panel.hidden = false;
-  if (panel.dataset.addressLookup === "locked") lockTextarea(parts);
   findButton.addEventListener("click", () => void search(parts));
   searchInput.addEventListener("keydown", (event) => {
     if (event.key !== "Enter") return;
     event.preventDefault();
     void search(parts);
   });
-  select.addEventListener("change", () => {
-    if (!select.value) return;
-    textarea.value = select.value;
-  });
+  select.addEventListener("change", () => chooseAddress(parts));
 };
 
 /** Boot every address-lookup panel on the page. */

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1638,6 +1638,12 @@ fieldset.inset {
   gap: var(--space-s);
 }
 
+/* The "Number of packages" selector only ever holds small counts, so keep it
+   narrow rather than stretching to the container width. */
+select[data-package-members] {
+  max-width: 5rem;
+}
+
 /* Booking-form running total: the "show total" button and the live summary the
    running-total script renders into the adjacent <output>. */
 .running-total {

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -561,7 +561,7 @@ const AttendeeEditForm = ({
         />
       </label>
 
-      <Raw html={renderAddressLookupPanel("editable")} />
+      <Raw html={renderAddressLookupPanel()} />
       <label for="address">
         {t("common.address")}
         <textarea

--- a/src/ui/templates/components/address-lookup.tsx
+++ b/src/ui/templates/components/address-lookup.tsx
@@ -8,9 +8,8 @@
  * messages from the panel's data attributes and never carries strings of its
  * own.
  *
- * Modes: "locked" (public booking form — the script makes the textarea
- * read-only until the Edit button unlocks it) and "editable" (admin attendee
- * forms — the textarea always stays editable).
+ * The address textarea always stays editable — searching a postcode fills it
+ * in, but the customer can type or correct it at any point.
  */
 
 import { t } from "#i18n";
@@ -19,17 +18,15 @@ import {
   activeAddressLookupProvider,
 } from "#shared/address-lookup/providers.ts";
 
-export type AddressLookupMode = "locked" | "editable";
-
 /** The search panel markup, or "" when no lookup provider is configured. */
-export const renderAddressLookupPanel = (mode: AddressLookupMode): string => {
+export const renderAddressLookupPanel = (): string => {
   const provider = activeAddressLookupProvider();
   if (!provider) return "";
   const definition = ADDRESS_LOOKUP_PROVIDERS[provider];
   return String(
     <fieldset
       class="address-lookup"
-      data-address-lookup={mode}
+      data-address-lookup={true}
       data-error={t("address_lookup.failed")}
       data-no-results={t("address_lookup.no_results")}
       data-placeholder={t("address_lookup.choose_placeholder")}
@@ -55,11 +52,6 @@ export const renderAddressLookupPanel = (mode: AddressLookupMode): string => {
         <select data-address-results={true}></select>
       </label>
       <p data-address-status={true} hidden></p>
-      {mode === "locked" && (
-        <button data-address-edit={true} hidden type="button">
-          {t("address_lookup.edit")}
-        </button>
-      )}
     </fieldset>,
   );
 };

--- a/src/ui/templates/fields.ts
+++ b/src/ui/templates/fields.ts
@@ -43,10 +43,7 @@ import { validateSafeServerFetchUrl } from "#shared/url-safety.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import { EmailFormatSchema } from "#shared/validation/email.ts";
 import { parseOptionalMinorUnits } from "#shared/validation/money.ts";
-import {
-  type AddressLookupMode,
-  renderAddressLookupPanel,
-} from "#templates/components/address-lookup.tsx";
+import { renderAddressLookupPanel } from "#templates/components/address-lookup.tsx";
 import { formattingHint } from "#templates/components/formatting-hint.ts";
 import { moneyPattern } from "#templates/components/price-input.tsx";
 
@@ -1101,18 +1098,15 @@ export const fieldsApi = { getSettingCached: settings.getCachedRaw };
  * Give the address field its postcode search panel when a lookup provider is
  * configured (no provider ⇒ the plain textarea, unchanged).
  */
-const withAddressLookup = (field: Field, mode: AddressLookupMode): Field => {
-  const panel = renderAddressLookupPanel(mode);
+const withAddressLookup = (field: Field): Field => {
+  const panel = renderAddressLookupPanel();
   return panel ? { ...field, beforeHtml: panel } : field;
 };
 
 /** Resolve one contact field, attaching the address search panel. */
-const resolveContactField = (
-  name: ContactField,
-  addressLookupMode: AddressLookupMode,
-): Field =>
+const resolveContactField = (name: ContactField): Field =>
   name === "address"
-    ? withAddressLookup(contactFieldMap[name], addressLookupMode)
+    ? withAddressLookup(contactFieldMap[name])
     : contactFieldMap[name];
 
 /**
@@ -1120,14 +1114,12 @@ const resolveContactField = (
  * Always includes name. Adds contact fields based on the comma-separated setting.
  * When isPaid is true and Square is the active provider, email is always included
  * because Square requires an email address for checkout.
- * The address field carries the postcode search panel when a lookup provider is
- * configured: "locked" (public — read-only until Edit) unless the caller is an
- * admin form that keeps the textarea always editable.
+ * The address field carries the postcode search panel (always editable) when a
+ * lookup provider is configured.
  */
 export const getTicketFields = (
   fields: ListingFields,
   isPaid: boolean,
-  addressLookupMode: AddressLookupMode = "locked",
 ): Field[] => {
   const effective =
     isPaid &&
@@ -1135,10 +1127,7 @@ export const getTicketFields = (
       ? withRequiredEmail(fields)
       : fields;
   const parsed = parseListingFields(effective);
-  return [
-    nameField,
-    ...parsed.map((f) => resolveContactField(f, addressLookupMode)),
-  ];
+  return [nameField, ...parsed.map(resolveContactField)];
 };
 
 /** Validate ticket fields, mapping validation failure to a response via onError */
@@ -1208,9 +1197,8 @@ export const getAddAttendeeFields = (
   // Admin enters a customer's details here, so disable native autofill: we don't
   // want the operator's browser to store or suggest other customers' PII. The
   // shared ticket fields keep their semantic autocomplete for the public form,
-  // so override on copies rather than mutating the originals. The address
-  // search panel is "editable" — admin textareas are never locked.
-  const contactFields = getTicketFields(fields, false, "editable").map(
+  // so override on copies rather than mutating the originals.
+  const contactFields = getTicketFields(fields, false).map(
     (f): Field => ({ ...f, autocomplete: "off" }),
   );
   const result = [...contactFields, addAttendeeQuantityField];

--- a/test/lib/address-lookup/client.test.ts
+++ b/test/lib/address-lookup/client.test.ts
@@ -1,7 +1,8 @@
 /**
  * Address-lookup client enhancement: reveals the server-rendered panel,
- * searches the endpoint, fills the select, copies the chosen line into the
- * textarea, and manages the locked/editable textarea modes.
+ * searches the endpoint, fills the select, and copies the chosen line into the
+ * always-editable textarea (re-hiding the dropdown and firing an input event
+ * so dependent enhancements refresh).
  */
 
 import { expect } from "@std/expect";
@@ -15,7 +16,7 @@ import {
 } from "#test-utils/fake-dom.ts";
 import { setupFetchStub } from "#test-utils/fetch-stub.ts";
 
-const panelSpec = (mode: "locked" | "editable"): ElementSpec => ({
+const panelSpec = (): ElementSpec => ({
   children: [
     {
       children: [{ data: { addressSearch: "" }, tag: "input", type: "text" }],
@@ -29,12 +30,9 @@ const panelSpec = (mode: "locked" | "editable"): ElementSpec => ({
       tag: "label",
     },
     { data: { addressStatus: "" }, hidden: true, tag: "p" },
-    ...(mode === "locked"
-      ? [{ data: { addressEdit: "" }, hidden: true, tag: "button" }]
-      : []),
   ],
   data: {
-    addressLookup: mode,
+    addressLookup: "",
     error: "Lookup failed",
     noResults: "No addresses found",
     placeholder: "Select an address…",
@@ -44,8 +42,8 @@ const panelSpec = (mode: "locked" | "editable"): ElementSpec => ({
   tag: "div",
 });
 
-const formSpec = (mode: "locked" | "editable"): ElementSpec => ({
-  children: [panelSpec(mode), { name: "address", tag: "textarea" }],
+const formSpec = (): ElementSpec => ({
+  children: [panelSpec(), { name: "address", tag: "textarea" }],
   tag: "form",
 });
 
@@ -57,17 +55,15 @@ type Parts = {
   resultsLabel: FakeElement;
   select: FakeElement;
   status: FakeElement;
-  editButton: FakeElement | null;
   textarea: FakeElement;
 };
 
 /** Install the DOM, run the enhancement, and hand back the pieces. */
-const setup = (mode: "locked" | "editable"): Parts => {
-  const [form] = installFakeDom([formSpec(mode)]);
+const setup = (): Parts => {
+  const [form] = installFakeDom([formSpec()]);
   initAddressLookup();
   const one = (selector: string) => form!.querySelector(selector)!;
   return {
-    editButton: form!.querySelector("[data-address-edit]"),
     findButton: one("[data-address-find]"),
     form: form!,
     panel: one("[data-address-lookup]"),
@@ -108,7 +104,7 @@ describe("address lookup client", () => {
 
   test("a select without its results-label wrapper stays disabled", () => {
     // The select alone isn't enough — revealing it needs the label to unhide.
-    const partial = panelSpec("locked");
+    const partial = panelSpec();
     partial.children = partial.children!.map((c) =>
       "addressResultsLabel" in (c.data ?? {})
         ? { data: { addressResults: "" }, tag: "select" as const }
@@ -125,13 +121,13 @@ describe("address lookup client", () => {
   });
 
   test("leaves the panel hidden when the address textarea is missing", () => {
-    const [panel] = installFakeDom([panelSpec("locked")]);
+    const [panel] = installFakeDom([panelSpec()]);
     initAddressLookup();
     expect(panel!.hidden).toBe(true);
   });
 
   test("leaves a panel missing its own controls hidden", () => {
-    const gutted = { ...panelSpec("locked"), children: [] };
+    const gutted = { ...panelSpec(), children: [] };
     const form = initPanelInForm(gutted);
     expect(form.querySelector("[data-address-lookup]")!.hidden).toBe(true);
   });
@@ -148,42 +144,15 @@ describe("address lookup client", () => {
     test(`leaves a panel missing its ${missing} control hidden`, () => {
       const hasControl = (spec: ElementSpec): boolean =>
         missing in (spec.data ?? {}) || (spec.children ?? []).some(hasControl);
-      const partial = panelSpec("locked");
+      const partial = panelSpec();
       partial.children = partial.children!.filter((c) => !hasControl(c));
       const form = initPanelInForm(partial);
       expect(form.querySelector("[data-address-lookup]")!.hidden).toBe(true);
     });
   }
 
-  test("locked mode without an Edit button never locks the textarea", () => {
-    // The server always renders the Edit button in locked mode; if it is
-    // missing, locking would trap the user, so the textarea stays editable.
-    const noEdit = panelSpec("locked");
-    noEdit.children = noEdit.children!.filter(
-      (c) => !("addressEdit" in (c.data ?? {})),
-    );
-    const form = initPanelInForm(noEdit);
-    expect(form.querySelector("textarea")!.readOnly).toBe(false);
-  });
-
-  test("a locked textarea outside any form still locks and unlocks", () => {
-    const [, textarea] = installFakeDom([
-      panelSpec("locked"),
-      { name: "address", tag: "textarea" },
-    ]);
-    initAddressLookup();
-    expect(textarea!.readOnly).toBe(true);
-  });
-
-  test("locked mode reveals the panel, locks the textarea, shows Edit", () => {
-    const { editButton, panel, textarea } = setup("locked");
-    expect(panel.hidden).toBe(false);
-    expect(textarea.readOnly).toBe(true);
-    expect(editButton!.hidden).toBe(false);
-  });
-
-  test("editable mode reveals the panel and leaves the textarea editable", () => {
-    const { panel, textarea } = setup("editable");
+  test("reveals the panel and leaves the textarea editable", () => {
+    const { panel, textarea } = setup();
     expect(panel.hidden).toBe(false);
     expect(textarea.readOnly).toBe(false);
   });
@@ -198,8 +167,7 @@ describe("address lookup client", () => {
         jsonResponse({ addresses: ["10 Downing Street", "11 Downing Street"] }),
       );
     });
-    const { findButton, resultsLabel, searchInput, select, status } =
-      setup("editable");
+    const { findButton, resultsLabel, searchInput, select, status } = setup();
     searchInput.value = "sw1a 2aa";
 
     findButton.dispatch("click");
@@ -220,7 +188,7 @@ describe("address lookup client", () => {
 
   test("shows the searching message while the lookup is in flight", async () => {
     stubFetch(() => new Promise(() => {})); // never resolves
-    const { findButton, searchInput, status } = setup("editable");
+    const { findButton, searchInput, status } = setup();
     searchInput.value = "SW1A 2AA";
 
     findButton.dispatch("click");
@@ -235,7 +203,7 @@ describe("address lookup client", () => {
     stubFetch(() =>
       Promise.resolve(jsonResponse({ addresses: ["10 Downing Street"] }, 500)),
     );
-    const { findButton, searchInput, select, status } = setup("editable");
+    const { findButton, searchInput, select, status } = setup();
     searchInput.value = "SW1A 2AA";
 
     findButton.dispatch("click");
@@ -247,7 +215,7 @@ describe("address lookup client", () => {
 
   test("an empty search box never calls the endpoint", async () => {
     stubFetch(() => Promise.reject(new Error("should not be called")));
-    const { findButton, searchInput } = setup("editable");
+    const { findButton, searchInput } = setup();
     searchInput.value = "   ";
 
     findButton.dispatch("click");
@@ -258,7 +226,7 @@ describe("address lookup client", () => {
 
   test("Enter in the search box searches instead of submitting the form", async () => {
     stubFetch(() => Promise.resolve(jsonResponse({ addresses: ["A"] })));
-    const { searchInput, select } = setup("editable");
+    const { searchInput, select } = setup();
     searchInput.value = "SW1A 2AA";
     let prevented = false;
 
@@ -276,7 +244,7 @@ describe("address lookup client", () => {
 
   test("other keys in the search box are ignored", async () => {
     stubFetch(() => Promise.reject(new Error("should not be called")));
-    const { searchInput } = setup("editable");
+    const { searchInput } = setup();
     searchInput.value = "SW1A 2AA";
 
     searchInput.dispatch("keydown", { key: "a", preventDefault: () => {} });
@@ -287,7 +255,7 @@ describe("address lookup client", () => {
 
   test("no matches shows the no-results message and keeps the select hidden", async () => {
     stubFetch(() => Promise.resolve(jsonResponse({ addresses: [] })));
-    const { findButton, resultsLabel, searchInput, status } = setup("editable");
+    const { findButton, resultsLabel, searchInput, status } = setup();
     searchInput.value = "ZZ99 9ZZ";
 
     findButton.dispatch("click");
@@ -300,7 +268,7 @@ describe("address lookup client", () => {
 
   /** Run a search with the current fetch stub and assert the shown status. */
   const searchExpectingStatus = async (expected: string): Promise<void> => {
-    const { findButton, searchInput, status } = setup("editable");
+    const { findButton, searchInput, status } = setup();
     searchInput.value = "SW1A 2AA";
 
     findButton.dispatch("click");
@@ -331,8 +299,8 @@ describe("address lookup client", () => {
     // The server always renders every data-* string; if one is missing the
     // status simply stays blank instead of showing "undefined".
     stubFetch(() => Promise.resolve(jsonResponse({ addresses: [] })));
-    const bare = panelSpec("editable");
-    bare.data = { addressLookup: "editable" };
+    const bare = panelSpec();
+    bare.data = { addressLookup: "" };
     const [form] = installFakeDom([
       { children: [bare, { name: "address", tag: "textarea" }], tag: "form" },
     ]);
@@ -349,7 +317,7 @@ describe("address lookup client", () => {
   });
 
   test("choosing an address replaces whatever the textarea held", () => {
-    const { select, textarea } = setup("editable");
+    const { select, textarea } = setup();
     textarea.value = "half-typed address";
     select.value = "10 Downing Street, LONDON";
 
@@ -358,52 +326,37 @@ describe("address lookup client", () => {
     expect(textarea.value).toBe("10 Downing Street, LONDON");
   });
 
+  test("choosing an address re-hides the dropdown", () => {
+    const { resultsLabel, select, textarea } = setup();
+    resultsLabel.hidden = false;
+    select.value = "10 Downing Street, LONDON";
+
+    select.dispatch("change");
+
+    expect(textarea.value).toBe("10 Downing Street, LONDON");
+    expect(resultsLabel.hidden).toBe(true);
+  });
+
+  test("choosing an address fires an input event on the textarea", () => {
+    const { select, textarea } = setup();
+    let inputs = 0;
+    textarea.addEventListener("input", () => {
+      inputs += 1;
+    });
+    select.value = "10 Downing Street, LONDON";
+
+    select.dispatch("change");
+
+    expect(inputs).toBe(1);
+  });
+
   test("choosing the placeholder leaves the textarea alone", () => {
-    const { select, textarea } = setup("locked");
+    const { select, textarea } = setup();
     textarea.value = "already chosen";
     select.value = "";
 
     select.dispatch("change");
 
     expect(textarea.value).toBe("already chosen");
-  });
-
-  test("Edit unlocks the textarea for corrections and focuses it", () => {
-    const { editButton, textarea } = setup("locked");
-
-    editButton!.dispatch("click");
-
-    expect(textarea.readOnly).toBe(false);
-    expect(editButton!.hidden).toBe(true);
-    expect(textarea.focused).toBe(true);
-  });
-
-  test("submitting with a locked empty address unlocks and resubmits", () => {
-    const { form, textarea } = setup("locked");
-    let prevented = false;
-
-    form.dispatch("submit", {
-      preventDefault: () => {
-        prevented = true;
-      },
-    });
-
-    expect(prevented).toBe(true);
-    expect(textarea.readOnly).toBe(false);
-  });
-
-  test("submitting with a chosen address goes straight through", () => {
-    const { form, textarea } = setup("locked");
-    textarea.value = "10 Downing Street";
-    let prevented = false;
-
-    form.dispatch("submit", {
-      preventDefault: () => {
-        prevented = true;
-      },
-    });
-
-    expect(prevented).toBe(false);
-    expect(textarea.readOnly).toBe(true);
   });
 });

--- a/test/lib/address-lookup/panel.test.ts
+++ b/test/lib/address-lookup/panel.test.ts
@@ -1,8 +1,8 @@
 /**
  * The server-rendered postcode search panel: gated on the configured
  * provider, hidden by default, carrying all client copy in data attributes,
- * and threaded onto the address field by getTicketFields (public "locked",
- * admin "editable").
+ * and threaded onto the address field by getTicketFields. The address
+ * textarea always stays editable.
  */
 
 import { expect } from "@std/expect";
@@ -22,18 +22,18 @@ afterEach(() => {
 
 describe("renderAddressLookupPanel", () => {
   test("renders nothing while no provider is configured", () => {
-    expect(renderAddressLookupPanel("locked")).toBe("");
+    expect(renderAddressLookupPanel()).toBe("");
   });
 
   test("renders nothing for an unrecognised stored provider value", () => {
     settings.setForTest({ address_lookup_provider: "surprise" });
-    expect(renderAddressLookupPanel("locked")).toBe("");
+    expect(renderAddressLookupPanel()).toBe("");
   });
 
   test("renders a hidden panel with the provider's search copy", () => {
     enableProviderForTest();
-    const html = renderAddressLookupPanel("locked");
-    expect(html).toContain('data-address-lookup="locked"');
+    const html = renderAddressLookupPanel();
+    expect(html).toContain("data-address-lookup");
     expect(html).toContain("hidden");
     expect(html).toContain(">Postcode<");
     expect(html).toContain('placeholder="e.g. SW1A 1AA"');
@@ -47,12 +47,9 @@ describe("renderAddressLookupPanel", () => {
     expect(html).toContain("data-placeholder=");
   });
 
-  test("locked mode has an Edit button; editable mode does not", () => {
+  test("never renders an Edit button — the textarea stays editable", () => {
     enableProviderForTest();
-    expect(renderAddressLookupPanel("locked")).toContain("data-address-edit");
-    expect(renderAddressLookupPanel("editable")).not.toContain(
-      "data-address-edit",
-    );
+    expect(renderAddressLookupPanel()).not.toContain("data-address-edit");
   });
 });
 
@@ -60,16 +57,16 @@ describe("address field panel threading", () => {
   const addressField = (fields: Field[]): Field =>
     fields.find((f) => f.name === "address")!;
 
-  test("public ticket fields lock the address behind the panel", () => {
+  test("public ticket fields attach the panel to the address field", () => {
     enableProviderForTest();
     const field = addressField(getTicketFields("address", false));
-    expect(field.beforeHtml).toContain('data-address-lookup="locked"');
+    expect(field.beforeHtml).toContain("data-address-lookup");
   });
 
-  test("admin add-attendee fields keep the address editable", () => {
+  test("admin add-attendee fields attach the panel to the address field", () => {
     enableProviderForTest();
     const field = addressField(getAddAttendeeFields("address", false));
-    expect(field.beforeHtml).toContain('data-address-lookup="editable"');
+    expect(field.beforeHtml).toContain("data-address-lookup");
   });
 
   test("no provider means the plain field, with no panel attached", () => {
@@ -88,7 +85,7 @@ describe("address field panel threading", () => {
   test("renderFields emits the panel directly before the address label", () => {
     enableProviderForTest();
     const html = renderFields(getTicketFields("address", false));
-    const panelAt = html.indexOf('data-address-lookup="locked"');
+    const panelAt = html.indexOf("data-address-lookup");
     const labelAt = html.indexOf('name="address"');
     expect(panelAt).toBeGreaterThan(-1);
     expect(panelAt).toBeLessThan(labelAt);

--- a/test/lib/address-lookup/route.test.ts
+++ b/test/lib/address-lookup/route.test.ts
@@ -1,7 +1,8 @@
 /**
  * GET /address-lookup through the full request pipeline, plus the search
- * panel appearing on the public booking form ("locked") and the admin
- * attendee forms ("editable") only while a provider is configured.
+ * panel appearing on the public booking form and the admin attendee forms
+ * only while a provider is configured (the address textarea always stays
+ * editable).
  */
 
 import { expect } from "@std/expect";
@@ -134,20 +135,22 @@ describeWithEnv("address lookup search panels", { db: true }, () => {
     expect(html).not.toContain("data-address-lookup");
   });
 
-  test("the booking form renders a locked panel when a provider is set", async () => {
+  test("the booking form renders the panel when a provider is set", async () => {
     const { listing } = await setupListingAndLogin({ fields: "address" });
     await enableEasypostcodes();
     const html = await bookingFormHtml(listing.slug);
-    expect(html).toContain('data-address-lookup="locked"');
+    expect(html).toContain("data-address-lookup");
     // The panel sits directly above the address textarea, hidden until the
     // client script reveals it.
     expect(html.indexOf("data-address-lookup")).toBeLessThan(
       html.indexOf('name="address"'),
     );
     expect(html).toContain('placeholder="e.g. SW1A 1AA"');
+    // The textarea is always editable — no Edit button is rendered.
+    expect(html).not.toContain("data-address-edit");
   });
 
-  test("the admin attendee form renders an always-editable panel", async () => {
+  test("the admin attendee form renders the panel", async () => {
     await setupListingAndLogin();
     await enableEasypostcodes();
     const { cookie } = await getTestSession();
@@ -156,9 +159,7 @@ describeWithEnv("address lookup search panels", { db: true }, () => {
       mockRequest("/admin/attendees/new", { headers: { cookie } }),
     );
     const html = await response.text();
-    expect(html).toContain('data-address-lookup="editable"');
-    expect(html).not.toContain('data-address-lookup="locked"');
-    // Admin mode has no Edit button — the textarea is never locked.
+    expect(html).toContain("data-address-lookup");
     expect(html).not.toContain("data-address-edit");
   });
 });

--- a/test/routes/renewal.test.ts
+++ b/test/routes/renewal.test.ts
@@ -164,7 +164,7 @@ describeWithEnv("routes > renewal", { db: true }, () => {
 
       const html = await response.text();
       expect(response.status).toBe(200);
-      expect(html).toContain('data-address-lookup="locked"');
+      expect(html).toContain("data-address-lookup");
     });
 
     test("returns 404 for unknown token", async () => {

--- a/test/test-utils/fake-dom.ts
+++ b/test/test-utils/fake-dom.ts
@@ -20,13 +20,8 @@ export type FakeElement = {
   disabled: boolean;
   hidden: boolean;
   readOnly: boolean;
-  /** True after `focus()` was called (test-observable focus). */
-  focused: boolean;
-  focus: () => void;
   /** The enclosing `<form>` element, linked by {@link installFakeDom}. */
   form: FakeElement | null;
-  /** Re-dispatches "submit" listeners, like the DOM `form.requestSubmit()`. */
-  requestSubmit: () => void;
   textContent: string;
   dataset: Record<string, string>;
   children: FakeElement[];
@@ -164,10 +159,6 @@ const makeElement = (spec: ElementSpec): FakeElement => {
       for (const listener of listeners.get(event.type) ?? []) listener(event);
       return true;
     },
-    focus: () => {
-      el.focused = true;
-    },
-    focused: false,
     form: null,
     getAttribute: (name) => attrs.get(name) ?? null,
     hidden: spec.hidden ?? false,
@@ -180,7 +171,6 @@ const makeElement = (spec: ElementSpec): FakeElement => {
       children.length = 0;
       children.push(...next);
     },
-    requestSubmit: () => el.dispatch("submit", { preventDefault: () => {} }),
     required: spec.required ?? false,
     tag: spec.tag ?? "input",
     textContent: "",


### PR DESCRIPTION
## What & why

The public booking form used to render the address as a read-only textarea behind an **"Edit address"** button (the address-lookup "locked" mode). This change removes that button and makes the address field always editable, then tidies up the postcode dropdown behaviour.

## Changes

- **Address field always editable** — dropped the "Edit address" button and collapsed the address-lookup panel's `locked`/`editable` modes into a single always-editable behaviour. `renderAddressLookupPanel()` no longer takes a mode, and the client script no longer locks the textarea or wires an unlock-on-submit fallback.
- **Re-hide the dropdown after choosing** — selecting an address from the postcode results now hides the results dropdown again.
- **Live char count on prefill** — after an address is copied into the textarea, the script fires an `input` event so the existing character counter below the field refreshes immediately with the prefilled value.
- **Narrower "Number of packages" selector** — capped `select[data-package-members]` at `max-width: 5rem` so it no longer stretches to the full container width.
- Removed the now-unused `address_lookup.edit` locale string and updated the client/panel/route/renewal tests to match (including new coverage for the dropdown re-hide and the input event).

## Testing

- `deno check` on all touched source and test files
- `deno task lint`
- `deno test` for `test/lib/address-lookup/{client,panel,route}.test.ts` and `test/routes/renewal.test.ts` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmQyE6Lmtw6j2qpZ5EK7LZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmQyE6Lmtw6j2qpZ5EK7LZ)_