### PR TITLE
Tidy up the deliveries date picker wiring

### DIFF
--- a/src/features/admin/deliveries.ts
+++ b/src/features/admin/deliveries.ts
@@ -14,9 +14,8 @@
 import { unique } from "#fp";
 import { t } from "#i18n";
 import { getDateFilter, getMonthFilter } from "#routes/admin/actions.ts";
-import { DELIVERY_FORM, requireDeliveryOr, withAuth } from "#routes/auth.ts";
-import { applyFlash } from "#routes/csrf.ts";
-import { errorRedirect, htmlResponse, redirect } from "#routes/response.ts";
+import { DELIVERY_FORM, deliveryPage, withAuth } from "#routes/auth.ts";
+import { errorRedirect, redirect } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { addDays, formatDateLabel } from "#shared/dates.ts";
 import { decryptAttendees, getAttendeesByIds } from "#shared/db/attendees.ts";
@@ -177,49 +176,43 @@ const buildDateNav = async (
  * their only page and are pinned to today and tomorrow; staff (owner/manager)
  * reach it from the Calendar submenu and may open any date via the calendar
  * picker, seeing that date and the day after it. */
-const handleDeliveriesGet = (request: Request): Promise<Response> =>
-  requireDeliveryOr(request, async (session) => {
-    applyFlash(request);
-    const flash = getFlash();
-    const staff = isStaffRole(session.adminLevel);
-    const agentIds = await userAgents.getIds(session.userId);
-    if (agentIds.length === 0) {
-      return htmlResponse(
-        agentDeliveriesPage(
-          [],
-          settings.phonePrefix,
-          { error: flash.error, noAgents: true, success: flash.success },
-          session,
-          null,
-        ),
-      );
-    }
-
-    const today = todayInTz(settings.timezone);
-    // Only staff may open a different date; an agent's date/month params are
-    // ignored so a driver always sees just today and tomorrow.
-    const selected = staff ? getDateFilter(request) : null;
-    const viewMonth = staff ? getMonthFilter(request) : null;
-    const baseDate = selected ?? today;
-    const tomorrow = addDays(baseDate, 1);
-    const legs = await getAgentRunSheet(agentIds, [baseDate, tomorrow]);
-
-    const privateKey = await requireRequestPrivateKey();
-    const lookups = await loadLegLookups(legs, privateKey);
-    const groups = buildGroups(legs, baseDate, tomorrow, today, lookups);
-    const dateNav = staff
-      ? await buildDateNav(agentIds, today, selected, viewMonth)
-      : null;
-    return htmlResponse(
-      agentDeliveriesPage(
-        groups,
-        settings.phonePrefix,
-        { error: flash.error, noAgents: false, success: flash.success },
-        session,
-        dateNav,
-      ),
+const handleDeliveriesGet = deliveryPage(async (session, request) => {
+  const flash = getFlash();
+  const staff = isStaffRole(session.adminLevel);
+  const agentIds = await userAgents.getIds(session.userId);
+  if (agentIds.length === 0) {
+    return agentDeliveriesPage(
+      [],
+      settings.phonePrefix,
+      { error: flash.error, noAgents: true, success: flash.success },
+      session,
+      null,
     );
-  });
+  }
+
+  const today = todayInTz(settings.timezone);
+  // Only staff may open a different date; an agent's date/month params are
+  // ignored so a driver always sees just today and tomorrow.
+  const selected = staff ? getDateFilter(request) : null;
+  const viewMonth = staff ? getMonthFilter(request) : null;
+  const baseDate = selected ?? today;
+  const tomorrow = addDays(baseDate, 1);
+  const legs = await getAgentRunSheet(agentIds, [baseDate, tomorrow]);
+
+  const privateKey = await requireRequestPrivateKey();
+  const lookups = await loadLegLookups(legs, privateKey);
+  const groups = buildGroups(legs, baseDate, tomorrow, today, lookups);
+  const dateNav = staff
+    ? await buildDateNav(agentIds, today, selected, viewMonth)
+    : null;
+  return agentDeliveriesPage(
+    groups,
+    settings.phonePrefix,
+    { error: flash.error, noAgents: false, success: flash.success },
+    session,
+    dateNav,
+  );
+});
 
 /** Handle POST /admin/deliveries/mark — toggle a leg done, scoped to the
  * agent's own logistics agents. */

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -410,17 +410,20 @@ export type SessionGuard<TSession> = (
   handler: (session: TSession) => Response | Promise<Response>,
 ) => Promise<Response>;
 
-/** Factory for creating authenticated page handlers */
+/** Factory for creating authenticated page handlers. The render callback is
+ * given the request too, for pages that read query params (e.g. the deliveries
+ * run sheet's date picker); callers that only need the session simply ignore
+ * it. */
 export const authPage =
   <TSession>(requireSession: SessionGuard<TSession>) =>
   (
-    render: (session: TSession) => string | Promise<string>,
+    render: (session: TSession, request: Request) => string | Promise<string>,
   ): ((request: Request) => Promise<Response>) =>
   (request) =>
     requireSession(request, async (session) => {
       const { applyFlash } = await import("#routes/csrf.ts");
       applyFlash(request);
-      return htmlResponse(await render(session));
+      return htmlResponse(await render(session, request));
     });
 
 /** Owner-only GET page: authenticate, apply flash, render HTML */

--- a/src/ui/templates/admin/deliveries.tsx
+++ b/src/ui/templates/admin/deliveries.tsx
@@ -14,7 +14,6 @@
 import { t } from "#i18n";
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
-import { isStaffRole } from "#shared/types.ts";
 import { flashProps } from "#templates/admin/admin-page.tsx";
 import { markAdminFooter } from "#templates/admin/footer.tsx";
 import { AdminNav } from "#templates/admin/nav.tsx";
@@ -217,10 +216,9 @@ export const agentDeliveriesPage = (
         </>
       )}
       <Flash {...flashProps(opts.error, opts.success)} />
-      {/* Only staff steer the date; the picker is absent for agents. */}
-      {isStaffRole(session.adminLevel) && dateNav && (
-        <DeliveriesDatePicker nav={dateNav} />
-      )}
+      {/* The route supplies a picker only for staff; agents get null and so
+          stay pinned to today and tomorrow. */}
+      {dateNav && <DeliveriesDatePicker nav={dateNav} />}
       {opts.noAgents ? (
         <p>
           <em>{t("deliveries.no_agents")}</em>

--- a/test/ui/templates/admin/deliveries.test.ts
+++ b/test/ui/templates/admin/deliveries.test.ts
@@ -181,7 +181,9 @@ describe("agentDeliveriesPage", () => {
     expect(html).toContain("Marked done");
   });
 
-  test("agents never see the date picker even if one is somehow passed", () => {
+  test("no date picker renders when none is supplied (the agent's case)", () => {
+    // The route passes null for agents, so a driver stays pinned to today and
+    // tomorrow with no picker.
     const html = agentDeliveriesPage(
       [
         { bookings: [], heading: "Today" },
@@ -190,7 +192,7 @@ describe("agentDeliveriesPage", () => {
       "44",
       { noAgents: false },
       agentSession,
-      dateNav(),
+      null,
     );
     expect(html).not.toContain("date-picker");
   });


### PR DESCRIPTION
A small quality follow-up to #1627 (staff can open any date on the deliveries run sheet). No behaviour change — just simpler internals.

## What changed

**1. Reuse the shared authed-page helper instead of re-implementing it.**
The run sheet needed the request object to read the `?date=`/`?cal=` picker params. The first version got at it by hand-rolling the auth + flash + response plumbing that `authPage` already provides. Now `authPage` simply passes the request to its render callback (every other page ignores the extra argument), so the run sheet uses the one shared helper and returns a plain page string like all the other admin pages.

**2. Gate the date picker on the picker data alone.**
The template used to double-check the staff role before showing the picker. That was redundant: the route is the single place that decides who gets a picker (staff get one, delivery agents get none), so the template now just renders whatever it's handed. One rule, one place.

## Tests

The existing deliveries tests still cover the behaviour: staff see the picker wired back to the run sheet, agents get none and stay pinned to today and tomorrow. The template test now asserts the real contract (no picker when none is supplied) rather than an arrangement the route can't produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpoXy9kt7GbgBX7DL6T5gZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpoXy9kt7GbgBX7DL6T5gZ)_