### PR TITLE
Let staff open any date on the deliveries run sheet

### DIFF
--- a/src/features/admin/deliveries.ts
+++ b/src/features/admin/deliveries.ts
@@ -2,24 +2,29 @@
  * Delivery run sheet routes.
  *
  * `/admin/deliveries` shows the drop-offs and collections for the logistics
- * agents a user drives, today and tomorrow, with a per-leg done toggle. An
- * agent-class user is sent here as their only page (every other admin route is
- * closed to agents by the default auth gate); owners and managers reach it from
- * the Calendar submenu and, unlike agents, keep the full staff navigation.
+ * agents a user drives, with a per-leg done toggle. An agent-class user is sent
+ * here as their only page (every other admin route is closed to agents by the
+ * default auth gate) and is pinned to today and tomorrow. Owners and managers
+ * reach it from the Calendar submenu, keep the full staff navigation, and get
+ * the shared calendar date picker so they can open any date (and the day after
+ * it) rather than only today and tomorrow.
  */
 
 /* jscpd:ignore-start */
 import { unique } from "#fp";
 import { t } from "#i18n";
-import { DELIVERY_FORM, deliveryPage, withAuth } from "#routes/auth.ts";
-import { errorRedirect, redirect } from "#routes/response.ts";
+import { getDateFilter, getMonthFilter } from "#routes/admin/actions.ts";
+import { DELIVERY_FORM, requireDeliveryOr, withAuth } from "#routes/auth.ts";
+import { applyFlash } from "#routes/csrf.ts";
+import { errorRedirect, htmlResponse, redirect } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
-import { addDays } from "#shared/dates.ts";
+import { addDays, formatDateLabel } from "#shared/dates.ts";
 import { decryptAttendees, getAttendeesByIds } from "#shared/db/attendees.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import {
   type AgentRunLeg,
   getAgentRunSheet,
+  getAgentRunSheetDates,
   setLegDone,
 } from "#shared/db/logistics.ts";
 import {
@@ -31,12 +36,14 @@ import { userAgents } from "#shared/db/user-agents.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { todayInTz } from "#shared/timezone.ts";
-import type { Attendee } from "#shared/types.ts";
+import { type Attendee, isStaffRole } from "#shared/types.ts";
 import {
   agentDeliveriesPage,
+  type DeliveriesDateNav,
   type DeliveryBookingView,
   type DeliveryDayGroup,
 } from "#templates/admin/deliveries.tsx";
+import type { DatePickerDate } from "#templates/date-picker.tsx";
 
 /* jscpd:ignore-end */
 
@@ -96,20 +103,32 @@ const bookingsForDate = (
   );
 };
 
-/** Group the run sheet into Today / Tomorrow sections. */
+/** A day's heading relative to the real today: the opened day and its
+ * following day read as "Today"/"Tomorrow" when they line up with the real
+ * calendar, and as a full date label ("Monday 6 July 2026") otherwise — so a
+ * staff member who opens a future date sees which day each section is. */
+const dayHeading = (date: string, today: string): string =>
+  date === today
+    ? t("deliveries.today")
+    : date === addDays(today, 1)
+      ? t("deliveries.tomorrow")
+      : formatDateLabel(date);
+
+/** Group the run sheet into two sections: the opened day and the day after. */
 const buildGroups = (
   legs: AgentRunLeg[],
-  today: string,
+  baseDate: string,
   tomorrow: string,
+  today: string,
   lookups: LegLookups,
 ): DeliveryDayGroup[] => [
   {
-    bookings: bookingsForDate(legs, today, lookups),
-    heading: t("deliveries.today"),
+    bookings: bookingsForDate(legs, baseDate, lookups),
+    heading: dayHeading(baseDate, today),
   },
   {
     bookings: bookingsForDate(legs, tomorrow, lookups),
-    heading: t("deliveries.tomorrow"),
+    heading: dayHeading(tomorrow, today),
   },
 ];
 
@@ -136,34 +155,71 @@ const loadLegLookups = async (
   };
 };
 
+/** Build the staff date picker for the run sheet: every date the user's agents
+ * have a delivery on is a selectable link, using the same calendar component as
+ * the calendar page. Agents never see it, so this only runs for staff. */
+const buildDateNav = async (
+  agentIds: number[],
+  today: string,
+  selected: string | null,
+  viewMonth: string | null,
+): Promise<DeliveriesDateNav> => {
+  const deliveryDates = await getAgentRunSheetDates(agentIds);
+  const availableDates: DatePickerDate[] = deliveryDates.map((date) => ({
+    label: formatDateLabel(date),
+    selectable: true,
+    value: date,
+  }));
+  return { availableDates, selected, today, viewMonth };
+};
+
 /** Handle GET /admin/deliveries — render the run sheet. Agents are sent here as
- * their only page; staff (owner/manager) reach it from the Calendar submenu. */
-const handleDeliveriesGet = deliveryPage(async (session) => {
-  const flash = getFlash();
-  const agentIds = await userAgents.getIds(session.userId);
-  if (agentIds.length === 0) {
-    return agentDeliveriesPage(
-      [],
-      settings.phonePrefix,
-      { error: flash.error, noAgents: true, success: flash.success },
-      session,
+ * their only page and are pinned to today and tomorrow; staff (owner/manager)
+ * reach it from the Calendar submenu and may open any date via the calendar
+ * picker, seeing that date and the day after it. */
+const handleDeliveriesGet = (request: Request): Promise<Response> =>
+  requireDeliveryOr(request, async (session) => {
+    applyFlash(request);
+    const flash = getFlash();
+    const staff = isStaffRole(session.adminLevel);
+    const agentIds = await userAgents.getIds(session.userId);
+    if (agentIds.length === 0) {
+      return htmlResponse(
+        agentDeliveriesPage(
+          [],
+          settings.phonePrefix,
+          { error: flash.error, noAgents: true, success: flash.success },
+          session,
+          null,
+        ),
+      );
+    }
+
+    const today = todayInTz(settings.timezone);
+    // Only staff may open a different date; an agent's date/month params are
+    // ignored so a driver always sees just today and tomorrow.
+    const selected = staff ? getDateFilter(request) : null;
+    const viewMonth = staff ? getMonthFilter(request) : null;
+    const baseDate = selected ?? today;
+    const tomorrow = addDays(baseDate, 1);
+    const legs = await getAgentRunSheet(agentIds, [baseDate, tomorrow]);
+
+    const privateKey = await requireRequestPrivateKey();
+    const lookups = await loadLegLookups(legs, privateKey);
+    const groups = buildGroups(legs, baseDate, tomorrow, today, lookups);
+    const dateNav = staff
+      ? await buildDateNav(agentIds, today, selected, viewMonth)
+      : null;
+    return htmlResponse(
+      agentDeliveriesPage(
+        groups,
+        settings.phonePrefix,
+        { error: flash.error, noAgents: false, success: flash.success },
+        session,
+        dateNav,
+      ),
     );
-  }
-
-  const today = todayInTz(settings.timezone);
-  const tomorrow = addDays(today, 1);
-  const legs = await getAgentRunSheet(agentIds, [today, tomorrow]);
-
-  const privateKey = await requireRequestPrivateKey();
-  const lookups = await loadLegLookups(legs, privateKey);
-  const groups = buildGroups(legs, today, tomorrow, lookups);
-  return agentDeliveriesPage(
-    groups,
-    settings.phonePrefix,
-    { error: flash.error, noAgents: false, success: flash.success },
-    session,
-  );
-});
+  });
 
 /** Handle POST /admin/deliveries/mark — toggle a leg done, scoped to the
  * agent's own logistics agents. */

--- a/src/locales/en/deliveries.json
+++ b/src/locales/en/deliveries.json
@@ -1,7 +1,8 @@
 {
   "deliveries.title": "Deliveries",
   "deliveries.no_agents": "You have no logistics agents assigned yet. Ask the site owner to assign you.",
-  "deliveries.none_scheduled": "No deliveries scheduled for today or tomorrow.",
+  "deliveries.none_scheduled": "No deliveries scheduled for these dates.",
+  "deliveries.select_date": "Select a delivery date",
   "deliveries.nothing_scheduled": "Nothing scheduled.",
   "deliveries.dropoff": "Drop-off",
   "deliveries.collection": "Collection",

--- a/src/shared/db/logistics.ts
+++ b/src/shared/db/logistics.ts
@@ -246,6 +246,33 @@ export const getAgentRunSheet = async (
 };
 
 /**
+ * The distinct calendar dates on which the given logistics agents have any
+ * run-sheet leg: every drop-off date (`start_at`) and every collection date
+ * (`end_at - 1 day`, the last booked day — see {@link getAgentRunSheet}). These
+ * are the days a staff member can open on the run sheet's date picker. Empty
+ * input yields no query.
+ */
+export const getAgentRunSheetDates = async (
+  agentIds: number[],
+): Promise<string[]> => {
+  if (agentIds.length === 0) return [];
+  const placeholders = inPlaceholders(agentIds);
+  const rows = await queryAll<{ date: string }>(
+    // quantity > 0 mirrors the run-sheet query: a no-quantity sentinel line is
+    // never an operational delivery, so it must not offer a date to open.
+    `SELECT DATE(start_at) AS date FROM listing_attendees
+        WHERE start_agent_id IN (${placeholders})
+          AND start_at IS NOT NULL AND quantity > 0
+      UNION
+      SELECT DATE(end_at, '-1 day') AS date FROM listing_attendees
+        WHERE end_agent_id IN (${placeholders})
+          AND end_at IS NOT NULL AND quantity > 0`,
+    [...agentIds, ...agentIds],
+  );
+  return rows.map((row) => row.date).sort((a, b) => a.localeCompare(b));
+};
+
+/**
  * Mark a booking leg done/undone, but only when the leg's logistics agent is
  * one of `agentIds` — this enforces that an agent user can only update their
  * own runs. Returns true when a row was updated (i.e. the agent owns the leg).

--- a/src/ui/templates/admin/deliveries.tsx
+++ b/src/ui/templates/admin/deliveries.tsx
@@ -1,23 +1,62 @@
 /**
  * Delivery agent run sheet.
  *
- * The only page a delivery-agent user can see. It lists the drop-offs and
- * collections assigned to the logistics agents that user drives, for today and
- * tomorrow, with addresses (and map links), phone numbers and the logistics
- * time. Each leg can be toggled done so a driver can tick off their round.
+ * A delivery-agent user only ever sees today and tomorrow — the two days a
+ * driver works from. Staff (owner/manager) get the same run sheet plus the
+ * shared calendar date picker, so they can open any date (and its following
+ * day) rather than being pinned to today. It lists the drop-offs and
+ * collections assigned to the logistics agents that user drives, with
+ * addresses (and map links), phone numbers and the logistics time. Each leg
+ * can be toggled done so a driver can tick off their round.
  */
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
+import { isStaffRole } from "#shared/types.ts";
 import { flashProps } from "#templates/admin/admin-page.tsx";
 import { markAdminFooter } from "#templates/admin/footer.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
 import { MapsLinks } from "#templates/components/maps-links.tsx";
 import { PhoneLinks } from "#templates/components/phone-links.tsx";
+import { DatePicker, type DatePickerDate } from "#templates/date-picker.tsx";
 import { Layout } from "#templates/layout.tsx";
 /* jscpd:ignore-end */
+
+/** The date-picker context shown to staff so they can open any delivery date.
+ * `selected` is the currently opened date (null = today's default view). */
+export type DeliveriesDateNav = {
+  availableDates: DatePickerDate[];
+  today: string;
+  selected: string | null;
+  viewMonth: string | null;
+};
+
+/** The calendar date picker, wired to reopen the run sheet on a chosen date.
+ * Uses the same component as the calendar page, so paging months and jumping
+ * dates behave identically. */
+const DeliveriesDatePicker = ({
+  nav,
+}: {
+  nav: DeliveriesDateNav;
+}): JSX.Element => (
+  <DatePicker
+    anchorId="calendar"
+    ariaLabel={t("deliveries.select_date")}
+    clearHref="/admin/deliveries"
+    dates={nav.availableDates}
+    dayHref={(value) => `/admin/deliveries?date=${value}`}
+    monthHref={(month) =>
+      `/admin/deliveries?${
+        nav.selected ? `date=${nav.selected}&` : ""
+      }cal=${month}#calendar`
+    }
+    selected={nav.selected}
+    today={nav.today}
+    viewMonth={nav.viewMonth}
+  />
+);
 
 /** A single drop-off or collection job within a booking on the run sheet. */
 export type DeliveryLegView = {
@@ -153,13 +192,16 @@ export interface DeliveriesPageOpts {
 }
 
 /**
- * Render the agent run sheet, grouped by day.
+ * Render the agent run sheet, grouped by day. Staff are given the calendar
+ * date picker (`dateNav`) so they can open any date; agents pass `null` and
+ * stay pinned to today.
  */
 export const agentDeliveriesPage = (
   groups: DeliveryDayGroup[],
   phonePrefix: string,
   opts: DeliveriesPageOpts,
   session: AdminSession,
+  dateNav: DeliveriesDateNav | null,
 ): string =>
   String(
     <Layout title={t("deliveries.title")}>
@@ -175,6 +217,10 @@ export const agentDeliveriesPage = (
         </>
       )}
       <Flash {...flashProps(opts.error, opts.success)} />
+      {/* Only staff steer the date; the picker is absent for agents. */}
+      {isStaffRole(session.adminLevel) && dateNav && (
+        <DeliveriesDatePicker nav={dateNav} />
+      )}
       {opts.noAgents ? (
         <p>
           <em>{t("deliveries.no_agents")}</em>

--- a/test/lib/db/logistics-runsheet.test.ts
+++ b/test/lib/db/logistics-runsheet.test.ts
@@ -6,6 +6,7 @@ import { setGroupPackageMembers } from "#shared/db/groups.ts";
 import {
   type DeliveryLegKind,
   getAgentRunSheet,
+  getAgentRunSheetDates,
   type LogisticsAssignment,
   setLegDone,
   setLogisticsAssignments,
@@ -376,6 +377,61 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
         [attendeeId],
       );
       expect(rows.map((row) => row.start_done)).toEqual([1, 1]);
+    });
+  });
+
+  describe("getAgentRunSheetDates", () => {
+    test("returns [] for no agent ids without hitting the database", async () => {
+      const { entries, dates } = await runWithQueryLogContext(async () => {
+        enableQueryLog();
+        const dates = await getAgentRunSheetDates([]);
+        return { dates, entries: getQueryLog() };
+      });
+      expect(dates).toEqual([]);
+      expect(entries).toHaveLength(0);
+    });
+
+    test("returns the drop-off and collection dates, sorted and deduped", async () => {
+      // Drop-off D1, collection on D2 (end_at = D3, exclusive → last booked day).
+      await makeBooking({
+        endAgentId: van,
+        endDate: D3,
+        startAgentId: van,
+        startDate: D1,
+      });
+      // A second booking dropped off the same day the first is collected, so D2
+      // is offered by both — it must appear only once.
+      await makeBooking({
+        endAgentId: van,
+        endDate: D4,
+        startAgentId: van,
+        startDate: D2,
+      });
+      expect(await getAgentRunSheetDates([van])).toEqual([D1, D2, D3]);
+    });
+
+    test("excludes dates for agents outside the set", async () => {
+      await makeBooking({
+        endAgentId: other,
+        endDate: D2,
+        startAgentId: other,
+        startDate: D1,
+      });
+      expect(await getAgentRunSheetDates([van])).toEqual([]);
+    });
+
+    test("ignores no-quantity sentinel lines", async () => {
+      const { attendeeId, listingId } = await makeBooking({
+        endAgentId: van,
+        endDate: D2,
+        startAgentId: van,
+        startDate: D1,
+      });
+      await getDb().execute({
+        args: [attendeeId, listingId],
+        sql: "UPDATE listing_attendees SET quantity = 0 WHERE attendee_id = ? AND listing_id = ?",
+      });
+      expect(await getAgentRunSheetDates([van])).toEqual([]);
     });
   });
 

--- a/test/lib/server-agent-deliveries.test.ts
+++ b/test/lib/server-agent-deliveries.test.ts
@@ -2,11 +2,13 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { signCsrfToken } from "#shared/csrf.ts";
-import { addDays } from "#shared/dates.ts";
+import { addDays, formatDateLabel } from "#shared/dates.ts";
 import { getDb } from "#shared/db/client.ts";
 import { setLogisticsAssignments } from "#shared/db/logistics.ts";
 import { logisticsAgentsTable } from "#shared/db/logistics-agents.ts";
 import { settings } from "#shared/db/settings.ts";
+import { userAgents } from "#shared/db/user-agents.ts";
+import { getUserByUsername } from "#shared/db/users.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import {
   awaitTestRequest,
@@ -19,18 +21,38 @@ import {
   mockRequest,
   testCookie,
 } from "#test-utils";
+import { TEST_ADMIN_USERNAME } from "#test-utils/internal.ts";
+
+/** Assign logistics agents (vans) to the owner test user, so the staff run
+ * sheet — scoped to the viewer's own agents — has deliveries to show. */
+const assignOwnerAgents = async (agentIds: number[]): Promise<void> => {
+  const owner = (await getUserByUsername(TEST_ADMIN_USERNAME))!;
+  await userAgents.setIds(owner.id, agentIds);
+};
+
+/** Fetch the owner run sheet for a specific date (the `?date=` picker link). */
+const fetchDeliveriesForDate = async (date: string): Promise<string> => {
+  const response = await handleRequest(
+    mockRequest(`/admin/deliveries?date=${date}`, {
+      headers: { cookie: await testCookie() },
+    }),
+  );
+  expect(response.status).toBe(200);
+  return response.text();
+};
 
 /** Create a logistics agent and return its id. */
 const makeVan = async (name: string): Promise<number> =>
   (await logisticsAgentsTable.insert({ name })).id;
 
-/** Create a booking dropped off today with the given drop-off/collection
- * agents. `durationDays` is the hire length in whole days: `end_at` is the
- * exclusive end (start + duration), so a 1-day hire is collected the same day
- * and a 2-day hire the next day. */
-const makeTodayBooking = async (
+/** Create a booking dropped off on `startDate` with the given drop-off/
+ * collection agents. `durationDays` is the hire length in whole days: `end_at`
+ * is the exclusive end (start + duration), so a 1-day hire is collected the
+ * same day and a 2-day hire the next day. Defaults to today's drop-off. */
+const makeBookingOn = async (
   startAgent: number,
   endAgent: number,
+  startDate: string,
   durationDays = 1,
   name = "Bouncy Castle",
 ): Promise<{ attendeeId: number; listingId: number; listingName: string }> => {
@@ -61,11 +83,10 @@ const makeTodayBooking = async (
       ],
     ]),
   );
-  const today = todayInTz(settings.timezone);
-  const endDate = addDays(today, durationDays);
+  const endDate = addDays(startDate, durationDays);
   await getDb().execute({
     args: [
-      `${today}T00:00:00Z`,
+      `${startDate}T00:00:00Z`,
       `${endDate}T00:00:00Z`,
       attendee.id,
       listing.id,
@@ -78,6 +99,21 @@ const makeTodayBooking = async (
     listingName: name,
   };
 };
+
+/** Create a booking dropped off today (the common case for agent run sheets). */
+const makeTodayBooking = (
+  startAgent: number,
+  endAgent: number,
+  durationDays = 1,
+  name = "Bouncy Castle",
+): Promise<{ attendeeId: number; listingId: number; listingName: string }> =>
+  makeBookingOn(
+    startAgent,
+    endAgent,
+    todayInTz(settings.timezone),
+    durationDays,
+    name,
+  );
 
 const markRequest = async (
   cookie: string,
@@ -338,6 +374,57 @@ describeWithEnv("server (agent deliveries)", { db: true }, () => {
   test("staff with no assigned agents see the no-agents prompt", async () => {
     const html = await fetchDeliveriesHtml();
     expect(html).toContain("no logistics agents assigned");
+  });
+
+  test("staff can open a future date and see that day's deliveries", async () => {
+    const van = await makeVan("Van 1");
+    await assignOwnerAgents([van]);
+    const today = todayInTz(settings.timezone);
+    const future = addDays(today, 10);
+    await makeBookingOn(van, van, future, 1, "Future Castle");
+
+    const html = await fetchDeliveriesForDate(future);
+    // The picked day's booking is shown, headed by its full date label (it is
+    // neither today nor tomorrow).
+    expect(html).toContain("Future Castle");
+    expect(html).toContain(formatDateLabel(future));
+  });
+
+  test("staff run sheet offers a date picker linking to their delivery dates", async () => {
+    const van = await makeVan("Van 1");
+    await assignOwnerAgents([van]);
+    const future = addDays(todayInTz(settings.timezone), 10);
+    await makeBookingOn(van, van, future, 1, "Future Castle");
+
+    const html = await fetchDeliveriesHtml();
+    // The shared calendar picker renders, with the future delivery date as a
+    // selectable link back into the run sheet.
+    expect(html).toContain("date-picker");
+    expect(html).toContain(`/admin/deliveries?date=${future}`);
+  });
+
+  test("an agent cannot steer the date — the ?date= param is ignored", async () => {
+    const van = await makeVan("Van 1");
+    const { cookie } = await createTestAgentSession({
+      agentIds: [van],
+      token: "a15",
+      username: "agent15",
+    });
+    const today = todayInTz(settings.timezone);
+    const future = addDays(today, 10);
+    await makeBookingOn(van, van, today, 1, "Today Castle");
+    await makeBookingOn(van, van, future, 1, "Future Castle");
+
+    const response = await awaitTestRequest(
+      `/admin/deliveries?date=${future}`,
+      { cookie },
+    );
+    const html = await response.text();
+    // The agent stays pinned to today and tomorrow: today's booking shows, the
+    // future one the param asked for does not, and no date picker is offered.
+    expect(html).toContain("Today Castle");
+    expect(html).not.toContain("Future Castle");
+    expect(html).not.toContain("date-picker");
   });
 
   test("logging in as an agent lands on the run sheet", async () => {

--- a/test/ui/templates/admin/deliveries.test.ts
+++ b/test/ui/templates/admin/deliveries.test.ts
@@ -4,6 +4,7 @@ import { signCsrfToken } from "#shared/csrf.ts";
 import type { AdminSession } from "#shared/types.ts";
 import {
   agentDeliveriesPage,
+  type DeliveriesDateNav,
   type DeliveryBookingView,
   type DeliveryDayGroup,
   type DeliveryLegView,
@@ -12,6 +13,20 @@ import { setupTestEncryptionKey } from "#test-utils";
 
 /** Agent-class session so the page renders the agent header (no staff nav). */
 const agentSession: AdminSession = { adminLevel: "agent" };
+
+/** Staff session so the page renders the calendar date picker. */
+const managerSession: AdminSession = { adminLevel: "manager" };
+
+/** A date picker offering one selectable delivery date. */
+const dateNav = (over: Partial<DeliveriesDateNav> = {}): DeliveriesDateNav => ({
+  availableDates: [
+    { label: "Monday 6 July 2026", selectable: true, value: "2026-07-06" },
+  ],
+  selected: null,
+  today: "2026-07-06",
+  viewMonth: null,
+  ...over,
+});
 
 beforeAll(async () => {
   setupTestEncryptionKey();
@@ -41,11 +56,11 @@ const booking = (
 });
 
 describe("agentDeliveriesPage", () => {
-  /** Render the deliveries page for the standard "agent has groups" case:
-   *  `agentDeliveriesPage(groups, "44", { noAgents: false }, agentSession)`.
-   *  Every test in this block that passes groups uses this exact call. */
+  /** Render the deliveries page for the standard "agent has groups" case.
+   *  Agents get no date picker, so `dateNav` is null. Every test in this block
+   *  that passes groups uses this exact call. */
   const renderDeliveries = (groups: DeliveryDayGroup[]): string =>
-    agentDeliveriesPage(groups, "44", { noAgents: false }, agentSession);
+    agentDeliveriesPage(groups, "44", { noAgents: false }, agentSession, null);
 
   test("shows a prompt when no agents are assigned", () => {
     const html = agentDeliveriesPage(
@@ -53,6 +68,7 @@ describe("agentDeliveriesPage", () => {
       "44",
       { noAgents: true },
       agentSession,
+      null,
     );
     expect(html).toContain("no logistics agents assigned");
     expect(html).toContain("/admin/logout");
@@ -149,6 +165,7 @@ describe("agentDeliveriesPage", () => {
       "44",
       { error: "Something went wrong", noAgents: true },
       agentSession,
+      null,
     );
     expect(html).toContain("Something went wrong");
   });
@@ -159,7 +176,56 @@ describe("agentDeliveriesPage", () => {
       "44",
       { noAgents: true, success: "Marked done" },
       agentSession,
+      null,
     );
     expect(html).toContain("Marked done");
+  });
+
+  test("agents never see the date picker even if one is somehow passed", () => {
+    const html = agentDeliveriesPage(
+      [
+        { bookings: [], heading: "Today" },
+        { bookings: [], heading: "Tomorrow" },
+      ],
+      "44",
+      { noAgents: false },
+      agentSession,
+      dateNav(),
+    );
+    expect(html).not.toContain("date-picker");
+  });
+
+  test("staff get the calendar date picker linking each date to the run sheet", () => {
+    const html = agentDeliveriesPage(
+      [
+        { bookings: [], heading: "Today" },
+        { bookings: [], heading: "Tomorrow" },
+      ],
+      "44",
+      { noAgents: false },
+      managerSession,
+      dateNav(),
+    );
+    // The shared calendar component renders, wired to reopen the run sheet.
+    expect(html).toContain("date-picker");
+    expect(html).toContain('href="/admin/deliveries?date=2026-07-06"');
+    // Month paging keeps the deliveries route (not the calendar page).
+    expect(html).toContain("/admin/deliveries?cal=");
+  });
+
+  test("staff picker keeps the opened date while paging months", () => {
+    const html = agentDeliveriesPage(
+      [
+        { bookings: [], heading: "Sunday 12 July 2026" },
+        { bookings: [], heading: "Monday 13 July 2026" },
+      ],
+      "44",
+      { noAgents: false },
+      managerSession,
+      dateNav({ selected: "2026-07-12" }),
+    );
+    // Paging months carries the selected date so it stays highlighted (the
+    // ampersand is HTML-escaped in the rendered href).
+    expect(html).toContain("/admin/deliveries?date=2026-07-12&amp;cal=");
   });
 });


### PR DESCRIPTION
## What changed

The deliveries run sheet used to show only **today and tomorrow** for everyone. That's the right view for a delivery agent, who works a fixed two-day round — but owners and managers often need to look further ahead, to check next week's drop-offs or a future date's collections.

Now **staff (owners and managers) get a calendar date picker** on the run sheet — the same one already used on the calendar page. Picking a date opens the run sheet for that date **and the day after it**. Every date a staff member's agents have a delivery on is a selectable link, and staff can page through months just like on the calendar.

Day headings stay friendly: they read "Today" and "Tomorrow" when they line up with the real calendar, and show the full date (e.g. "Monday 6 July 2026") otherwise, so it's always clear which day each section is.

**Delivery agents are unchanged.** They still only ever see today and tomorrow and never get the picker — a hand-crafted `?date=` link is ignored for them, so a driver can't be nudged off their round.

## How it works

- New `getAgentRunSheetDates` query returns the distinct drop-off and collection dates a set of agents have, feeding the picker's selectable dates.
- The run-sheet route reads the `?date=` / `?cal=` params (staff only), shows that date plus the next day, and builds the picker.
- The deliveries template renders the shared `DatePicker` for staff, wired back to `/admin/deliveries`.

## Tests

- Unit tests for `getAgentRunSheetDates` (dates, dedup/sort, agent scoping, no-quantity lines, empty input issues no query).
- Template tests: staff see the picker with links back to the run sheet; agents never do.
- End-to-end tests: a staff member can open a future date and see that day's deliveries under its date heading; the picker links to delivery dates; an agent's `?date=` param is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpoXy9kt7GbgBX7DL6T5gZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpoXy9kt7GbgBX7DL6T5gZ)_