### PR TITLE
Fix "Logistics saved for {value}" showing a raw placeholder

### DIFF
--- a/src/locales/en/logistics.json
+++ b/src/locales/en/logistics.json
@@ -27,7 +27,7 @@
   "attendee_logistics.map_label": "Map of the pinned location",
   "attendee_logistics.diff_heading": "The chosen address differs from what's typed:",
   "attendee_logistics.save": "Save Logistics",
-  "attendee_logistics.saved": "Logistics saved for '{value}'",
+  "attendee_logistics.saved": "Logistics saved for ''{value}''",
   "attendee_logistics.others_heading": "Other Attendees",
   "attendee_logistics.others_hint": "Everyone else with a booking on the same dates. Open one to plan its times alongside this job.",
   "attendee_logistics.col_attendee": "Attendee",

--- a/test/lib/i18n.test.ts
+++ b/test/lib/i18n.test.ts
@@ -9,6 +9,7 @@ import {
   runWithLocale,
   t,
 } from "#i18n";
+import en from "#locales/en/index.ts";
 import { setTestEnv } from "#test-utils";
 
 describe("i18n", () => {
@@ -62,6 +63,28 @@ describe("i18n", () => {
       expect(t("modifiers.err_child_only_addon", { name: "Retreat" })).toBe(
         "'Retreat' is an opt-in add-on reachable only through a required child listing, so no booking page would offer it — scope it to the parent (or another bookable listing), or remove it as a child, before saving.",
       );
+      // The logistics "saved" flash wraps the attendee name the same way; a
+      // single-quoted `'{value}'` would have shown the literal text `{value}`.
+      expect(t("attendee_logistics.saved", { value: "Retreat" })).toBe(
+        "Logistics saved for 'Retreat'",
+      );
+    });
+
+    test("no locale message single-quotes a whole placeholder (ICU escaping trap)", () => {
+      // In ICU MessageFormat a lone `'` immediately before `{` starts a quoted
+      // literal, so `'{value}'` renders the literal text `{value}` with the
+      // value never substituted (and the quote marks stripped). To wrap an
+      // interpolated value in literal single quotes the quotes must be doubled
+      // (`''{value}''`). This scans every locale string for the single-quote
+      // form so the bug can't be reintroduced in a new message. The doubled
+      // form is excluded by the lookarounds; deliberate brace escaping like
+      // `'{'` (settings.advanced.custom_css_placeholder) never matches because
+      // there is no `{identifier}` between the quotes.
+      const SINGLE_QUOTED_PLACEHOLDER = /(?<!')'\{[A-Za-z_$][\w$]*\}'(?!')/;
+      const offenders = Object.entries(en as Record<string, string>)
+        .filter(([, value]) => SINGLE_QUOTED_PLACEHOLDER.test(value))
+        .map(([key, value]) => `${key}: ${value}`);
+      expect(offenders).toEqual([]);
     });
 
     test("handles ICU plural format", () => {


### PR DESCRIPTION
## What was wrong

After saving an attendee's Logistics tab, the confirmation banner read literally **"Logistics saved for {value}"** instead of showing the attendee's name.

The message text was `Logistics saved for '{value}'`. These messages use ICU MessageFormat, where a single straight quote `'` right before `{` is treated as an escape character — it tells ICU "print the next part exactly as written". So the `{value}` slot that should have been filled with the attendee's name was printed as-is, quotes and all.

## The fix

Doubling the quotes (`''{value}''`) is how ICU means "show a real quote mark here". The banner now correctly reads **Logistics saved for 'Jane Smith'**. This matches the way the listings and modifiers messages already write quoted names.

## Making sure it can't come back

- A regression test that saves logistics and checks the banner fills in the name.
- A wider safety-net test that scans **every** message in the locale file for the same single-quote-around-a-placeholder mistake, so a new message can never slip the bug back in. It correctly ignores the already-correct doubled form and the deliberate brace examples in the custom-CSS help text.

Both tests were confirmed to fail on the old text and pass on the fixed text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKFeC4ajQsSnK1m59Ax4ED

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKFeC4ajQsSnK1m59Ax4ED)_