### PR TITLE
Roll back partial bookings in the bookTestAttendee test helper

### DIFF
--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -944,6 +944,17 @@ describe("test-utils", () => {
       // attendee is left occupying capacity or skewing later assertions.
       const { getAttendeesRaw } = await import("#shared/db/attendees.ts");
       expect((await getAttendeesRaw(open.id)).length).toBe(0);
+
+      // Regression: the rollback must also reverse the contact-activity count
+      // that the greedy create recorded — under the same source — or the
+      // contact keeps a booking that no longer exists.
+      const { getContactCountFields, hashEmail } = await import(
+        "#shared/db/contact-preferences.ts"
+      );
+      const counts = await getContactCountFields(
+        await hashEmail("partial@test.com"),
+      );
+      expect(counts.publicBookingCount).toBe(0);
     });
   });
 

--- a/test/lib/test-utils.test.ts
+++ b/test/lib/test-utils.test.ts
@@ -931,13 +931,19 @@ describe("test-utils", () => {
       expect(attendee.id).toBeGreaterThan(0);
     });
 
-    test("fails loudly when a listing can't take the booking", async () => {
+    test("rolls back the partial booking and fails loudly when a listing can't take it", async () => {
       const open = await createTestListing({ maxAttendees: 10 });
       const full = await createTestListing({ maxAttendees: 1, name: "Full" });
       await bookTestAttendee([full.id], "Filler"); // uses the only spot
+
       await expect(
         bookTestAttendee([open.id, full.id], "Partial"),
-      ).rejects.toThrow("a listing was full or blocked");
+      ).rejects.toThrow("Failed to book test attendee onto all 2 listing(s)");
+
+      // The booking that DID land on `open` is rolled back, so no stray
+      // attendee is left occupying capacity or skewing later assertions.
+      const { getAttendeesRaw } = await import("#shared/db/attendees.ts");
+      expect((await getAttendeesRaw(open.id)).length).toBe(0);
     });
   });
 

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -4,6 +4,7 @@ import { signCsrfToken } from "#shared/csrf.ts";
 import {
   createAttendeeAtomic,
   decryptAttendees,
+  ensureAllBookings,
   getAttendeesRaw,
 } from "#shared/db/attendees.ts";
 import type { ListingInput } from "#shared/db/listings.ts";
@@ -27,15 +28,17 @@ export const bookTestAttendee = async (
     name,
   });
   if (!result.success) {
-    throw new Error(`Failed to create attendee: ${result.reason}`);
+    throw new Error(`Failed to create test attendee: ${result.reason}`);
   }
-  // createAttendeeAtomic is greedy on the plain path: it reports success once
-  // any booking lands, so a full/blocked listing would silently yield an
-  // attendee booked onto fewer listings than asked for. Fail loudly instead —
-  // there's one result entry per booked listing.
-  if (result.attendees.length !== listingIds.length) {
+  // createAttendeeAtomic is greedy: it reports success once any booking lands,
+  // so a full/blocked listing would silently leave the attendee booked onto
+  // fewer listings than asked for. Reuse production's "no half-saved attendee"
+  // rule, which rolls the partial attendee back and reports failure, then fail
+  // the setup loudly rather than leaving stray bookings to skew the test.
+  const check = await ensureAllBookings(result, listingIds.length, "admin");
+  if (!check.ok) {
     throw new Error(
-      `Expected ${listingIds.length} booking(s) but only ${result.attendees.length} landed — a listing was full or blocked`,
+      `Failed to book test attendee onto all ${listingIds.length} listing(s): ${check.reason}`,
     );
   }
   return result.attendees[0]!;

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -22,20 +22,25 @@ export const bookTestAttendee = async (
   name = "Alice",
   email?: string,
 ): Promise<Attendee> => {
+  // Record the booking (and, on rollback, reverse its contact-activity count)
+  // under one source so the greedy create and the cleanup can't drift.
+  const source = "public";
   const result = await createAttendeeAtomic({
     bookings: listingIds.map((listingId) => ({ listingId })),
     email: email ?? `${name.toLowerCase()}@test.com`,
     name,
+    source,
   });
   if (!result.success) {
-    throw new Error(`Failed to create test attendee: ${result.reason}`);
+    throw new Error(`Failed to create attendee: ${result.reason}`);
   }
   // createAttendeeAtomic is greedy: it reports success once any booking lands,
   // so a full/blocked listing would silently leave the attendee booked onto
   // fewer listings than asked for. Reuse production's "no half-saved attendee"
-  // rule, which rolls the partial attendee back and reports failure, then fail
-  // the setup loudly rather than leaving stray bookings to skew the test.
-  const check = await ensureAllBookings(result, listingIds.length, "admin");
+  // rule, which rolls the partial attendee back (reversing the same source's
+  // booking count) and reports failure, then fail the setup loudly rather than
+  // leaving stray bookings to skew the test.
+  const check = await ensureAllBookings(result, listingIds.length, source);
   if (!check.ok) {
     throw new Error(
       `Failed to book test attendee onto all ${listingIds.length} listing(s): ${check.reason}`,


### PR DESCRIPTION
## What this changes

A follow-up to #1625. A Codex review there pointed out that the `bookTestAttendee` test helper's partial-booking guard only *threw* — it never removed the attendee that `createAttendeeAtomic` had already inserted.

`createAttendeeAtomic` is greedy: it reports success as soon as one booking lands. So if you ask it to book onto two listings and one is full, it books the open one, reports success, and returns. The old guard noticed the shortfall and threw — but the attendee (and its booking on the open listing) stayed in the database. A test that catches that rejection and carries on could then see a stray attendee occupying capacity or skewing later counts.

The fix reuses the production helper `ensureAllBookings`, which already rolls the partial attendee back and reports failure — "the no half-saved attendee rule lives in one place" — so the test helper now cleans up before failing loudly.

## Verification

- The covering test now also asserts the rollback: after a deliberately-failed multi-listing booking, the open listing has **no** leftover attendee.
- `deno task typecheck`, `deno task lint:ci`, and `deno task cpd` (0% duplication, both configs) pass.
- `test/lib/test-utils.test.ts` runs green (205 tests).

Test-only change — no product source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MeqQm2dPU3Zja5azPyHAx

---
_Generated by [Claude Code](https://claude.ai/code/session_019MeqQm2dPU3Zja5azPyHAx)_