### PR TITLE
Move the Site content editors' guide link into a GuideFooter

### DIFF
--- a/src/features/admin/entity-pages.ts
+++ b/src/features/admin/entity-pages.ts
@@ -133,6 +133,9 @@ export interface EntityPageDef<E, Id extends EntityId = number> {
   /** Extra content rendered inside the prose block beside the page `<h1>`
    *  (e.g. the attendee page's "Add a note" link). */
   proseExtra?: (entity: E, ctx: PageCtx) => Promise<JSX.Element | null>;
+  /** A guide link rendered at the very bottom of the body via `GuideFooter`,
+   *  matching every other admin page (e.g. the Site content editors). */
+  guideFooter?: (entity: E, ctx: PageCtx) => Promise<JSX.Element | null>;
   tabs: readonly TabDef<E>[];
 }
 
@@ -219,6 +222,17 @@ export interface EntityPage<E, Id extends EntityId = number> {
   path: (id: Id, slug?: string) => string;
 }
 
+/** Resolve one of the page's optional element slots (banner, guide footer,
+ * prose extra): run its loader when present, else null. */
+const resolveSlot = <E>(
+  loader:
+    | ((entity: E, ctx: PageCtx) => Promise<JSX.Element | null>)
+    | undefined,
+  entity: E,
+  ctx: PageCtx,
+): Promise<JSX.Element | null> =>
+  loader ? loader(entity, ctx) : Promise.resolve(null);
+
 /** Turn one page definition into its handlers + path helper. */
 export const defineEntityPage = <E, Id extends EntityId = number>(
   def: EntityPageDef<E, Id>,
@@ -256,11 +270,17 @@ export const defineEntityPage = <E, Id extends EntityId = number>(
         sections.push(await loadSection(section, entity, ctx));
       }
     }
+    const [banner, guideFooter, proseExtra] = await Promise.all([
+      resolveSlot(def.banner, entity, ctx),
+      resolveSlot(def.guideFooter, entity, ctx),
+      resolveSlot(def.proseExtra, entity, ctx),
+    ]);
     return htmlResponse(
       entityPageView({
-        banner: def.banner ? await def.banner(entity, ctx) : null,
+        banner,
+        guideFooter,
         navActive: def.navActive,
-        proseExtra: def.proseExtra ? await def.proseExtra(entity, ctx) : null,
+        proseExtra,
         sections,
         session,
         tabs: tabLinks(tabStates, def.basePath(id), activeSlug),

--- a/src/features/admin/site-content-page.ts
+++ b/src/features/admin/site-content-page.ts
@@ -15,7 +15,7 @@ import { requireSiteOr } from "#routes/auth.ts";
 import { isReadOnly } from "#shared/env.ts";
 import { isStorageEnabled } from "#shared/storage.ts";
 import type { ImageUseItemType } from "#shared/types.ts";
-import { contentGuideLink } from "#templates/admin/site-content.tsx";
+import { contentGuideFooter } from "#templates/admin/site-content.tsx";
 import { loadItemImagesPanel } from "./item-images.ts";
 
 /** The Edit (and Items) tabs mutate the entity, so they hide in read-only mode
@@ -39,8 +39,8 @@ export interface SiteContentPageDef<E extends { id: number }> {
   editPanel: (entity: E) => JSX.Element;
   /** The locale key for the delete action on the Actions tab. */
   deleteLabelKey: string;
-  /** A guide section anchor (e.g. "public-site") linked beside the page title,
-   * so the operator can jump to the relevant help. */
+  /** A guide section anchor (e.g. "public-site") linked in the page's guide
+   * footer, so the operator can jump to the relevant help. */
   guideAnchor: string;
   extraTabs?: readonly TabDef<E>[];
 }
@@ -95,9 +95,9 @@ export const defineSiteContentPage = <E extends { id: number }>(
   return defineEntityPage({
     basePath: def.basePath,
     guard: requireSiteOr,
+    guideFooter: () => Promise.resolve(contentGuideFooter(def.guideAnchor)),
     load: def.load,
     navActive: def.navActive,
-    proseExtra: () => Promise.resolve(contentGuideLink(def.guideAnchor)),
     tabs: [editTab, ...(def.extraTabs ?? []), imagesTab, actionsTab],
     titleOf: def.titleOf,
   });

--- a/src/ui/templates/admin/entity-pages.tsx
+++ b/src/ui/templates/admin/entity-pages.tsx
@@ -217,6 +217,10 @@ export interface EntityPageView {
   banner: JSX.Element | null;
   tabs: TabLink[];
   sections: LoadedSection[];
+  /** Optional guide link rendered at the very bottom of the body, matching the
+   *  `GuideFooter` every other admin page uses (e.g. the Site content editors'
+   *  "Guide: pages, news & images" link). */
+  guideFooter?: JSX.Element | null;
 }
 
 /** The whole entity page: title → banner → tab strip → active tab's
@@ -240,5 +244,6 @@ export const entityPageView = (view: EntityPageView): string =>
           <div class="table-controls">{section}</div>
         ))}
       </section>
+      {view.guideFooter}
     </Layout>,
   );

--- a/src/ui/templates/admin/site-content.tsx
+++ b/src/ui/templates/admin/site-content.tsx
@@ -14,6 +14,7 @@ import { AdminPage } from "#templates/admin/admin-page.tsx";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
 import {
   ActionButton,
+  GuideFooter,
   SaveChangesButton,
 } from "#templates/components/actions.tsx";
 
@@ -75,14 +76,13 @@ export const contentEditPanel = (
   </CsrfForm>
 );
 
-/** The "Guide: …" help link shown beside a Site content page's title, jumping
- * to the given guide section anchor. */
-export const contentGuideLink = (anchor: string): JSX.Element => (
-  <p class="prose guide-link">
-    <a href={`/admin/guide#${anchor}`}>
-      <Raw html={t("common.guide_website_content")} />
-    </a>
-  </p>
+/** The "Guide: …" help link for a Site content page, rendered as a
+ * `GuideFooter` at the bottom of the body (matching every other admin page)
+ * and jumping to the given guide section anchor. */
+export const contentGuideFooter = (anchor: string): JSX.Element => (
+  <GuideFooter href={`/admin/guide#${anchor}`}>
+    <Raw html={t("common.guide_website_content")} />
+  </GuideFooter>
 );
 
 /** Curried type-the-name delete confirmation page for a Site-tab entity.

--- a/test/lib/server-news-admin.test.ts
+++ b/test/lib/server-news-admin.test.ts
@@ -115,7 +115,8 @@ describeWithEnv("server (admin news)", { db: true }, () => {
       expect(html).toContain(
         `Public link: <a href="/news/${post.slug}" rel="noopener" target="_blank">/news/${post.slug}</a>`,
       );
-      // A guide link sits beside the page title.
+      // A guide footer sits at the bottom of the body.
+      expect(html).toContain('class="guide-footer"');
       expect(html).toContain('href="/admin/guide#public-site"');
       // The shared tabbed strip carries Edit and Actions (Images is hidden
       // while storage is off — the live panel is covered in the news image

--- a/test/lib/server-site-pages.test.ts
+++ b/test/lib/server-site-pages.test.ts
@@ -156,7 +156,8 @@ describeWithEnv("server (admin site pages)", { db: true }, () => {
       expect(html).toContain(
         `Public link: <a href="/page/${page.slug}" rel="noopener" target="_blank">/page/${page.slug}</a>`,
       );
-      // A guide link sits beside the page title.
+      // A guide footer sits at the bottom of the body.
+      expect(html).toContain('class="guide-footer"');
       expect(html).toContain('href="/admin/guide#public-site"');
       // The tabbed strip carries Edit, Items and Actions (Images hidden while
       // storage is off). The item manager lives on the Items tab, not here.


### PR DESCRIPTION
## What & why

The shared `GuideFooter` component already renders a page's "…guide" link in a `p.guide-footer` at the bottom of the body on every admin page (calendar, modifiers, scanner, ledger, users, holidays, …). The **News** and **Pages** editors were the last hold-outs: their guide link rendered *beside the page title* (via the entity-page `proseExtra` slot) instead of as a footer, so it didn't match the rest of admin.

This moves that link into a proper `GuideFooter` at the bottom of the body, so all admin guide links now use the same component and sit in the same place.

## Changes

- **Entity-page shell** (`src/features/admin/entity-pages.ts` + `src/ui/templates/admin/entity-pages.tsx`): add an optional `guideFooter` slot, rendered as the last element of the page body (after the tab panel). The existing `proseExtra` slot is untouched — the attendee page still uses it for its "Add a note" link beside the heading.
- **Site content** (`src/ui/templates/admin/site-content.tsx`): `contentGuideLink` (a `p.prose.guide-link` beside the title) becomes `contentGuideFooter`, returning a `<GuideFooter>` with the same `/admin/guide#…` anchor and copy.
- **Wiring** (`src/features/admin/site-content-page.ts`): the shared Site-content page def now supplies `guideFooter` instead of `proseExtra`.
- Extracted the optional-slot resolution (banner / guideFooter / proseExtra) into a small `resolveSlot` helper so `renderPage` stays under the cognitive-complexity limit.

## Testing

- `deno task typecheck` — clean
- `deno task lint:ci` — clean
- Updated and ran the News/Pages admin server tests (they now assert the `guide-footer` at the bottom); entity-page shell/core, entity-page template, and actions component tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8oG43FFXYThDoUXjgJxKe)_