### PR TITLE
Pin entity tabs and attendee notes across page navigations

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1380,6 +1380,10 @@ output.success {
 /* Per-attendee operator/system notes */
 .attendee-notes {
   margin-bottom: var(--space-l);
+  /* The notes banner sits above the tab strip on every attendee tab, so pin it
+     too: switching tabs keeps the same alerts in place instead of re-fading
+     them in on each navigation. */
+  view-transition-name: attendee-notes;
 }
 .system-note {
   background: var(--color-surface-alt, #f4f4f4);
@@ -3373,6 +3377,10 @@ label:hover .embed-toggle-badge,
   /* The base `nav` rule centres its row; the tab strip reads left-to-right
      like the page content beneath it, so pin it to the start. */
   justify-content: flex-start;
+  /* Hold the tab strip still across cross-document navigations: moving between
+     an entity's tabs (Edit → Attendees → Actions) keeps the same strip in
+     place while only the panel beneath it transitions. */
+  view-transition-name: entity-tabs;
 
   ul {
     display: flex;


### PR DESCRIPTION
## What changed

The site already smoothly cross-fades between pages as you move around. One element — the admin sidebar — was told to hold still during those transitions instead of fading, so it feels pinned in place like part of an app.

This does the same for two more elements that stay put as you move between an item's or a person's tabs:

- **The tab strip on items** (the Edit / Attendees / Actions row across an item, attendee, page, or news post) now stays fixed in place while only the panel beneath it changes.
- **The notes banner on attendees** (the alerts and system notes shown above the tabs) now stays fixed too, so switching tabs no longer makes those notes re-fade in each time.

## Why

Moving between tabs of the same thing felt slightly flickery, because the strip and the notes were being redrawn on every navigation. Naming them so the browser recognises them as "the same element" on both pages keeps them steady, which reads as calmer and more app-like.

## How

Two lines of CSS in `src/ui/static/style.scss`: a `view-transition-name` on `.entity-tabs` and one on `.attendee-notes`, following the exact pattern already used for the admin sidebar. Each of these elements only ever appears once per page, so the names stay unique as required. Browsers without view-transition support simply navigate as before — this is pure progressive enhancement, and it's already switched off under reduced-motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDx3oexW3LwS1hEEAMn7L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDx3oexW3LwS1hEEAMn7L9)_