### PR TITLE
Delete the remaining stray alias exports and call the objects directly

### DIFF
--- a/src/features/admin/holidays.ts
+++ b/src/features/admin/holidays.ts
@@ -7,12 +7,7 @@ import { createOwnerCrudHandlers } from "#routes/admin/owner-crud.ts";
 import { type HolidayInput, holidays } from "#shared/db/holidays.ts";
 import { HOLIDAY_DEMO_FIELDS, wrapResourceForDemo } from "#shared/demo.ts";
 import { defineNamedResource } from "#shared/rest/resource.ts";
-import {
-  adminHolidayDeletePage,
-  adminHolidayEditPage,
-  adminHolidayNewPage,
-  adminHolidaysPage,
-} from "#templates/admin/holidays.tsx";
+import { adminHolidaysPage, holidayPages } from "#templates/admin/holidays.tsx";
 import { getHolidayFields } from "#templates/fields.ts";
 
 /** Extract holiday input from validated form values */
@@ -45,10 +40,10 @@ const crud = createOwnerCrudHandlers({
   getAll: holidays.getAll,
   getName: (h) => h.name,
   listPath: "/admin/holidays",
-  renderDelete: adminHolidayDeletePage,
-  renderEdit: adminHolidayEditPage,
+  renderDelete: holidayPages.deletePage,
+  renderEdit: holidayPages.editPage,
   renderList: adminHolidaysPage,
-  renderNew: adminHolidayNewPage,
+  renderNew: holidayPages.newPage,
   resource: wrapResourceForDemo(holidaysResource, HOLIDAY_DEMO_FIELDS),
   singular: "Holiday",
 });

--- a/src/features/admin/settings-logistics.ts
+++ b/src/features/admin/settings-logistics.ts
@@ -40,10 +40,9 @@ import { defineNamedResource } from "#shared/rest/resource.ts";
 import { isDeliveryRole } from "#shared/types.ts";
 import {
   type AgentUserOption,
-  adminLogisticsAgentDeletePage,
   adminLogisticsAgentEditPage,
-  adminLogisticsAgentNewPage,
   adminLogisticsPage,
+  logisticsAgentPages,
 } from "#templates/admin/logistics.tsx";
 import { logisticsAgentFields } from "#templates/fields.ts";
 
@@ -101,9 +100,9 @@ const crud = createOwnerCrudHandlers({
   getAll: logisticsAgents.getAll,
   getName: (a) => a.name,
   listPath: "/admin/logistics",
-  renderDelete: adminLogisticsAgentDeletePage,
+  renderDelete: logisticsAgentPages.deletePage,
   renderList: adminLogisticsPage,
-  renderNew: adminLogisticsAgentNewPage,
+  renderNew: logisticsAgentPages.newPage,
   resource: logisticsAgentsResource,
   singular: "Logistics agent",
 });

--- a/src/features/admin/settings-square.ts
+++ b/src/features/admin/settings-square.ts
@@ -23,7 +23,7 @@ type SquareFields = {
   sandbox: boolean;
 };
 
-const squareRoutes = defineProviderCredentialsRoute<SquareFields>({
+export const squareRoutes = defineProviderCredentialsRoute<SquareFields>({
   extraFields: (form) => ({
     locationId: form.getString("square_location_id"),
     sandbox: form.get("square_sandbox") === "on",
@@ -53,9 +53,6 @@ const squareRoutes = defineProviderCredentialsRoute<SquareFields>({
   },
 });
 
-/** Handle POST /admin/settings/square - owner only */
-export const handleAdminSquarePost = squareRoutes.save;
-
 /**
  * Handle POST /admin/settings/square-webhook - owner only
  */
@@ -67,6 +64,3 @@ export const handleAdminSquareWebhookPost = settingsSecret({
   save: (v) => settings.update.square.webhookSignatureKey(v),
   validate: validateSquareWebhookSignatureKey,
 });
-
-/** Handle POST /admin/settings/square/test - owner only */
-export const handleSquareTestPost = squareRoutes.test;

--- a/src/features/admin/settings-statuses.ts
+++ b/src/features/admin/settings-statuses.ts
@@ -38,9 +38,9 @@ import type { FormParams } from "#shared/form-data.ts";
 import { validateReservationAmount } from "#shared/reservation-amount.ts";
 import type { AdminSession } from "#shared/types.ts";
 import {
-  adminAttendeeStatusDeletePage,
   adminAttendeeStatusesPage,
   adminAttendeeStatusFormPage,
+  statusPages,
 } from "#templates/admin/settings-statuses.tsx";
 
 const LIST_PATH = "/admin/settings/statuses";
@@ -181,7 +181,7 @@ const editPost = ownerFormById(async (id, _session, form) => {
 });
 
 const deleteGet = ownerStatusPage((status, session) =>
-  adminAttendeeStatusDeletePage(status, session, getFlash().error),
+  statusPages.deletePage(status, session, getFlash().error),
 );
 
 const deletePost = ownerFormById(async (id, _session, form) => {

--- a/src/features/admin/settings-stripe.ts
+++ b/src/features/admin/settings-stripe.ts
@@ -16,7 +16,7 @@ import {
   testStripeConnection,
 } from "#shared/stripe.ts";
 
-const stripeRoutes = defineProviderCredentialsRoute<undefined>({
+export const stripeRoutes = defineProviderCredentialsRoute<undefined>({
   // Provision the Stripe webhook before the key is persisted, so a setup
   // failure aborts the save leaving nothing configured.
   afterSave: async (value) => {
@@ -49,9 +49,3 @@ const stripeRoutes = defineProviderCredentialsRoute<undefined>({
     return null;
   },
 });
-
-/** Handle POST /admin/settings/stripe - owner only */
-export const handleAdminStripePost = stripeRoutes.save;
-
-/** Handle POST /admin/settings/stripe/test - owner only */
-export const handleStripeTestPost = stripeRoutes.test;

--- a/src/features/admin/settings-sumup.ts
+++ b/src/features/admin/settings-sumup.ts
@@ -12,7 +12,7 @@ type SumupFields = {
   merchantCode: string;
 };
 
-const sumupRoutes = defineProviderCredentialsRoute<SumupFields>({
+export const sumupRoutes = defineProviderCredentialsRoute<SumupFields>({
   extraFields: (form) => ({
     merchantCode: form.getString("sumup_merchant_code"),
   }),
@@ -36,9 +36,3 @@ const sumupRoutes = defineProviderCredentialsRoute<SumupFields>({
     return null;
   },
 });
-
-/** Handle POST /admin/settings/sumup - owner only */
-export const handleAdminSumupPost = sumupRoutes.save;
-
-/** Handle POST /admin/settings/sumup/test - owner only */
-export const handleSumupTestPost = sumupRoutes.test;

--- a/src/features/admin/settings.ts
+++ b/src/features/admin/settings.ts
@@ -48,18 +48,11 @@ import {
 import { handleAdminSettingsPost } from "#routes/admin/settings-password.ts";
 import { handleSmsGatewayPost } from "#routes/admin/settings-sms.ts";
 import {
-  handleAdminSquarePost,
   handleAdminSquareWebhookPost,
-  handleSquareTestPost,
+  squareRoutes,
 } from "#routes/admin/settings-square.ts";
-import {
-  handleAdminStripePost,
-  handleStripeTestPost,
-} from "#routes/admin/settings-stripe.ts";
-import {
-  handleAdminSumupPost,
-  handleSumupTestPost,
-} from "#routes/admin/settings-sumup.ts";
+import { stripeRoutes } from "#routes/admin/settings-stripe.ts";
+import { sumupRoutes } from "#routes/admin/settings-sumup.ts";
 import { handleSuperuserPost } from "#routes/admin/settings-superuser.ts";
 import {
   handleAppleWalletPost,
@@ -103,13 +96,13 @@ export const settingsRoutes = defineRoutes({
   "POST /admin/settings/show-public-api": handleShowPublicApiPost,
   "POST /admin/settings/show-public-site": handleShowPublicSitePost,
   "POST /admin/settings/sms-gateway": handleSmsGatewayPost,
-  "POST /admin/settings/square": handleAdminSquarePost,
+  "POST /admin/settings/square": squareRoutes.save,
   "POST /admin/settings/square-webhook": handleAdminSquareWebhookPost,
-  "POST /admin/settings/square/test": handleSquareTestPost,
-  "POST /admin/settings/stripe": handleAdminStripePost,
-  "POST /admin/settings/stripe/test": handleStripeTestPost,
-  "POST /admin/settings/sumup": handleAdminSumupPost,
-  "POST /admin/settings/sumup/test": handleSumupTestPost,
+  "POST /admin/settings/square/test": squareRoutes.test,
+  "POST /admin/settings/stripe": stripeRoutes.save,
+  "POST /admin/settings/stripe/test": stripeRoutes.test,
+  "POST /admin/settings/sumup": sumupRoutes.save,
+  "POST /admin/settings/sumup/test": sumupRoutes.test,
   "POST /admin/settings/superuser": handleSuperuserPost,
   "POST /admin/settings/terms": handleTermsPost,
   "POST /admin/settings/theme": handleThemePost,

--- a/src/features/api/index.ts
+++ b/src/features/api/index.ts
@@ -69,10 +69,7 @@ import {
   getGroupRemainingForListing,
 } from "#shared/db/attendees/capacity.ts";
 import { hasAvailableSpots } from "#shared/db/attendees.ts";
-import {
-  isBookingRateLimited,
-  recordBookingAttempt,
-} from "#shared/db/booking-attempts.ts";
+import { bookingLimiter } from "#shared/db/booking-attempts.ts";
 import { isHiddenPackageMember } from "#shared/db/groups.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import {
@@ -606,13 +603,13 @@ const checkBookingRateLimit = async (
   server?: ServerContext,
 ): Promise<Response | null> => {
   const ip = getClientIp(request, server);
-  if (await isBookingRateLimited(ip)) {
+  if (await bookingLimiter.isLimited(ip)) {
     return apiResponse(
       { error: "Too many booking attempts. Please try again later." },
       429,
     );
   }
-  await recordBookingAttempt(ip);
+  await bookingLimiter.record(ip);
   return null;
 };
 

--- a/src/shared/db/booking-attempts.ts
+++ b/src/shared/db/booking-attempts.ts
@@ -11,14 +11,8 @@ import { makeIpRateLimiter } from "#shared/db/login-attempts.ts";
 import { BOOKING_LOCKOUT_MS, MAX_BOOKING_ATTEMPTS } from "#shared/limits.ts";
 
 /** "book:" namespaces the counters away from login and other limiters. */
-const limiter = makeIpRateLimiter(
+export const bookingLimiter = makeIpRateLimiter(
   "book:",
   MAX_BOOKING_ATTEMPTS,
   BOOKING_LOCKOUT_MS,
 );
-
-/** Check if an IP has exceeded the booking rate limit. */
-export const isBookingRateLimited = limiter.isLimited;
-
-/** Record a booking attempt for an IP; returns true if now locked out. */
-export const recordBookingAttempt = limiter.record;

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -92,14 +92,8 @@ import {
   isPaymentProviderSetting,
   isSuperuserChoice,
 } from "#shared/types.ts";
-import {
-  createAppleWalletReadSettings,
-  createAppleWalletUpdateSettings,
-} from "#shared/wallets/apple-wallet-settings.ts";
-import {
-  createGoogleWalletReadSettings,
-  createGoogleWalletUpdateSettings,
-} from "#shared/wallets/google-wallet-settings.ts";
+import { appleWallet } from "#shared/wallets/apple-wallet-settings.ts";
+import { googleWallet } from "#shared/wallets/google-wallet-settings.ts";
 import type { EncryptedUpdateFn } from "#shared/wallets/wallet-settings-types.ts";
 import type { EmailContent } from "#templates/email/shared.ts";
 
@@ -899,7 +893,7 @@ const settingsBase = {
     },
   },
   // --- Apple Wallet ---
-  appleWallet: createAppleWalletReadSettings(snap as (k: string) => string),
+  appleWallet: appleWallet.createReadSettings(snap as (k: string) => string),
   get autoPurgeOrphans(): boolean {
     return snap("auto_purge_orphans");
   },
@@ -977,7 +971,7 @@ const settingsBase = {
   getCachedRaw: getRawCached,
 
   // --- Google Wallet ---
-  googleWallet: createGoogleWalletReadSettings(snap as (k: string) => string),
+  googleWallet: googleWallet.createReadSettings(snap as (k: string) => string),
 
   get hasLogistics(): boolean {
     return snap("has_logistics");
@@ -1125,7 +1119,7 @@ const settingsBase = {
       ) => Promise<void>,
     },
     // --- Apple Wallet writes ---
-    appleWallet: createAppleWalletUpdateSettings(encryptedUpdate),
+    appleWallet: appleWallet.createUpdateSettings(encryptedUpdate),
     autoPurgeOrphans: boolUpdate(
       CONFIG_KEYS.AUTO_PURGE_ORPHANS,
       "auto_purge_orphans",
@@ -1176,7 +1170,7 @@ const settingsBase = {
       "external_order_enabled",
     ),
     // --- Google Wallet writes ---
-    googleWallet: createGoogleWalletUpdateSettings(encryptedUpdate),
+    googleWallet: googleWallet.createUpdateSettings(encryptedUpdate),
     hasLogistics: boolUpdate(CONFIG_KEYS.HAS_LOGISTICS, "has_logistics"),
     listingDefaults: async (v: ListingDefaults): Promise<void> => {
       const json = serializeListingDefaults(v);

--- a/src/shared/wallets/apple-wallet-settings.ts
+++ b/src/shared/wallets/apple-wallet-settings.ts
@@ -7,7 +7,7 @@
 import type { SigningCredentials } from "#shared/apple-wallet.ts";
 import { createWalletSettingsKit } from "#shared/wallets/wallet-settings-types.ts";
 
-const kit = createWalletSettingsKit<
+export const appleWallet = createWalletSettingsKit<
   SigningCredentials,
   "passTypeId" | "teamId" | "signingCert" | "signingKey" | "wwdrCert"
 >({
@@ -44,7 +44,3 @@ const kit = createWalletSettingsKit<
     },
   },
 });
-
-export const getHostAppleWalletConfig = kit.getHostConfig;
-export const createAppleWalletReadSettings = kit.createReadSettings;
-export const createAppleWalletUpdateSettings = kit.createUpdateSettings;

--- a/src/shared/wallets/google-wallet-settings.ts
+++ b/src/shared/wallets/google-wallet-settings.ts
@@ -7,7 +7,7 @@
 import type { GoogleWalletCredentials } from "#shared/google-wallet.ts";
 import { createWalletSettingsKit } from "#shared/wallets/wallet-settings-types.ts";
 
-const kit = createWalletSettingsKit<
+export const googleWallet = createWalletSettingsKit<
   GoogleWalletCredentials,
   "issuerId" | "serviceAccountEmail" | "serviceAccountKey"
 >({
@@ -34,7 +34,3 @@ const kit = createWalletSettingsKit<
     },
   },
 });
-
-export const getHostGoogleWalletConfig = kit.getHostConfig;
-export const createGoogleWalletReadSettings = kit.createReadSettings;
-export const createGoogleWalletUpdateSettings = kit.createUpdateSettings;

--- a/src/ui/templates/admin/holidays.tsx
+++ b/src/ui/templates/admin/holidays.tsx
@@ -49,75 +49,66 @@ export const holidayToFieldValues = (
 ): Record<string, string | number | null> =>
   entityToFieldValues(holiday, getHolidayFields(), {});
 
-const { deletePage, editPage, listPage, newPage } =
-  defineAdminResourcePages<Holiday>({
-    active: "/admin/holidays",
-    basePath: "/admin/holidays",
-    delete: {
-      confirm: (holiday) => ({
-        args: {
-          end: holiday.end_date,
-          name: escapeHtml(holiday.name),
-          start: holiday.start_date,
-        },
-        key: "holidays.delete.confirm",
-      }),
-      danger: false,
-      heading: t("holidays.delete.heading"),
-      label: t("holidays.delete.confirm_label"),
-      name: (holiday) => holiday.name,
-      prompt: (holiday) => ({
-        args: { name: holiday.name },
-        key: "holidays.delete.confirm_prompt",
-      }),
-    },
-    labels: {
-      addHeading: t("holidays.add.heading"),
-      addSubmit: t("holidays.add.submit"),
-      addTitle: t("holidays.add.title"),
-      deleteButton: t("holidays.delete.submit"),
-      deleteLabel: t("holidays.delete.confirm_label"),
-      deleteTitle: t("holidays.delete.heading"),
-      editHeading: t("holidays.edit.heading"),
-      editTitle: t("holidays.edit.title"),
-      listTitle: t("terms.holidays"),
-    },
-    list: {
-      actions: (
-        <ActionButton href="/admin/holidays/new" icon="plus">
-          {t("holidays.add_holiday")}
-        </ActionButton>
-      ),
-      columns: holidayColumns,
-      empty: <p>{t("holidays.no_holidays")}</p>,
-      guideFooter: (
-        <GuideFooter href="/admin/guide#holidays">
-          {t("holidays.guide_link")}
-        </GuideFooter>
-      ),
-    },
-    renderFields: (holiday) => (
-      <Raw
-        html={renderFields(
-          getHolidayFields(),
-          holiday ? holidayToFieldValues(holiday) : {},
-        )}
-      />
+export const holidayPages = defineAdminResourcePages<Holiday>({
+  active: "/admin/holidays",
+  basePath: "/admin/holidays",
+  delete: {
+    confirm: (holiday) => ({
+      args: {
+        end: holiday.end_date,
+        name: escapeHtml(holiday.name),
+        start: holiday.start_date,
+      },
+      key: "holidays.delete.confirm",
+    }),
+    danger: false,
+    heading: t("holidays.delete.heading"),
+    label: t("holidays.delete.confirm_label"),
+    name: (holiday) => holiday.name,
+    prompt: (holiday) => ({
+      args: { name: holiday.name },
+      key: "holidays.delete.confirm_prompt",
+    }),
+  },
+  labels: {
+    addHeading: t("holidays.add.heading"),
+    addSubmit: t("holidays.add.submit"),
+    addTitle: t("holidays.add.title"),
+    deleteButton: t("holidays.delete.submit"),
+    deleteLabel: t("holidays.delete.confirm_label"),
+    deleteTitle: t("holidays.delete.heading"),
+    editHeading: t("holidays.edit.heading"),
+    editTitle: t("holidays.edit.title"),
+    listTitle: t("terms.holidays"),
+  },
+  list: {
+    actions: (
+      <ActionButton href="/admin/holidays/new" icon="plus">
+        {t("holidays.add_holiday")}
+      </ActionButton>
     ),
-  });
+    columns: holidayColumns,
+    empty: <p>{t("holidays.no_holidays")}</p>,
+    guideFooter: (
+      <GuideFooter href="/admin/guide#holidays">
+        {t("holidays.guide_link")}
+      </GuideFooter>
+    ),
+  },
+  renderFields: (holiday) => (
+    <Raw
+      html={renderFields(
+        getHolidayFields(),
+        holiday ? holidayToFieldValues(holiday) : {},
+      )}
+    />
+  ),
+});
 
 /** Admin holidays list page. */
 export const adminHolidaysPage = (
   holidays: Holiday[],
   session: AdminSession,
   successMessage?: string,
-): string => listPage(holidays, session, undefined, successMessage);
-
-/** Admin holiday create page. */
-export const adminHolidayNewPage = newPage;
-
-/** Admin holiday edit page. */
-export const adminHolidayEditPage = editPage;
-
-/** Admin holiday delete confirmation page. */
-export const adminHolidayDeletePage = deletePage;
+): string =>
+  holidayPages.listPage(holidays, session, undefined, successMessage);

--- a/src/ui/templates/admin/logistics.tsx
+++ b/src/ui/templates/admin/logistics.tsx
@@ -154,7 +154,7 @@ type AgentEditCtx = {
   selected: ReadonlySet<number>;
 };
 
-const { deletePage, editPage, newPage } = defineAdminResourcePages<
+export const logisticsAgentPages = defineAdminResourcePages<
   LogisticsAgent,
   AgentEditCtx
 >({
@@ -204,9 +204,6 @@ const { deletePage, editPage, newPage } = defineAdminResourcePages<
     ),
 });
 
-/** Admin logistics-agent create page (linked from the inline form fallback). */
-export const adminLogisticsAgentNewPage = newPage;
-
 /** Admin logistics-agent edit page. Grouped into fieldsets: the agent's details
  *  and the users assigned to drive it. */
 export const adminLogisticsAgentEditPage = (
@@ -216,10 +213,7 @@ export const adminLogisticsAgentEditPage = (
   session: AdminSession,
   error?: string,
 ): string =>
-  editPage(agent, session, error, {
+  logisticsAgentPages.editPage(agent, session, error, {
     selected: selectedUserIds,
     users,
   });
-
-/** Admin logistics-agent delete confirmation page. */
-export const adminLogisticsAgentDeletePage = deletePage;

--- a/src/ui/templates/admin/settings-statuses.tsx
+++ b/src/ui/templates/admin/settings-statuses.tsx
@@ -125,40 +125,39 @@ const deleteChildren = (status: AttendeeStatus): JSX.Element => (
   <p>{t("statuses.delete_confirm", { name: status.name })}</p>
 );
 
-const { deletePage, editPage, listPage, newPage } =
-  defineAdminResourcePages<AttendeeStatus>({
-    active: LIST_PATH,
-    basePath: LIST_PATH,
-    delete: {
-      children: deleteChildren,
-      danger: false,
-      heading: t("statuses.delete_title"),
-      label: t("common.name"),
-      name: (status) => status.name,
-    },
-    labels: {
-      addHeading: t("statuses.form_title_add"),
-      addSubmit: t("statuses.form_create_button"),
-      addTitle: t("statuses.form_title_add"),
-      deleteButton: t("statuses.delete_button"),
-      deleteLabel: t("common.name"),
-      deleteTitle: t("statuses.delete_title"),
-      editHeading: t("statuses.form_title_edit"),
-      editSubmit: t("statuses.form_save_button"),
-      editTitle: t("statuses.form_title_edit"),
-      listTitle: t("statuses.attendee_statuses_page_title"),
-    },
-    list: {
-      actions: (
-        <ActionButton href={`${LIST_PATH}/new`} icon="plus">
-          {t("statuses.add_status_button")}
-        </ActionButton>
-      ),
-      columns: statusColumns,
-      intro: <ProseIntro html={t("statuses.attendee_statuses_description")} />,
-    },
-    renderFields: renderStatusFields,
-  });
+export const statusPages = defineAdminResourcePages<AttendeeStatus>({
+  active: LIST_PATH,
+  basePath: LIST_PATH,
+  delete: {
+    children: deleteChildren,
+    danger: false,
+    heading: t("statuses.delete_title"),
+    label: t("common.name"),
+    name: (status) => status.name,
+  },
+  labels: {
+    addHeading: t("statuses.form_title_add"),
+    addSubmit: t("statuses.form_create_button"),
+    addTitle: t("statuses.form_title_add"),
+    deleteButton: t("statuses.delete_button"),
+    deleteLabel: t("common.name"),
+    deleteTitle: t("statuses.delete_title"),
+    editHeading: t("statuses.form_title_edit"),
+    editSubmit: t("statuses.form_save_button"),
+    editTitle: t("statuses.form_title_edit"),
+    listTitle: t("statuses.attendee_statuses_page_title"),
+  },
+  list: {
+    actions: (
+      <ActionButton href={`${LIST_PATH}/new`} icon="plus">
+        {t("statuses.add_status_button")}
+      </ActionButton>
+    ),
+    columns: statusColumns,
+    intro: <ProseIntro html={t("statuses.attendee_statuses_description")} />,
+  },
+  renderFields: renderStatusFields,
+});
 
 /** List of attendee statuses with reorder, edit and delete controls. */
 export const adminAttendeeStatusesPage = (
@@ -166,7 +165,7 @@ export const adminAttendeeStatusesPage = (
   session: AdminSession,
   error?: string,
   success?: string,
-): string => listPage(statuses, session, error, success);
+): string => statusPages.listPage(statuses, session, error, success);
 
 /** Shared new/edit form for an attendee status. Kept as a public export
  *  because the route handler renders one combined form page; the factory's
@@ -180,9 +179,6 @@ export const adminAttendeeStatusFormPage = (
 ): string => {
   const { status, error } = opts;
   return status === undefined
-    ? newPage(session, error)
-    : editPage(status, session, error);
+    ? statusPages.newPage(session, error)
+    : statusPages.editPage(status, session, error);
 };
-
-/** Confirmation page for deleting an attendee status. */
-export const adminAttendeeStatusDeletePage = deletePage;

--- a/test/lib/server-settings/apple-wallet.test.ts
+++ b/test/lib/server-settings/apple-wallet.test.ts
@@ -412,7 +412,7 @@ const setWalletEnvVars = () =>
   });
 
 describeWithEnv(
-  "getHostAppleWalletConfig",
+  "appleWallet.getHostConfig",
   {
     env: {
       APPLE_WALLET_PASS_TYPE_ID: undefined,

--- a/test/lib/server-settings/google-wallet.test.ts
+++ b/test/lib/server-settings/google-wallet.test.ts
@@ -328,7 +328,7 @@ const setGoogleWalletEnvVars = async () => {
 };
 
 describeWithEnv(
-  "getHostGoogleWalletConfig",
+  "googleWallet.getHostConfig",
   {
     env: {
       GOOGLE_WALLET_ISSUER_ID: undefined,

--- a/test/ui/templates/admin/holidays.test.tsx
+++ b/test/ui/templates/admin/holidays.test.tsx
@@ -2,12 +2,7 @@ import { expect } from "@std/expect";
 import { beforeAll, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
 import type { AdminSession, Holiday } from "#shared/types.ts";
-import {
-  adminHolidayDeletePage,
-  adminHolidayEditPage,
-  adminHolidayNewPage,
-  adminHolidaysPage,
-} from "#templates/admin/holidays.tsx";
+import { adminHolidaysPage, holidayPages } from "#templates/admin/holidays.tsx";
 import { setupTestEncryptionKey } from "#test-utils";
 
 const session: AdminSession = { adminLevel: "owner" };
@@ -54,9 +49,9 @@ describe("adminHolidaysPage (resource factory list page)", () => {
   });
 });
 
-describe("adminHolidayNewPage (resource factory new page)", () => {
+describe("holidayPages.newPage (resource factory new page)", () => {
   test("renders the create form posting to the base path with the add fields", () => {
-    const html = adminHolidayNewPage(session);
+    const html = holidayPages.newPage(session);
     expect(html).toContain('action="/admin/holidays"');
     expect(html).toContain('name="name"');
     expect(html).toContain('name="start_date"');
@@ -66,14 +61,14 @@ describe("adminHolidayNewPage (resource factory new page)", () => {
   });
 
   test("renders the error flash when an error is passed", () => {
-    const html = adminHolidayNewPage(session, "Start Date is required");
+    const html = holidayPages.newPage(session, "Start Date is required");
     expect(html).toContain("Start Date is required");
   });
 });
 
-describe("adminHolidayEditPage (resource factory edit page)", () => {
+describe("holidayPages.editPage (resource factory edit page)", () => {
   test("renders the edit form posting to the edit path with prefilled values", () => {
-    const html = adminHolidayEditPage(holiday, session);
+    const html = holidayPages.editPage(holiday, session);
     expect(html).toContain('action="/admin/holidays/42/edit"');
     expect(html).toContain("Christmas");
     expect(html).toContain("2026-12-25");
@@ -81,15 +76,15 @@ describe("adminHolidayEditPage (resource factory edit page)", () => {
   });
 
   test("renders the delete section linking to the delete confirmation page", () => {
-    const html = adminHolidayEditPage(holiday, session);
+    const html = holidayPages.editPage(holiday, session);
     expect(html).toContain('href="/admin/holidays/42/delete"');
     expect(html).toContain("Delete");
   });
 });
 
-describe("adminHolidayDeletePage (resource factory delete confirmation)", () => {
+describe("holidayPages.deletePage (resource factory delete confirmation)", () => {
   test("renders the type-the-name confirmation form posting to the delete path", () => {
-    const html = adminHolidayDeletePage(holiday, session);
+    const html = holidayPages.deletePage(holiday, session);
     expect(html).toContain('action="/admin/holidays/42/delete"');
     expect(html).toContain('name="confirm_identifier"');
     // The name to type is shown as the confirm target.
@@ -98,7 +93,7 @@ describe("adminHolidayDeletePage (resource factory delete confirmation)", () => 
   });
 
   test("renders the error flash when an error is passed", () => {
-    const html = adminHolidayDeletePage(
+    const html = holidayPages.deletePage(
       holiday,
       session,
       "Holiday name does not match",


### PR DESCRIPTION
## What this does

A follow-up to #1649, applying the same "No alias exports — expose the shared mechanism itself" rule to the alias families that live outside the cached DB tables. Net **−78 lines**, no behaviour change.

## Alias families removed

| Module(s) | Deleted aliases | Object now exported |
|---|---|---|
| `wallets/apple-wallet-settings.ts`, `google-wallet-settings.ts` | `getHost*WalletConfig`, `create*Wallet{Read,Update}Settings` | `appleWallet` / `googleWallet` |
| `db/booking-attempts.ts` | `isBookingRateLimited`, `recordBookingAttempt` | `bookingLimiter` |
| `admin/settings-{square,sumup,stripe}.ts` | `handleAdmin*Post`, `handle*TestPost` | `squareRoutes` / `sumupRoutes` / `stripeRoutes` |
| `templates/admin/{holidays,logistics,settings-statuses}.tsx` | `admin*Page = newPage/editPage/deletePage` | `holidayPages` / `logisticsAgentPages` / `statusPages` |

Callers now use the members directly — e.g. `appleWallet.getHostConfig(...)`, `bookingLimiter.isLimited(ip)`, the admin route map calls `squareRoutes.save` / `.test`, and the resource routes render `holidayPages.newPage`. The stale `describe(...)` test labels that named the old exports were updated to match.

## Kept (not aliases)

`handleAdminSquareWebhookPost` (a real `settingsSecret(...)` handler) and the list/edit/form page wrappers that call `listPage`/`editPage` with extra arguments — all rewired to the new object members. The `X = Schema.options` constants (`CONTACT_FIELDS`, `VALID_EMAIL_PROVIDERS`, `ADDRESS_LOOKUP_SETTINGS`) are deliberately left alone — those are the repo's endorsed schema-tized pattern, not aliases.

## Checks

`typecheck`, `lint`, and `cpd` (0 clones) pass; the affected wallet / booking / provider-settings / admin-page test suites pass (292 in isolation). Every conversion is a bare member reference or an inline call (no new wrapper arrows), so there's no coverage regression of the kind that needed a follow-up fix in #1649.

Note: the two `deploy/chobble/*` commit statuses fail with *"Organization suspended - resolve billing to deploy"* — a Deno Deploy billing issue affecting every commit org-wide, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBBMhJLEuyecrWK8CaHfMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBBMhJLEuyecrWK8CaHfMK)_