### PR TITLE
Harden the chart-of-accounts tests

### DIFF
--- a/test/shared/accounting/accounts.test.ts
+++ b/test/shared/accounting/accounts.test.ts
@@ -3,34 +3,50 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   attendeeAccount,
   BOOKING_FEE_INCOME,
+  costAccount,
+  isRowAccountType,
+  isSingletonAccountType,
   modifierAccount,
+  ROW_ACCOUNT_CONSTRUCTORS,
   revenueAccount,
+  SINGLETON_ACCOUNTS,
   WORLD,
+  WRITEOFF,
 } from "#shared/accounting/accounts.ts";
 
 describe("accounting > accounts", () => {
   test("exposes the fixed singleton accounts", () => {
     expect(WORLD).toEqual({ id: "world", type: "external" });
     expect(BOOKING_FEE_INCOME).toEqual({ id: "booking", type: "fee_income" });
+    expect(WRITEOFF).toEqual({ id: "default", type: "writeoff" });
   });
 
-  test("builds row-backed accounts from a valid id", () => {
-    expect(attendeeAccount(3)).toEqual({ id: "3", type: "attendee" });
-    expect(revenueAccount(7)).toEqual({ id: "7", type: "revenue" });
-    expect(modifierAccount(11)).toEqual({ id: "11", type: "modifier" });
-  });
-
-  const builders: [name: string, build: (id: number) => unknown][] = [
-    ["attendeeAccount", attendeeAccount],
-    ["revenueAccount", revenueAccount],
-    ["modifierAccount", modifierAccount],
+  // Each row builder maps its rows onto its OWN account type — a swapped `kind`
+  // would silently divert money to another type's account.
+  const builders: [
+    name: string,
+    build: (id: number) => unknown,
+    type: string,
+  ][] = [
+    ["attendeeAccount", attendeeAccount, "attendee"],
+    ["revenueAccount", revenueAccount, "revenue"],
+    ["costAccount", costAccount, "cost"],
+    ["modifierAccount", modifierAccount, "modifier"],
   ];
+
+  for (const [builderName, build, type] of builders) {
+    test(`${builderName} builds a ${type} account from a valid id`, () => {
+      expect(build(3)).toEqual({ id: "3", type });
+    });
+  }
 
   const badIds: [name: string, id: number][] = [
     ["zero", 0],
     ["negative", -1],
     ["fractional", 1.5],
     ["unsafe (too large)", 2 ** 53],
+    ["NaN", Number.NaN],
+    ["infinite", Number.POSITIVE_INFINITY],
   ];
 
   for (const [builderName, build] of builders) {
@@ -40,4 +56,51 @@ describe("accounting > accounts", () => {
       });
     }
   }
+
+  describe("account-type guards", () => {
+    test("isRowAccountType accepts the row-backed types only", () => {
+      for (const type of ["attendee", "cost", "modifier", "revenue"]) {
+        expect(isRowAccountType(type)).toBe(true);
+      }
+      for (const type of ["external", "fee_income", "writeoff", "", "nope"]) {
+        expect(isRowAccountType(type)).toBe(false);
+      }
+    });
+
+    test("isSingletonAccountType accepts the singleton types only", () => {
+      for (const type of ["external", "fee_income", "writeoff"]) {
+        expect(isSingletonAccountType(type)).toBe(true);
+      }
+      for (const type of ["attendee", "cost", "modifier", "revenue", "nope"]) {
+        expect(isSingletonAccountType(type)).toBe(false);
+      }
+    });
+  });
+
+  describe("dispatch tables", () => {
+    test("every singleton type resolves to its own account", () => {
+      expect(SINGLETON_ACCOUNTS.external).toEqual(WORLD);
+      expect(SINGLETON_ACCOUNTS.fee_income).toEqual(BOOKING_FEE_INCOME);
+      expect(SINGLETON_ACCOUNTS.writeoff).toEqual(WRITEOFF);
+    });
+
+    test("every row type resolves to a constructor for its own account type", () => {
+      expect(ROW_ACCOUNT_CONSTRUCTORS.attendee(5)).toEqual({
+        id: "5",
+        type: "attendee",
+      });
+      expect(ROW_ACCOUNT_CONSTRUCTORS.cost(5)).toEqual({
+        id: "5",
+        type: "cost",
+      });
+      expect(ROW_ACCOUNT_CONSTRUCTORS.modifier(5)).toEqual({
+        id: "5",
+        type: "modifier",
+      });
+      expect(ROW_ACCOUNT_CONSTRUCTORS.revenue(5)).toEqual({
+        id: "5",
+        type: "revenue",
+      });
+    });
+  });
 });

--- a/test/shared/accounting/accounts.test.ts
+++ b/test/shared/accounting/accounts.test.ts
@@ -36,6 +36,8 @@ describe("accounting > accounts", () => {
 
   for (const [builderName, build, type] of builders) {
     test(`${builderName} builds a ${type} account from a valid id`, () => {
+      // 1 is the smallest accepted id — the boundary of the `id > 0` guard.
+      expect(build(1)).toEqual({ id: "1", type });
       expect(build(3)).toEqual({ id: "3", type });
     });
   }


### PR DESCRIPTION
## What

`src/shared/accounting/accounts.ts` maps domain rows onto ledger accounts — it's where "attendee 3" becomes the account `attendee:3`. A wrong account type, or a bad id slipping past the guard, silently diverts money to the wrong account's balance/statements/refunds. The existing test left real gaps, so this fills them:

- **All four row builders covered** — adds `costAccount` (previously untested for both valid and bad ids), and asserts each builder maps to its **own** account type, so a swapped `kind` (money diverted to another type) is caught.
- **More bad-id cases** — rejects `NaN` and infinite ids alongside the existing zero / negative / fractional / unsafe-too-large cases, pinning the full `Number.isSafeInteger(id) && id > 0` guard.
- **The type guards** — `isRowAccountType` / `isSingletonAccountType` accept exactly their own type sets and reject the other set (plus junk).
- **The dispatch tables** — `SINGLETON_ACCOUNTS` and `ROW_ACCOUNT_CONSTRUCTORS` each resolve every type to the correct account/constructor, so a swapped entry fails a test.

## Notes
- Pure, harness-free unit tests (35 steps). Same playbook as the recent fields/payments/auth hardening — a focused module hardened toward a full behavioural mutation kill.
- No production changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MeqQm2dPU3Zja5azPyHAx)_