### PR TITLE
Schematize the api_keys table onto defineTable; share the id/created + column fragments

### DIFF
--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -26,6 +26,7 @@ import type {
   OwnerKeyEncrypted,
 } from "#shared/crypto/sealed.ts";
 import { queryAll, queryBatch, resultRows } from "#shared/db/client.ts";
+import { idAndCreatedSchema } from "#shared/db/common-schema.ts";
 import {
   decryptListingWithCount,
   LISTING_COUNT_GROUP_BY,
@@ -79,9 +80,8 @@ export const activityLogTable = defineTable<
   name: "activity_log",
   primaryKey: "id",
   schema: {
+    ...idAndCreatedSchema(nowIso),
     attendee_id: col.simple<number | null>(),
-    created: col.withDefault(() => nowIso()),
-    id: col.generated<number>(),
     listing_id: col.simple<number | null>(),
     message: col.simple<StoredLogMessage>(),
   },

--- a/src/shared/db/api-keys.ts
+++ b/src/shared/db/api-keys.ts
@@ -9,20 +9,60 @@
  * Keys inherit admin_level from their parent user.
  */
 
+import { mapParallel } from "#fp";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import { wrapKeyWithToken } from "#shared/crypto/keys.ts";
+import type { BlindIndex, WrappedKey } from "#shared/crypto/sealed.ts";
 import {
   deleteByField,
   execute,
   executeUpdate,
-  insert,
   queryAll,
   queryOne,
 } from "#shared/db/client.ts";
+import { idAndCreatedSchema } from "#shared/db/common-schema.ts";
+import { defineIdTable } from "#shared/db/define-id-table.ts";
+import { col } from "#shared/db/table.ts";
 import { nowIso } from "#shared/now.ts";
 import { getTouchOverride } from "#shared/test-overrides.ts";
 import type { ApiKey } from "#shared/types.ts";
+
+/** A row with its `name` decrypted for display — the table's read shape. */
+type ApiKeyRow = {
+  id: number;
+  user_id: number;
+  key_index: BlindIndex;
+  wrapped_data_key: WrappedKey;
+  name: string;
+  created: string;
+  last_used: string;
+};
+
+/** Fields a caller supplies to create a key: `name` is plaintext (the table
+ * encrypts it), and `created`/`last_used` fall back to their column defaults. */
+type ApiKeyInput = {
+  userId: number;
+  keyIndex: BlindIndex;
+  wrappedDataKey: WrappedKey;
+  name: string;
+};
+
+/** Declarative api_keys table — `name` is encrypted at rest (decrypted on read),
+ * every other column is stored as-is. The single source of the column set and
+ * the encrypt/decrypt policy for this table. */
+const apiKeysTable = defineIdTable<ApiKeyRow, ApiKeyInput>("api_keys", {
+  ...idAndCreatedSchema(nowIso),
+  key_index: col.simple<BlindIndex>(),
+  last_used: col.withDefault(() => ""),
+  name: col.encrypted(encrypt, decrypt),
+  user_id: col.simple<number>(),
+  wrapped_data_key: col.simple<WrappedKey>(),
+});
+
+/** The api_keys columns, in one place, for the reads that select every column. */
+const API_KEY_COLUMNS =
+  "id, user_id, key_index, wrapped_data_key, name, created, last_used";
 
 /**
  * Create a new API key for a user.
@@ -38,31 +78,26 @@ export const createApiKey = async (
   const apiKey = generateToken();
   const keyIndex = await hmacHash(apiKey);
   const wrappedDataKey = await wrapKeyWithToken(dataKey, apiKey);
-  const encryptedName = await encrypt(name);
-
-  const { sql, args } = insert("api_keys", {
-    created: nowIso(),
-    key_index: keyIndex,
-    last_used: "",
-    name: encryptedName,
-    user_id: userId,
-    wrapped_data_key: wrappedDataKey,
+  const row = await apiKeysTable.insert({
+    keyIndex,
+    name,
+    userId,
+    wrappedDataKey,
   });
-  const result = await execute(sql, args);
-
-  return { apiKey, id: Number(result.lastInsertRowid) };
+  return { apiKey, id: row.id };
 };
 
 /**
  * Look up an API key by its plaintext token.
- * Returns the row if found (for auth), null otherwise.
+ * Returns the row (name still sealed — the auth path never reads it) if found,
+ * null otherwise.
  */
 export const getApiKeyByToken = async (
   token: string,
 ): Promise<ApiKey | null> => {
   const keyIndex = await hmacHash(token);
   return queryOne<ApiKey>(
-    "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE key_index = ?",
+    `SELECT ${API_KEY_COLUMNS} FROM api_keys WHERE key_index = ?`,
     [keyIndex],
   );
 };
@@ -75,19 +110,17 @@ export const getApiKeysForUser = async (
 ): Promise<
   Array<{ id: number; name: string; created: string; lastUsed: string }>
 > => {
-  const rows = await queryAll<ApiKey>(
-    "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE user_id = ? ORDER BY id ASC",
+  const rows = await queryAll<ApiKeyRow>(
+    `SELECT ${API_KEY_COLUMNS} FROM api_keys WHERE user_id = ? ORDER BY id ASC`,
     [userId],
   );
-
-  return Promise.all(
-    rows.map(async (row) => ({
-      created: row.created,
-      id: row.id,
-      lastUsed: row.last_used,
-      name: await decrypt(row.name),
-    })),
-  );
+  const decrypted = await mapParallel(apiKeysTable.fromDb)(rows);
+  return decrypted.map((row) => ({
+    created: row.created,
+    id: row.id,
+    lastUsed: row.last_used,
+    name: row.name,
+  }));
 };
 
 /**
@@ -97,12 +130,13 @@ export const getApiKeyForUser = async (
   id: number,
   userId: number,
 ): Promise<{ id: number; name: string }> => {
-  const row = await queryOne<ApiKey>(
-    "SELECT id, user_id, key_index, wrapped_data_key, name, created, last_used FROM api_keys WHERE id = ? AND user_id = ?",
+  const row = await queryOne<ApiKeyRow>(
+    `SELECT ${API_KEY_COLUMNS} FROM api_keys WHERE id = ? AND user_id = ?`,
     [id, userId],
   );
   if (!row) throw new Error(`API key ${id} not found for user ${userId}`);
-  return { id: row.id, name: await decrypt(row.name) };
+  const decrypted = await apiKeysTable.fromDb(row);
+  return { id: decrypted.id, name: decrypted.name };
 };
 
 /**

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -100,6 +100,9 @@ export const createSession = async (
   cacheSession(tokenHash, session);
 };
 
+/** The sessions columns selected by the by-token and list reads. */
+const SESSION_COLUMNS = "token, csrf_token, expires, wrapped_data_key, user_id";
+
 /**
  * Get a session by token (with 10s TTL cache)
  * Token is hashed for database lookup
@@ -113,7 +116,7 @@ export const getSession = async (token: string): Promise<Session | null> => {
 
   // Query DB and cache result (token column contains the hash)
   const session = await queryOne<Session>(
-    "SELECT token, csrf_token, expires, wrapped_data_key, user_id FROM sessions WHERE token = ?",
+    `SELECT ${SESSION_COLUMNS} FROM sessions WHERE token = ?`,
     [tokenHash],
   );
   cacheSession(tokenHash, session);
@@ -143,7 +146,7 @@ export const deleteAllSessions = async (): Promise<void> => {
  */
 export const getAllSessions = (): Promise<Session[]> =>
   queryAll<Session>(
-    "SELECT token, csrf_token, expires, wrapped_data_key, user_id FROM sessions ORDER BY expires DESC",
+    `SELECT ${SESSION_COLUMNS} FROM sessions ORDER BY expires DESC`,
   );
 
 /**


### PR DESCRIPTION
## What this does

Brings `api-keys.ts` — the last DB module still entirely hand-rolled — onto the same declarative table infrastructure every other module uses, and removes the duplicated column lists it and `sessions.ts` carried. This is a **consistency / schematization** change following the SQL-layer dig, not a line-count reduction.

## The problem

`api-keys.ts` hand-wrote everything the shared infra exists to remove:
- the column list `id, user_id, key_index, wrapped_data_key, name, created, last_used` was spelled **three times**;
- `createApiKey` built its insert with manual `encrypt(name)` + `insert(...)`;
- `getApiKeysForUser` / `getApiKeyForUser` each had a by-hand `await decrypt(row.name)` mapper.

## The change

- **`apiKeysTable = defineIdTable(...)`** with a `col` schema — `name` is `col.encrypted(encrypt, decrypt)`, the rest `col.simple` / `col.withDefault`. `createApiKey` now calls `apiKeysTable.insert(...)`, and the display reads decrypt through `apiKeysTable.fromDb`.
- **`getApiKeyByToken` stays on the raw sealed-row path.** The auth path only reads `user_id` / `wrapped_data_key`, never the name, so it needn't decrypt. The shared `ApiKey` type keeps its sealed `name: EnvKeyEncrypted`; the decrypted read shape is a local `ApiKeyRow`. No ripple into `types.ts`.
- **Column consts:** one `API_KEY_COLUMNS` (was 3 copies) and one `SESSION_COLUMNS` in `sessions.ts` (was 2).
- **Shared fragment:** both `api_keys` and `activity_log` now build their `id`/`created` columns from the existing `idAndCreatedSchema(nowIso)` fragment instead of repeating the pair (this also removed a duplication the new table would otherwise have introduced).

## Honest note on scope

This adds a few net lines — the declarative schema + `ApiKeyRow`/`ApiKeyInput` types cost more than the inline strings they replace. The win is **one mechanism across the whole DB layer** (the next person editing api-keys finds the `defineTable` pattern they expect) and dropping the hand-rolled column strings, crypto, and mappers. `sessions.ts` deliberately keeps its bespoke 10s-TTL cache and pre-hashed token (no encryption transform), so it gets only the column-const dedup, not a full table.

## Checks

`typecheck`, `lint`, and `cpd` (0 clones) pass. Affected tests (api-keys, sessions, activity-log, Bearer auth lockout) pass, and `api-keys.ts` is at **100% line/branch coverage**. Behaviour-preserving throughout.

Note: the two `deploy/chobble/*` commit statuses fail with *"Organization suspended - resolve billing to deploy"* — a Deno Deploy billing issue affecting every commit org-wide, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBBMhJLEuyecrWK8CaHfMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBBMhJLEuyecrWK8CaHfMK)_