### PR TITLE
Click SumUp's "Back to merchant website" after paying

### DIFF
--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -113,5 +113,47 @@ export const sumup: PaymentProvider = {
       'button:has-text("Pay")',
       'button[type="submit"]',
     ]);
+
+    await returnToMerchant(page);
   },
+};
+
+/**
+ * SumUp's sandbox checkout does NOT auto-redirect after a successful payment: it
+ * parks on a "Payment successful" confirmation page (still on checkout.sumup.com)
+ * with a "Back to merchant website" button the customer must click to return to
+ * the app's return URL. Click it so the browser heads home — without it the run
+ * stalls on the SumUp page and dies as a misleading "did not land on a success
+ * page" timeout even though the payment (and its webhook) already succeeded.
+ *
+ * Best-effort and non-fatal: if a future SumUp variant auto-redirects, the
+ * button never appears (or the browser has already left the SumUp origin) and we
+ * simply return, letting the caller's return-URL wait confirm the landing.
+ */
+const returnToMerchant = async (page: Page): Promise<void> => {
+  const namePattern = /back to merchant|return to merchant|merchant website/i;
+  const link = page
+    .getByRole("link", { name: namePattern })
+    .or(page.getByRole("button", { name: namePattern }))
+    .first();
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    // Already redirected away from SumUp's checkout — nothing to click.
+    if (!page.url().includes("checkout.sumup.com")) return;
+    try {
+      if (await link.isVisible({ timeout: 500 })) {
+        await link.click({ timeout: 5_000 });
+        log("  clicked SumUp's 'Back to merchant website' to return to the app");
+        return;
+      }
+    } catch {
+      // Page navigating or the node detached mid-check; re-evaluate next loop.
+    }
+    await page.waitForTimeout(500);
+  }
+  warn(
+    "  SumUp: no 'Back to merchant website' button appeared after paying — " +
+      "relying on an auto-redirect that may not happen.",
+  );
 };

--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -137,10 +137,23 @@ const returnToMerchant = async (page: Page): Promise<void> => {
     .or(page.getByRole("button", { name: namePattern }))
     .first();
 
+  // SumUp serves its hosted checkout from more than one host — the docs return
+  // checkout.sumup.com, but pay.sumup.com is also used (the app's CSP allows
+  // both). Match any *.sumup.com origin so a pay.sumup.com checkout still gets
+  // the "Back to merchant website" click rather than being mistaken for a
+  // redirect that already happened.
+  const onSumUp = (): boolean => {
+    try {
+      return new URL(page.url()).hostname.endsWith(".sumup.com");
+    } catch {
+      return false;
+    }
+  };
+
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     // Already redirected away from SumUp's checkout — nothing to click.
-    if (!page.url().includes("checkout.sumup.com")) return;
+    if (!onSumUp()) return;
     try {
       if (await link.isVisible({ timeout: 500 })) {
         await link.click({ timeout: 5_000 });


### PR DESCRIPTION
## What was happening

The "Payment sandbox e2e" run for SumUp was failing at the very end with:

```
✖ Error: did not land on a success page after checkout.
URL: https://checkout.sumup.com/pay/c-...
  ...
  Payment successful
  Back to merchant website
```

The payment itself **succeeded** — the job log shows `POST /payment/webhook 200`, i.e. the app recorded the payment. The failure was purely in the browser harness: SumUp's sandbox hosted checkout does **not** auto-redirect after a successful payment. It parks on a "Payment successful" confirmation page (still on `checkout.sumup.com`) with a **"Back to merchant website"** button the customer has to click to return to the app's return URL.

Our `sumup.payHostedCheckout` clicked **Pay** and returned immediately, so the browser stayed on `checkout.sumup.com`. `assertPaidBookingConfirmed`'s wait-for-return (`flow.ts:246`) then timed out after 90s and threw the misleading "did not land on a success page after checkout" error — even though the money had already been taken and webhooked.

The `payHostedCheckout` contract says it should return *"once the payment has been submitted and the browser is heading back to the app's return URL"* — the SumUp implementation was stopping one click short of that.

## The fix

After clicking Pay, `sumup.ts` now clicks "Back to merchant website" so the browser navigates back to the app. This covers both the simple booking and the complex-order journey, since both go through `payHostedCheckout`.

The step is best-effort and non-fatal: it polls up to 30s for the button, returns early if the browser has already left the SumUp origin, and if a future SumUp variant auto-redirects (no button), it logs a warning and continues — letting the existing return-URL wait confirm the landing.

## Testing

- `npx tsc --noEmit` passes.
- A full sandbox run requires SumUp secrets in CI; the polling logic mirrors the existing best-effort `withFirstVisible` pattern used elsewhere in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKdfSRbUwpCcbdpA6jL6MR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKdfSRbUwpCcbdpA6jL6MR)_