### PR TITLE
Give every admin form section a proper legend heading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,16 @@ mechanisms to copy:
   `FormValuesFor<>` value types; `createFormRoute`/`createAuthedFormRoute`
   (`src/shared/app-forms.ts`) wire that same schema to both the GET (render)
   and POST (validate) handlers.
+- **Form section headers are a `FormSection[]`, never a hand-rolled heading.**
+  A form's grouped sections are modelled as data — a `FormSection[]` (`legend`
+  + `children`) rendered by `FormSections`
+  (`src/ui/templates/components/aggregate-sections.tsx`), which turns each entry
+  into a legend-led `SectionFieldset`. A single section uses `SectionFieldset`
+  directly. Never head a form section with an `<h3>`/`<h4>` — a `<legend>` is
+  the section header, and routing every section through `FormSections`/
+  `SectionFieldset` keeps that so. The listing form (`listings/form-sections.tsx`)
+  and the attendee form (`admin/attendee-form.tsx`) both build a `FormSection[]`;
+  see them for conditional sections (`compact` drops the ones that don't apply).
 - **A data table plus one fold.** `LISTING_DEFAULT_FIELDS` +
   `resolveListingDefaults` (`src/shared/listing-defaults.ts`); the admin
   guide's `GuideSection[]` + `renderGuideSections`.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -150,8 +150,8 @@ test/test-utils/test-browser.ts:249:27  ?? → ||  # button attribute capture fa
 test/test-utils/test-browser.ts:256:49  ?? → ||  # button value fallback is "", so empty value and absent value agree
 test/test-utils/test-browser.ts:351:58  ?? → ||  # RequestInit.method is omitted or a non-empty method string in every caller
 test/test-utils/test-browser.ts:414:28  ?? → ||  # forms[0] is a FormInfo object when present, otherwise undefined
-src/ui/templates/admin/listing-defaults.tsx:90:19  ?? → ||  # UrlControl value: string|undefined; the only falsy-non-null string is "" which equals the "" fallback, so ?? and || coincide
-src/ui/templates/admin/listing-defaults.tsx:119:42  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
+src/ui/templates/admin/listing-defaults.tsx:105:19  ?? → ||  # UrlControl value: string|undefined; the only falsy-non-null string is "" which equals the "" fallback, so ?? and || coincide
+src/ui/templates/admin/listing-defaults.tsx:131:38  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
 src/shared/booking/build-tree.ts:132:48  ?? → ||    # childrenByParentId.get(): readonly TicketListing[]|undefined — an array is always truthy
 src/shared/booking/build-tree.ts:172:62  ?? → ||    # packageQuantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
 src/shared/booking/build-tree.ts:205:38  ?? → ||    # input.root: RootRef-minus-listing|undefined — an object literal is always truthy, so ?? and || coincide

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1776,8 +1776,8 @@ label.terms-agree {
 }
 
 /* Listing form sections: grouped <fieldset>s with a heading legend, and a
-   collapsible <details> for the technical/advanced fields. Field spacing inside
-   each section comes from the nested .stack; the form's gap spaces the sections
+   collapsible <details> for the technical/advanced fields. Each fieldset is a
+   flex column, so it spaces its own fields; the form's gap spaces the sections
    themselves. */
 .listing-section {
   margin: 0;

--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -2070,18 +2070,6 @@ form.listing-form--templated.listing-form--no-daily:not(
   cursor: not-allowed;
 }
 
-/* Customise toggle in listing forms */
-.listing-customise-toggle {
-  display: block;
-  margin-block: var(--space-m);
-}
-
-/* "Use defaults" toggle in listing forms */
-.listing-use-defaults-toggle {
-  display: block;
-  margin-block: var(--space-m);
-}
-
 /* Header image */
 .header-image {
   max-width: 100%;

--- a/src/ui/templates/admin/attendee-form.tsx
+++ b/src/ui/templates/admin/attendee-form.tsx
@@ -16,6 +16,7 @@
  * attendee entity page's Edit tab embeds.
  */
 
+import { compact } from "#fp";
 import { t } from "#i18n";
 import type { BalanceNotice } from "#routes/admin/attendee-form-model.ts";
 import {
@@ -65,6 +66,10 @@ import {
 import { EditQuestions } from "#templates/admin/attendees.tsx";
 import { SaveActions } from "#templates/components/actions.tsx";
 import { AddressFieldWithLookup } from "#templates/components/address-field.tsx";
+import {
+  type FormSection,
+  FormSections,
+} from "#templates/components/aggregate-sections.tsx";
 import { ErrorAlert } from "#templates/components/error.tsx";
 import { ProseHeading } from "#templates/components/prose-heading.tsx";
 import {
@@ -475,14 +480,12 @@ const SharedDateFields = ({
   data,
 }: {
   data: AttendeeFormTemplateData;
-}): JSX.Element | null => {
-  if (!data.hasDailyListings) return null;
+}): JSX.Element => {
   // Shown when there's no saved/known date yet (a bare create form); the PE
   // re-shows it whenever the dates are dirtied so the operator re-saves.
   const noticeHidden = !(data.mode === "create" && !data.parsed.startDate);
   return (
     <>
-      <h3>{t("attendee_form.dates_heading")}</h3>
       <p class="small">{t("attendee_form.dates_hint")}</p>
       {data.dateError && <ErrorAlert>{data.dateError}</ErrorAlert>}
       <label for={START_DATE_FIELD}>
@@ -567,6 +570,113 @@ const formHasError = (data: AttendeeFormTemplateData): boolean =>
  * custom questions, and the listing editor — all inside one CsrfForm. The
  * CsrfForm renders the flash inline when a redirect targeted this form's id.
  */
+/** The attendee's own contact fields — name, status, and the optional email,
+ * phone, address, and special instructions. The form's first section. */
+const ContactDetailFields = ({
+  data,
+}: {
+  data: AttendeeFormTemplateData;
+}): JSX.Element => (
+  <>
+    <label for="name">
+      {t("common.name")}
+      <input
+        autocomplete="off"
+        autofocus={!formHasError(data)}
+        id="name"
+        name="name"
+        required
+        type="text"
+        value={data.parsed.name}
+      />
+    </label>
+
+    <StatusField data={data} />
+
+    <label for="email">
+      {t("common.email")}
+      <input
+        autocomplete="off"
+        id="email"
+        name="email"
+        type="email"
+        value={data.parsed.email || ""}
+      />
+    </label>
+
+    <label for="phone">
+      {t("common.phone")}
+      <input
+        autocomplete="off"
+        id="phone"
+        name="phone"
+        pattern={PHONE_INPUT_PATTERN}
+        title={t("attendee_form.phone_title")}
+        type="text"
+        value={data.parsed.phone || ""}
+      />
+    </label>
+
+    <AddressFieldWithLookup address={data.parsed.address || ""} />
+
+    <label for="special_instructions">
+      {t("common.special_instructions")}
+      <textarea
+        autocomplete="off"
+        id="special_instructions"
+        maxlength={250}
+        name="special_instructions"
+        rows={3}
+      >
+        {data.parsed.special_instructions || ""}
+      </textarea>
+    </label>
+  </>
+);
+
+/** The form's sections in order: contact details, then the custom questions
+ * and shared dates when they apply, then the listing registrations. Each is a
+ * legend-led {@link FormSection}, so a header can never regress to a bare
+ * heading. */
+const editFormSections = (data: AttendeeFormTemplateData): FormSection[] =>
+  compact([
+    {
+      children: <ContactDetailFields data={data} />,
+      legend: t("attendee_form.details_heading"),
+    },
+    data.questions.length > 0
+      ? {
+          children: (
+            <EditQuestions
+              questions={data.questions}
+              selectedAnswerIds={data.selectedAnswerIds}
+              selectedTextAnswers={data.selectedTextAnswers}
+            />
+          ),
+          legend: t("attendee_form.custom_questions"),
+        }
+      : undefined,
+    data.hasDailyListings
+      ? {
+          children: <SharedDateFields data={data} />,
+          legend: t("attendee_form.dates_heading"),
+        }
+      : undefined,
+    {
+      children: (
+        <>
+          {data.hasMixedTimings && (
+            <output class="warning">
+              {t("attendee_form.mixed_timings_warning")}
+            </output>
+          )}
+          <ListingEditor data={data} />
+        </>
+      ),
+      legend: t("attendee_form.registrations_heading"),
+    },
+  ]);
+
 const AttendeeEditForm = ({
   data,
 }: {
@@ -588,82 +698,7 @@ const AttendeeEditForm = ({
           the entity page shell. */}
       {!isEdit && <h1>{t("attendee_form.title_create")}</h1>}
 
-      {!isEdit && <h3>{t("attendee_form.details_heading")}</h3>}
-
-      <label for="name">
-        {t("common.name")}
-        <input
-          autocomplete="off"
-          autofocus={!formHasError(data)}
-          id="name"
-          name="name"
-          required
-          type="text"
-          value={data.parsed.name}
-        />
-      </label>
-
-      <StatusField data={data} />
-
-      <label for="email">
-        {t("common.email")}
-        <input
-          autocomplete="off"
-          id="email"
-          name="email"
-          type="email"
-          value={data.parsed.email || ""}
-        />
-      </label>
-
-      <label for="phone">
-        {t("common.phone")}
-        <input
-          autocomplete="off"
-          id="phone"
-          name="phone"
-          pattern={PHONE_INPUT_PATTERN}
-          title={t("attendee_form.phone_title")}
-          type="text"
-          value={data.parsed.phone || ""}
-        />
-      </label>
-
-      <AddressFieldWithLookup address={data.parsed.address || ""} />
-
-      <label for="special_instructions">
-        {t("common.special_instructions")}
-        <textarea
-          autocomplete="off"
-          id="special_instructions"
-          maxlength={250}
-          name="special_instructions"
-          rows={3}
-        >
-          {data.parsed.special_instructions || ""}
-        </textarea>
-      </label>
-
-      {data.questions.length > 0 && (
-        <>
-          <h3>{t("attendee_form.custom_questions")}</h3>
-          <EditQuestions
-            questions={data.questions}
-            selectedAnswerIds={data.selectedAnswerIds}
-            selectedTextAnswers={data.selectedTextAnswers}
-          />
-        </>
-      )}
-
-      <SharedDateFields data={data} />
-
-      <h3>{t("attendee_form.registrations_heading")}</h3>
-      {data.hasMixedTimings && (
-        <output class="warning">
-          {t("attendee_form.mixed_timings_warning")}
-        </output>
-      )}
-      <ListingEditor data={data} />
+      <FormSections sections={editFormSections(data)} />
 
       <LogisticsSection logistics={data.logistics} />
 

--- a/src/ui/templates/admin/attendee-logistics-tab.tsx
+++ b/src/ui/templates/admin/attendee-logistics-tab.tsx
@@ -23,6 +23,7 @@ import { CsrfForm } from "#shared/forms.tsx";
 import { LogisticsSection } from "#templates/admin/attendee-form.tsx";
 import { SaveActions } from "#templates/components/actions.tsx";
 import { AddressFieldWithLookup } from "#templates/components/address-field.tsx";
+import { SectionFieldset } from "#templates/components/aggregate-sections.tsx";
 import { ErrorAlert } from "#templates/components/error.tsx";
 
 /** One latitude/longitude input. The map script re-pins as these change. */
@@ -59,8 +60,10 @@ const PinnedLocation = ({
 }): JSX.Element => {
   const pinned = data.values.lat !== "" && data.values.lng !== "";
   return (
-    <>
-      <h3>{t("attendee_logistics.location_heading")}</h3>
+    <SectionFieldset
+      className="listing-section"
+      legend={t("attendee_logistics.location_heading")}
+    >
       <p class="small">{t("attendee_logistics.location_hint")}</p>
       {data.locationError && <ErrorAlert>{data.locationError}</ErrorAlert>}
       <div class="location-inputs">
@@ -82,7 +85,7 @@ const PinnedLocation = ({
         hidden={!pinned}
         role="img"
       ></div>
-    </>
+    </SectionFieldset>
   );
 };
 
@@ -149,15 +152,19 @@ export const AttendeeLogisticsPanel = ({
       action={`/admin/attendees/${data.attendee.id}/logistics`}
       id={ATTENDEE_LOGISTICS_FORM_ID}
     >
-      <h3>{t("attendee_logistics.address_heading")}</h3>
-      {data.addressError && <ErrorAlert>{data.addressError}</ErrorAlert>}
-      <AddressFieldWithLookup address={data.values.address} />
-      <output
-        class="warning"
-        data-address-diff
-        data-diff-heading={t("attendee_logistics.diff_heading")}
-        hidden
-      ></output>
+      <SectionFieldset
+        className="listing-section"
+        legend={t("attendee_logistics.address_heading")}
+      >
+        {data.addressError && <ErrorAlert>{data.addressError}</ErrorAlert>}
+        <AddressFieldWithLookup address={data.values.address} />
+        <output
+          class="warning"
+          data-address-diff
+          data-diff-heading={t("attendee_logistics.diff_heading")}
+          hidden
+        ></output>
+      </SectionFieldset>
 
       <PinnedLocation data={data} />
 

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -26,7 +26,9 @@ import type {
 } from "#shared/types.ts";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
+import { SectionFieldset } from "#templates/components/aggregate-sections.tsx";
 import { Badge } from "#templates/components/badge.tsx";
+import { DataTable } from "#templates/components/data-table.tsx";
 import {
   questionFieldset,
   questionWrapper,
@@ -56,10 +58,11 @@ const mergeRadioCell = ({
   </td>
 );
 
-/** A merge-decision table: an optional heading + a scroll-wrapped table whose
+/** A merge-decision table: an optional heading + a {@link DataTable} whose
  *  header row is the given column labels and whose body is the per-row decision
- *  markup. The PII-field, answer, and booking decision tables all share this
- *  shell. */
+ *  <tr>s. The PII-field, answer, and booking decision tables all share this
+ *  shell. A heading makes it a legend-led form section; without one it stays a
+ *  plain wrapper (the PII table leads the merge form, under its own heading). */
 const DecisionTable = ({
   heading,
   headers,
@@ -67,24 +70,22 @@ const DecisionTable = ({
 }: {
   heading?: string;
   headers: Child[];
-  children: Child;
-}): JSX.Element => (
-  <div>
-    {heading !== undefined && heading !== "" && <h4>{heading}</h4>}
-    <div class="table-scroll">
-      <table>
-        <thead>
-          <tr>
-            {headers.map((h) => (
-              <th>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>{children}</tbody>
-      </table>
-    </div>
-  </div>
-);
+  children: JSX.Element[];
+}): JSX.Element => {
+  const table = (
+    <DataTable
+      columns={headers.map((header) => ({ header }))}
+      rows={children}
+    />
+  );
+  return heading ? (
+    <SectionFieldset className="listing-section" legend={heading}>
+      {table}
+    </SectionFieldset>
+  ) : (
+    <div>{table}</div>
+  );
+};
 
 /** The "Amount paid: £X" paragraph, rendered when the attendee paid > 0. */
 const amountPaidPara = (attendee: Attendee): JSX.Element | null =>

--- a/src/ui/templates/admin/listing-defaults.tsx
+++ b/src/ui/templates/admin/listing-defaults.tsx
@@ -126,16 +126,14 @@ const DaysControl = ({
       />
       {t("listing_defaults.days_enable")}
     </label>
-    <div class="stack">
-      {VALID_DAY_NAMES.map((day) => (
-        <CheckboxLabel
-          checked={value?.includes(day) ?? false}
-          label={day}
-          name={inputName(field)}
-          value={day}
-        />
-      ))}
-    </div>
+    {VALID_DAY_NAMES.map((day) => (
+      <CheckboxLabel
+        checked={value?.includes(day) ?? false}
+        label={day}
+        name={inputName(field)}
+        value={day}
+      />
+    ))}
     <small>{hintFor(field)}</small>
   </fieldset>
 );
@@ -196,11 +194,9 @@ export const adminListingDefaultsPage = (
         <h2>{t("listing_defaults.title")}</h2>
         <p>{t("listing_defaults.intro")}</p>
       </div>
-      <div class="stack">
-        {fields.map((field) => (
-          <DefaultControl defaults={defaults} field={field} />
-        ))}
-      </div>
+      {fields.map((field) => (
+        <DefaultControl defaults={defaults} field={field} />
+      ))}
       <SubmitButton icon="save">{t("listing_defaults.save")}</SubmitButton>
     </CsrfForm>,
   );

--- a/src/ui/templates/admin/listings/form-sections.tsx
+++ b/src/ui/templates/admin/listings/form-sections.tsx
@@ -9,8 +9,9 @@ import { isStorageEnabled } from "#shared/storage.ts";
 import type { AdminSession, Group, ListingWithCount } from "#shared/types.ts";
 import { ListingGroupSelect } from "#templates/admin/group-select.tsx";
 import {
+  type FormSection,
+  FormSections,
   StackDetails,
-  StackFieldset,
 } from "#templates/components/aggregate-sections.tsx";
 import {
   getAssignBuiltSiteField,
@@ -215,7 +216,7 @@ export const ListingFormSections = ({
       mapNotNullish((name: string) => fieldMap.get(name))(names),
       values,
     );
-  const sections = [
+  const sections: FormSection[] = [
     {
       children: (
         <>
@@ -296,14 +297,7 @@ export const ListingFormSections = ({
         <input name="use_defaults" type="hidden" value="1" />
       )}
 
-      {sections.map(({ children, className, legend }) => (
-        <StackFieldset
-          className={className ?? "listing-section"}
-          legend={legend}
-        >
-          {children}
-        </StackFieldset>
-      ))}
+      <FormSections sections={sections} />
 
       <StackDetails
         className="listing-advanced"

--- a/src/ui/templates/admin/listings/form-sections.tsx
+++ b/src/ui/templates/admin/listings/form-sections.tsx
@@ -261,40 +261,39 @@ export const ListingFormSections = ({
   ];
   return (
     <>
-      {isTemplated && (
-        <fieldset class="checkboxes listing-customise-toggle">
-          <label>
-            <input
-              checked={customiseOpen}
-              id="customise-listing"
-              name="customise"
-              type="checkbox"
-              value="1"
-            />
-            {t("listings_table.customise")}{" "}
-            <small>{t("listings_table.customise_hint")}</small>
-          </label>
+      {(isTemplated || showUseDefaults) && (
+        <fieldset class="checkboxes">
+          {isTemplated && (
+            <label>
+              <input
+                checked={customiseOpen}
+                id="customise-listing"
+                name="customise"
+                type="checkbox"
+                value="1"
+              />
+              {t("listings_table.customise")}{" "}
+              <small>{t("listings_table.customise_hint")}</small>
+            </label>
+          )}
+          {showUseDefaults && (
+            <label>
+              <input
+                checked={useDefaultsChecked}
+                id="use-defaults"
+                name="use_defaults"
+                type="checkbox"
+                value="1"
+              />
+              {t("listing_defaults.use_defaults_toggle")}{" "}
+              <small>{t("listing_defaults.use_defaults_hint")}</small>
+            </label>
+          )}
         </fieldset>
       )}
 
-      {showUseDefaults ? (
-        <fieldset class="checkboxes listing-use-defaults-toggle">
-          <label>
-            <input
-              checked={useDefaultsChecked}
-              id="use-defaults"
-              name="use_defaults"
-              type="checkbox"
-              value="1"
-            />
-            {t("listing_defaults.use_defaults_toggle")}{" "}
-            <small>{t("listing_defaults.use_defaults_hint")}</small>
-          </label>
-        </fieldset>
-      ) : (
-        useDefaultsChecked && (
-          <input name="use_defaults" type="hidden" value="1" />
-        )
+      {!showUseDefaults && useDefaultsChecked && (
+        <input name="use_defaults" type="hidden" value="1" />
       )}
 
       {sections.map(({ children, className, legend }) => (

--- a/src/ui/templates/admin/logistics.tsx
+++ b/src/ui/templates/admin/logistics.tsx
@@ -29,6 +29,7 @@ import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
 import {
   CheckboxFieldset,
   CheckboxLabel,
+  SectionFieldset,
 } from "#templates/components/aggregate-sections.tsx";
 import {
   type DataColumn,
@@ -66,8 +67,12 @@ const AgentsSection = (agents: LogisticsAgent[]): JSX.Element => (
       dataTable(agentColumns)(agents)
     )}
     <CsrfForm action="/admin/logistics">
-      <h3>{t("logistics.add_agent")}</h3>
-      <Raw html={renderFields(logisticsAgentFields)} />
+      <SectionFieldset
+        className="listing-section"
+        legend={t("logistics.add_agent")}
+      >
+        <Raw html={renderFields(logisticsAgentFields)} />
+      </SectionFieldset>
       <SubmitButton icon="plus">{t("logistics.add_agent")}</SubmitButton>
     </CsrfForm>
   </article>

--- a/src/ui/templates/admin/sms.tsx
+++ b/src/ui/templates/admin/sms.tsx
@@ -15,6 +15,7 @@ import type {
 } from "#shared/types.ts";
 import { flashAdminPage } from "#templates/admin/admin-page.tsx";
 import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { SectionFieldset } from "#templates/components/aggregate-sections.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
 /* jscpd:ignore-end */
 
@@ -85,15 +86,19 @@ const ComposeForm = ({
         <CsrfForm action="/admin/sms">
           <input name="listing" type="hidden" value={String(listing.id)} />
           <input name="attendee" type="hidden" value={String(attendee.id)} />
-          <h3>{t("sms.contact.compose_heading")}</h3>
-          <label for="sms-message">{t("sms.contact.message_label")}</label>
-          <textarea
-            id="sms-message"
-            maxlength="1000"
-            name="message"
-            required
-            rows="4"
-          />
+          <SectionFieldset
+            className="listing-section"
+            legend={t("sms.contact.compose_heading")}
+          >
+            <label for="sms-message">{t("sms.contact.message_label")}</label>
+            <textarea
+              id="sms-message"
+              maxlength="1000"
+              name="message"
+              required
+              rows="4"
+            />
+          </SectionFieldset>
           <SubmitButton icon="check">{t("sms.contact.send")}</SubmitButton>
         </CsrfForm>
       )}

--- a/src/ui/templates/components/aggregate-sections.tsx
+++ b/src/ui/templates/components/aggregate-sections.tsx
@@ -9,7 +9,10 @@ type StackBaseProps = {
   className?: string | undefined;
 };
 
-const FieldsetBox = ({
+/** A form section: a bordered-off group of fields led by a <legend>. The
+ * fieldset is already a flex column with the standard gap, so its children
+ * stack on their own — no wrapper needed. */
+export const SectionFieldset = ({
   children,
   className,
   legend,
@@ -20,12 +23,39 @@ const FieldsetBox = ({
   </fieldset>
 );
 
-export const StackFieldset = (
-  props: StackBaseProps & { legend: string },
-): JSX.Element => (
-  <FieldsetBox className={props.className} legend={props.legend}>
-    <div class="stack">{props.children}</div>
-  </FieldsetBox>
+/**
+ * One section of a form: a heading (rendered as the fieldset's <legend>) and
+ * the fields that belong under it. This is the ONLY shape a form section takes
+ * — model a form as a `FormSection[]` and render it with {@link FormSections},
+ * so a section header can never drift back into a hand-rolled <h3>. A section
+ * whose `children` are absent (e.g. a conditional block that yielded nothing)
+ * is dropped, so callers can build the list with `compact`.
+ *
+ * Every section uses the shared "listing-section" legend styling by default;
+ * pass `className` only to add to it (the logistics agents fieldset does).
+ */
+export type FormSection = {
+  legend: string;
+  className?: string | undefined;
+  children: Child;
+};
+
+/** Render a form's `FormSection[]` as a run of {@link SectionFieldset}s. */
+export const FormSections = ({
+  sections,
+}: {
+  sections: readonly FormSection[];
+}): JSX.Element => (
+  <>
+    {sections.map((section) => (
+      <SectionFieldset
+        className={section.className ?? "listing-section"}
+        legend={section.legend}
+      >
+        {section.children}
+      </SectionFieldset>
+    ))}
+  </>
 );
 
 export const StackDetails = ({
@@ -54,12 +84,12 @@ export const CheckboxFieldset = ({
   hint: string;
   legend: string;
 }): JSX.Element => (
-  <FieldsetBox className={className} legend={legend}>
+  <SectionFieldset className={className} legend={legend}>
     <p>
       <small>{hint}</small>
     </p>
     {children}
-  </FieldsetBox>
+  </SectionFieldset>
 );
 
 export const CheckboxLabel = ({
@@ -154,7 +184,7 @@ export const RunningTotalsFieldset = ({
   children?: JSX.Element;
   config: RunningTotalsConfig;
 }): JSX.Element => (
-  <StackFieldset className={config.className} legend={config.legend}>
+  <SectionFieldset className={config.className} legend={config.legend}>
     {children}
     <p>
       <small>{config.note}</small>
@@ -163,7 +193,7 @@ export const RunningTotalsFieldset = ({
     <p>
       <a href={config.recalculateHref}>{config.recalculateLabel}</a>
     </p>
-  </StackFieldset>
+  </SectionFieldset>
 );
 
 export const recalculatePageRenderer =

--- a/src/ui/templates/components/aggregate-sections.tsx
+++ b/src/ui/templates/components/aggregate-sections.tsx
@@ -27,12 +27,13 @@ export const SectionFieldset = ({
  * One section of a form: a heading (rendered as the fieldset's <legend>) and
  * the fields that belong under it. This is the ONLY shape a form section takes
  * — model a form as a `FormSection[]` and render it with {@link FormSections},
- * so a section header can never drift back into a hand-rolled <h3>. A section
- * whose `children` are absent (e.g. a conditional block that yielded nothing)
- * is dropped, so callers can build the list with `compact`.
+ * so a section header can never drift back into a hand-rolled <h3>. Build the
+ * list with `compact` to drop sections that don't apply (see the attendee
+ * form's `editFormSections`).
  *
- * Every section uses the shared "listing-section" legend styling by default;
- * pass `className` only to add to it (the logistics agents fieldset does).
+ * A blank or absent `className` falls back to the shared "listing-section"
+ * legend styling; pass a `className` to override it — include "listing-section"
+ * plus any modifier, as the listing form's daily section does.
  */
 export type FormSection = {
   legend: string;
@@ -49,7 +50,7 @@ export const FormSections = ({
   <>
     {sections.map((section) => (
       <SectionFieldset
-        className={section.className ?? "listing-section"}
+        className={section.className || "listing-section"}
         legend={section.legend}
       >
         {section.children}

--- a/test/ui/templates/components/aggregate-sections.test.tsx
+++ b/test/ui/templates/components/aggregate-sections.test.tsx
@@ -53,6 +53,17 @@ describe("FormSections", () => {
       '<fieldset class="listing-section extra"><legend>L</legend>x</fieldset>',
     );
   });
+
+  test("falls back to listing-section for a blank className", () => {
+    const html = String(
+      FormSections({
+        sections: [{ children: "x", className: "", legend: "L" }],
+      }),
+    );
+    expect(html).toBe(
+      '<fieldset class="listing-section"><legend>L</legend>x</fieldset>',
+    );
+  });
 });
 
 describe("StackDetails", () => {

--- a/test/ui/templates/components/aggregate-sections.test.tsx
+++ b/test/ui/templates/components/aggregate-sections.test.tsx
@@ -5,8 +5,9 @@ import {
   CheckboxesFieldset,
   CheckboxForm,
   CheckboxLabel,
+  FormSections,
+  SectionFieldset,
   StackDetails,
-  StackFieldset,
 } from "#templates/components/aggregate-sections.tsx";
 import { setupTestEncryptionKey } from "#test-utils";
 
@@ -15,13 +16,41 @@ beforeAll(async () => {
   await signCsrfToken();
 });
 
-describe("StackFieldset", () => {
-  test("wraps its children in a stack inside a legend fieldset", () => {
+describe("SectionFieldset", () => {
+  test("puts its children directly in a legend fieldset", () => {
     const html = String(
-      StackFieldset({ children: "inner", legend: "Legend here" }),
+      SectionFieldset({ children: "inner", legend: "Legend here" }),
+    );
+    expect(html).toBe("<fieldset><legend>Legend here</legend>inner</fieldset>");
+  });
+});
+
+describe("FormSections", () => {
+  test("renders each section as a listing-section legend fieldset", () => {
+    const html = String(
+      FormSections({
+        sections: [
+          { children: "one", legend: "First" },
+          { children: "two", legend: "Second" },
+        ],
+      }),
     );
     expect(html).toBe(
-      '<fieldset><legend>Legend here</legend><div class="stack">inner</div></fieldset>',
+      '<fieldset class="listing-section"><legend>First</legend>one</fieldset>' +
+        '<fieldset class="listing-section"><legend>Second</legend>two</fieldset>',
+    );
+  });
+
+  test("keeps a section's own className when it supplies one", () => {
+    const html = String(
+      FormSections({
+        sections: [
+          { children: "x", className: "listing-section extra", legend: "L" },
+        ],
+      }),
+    );
+    expect(html).toBe(
+      '<fieldset class="listing-section extra"><legend>L</legend>x</fieldset>',
     );
   });
 });


### PR DESCRIPTION
## What changed

Admin forms were heading their sections in a few different ways — some used a `<legend>` inside a fieldset, others just dropped an `<h3>`/`<h4>` in the middle of the form. This tidies that up so a form section is always the same thing: a titled group with its heading as a `<legend>`.

### The listing-form toggles
The two checkboxes at the top of a listing form — "Customise" and "Use defaults" — were each in their own box with their own bespoke spacing rules. They're now a single group of two checkboxes, which reads better (the two related options sit closer together) and let us delete the custom styling entirely.

### One shared way to build form sections
There's now a single, reusable way to lay out a form's sections: you describe them as a plain list (each with a heading and its fields) and one helper turns them into properly-headed groups. Because every form goes through this, a section header can't quietly go back to being a bare `<h3>`. The listing form and the attendee form both build their sections this way now.

### Forms brought in line
Section headings that were plain headings are now legends, on the:
- attendee create/edit form (contact details, custom questions, dates, registrations)
- attendee logistics tab (address, pinned location)
- SMS compose form
- logistics "add agent" form
- attendee-merge decision tables (which now reuse the shared table component instead of rebuilding one)

### Tidy-ups along the way
- Removed wrapper `<div>`s that only existed to stack their contents — a form and a fieldset already stack their contents on their own, so the extra wrappers did nothing.
- Wrote down the new "sections are a list, headings are legends" rule in `AGENTS.md` so it stays the way we do it.

## What stays the same
No behaviour changes — the same fields, values, and submissions. This is a structural and styling clean-up. Existing tests pass; the new section helper has full test and mutation coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPZXqNG2TRoFxG8eMyfTxS)_