### PR TITLE
Share the listing-activity-log assertions and CSV-export test helper

### DIFF
--- a/test/e2e/duration-days/admin-pages.test.ts
+++ b/test/e2e/duration-days/admin-pages.test.ts
@@ -8,7 +8,8 @@ import {
   createDailyTestListing,
   describeWithEnv,
   expectFlashRedirect,
-  getListingActivityLog,
+  expectListingActivityLogContains,
+  expectListingActivityLogLacks,
   rawListingRange,
   setupListingAndLogin,
   updateTestListing,
@@ -119,16 +120,6 @@ describeWithEnv("e2e: multi-day bookings — admin pages", { db: true }, () => {
       thank_you_url: "https://example.com",
     });
 
-    /** Assert the listing's activity log records no duration-change reconciliation. */
-    const expectNoDurationChangeLogged = async (listingId: number) => {
-      const messages = (await getListingActivityLog(listingId)).map(
-        (l: { message: string }) => l.message,
-      );
-      expect(messages.some((m: string) => m.includes("duration changed"))).toBe(
-        false,
-      );
-    };
-
     test("changing duration via form updates listing and reconciles bookings", async () => {
       const listing = await createDailyTestListing({
         maxAttendees: 10,
@@ -165,13 +156,12 @@ describeWithEnv("e2e: multi-day bookings — admin pages", { db: true }, () => {
         "Listing updated Warning: group capacity exceeded on 2026-10-02",
       )(response);
 
-      const messages = (await getListingActivityLog(listingA.id)).map(
-        (l: { message: string }) => l.message,
-      );
-      expect(messages).toContain(
+      await expectListingActivityLogContains(
+        listingA.id,
         `Listing '${listingA.name}' duration changed to 2 day(s)`,
       );
-      expect(messages).toContain(
+      await expectListingActivityLogContains(
+        listingA.id,
         "Duration change caused group capacity overflow on 2026-10-02",
       );
     });
@@ -196,7 +186,7 @@ describeWithEnv("e2e: multi-day bookings — admin pages", { db: true }, () => {
 
       const after = await rawListingRange(listing.id);
       expect(after!.end_at).toBe(before!.end_at);
-      await expectNoDurationChangeLogged(listing.id);
+      await expectListingActivityLogLacks(listing.id, "duration changed");
     });
 
     test("editing a customisable listing's max duration leaves existing booking ranges untouched", async () => {
@@ -219,7 +209,7 @@ describeWithEnv("e2e: multi-day bookings — admin pages", { db: true }, () => {
       // customisable bookings are never rewritten from the listing duration.
       const after = await rawListingRange(listing.id);
       expect(after!.end_at).toBe(before!.end_at);
-      await expectNoDurationChangeLogged(listing.id);
+      await expectListingActivityLogLacks(listing.id, "duration changed");
     });
 
     test("changing duration on a standard listing does not reconcile or log a duration change", async () => {
@@ -244,7 +234,7 @@ describeWithEnv("e2e: multi-day bookings — admin pages", { db: true }, () => {
       // The value persists (inert until the listing becomes daily)…
       expect((await getListing(listing.id))?.duration_days).toBe(7);
       // …but no reconciliation activity is logged for a standard listing.
-      await expectNoDurationChangeLogged(listing.id);
+      await expectListingActivityLogLacks(listing.id, "duration changed");
     });
   });
 });

--- a/test/lib/server-listings/audit-log-and-daily-view.test.ts
+++ b/test/lib/server-listings/audit-log-and-daily-view.test.ts
@@ -11,6 +11,7 @@ import {
   createTestListing,
   describeWithEnv,
   expectHtmlResponse,
+  fetchListingExportCsv,
   getListingActivityLog,
   setupListingAndLogin,
   submitTicketForm,
@@ -262,11 +263,7 @@ describeWithEnv(
           "csv@test.com",
         );
 
-        const response = await awaitTestRequest(
-          `/admin/listing/${listing.id}/export`,
-          { cookie },
-        );
-        const csv = await response.text();
+        const csv = await fetchListingExportCsv(listing.id, cookie);
         expect(csv.startsWith("Name,Email")).toBe(true);
       });
 

--- a/test/lib/server-listings/export.test.ts
+++ b/test/lib/server-listings/export.test.ts
@@ -15,6 +15,7 @@ import {
   createTestListing,
   describeWithEnv,
   expectCsvDownloadHeaders,
+  fetchListingExportCsv,
   setupListingAndLogin,
   testRequiresAuth,
 } from "#test-utils";
@@ -67,13 +68,7 @@ describeWithEnv("server listings > export", { db: true }, () => {
         "jane@example.com",
       );
 
-      const response = await awaitTestRequest(
-        `/admin/listing/${listing.id}/export`,
-        {
-          cookie: cookie,
-        },
-      );
-      const csv = await response.text();
+      const csv = await fetchListingExportCsv(listing.id, cookie);
       expect(csv).toContain(
         "Name,Email,Phone,Address,Special Instructions,Quantity,Registered",
       );
@@ -101,13 +96,7 @@ describeWithEnv("server listings > export", { db: true }, () => {
         {},
       );
 
-      const response = await awaitTestRequest(
-        `/admin/listing/${listing.id}/export`,
-        {
-          cookie: cookie,
-        },
-      );
-      const csv = await response.text();
+      const csv = await fetchListingExportCsv(listing.id, cookie);
       expect(csv).toContain(",Checked In");
       // John Doe is checked in
       expect(csv).toContain("John Doe");
@@ -161,11 +150,7 @@ describeWithEnv("server listings > export", { db: true }, () => {
       await setListingQuestions(listing.id, [q.id]);
       await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
-      const response = await awaitTestRequest(
-        `/admin/listing/${listing.id}/export`,
-        { cookie },
-      );
-      const csv = await response.text();
+      const csv = await fetchListingExportCsv(listing.id, cookie);
       expect(csv).toContain("Shirt Size");
       expect(csv).toContain("Small");
     });

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -41,6 +41,31 @@ export const expectActivityLogShows = async (
   expect(body).toContain(verb);
 };
 
+const listingActivityLogHasMessage = async (
+  listingId: number,
+  substring: string,
+): Promise<boolean> => {
+  const { getListingActivityLog } = await import("#test-utils/activity-log.ts");
+  const entries = await getListingActivityLog(listingId);
+  return entries.some((entry) => entry.message.includes(substring));
+};
+
+/** Assert the listing's activity log has an entry whose message includes `substring`. */
+export const expectListingActivityLogContains = async (
+  listingId: number,
+  substring: string,
+): Promise<void> => {
+  expect(await listingActivityLogHasMessage(listingId, substring)).toBe(true);
+};
+
+/** Assert the listing's activity log has no entry whose message includes `substring`. */
+export const expectListingActivityLogLacks = async (
+  listingId: number,
+  substring: string,
+): Promise<void> => {
+  expect(await listingActivityLogHasMessage(listingId, substring)).toBe(false);
+};
+
 export const expectTestAttendeeCsvColumns = (
   row: string | undefined,
   quantity = 1,


### PR DESCRIPTION
## What changed

A small follow-up to the recent test-file splits. While splitting those files we extracted a few local helpers; two of them turned out to be things many tests want, so this promotes them into the shared test helpers and points existing hand-rolled copies at them.

### New: listing activity-log assertions

Added two helpers to the shared test assertions:

- `expectListingActivityLogContains(listingId, substring)`
- `expectListingActivityLogLacks(listingId, substring)`

They check whether a listing's activity log has (or doesn't have) an entry whose message contains a given piece of text. The duration-days tests had a private `expectNoDurationChangeLogged` doing exactly this by hand — it now calls the shared `Lacks` helper, and the group-overflow test's hand-written log checks use the `Contains` helper.

This fills a real gap: eleven test files read a listing's activity log, and the only shared helper before this (`wasActivityLogged`) does an exact, whole-log match rather than a per-listing substring one.

### Reused: the CSV-export fetch helper

`fetchListingExportCsv` (added during the duration-days split) now also backs the plain "fetch the export, read the CSV" spots in the listings export and audit-log tests, replacing the repeated fetch-then-read boilerplate. As a side benefit those spots now assert the export returns 200 before checking its contents, which they previously skipped.

Sites that check the export's headers or use a different auth path were deliberately left alone — the helper only fits the "fetch as this admin, read the CSV body" case.

## Why

These two patterns showed up repeatedly across the test suite. Having one shared, well-named helper each means future tests reuse them instead of re-rolling the same few lines (and, in the export case, remembering to assert the 200).

## Safety

No behaviour change beyond the added export 200 assertions. The linter and duplication checker stay clean, and the affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbPWPvXUWG3odFewSkmRa9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbPWPvXUWG3odFewSkmRa9)_