### PR TITLE
Continue menu consolidation: quick actions, Images sub-nav, tidy titles

### DIFF
--- a/src/features/admin/ledger.ts
+++ b/src/features/admin/ledger.ts
@@ -251,11 +251,14 @@ const buildStats = async (
   range: LedgerRange,
   listingId: number | null,
   listings: ListingWithCount[],
-): Promise<{ rows: DetailRow[]; heading: string }> => {
+): Promise<{ rows: DetailRow[]; heading: string | null }> => {
   if (listingId === null) {
     const totals = await ledgerTotals(range);
+    // No heading for the whole-business view — the page is already titled
+    // "Ledger", so an "All listings" heading only repeats that. A listing-scoped
+    // view still names the listing (below) so the figures' scope stays clear.
     return {
-      heading: t("admin.ledger.stats.all_heading"),
+      heading: null,
       rows: [
         moneyRow("admin.ledger.stats.income", totals.income),
         moneyRow("admin.ledger.stats.due", totals.due),

--- a/src/features/admin/servicing.tsx
+++ b/src/features/admin/servicing.tsx
@@ -47,7 +47,7 @@ import type { ListingWithCount } from "#shared/types.ts";
 import { parsePositiveMinorUnits } from "#shared/validation/money.ts";
 import { parsePositiveIntId } from "#shared/validation/number.ts";
 import { AdminPage } from "#templates/admin/admin-page.tsx";
-import { ActionButton, SubmitButton } from "#templates/components/actions.tsx";
+import { SubmitButton } from "#templates/components/actions.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
 import { PriceInput } from "#templates/components/price-input.tsx";
 
@@ -312,11 +312,6 @@ const renderServicingList = async (session: AuthSession): Promise<string> => {
   return String(
     <AdminPage active="/admin/servicing" session={session} title="Servicing">
       <h1>Servicing</h1>
-      <p>
-        <ActionButton href="/admin/servicing/new" icon="plus">
-          New service event
-        </ActionButton>
-      </p>
       <DataTable
         columns={[
           { header: "Name" },

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -139,7 +139,6 @@
   "admin.ledger.filter.to": "To",
   "admin.ledger.filter.listing": "Listing",
   "admin.ledger.filter.all_listings": "All listings",
-  "admin.ledger.stats.all_heading": "All listings",
   "admin.ledger.stats.income": "Total income",
   "admin.ledger.stats.due": "Total due",
   "admin.ledger.stats.refunded": "Total refunded",

--- a/src/locales/en/images.json
+++ b/src/locales/en/images.json
@@ -1,5 +1,4 @@
 {
-  "images.add": "Add Image",
   "images.column.thumbnail": "Thumbnail",
   "images.created": "Image created",
   "images.deleted": "Image deleted",

--- a/src/locales/en/modifiers.json
+++ b/src/locales/en/modifiers.json
@@ -1,5 +1,4 @@
 {
-  "modifiers.add_modifier": "Add Modifier",
   "modifiers.no_modifiers": "No modifiers configured.",
   "modifiers.rule_column": "Rule",
   "modifiers.uses_column": "Uses",

--- a/src/ui/templates/admin/dashboard.tsx
+++ b/src/ui/templates/admin/dashboard.tsx
@@ -42,13 +42,16 @@ import { AttendeeTable } from "#templates/attendee-table.tsx";
 import { ActionButton } from "#templates/components/actions.tsx";
 import { escapeHtml } from "#templates/layout.tsx";
 
-/** The "Add listing" action button — a quick create shortcut on the editor and
- *  staff dashboards (the listings index reaches the same create/import flows
- *  through its section sub-nav instead). */
-const AddListingButton = (): JSX.Element => (
+/** The dashboard's quick-create actions — shortcuts to add a listing or an
+ *  attendee straight from the home page (each section's own sub-nav reaches the
+ *  same create flows once you're inside it). */
+const DashboardQuickActions = (): JSX.Element => (
   <p class="actions">
     <ActionButton href="/admin/listing/new" icon="plus">
       {t("admin.dashboard.add_listing")}
+    </ActionButton>
+    <ActionButton href="/admin/attendees/new" icon="user-plus">
+      {t("admin.listings.add_attendee")}
     </ActionButton>
   </p>
 );
@@ -383,7 +386,7 @@ export const adminDashboardPage = (
     successMessage,
   )(
     <>
-      {!isReadOnly() && <AddListingButton />}
+      {!isReadOnly() && <DashboardQuickActions />}
 
       <ListingsTableBlock
         columnKeys={columnKeys}

--- a/src/ui/templates/admin/images.tsx
+++ b/src/ui/templates/admin/images.tsx
@@ -146,16 +146,11 @@ export const adminImagesPage = (
     successMessage,
   )(
     storageEnabled ? (
-      <>
-        {!isReadOnly() && (
-          <p class="actions">
-            <ActionButton href="/admin/images/new" icon="plus">
-              {t("images.add")}
-            </ActionButton>
-          </p>
-        )}
-        {images.length === 0 ? <p>{t("images.empty")}</p> : imageTable(images)}
-      </>
+      images.length === 0 ? (
+        <p>{t("images.empty")}</p>
+      ) : (
+        imageTable(images)
+      )
     ) : (
       storageDisabledNotice()
     ),

--- a/src/ui/templates/admin/ledger.tsx
+++ b/src/ui/templates/admin/ledger.tsx
@@ -673,7 +673,9 @@ export type LedgerPageData = {
   names: LedgerNames;
   truncated: boolean;
   stats: DetailRow[];
-  statsHeading: string;
+  /** Scope heading above the stats table — the listing name when scoped to one,
+   *  null for the whole-business view (which needs no heading). */
+  statsHeading: string | null;
   filters: LedgerFilterState;
   dates: DatePickerDate[];
   today: string;
@@ -800,11 +802,12 @@ const LedgerViewToggle = ({ data }: { data: LedgerPageData }): SafeHtml => (
   </p>
 );
 
-/** The range-scoped stats table: a heading naming the scope ("All listings" or
- *  one listing) above a key/value figure table. */
+/** The range-scoped stats table: a key/value figure table, headed by the
+ *  listing name when scoped to one listing (the whole-business view needs no
+ *  heading — the page title already says "Ledger"). */
 const LedgerStats = ({ data }: { data: LedgerPageData }): SafeHtml => (
   <>
-    <h2>{data.statsHeading}</h2>
+    {data.statsHeading && <h2>{data.statsHeading}</h2>}
     <DetailTable rows={data.stats} />
   </>
 );

--- a/src/ui/templates/admin/modifiers.tsx
+++ b/src/ui/templates/admin/modifiers.tsx
@@ -9,7 +9,6 @@ import type {
   ModifierAggregateRecalculation,
   ModifierRow,
 } from "#shared/db/modifiers.ts";
-import { isReadOnly } from "#shared/env.ts";
 import {
   booleanToCheckbox,
   CsrfForm,
@@ -29,7 +28,6 @@ import { AdminListPage } from "#templates/admin/list-page.tsx";
 import { MoneyAdjustSection } from "#templates/admin/money-adjust-section.tsx";
 import type { RecalculateRow } from "#templates/admin/recalculate.tsx";
 import {
-  ActionButton,
   GuideLink,
   SaveChangesButton,
   SubmitButton,
@@ -268,16 +266,9 @@ export const adminModifiersPage = (
 ): string =>
   AdminListPage({
     actions: (
-      <>
-        {!isReadOnly() && (
-          <ActionButton href="/admin/modifiers/new" icon="plus">
-            {t("modifiers.add_modifier")}
-          </ActionButton>
-        )}
-        <GuideLink href="/admin/guide#modifiers">
-          {t("modifiers.guide_link")}
-        </GuideLink>
-      </>
+      <GuideLink href="/admin/guide#modifiers">
+        {t("modifiers.guide_link")}
+      </GuideLink>
     ),
     active: "/admin/modifiers",
     children: (

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -207,6 +207,10 @@ const modifiersSub = (): NavItem[] =>
     "/admin/modifiers/new",
   );
 
+/** Images sub-nav: an "Add" create link. */
+const imagesSub = (): NavItem[] =>
+  sectionWithAdd("/admin/images", t("terms.images"), "/admin/images/new");
+
 /** Users sub-nav: an "Invite" link, then sessions/API keys. */
 const usersSub = (): NavItem[] => [
   navItem("/admin/users", t("terms.users")),
@@ -266,12 +270,18 @@ const section = (
  * editor; everything else is owner-only, so their list omits it entirely. */
 const sectionsForRole = (adminLevel: AdminSession["adminLevel"]): Section[] => {
   const siteSection = section("/admin/site", t("nav.site"), siteSub());
+  // The Images section only exists while storage is on — that's the same
+  // condition under which its top-level link appears (see `topLevelItems`).
+  const imagesSection = isStorageEnabled()
+    ? section("/admin/images", t("terms.images"), imagesSub())
+    : null;
   if (adminLevel === "editor") {
-    return [
+    return compact([
       section("/admin/listings", t("terms.listings"), listingsSub()),
       section("/admin/groups", t("terms.groups"), groupsSub()),
+      imagesSection,
       siteSection,
-    ];
+    ]);
   }
   const calendar = calendarSub();
   return compact([
@@ -281,6 +291,7 @@ const sectionsForRole = (adminLevel: AdminSession["adminLevel"]): Section[] => {
     section("/admin/attendees", t("terms.attendees"), attendeesSub()),
     section("/admin/modifiers", t("terms.modifiers"), modifiersSub()),
     section("/admin/groups", t("terms.groups"), groupsSub()),
+    imagesSection,
     adminLevel === "owner"
       ? section("/admin/users", t("terms.users"), usersSub())
       : null,

--- a/test/lib/server-admin-images.test.ts
+++ b/test/lib/server-admin-images.test.ts
@@ -33,7 +33,8 @@ describeWithEnv(
           await adminGet("/admin/images"),
           200,
           "No images yet.",
-          "Add Image",
+          // The create affordance now lives in the Images section sub-nav.
+          'href="/admin/images/new"',
         );
 
         await makeImage("Hero");

--- a/test/lib/server-ledger.test.ts
+++ b/test/lib/server-ledger.test.ts
@@ -627,8 +627,11 @@ describeWithEnv("server (admin ledger)", { db: true }, () => {
     await seededSale("Summer Concert", 2500);
     const response = await adminGet("/admin/ledger?view=dual");
     const html = await response.text();
-    // The four business-wide totals, headed "All listings".
+    // The by-listing filter offers the whole-business "All listings" scope, and
+    // the four business-wide totals render beneath it (no scope heading — the
+    // page is already titled "Ledger").
     expect(html).toContain("All listings");
+    expect(html).not.toContain("<h2>All listings</h2>");
     expect(html).toContain("Total income");
     expect(html).toContain("Total due");
     expect(html).toContain("Total refunded");

--- a/test/templates/admin/dashboard.test.ts
+++ b/test/templates/admin/dashboard.test.ts
@@ -54,10 +54,12 @@ describe("adminDashboardPage", () => {
     expect(html).toContain("Listing Name");
   });
 
-  test("renders add listing link", () => {
+  test("renders the add-listing and add-attendee quick actions", () => {
     const html = adminDashboardPage([], TEST_SESSION);
     expect(html).toContain('href="/admin/listing/new"');
     expect(html).toContain("Add Listing");
+    expect(html).toContain('href="/admin/attendees/new"');
+    expect(html).toContain("Add Attendee");
   });
 
   test("includes logout link", () => {

--- a/test/templates/admin/ledger.test.ts
+++ b/test/templates/admin/ledger.test.ts
@@ -544,7 +544,7 @@ describe("adminLedgerPage", () => {
     names: names(),
     returnUrl: "/admin/ledger",
     stats: [{ key: "Total income", value: "£25.00" }],
-    statsHeading: "All listings",
+    statsHeading: null,
     today: "2026-06-23",
     transfers: [transfer()],
     truncated: false,
@@ -559,8 +559,9 @@ describe("adminLedgerPage", () => {
     expect(html).toContain("Plain-language log");
     expect(html).toContain("Double-entry view");
     expect(html).toContain("Transfer from");
-    // The stats table and its heading render.
-    expect(html).toContain("All listings");
+    // The stats table renders; the whole-business view carries no scope heading
+    // (the page is already titled "Ledger").
+    expect(html).not.toContain("<h2>All listings</h2>");
     expect(html).toContain("Total income");
     expect(html).toContain("£25.00");
     // Both range pickers render with unique anchor ids.
@@ -572,6 +573,14 @@ describe("adminLedgerPage", () => {
     expect(html).toContain(
       '<option selected value="/admin/ledger">All listings</option>',
     );
+  });
+
+  test("heads the stats with the listing name when scoped to one listing", () => {
+    const html = adminLedgerPage(
+      pageData({ statsHeading: "Summer Concert" }),
+      SESSION,
+    );
+    expect(html).toContain("<h2>Summer Concert</h2>");
   });
 
   test("can switch to the double-entry transfer list", () => {

--- a/test/templates/admin/modifiers.test.ts
+++ b/test/templates/admin/modifiers.test.ts
@@ -59,7 +59,8 @@ describe("adminModifiersPage", () => {
     expect(html).toContain("Discount · 10%");
     expect(html).toContain("Charge · 500");
     expect(html).toContain("Multiply · ×1.5");
-    expect(html).toContain("Add Modifier");
+    // The create affordance now lives in the Modifiers section sub-nav.
+    expect(html).toContain('href="/admin/modifiers/new"');
     // The name links to the edit page; there is no separate actions column.
     expect(html).toContain("/admin/modifiers/1/edit");
   });

--- a/test/ui/templates/admin/nav.test.tsx
+++ b/test/ui/templates/admin/nav.test.tsx
@@ -2,7 +2,13 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import type { AdminLevel } from "#shared/types.ts";
 import { AdminNav } from "#templates/admin/nav.tsx";
-import { describeWithEnv, setTestEnv, withSetting } from "#test-utils";
+import {
+  describeWithEnv,
+  setTestEnv,
+  withSetting,
+  withStorageDisabled,
+  withStorageEnabled,
+} from "#test-utils";
 
 describeWithEnv("AdminNav", {}, () => {
   /** Assert every role in `adminLevels` sees a nav link to `href` labelled
@@ -399,6 +405,38 @@ describeWithEnv("AdminNav", {}, () => {
         }),
       );
       expect(html).not.toContain('href="/admin/site/contact"');
+    }));
+
+  test("the Images section sub-nav offers an Add link when storage is enabled", () =>
+    withStorageEnabled(() => {
+      const html = String(
+        AdminNav({ active: "/admin/images", session: { adminLevel: "owner" } }),
+      );
+      expect(html).toContain('href="/admin/images/new"');
+      const start = html.indexOf('class="admin-subnav"');
+      expect(start).toBeGreaterThan(-1);
+      const sub = html.slice(start, html.indexOf("</ul>", start));
+      expect(sub).toContain('href="/admin/images/new"');
+      expect(sub).toContain("Add");
+    }));
+
+  test("editors see the Images Add sub-nav link too when storage is enabled", () =>
+    withStorageEnabled(() => {
+      const html = String(
+        AdminNav({
+          active: "/admin/images",
+          session: { adminLevel: "editor" },
+        }),
+      );
+      expect(html).toContain('href="/admin/images/new"');
+    }));
+
+  test("the Images section is absent when storage is disabled", () =>
+    withStorageDisabled(() => {
+      const html = String(
+        AdminNav({ active: "/admin/images", session: { adminLevel: "owner" } }),
+      );
+      expect(html).not.toContain('href="/admin/images/new"');
     }));
 
   test("AdminNav uses SettingsNagBanner default (no items prop) when settingsNagItems is omitted", () => {


### PR DESCRIPTION
## Summary

Continues the admin-menu consolidation from #1606 — moving create affordances into the section sub-navs and trimming redundant page chrome.

- **Home dashboard** — adds an **Add attendee** quick action next to **Add listing**.
- **Servicing** — removes the page-level **New service event** button; the Servicing section sub-nav's **Add** link already covers it.
- **Images** — gives the Images section an **Add** sub-nav link (shown when storage is enabled, for the roles that see the Images top-level link) and removes the page-level **Add Image** button, matching every other section.
- **Modifiers** — removes the page-level **Add Modifier** button (the sub-nav **Add** covers it); the guide link stays.
- **Ledger** — drops the redundant **All listings** heading above the whole-business stats (the page is already titled "Ledger"). A listing-scoped view still names the listing above its figures, and the by-listing filter's "All listings" option is unchanged.

Removes the now-unused `images.add`, `modifiers.add_modifier`, and `admin.ledger.stats.all_heading` locale keys.

## Tests

- Added: Images section sub-nav renders an **Add** link when storage is on (owner + editor) and is absent when storage is off; the dashboard renders both quick actions; the ledger heads its stats with the listing name when scoped and omits the heading for the whole-business view.
- Updated: image, modifier, and ledger tests that asserted the removed button/heading text now check the new sub-nav entry points / absence of the heading.
- `typecheck`, `lint:ci`, and all affected test files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLkjMUp7JHS5TxdPTYwbCM)_