### PR TITLE
Move the migrations DB test to its mirror path

### DIFF
--- a/test/shared/db/migrations.test.ts
+++ b/test/shared/db/migrations.test.ts
@@ -20,6 +20,10 @@ import {
   SCHEMA_HASH,
 } from "#shared/db/migrations.ts";
 import {
+  markCurrentSchemaMigrationPending,
+  markMigrationsForRerun,
+} from "#test/lib/db/migration-test-helpers.ts";
+import {
   assertSchemaEmpty,
   describeWithEnv,
   invalidateTestDbCache,
@@ -28,10 +32,6 @@ import {
   stubNtfyFetch,
   tableExists,
 } from "#test-utils";
-import {
-  markCurrentSchemaMigrationPending,
-  markMigrationsForRerun,
-} from "./migration-test-helpers.ts";
 
 describeWithEnv("db > migrations", { db: true }, () => {
   describe("initDb version check", () => {


### PR DESCRIPTION
## What this changes

The unit-test coverage report listed `src/shared/db/migrations.ts` (712 lines) as untested — its unit test lived at `test/lib/db/migrations.test.ts`, which isn't the mirror path the report looks for.

This moves it to `test/shared/db/migrations.test.ts`. Its one folder-relative import — the shared `migration-test-helpers.ts`, which stays put under `test/lib/db/` alongside the per-migration tests that also use it — is repointed from `./migration-test-helpers.ts` to the location-independent `#test/...` alias.

No test content and no source changed.

## Verification

- `deno task typecheck` — passes.
- `deno task lint:ci` — passes.
- `deno task cpd` (0% duplication, both source and test) — passes.
- The moved test runs green: 27 tests.
- The report now credits `migrations.ts` as mirror-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MeqQm2dPU3Zja5azPyHAx

---
_Generated by [Claude Code](https://claude.ai/code/session_019MeqQm2dPU3Zja5azPyHAx)_