### PR TITLE
Fix wide tables stretching pages sideways on mobile

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1246,8 +1246,12 @@ td.cell-description {
   text-overflow: ellipsis;
 }
 
+/* The key column of a detail table sizes to its widest label rather than a
+   fixed width, so short labels don't leave a wide empty gutter and long ones
+   aren't clipped — the value column takes the rest, and the `.table-scroll`
+   wrapper handles any overflow on narrow screens. */
 .listing-details-table th {
-  width: 220px;
+  width: fit-content;
 }
 
 /* Income & ledger breakdown: a compact reconciliation table whose figures are

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -2803,12 +2803,18 @@ a.cal-day-selected:active {
   max-width: 15rem;
 }
 
-/* Stack a table with its controls/action rows, evenly spaced. */
+/* Stack a table with its controls/action rows, evenly spaced. Pinned to the
+   full container width: as a flex-column these groups would otherwise size to
+   their widest child, and a `.table-scroll` holding a `white-space: nowrap`
+   table reports that whole nowrap width as its content size — so without an
+   explicit width the group grows to the table's full width and pushes the page
+   sideways on mobile instead of letting the inner `.table-scroll` scroll. */
 .table-controls,
 .table-block {
   display: flex;
   flex-direction: column;
   gap: var(--space-m);
+  width: 100%;
 }
 
 /* Link/button rows attached to a table.


### PR DESCRIPTION
## What changed

Two small stylesheet fixes to how tables behave on the admin pages, especially on a phone.

### 1. Stop wide tables dragging the whole page sideways on mobile

On pages like **edit attendee** and **view listing**, you could scroll the whole page left-and-right on a phone — everything was slightly too wide for the screen.

The cause: the boxes that group a table with its buttons/controls didn't have a set width, so they grew to match their widest table. A table is told never to wrap its text, so it can be very wide — and that full width was being passed up to the page, pushing it past the edge of the screen.

The fix pins those groups to the width of the screen. The table itself still scrolls left-and-right *inside its own box* (as it always should), but the page around it now stays put. This affects every admin "edit/view" page, since they all lay their sections out the same way.

### 2. Size the detail-table label column to its content

The read-only key/value "details" tables at the top of the view-listing / view-attendee (and similar) pages pinned their first column — the labels — to a fixed 220px. Short labels left a wide empty gap; longer ones had no room to grow. Now that column sizes to its widest label, and the value column takes the rest.

## How it was checked

Both pages were rendered and measured in a real headless browser at 320px, 375px, 768px and 1280px wide. Before the fix the page was ~592px wide inside a 375px screen (hence the sideways scroll); after, it fits exactly, and the tables still scroll inside their own scroll area. The desktop layout is unchanged.

## Note on tests

These are stylesheet-only changes. The project's test harness renders HTML but has no browser layout engine, so it can't measure page width — there are no automated layout/visual tests in the codebase to extend. The verification above was done with a real browser instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dazkcj2hocEdEykmpgTZoF