### PR TITLE
Hold the page header still when switching between an entity's tabs

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -1377,6 +1377,13 @@ output.success {
   }
 }
 
+/* The attendee's status heading, shown above the tab strip whenever more than
+   one status exists. Like the notes below it, the heading is identical on every
+   attendee tab, so pin it too — switching tabs holds it still. */
+.attendee-status {
+  view-transition-name: attendee-status;
+}
+
 /* Per-attendee operator/system notes */
 .attendee-notes {
   margin-bottom: var(--space-l);
@@ -3371,6 +3378,14 @@ label:hover .embed-toggle-badge,
 }
 
 /* ── Entity pages: the tabbed admin "edit X" framework ── */
+
+/* The page header above the tab strip — the entity's `<h1>` title and any
+   prose extra (e.g. the attendee page's "Add a note" link). Its content is the
+   same on every one of an entity's tabs, so pin it: switching Edit → Attendees
+   → Actions keeps the same heading in place instead of re-fading it in. */
+.entity-header {
+  view-transition-name: entity-header;
+}
 
 .entity-tabs {
   margin: 0;

--- a/src/ui/templates/admin/attendee-page.tsx
+++ b/src/ui/templates/admin/attendee-page.tsx
@@ -236,7 +236,7 @@ export const attendeeBanner = ({
   return (
     <>
       {statuses.length > 1 && (
-        <div class="prose">
+        <div class="prose attendee-status">
           <h2>
             {t("attendee_form.status_heading", {
               value: status ? status.name : t("attendee_form.status_none"),

--- a/src/ui/templates/admin/entity-pages.tsx
+++ b/src/ui/templates/admin/entity-pages.tsx
@@ -211,7 +211,7 @@ export const entityPageView = (view: EntityPageView): string =>
   String(
     <Layout title={view.title}>
       <AdminNav active={view.navActive} session={view.session} />
-      <div class="prose">
+      <div class="prose entity-header">
         <h1>{view.title}</h1>
         {view.proseExtra}
       </div>

--- a/test/lib/server-attendee-form/status.test.ts
+++ b/test/lib/server-attendee-form/status.test.ts
@@ -161,6 +161,9 @@ describeWithEnv(
         const id = await seedAttendee(reservation.id, 900);
         const html = await getEdit(id);
         expect(html).toContain("<h2>Status: Reserved</h2>");
+        // The heading is wrapped in the .attendee-status pin so it holds still
+        // across the view transition between an attendee's tabs.
+        expect(html).toContain('<div class="prose attendee-status">');
       });
 
       test("edit page status heading reads None when the attendee has no status", async () => {

--- a/test/ui/templates/admin/entity-pages.test.ts
+++ b/test/ui/templates/admin/entity-pages.test.ts
@@ -218,11 +218,18 @@ describe("entityPageView", () => {
       proseExtra: Raw({ html: '<p><a href="/add-note">Add a note</a></p>' }),
     });
     // The extra content sits inside the same prose <div> as the heading.
-    const proseStart = html.indexOf('<div class="prose">');
+    const proseStart = html.indexOf('<div class="prose entity-header">');
     const proseEnd = html.indexOf("</div>", proseStart);
     const prose = html.slice(proseStart, proseEnd);
     expect(prose).toContain("<h1>Attendee: Jane</h1>");
     expect(prose).toContain('<a href="/add-note">Add a note</a>');
+  });
+
+  test("pins the header block across view transitions via .entity-header", () => {
+    const html = entityPageView(view);
+    // The header carries the view-transition-name hook so the entity title
+    // holds still while only the panel beneath the tabs transitions.
+    expect(html).toContain('<div class="prose entity-header">');
   });
 
   test("marks only the active tab with aria-current=page", () => {


### PR DESCRIPTION
## What this changes

When you move between the tabs on an attendee page (Overview → Edit → Actions, and the same on other admin "edit X" pages), the browser plays a little cross-fade between the old and new page. Until now, the big heading at the top of the page — the entity's name, plus the attendee's status line — faded out and back in on every tab switch, even though it reads exactly the same on all of that entity's tabs.

This change tells the browser to keep those unchanging bits in place during the transition, so only the content below the tab strip actually moves. It matches how the tab strip itself and the notes banner already behave.

## How

- Added a `view-transition-name` to the page header block (the title heading and the "Add a note" link beside it). Because this lives in the shared entity-page layout, **every** admin entity page — attendees, listings, and the rest — gets it, not just attendees.
- Added the same to the attendee status heading, which sits above the tabs whenever more than one status exists.

## Tests

- Locked the header's pinning hook into the entity-page render test.
- Strengthened the existing multi-status test to assert the status heading now carries its pinning wrapper.
- Full `lint:ci`, typecheck, and the affected test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhgqYzvm76S7HHFRgoSrLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhgqYzvm76S7HHFRgoSrLm)_