### PR TITLE
Hide the "Add" sub-menu when viewing a single attendee (and other single-item pages)

### DIFF
--- a/src/features/admin/attendee-page.ts
+++ b/src/features/admin/attendee-page.ts
@@ -213,7 +213,9 @@ export const attendeePage: EntityPage<LoadedAttendee> = defineEntityPage({
   basePath: (id) => `/admin/attendees/${id}`,
   guard: requireSessionOr,
   load: (id) => loadAttendeeForEdit(id),
-  navActive: "/admin/attendees",
+  // A single attendee is a page *within* the Attendees section: highlight the
+  // top-level link, but never re-open the section's "Add" sub-nav beside it.
+  navActive: { section: "/admin/attendees" },
   proseExtra: ({ attendee }) =>
     Promise.resolve(AddNoteLink({ attendeeId: attendee.id })),
   tabs: [

--- a/src/features/admin/entity-pages.ts
+++ b/src/features/admin/entity-pages.ts
@@ -41,6 +41,7 @@ import {
   type ResolvedAction,
   type SummaryRow,
 } from "#templates/admin/entity-pages.tsx";
+import type { NavActive } from "#templates/admin/nav.tsx";
 import type { IconName } from "#templates/components/actions.tsx";
 
 /** Entity row key: numeric ids for ordinary tables, strings for blind-index
@@ -120,8 +121,11 @@ export interface EntityPageDef<E, Id extends EntityId = number> {
   /** Concrete base URL for an id — URL minting only, never a route pattern. */
   basePath: (id: Id) => string;
   titleOf: (entity: E) => string;
-  /** Section highlighted in the admin nav. */
-  navActive: string;
+  /** What the admin nav marks active. A single-item entity page passes
+   * `{ section }` so the section's top link highlights without re-opening its
+   * "Add" sub-nav; a page that IS a real section route (e.g. the Site content
+   * editors, whose route is itself a sub-nav item) passes a plain route string. */
+  navActive: NavActive;
   /** The GET auth floor — the weakest role that may see any tab. */
   guard: SessionGuard<AuthSession>;
   load: (id: Id, session: AuthSession) => Promise<E | null>;

--- a/src/features/admin/group-page.ts
+++ b/src/features/admin/group-page.ts
@@ -111,7 +111,9 @@ export const groupPage: EntityPage<Group> = defineEntityPage({
   // resolves to just the Edit tab.
   guard: requireContentOr,
   load: (id) => loadGroupForPage(id),
-  navActive: "/admin/groups",
+  // A single group is a page *within* the Groups section — highlight the top
+  // link, no "Add" sub-nav (see attendee-page.ts).
+  navActive: { section: "/admin/groups" },
   tabs: [
     panelTab("", "entity.tab.overview", loadGroupOverviewPanel, staffOnly),
     panelTab(

--- a/src/features/admin/listing-page.ts
+++ b/src/features/admin/listing-page.ts
@@ -144,7 +144,11 @@ export const listingPage: EntityPage<LoadedListing> = defineEntityPage({
   // an editor's page resolves to just the Edit tab.
   guard: requireContentOr,
   load: (id) => loadListingForPage(id),
-  navActive: "/admin/",
+  // A single listing is a page *within* the Listings section — highlight the
+  // top link, no "Add"/"Import" sub-nav. (This previously pointed at the Home
+  // route purely to dodge the sub-nav; `{ section }` now expresses the intent
+  // directly and highlights the correct section.)
+  navActive: { section: "/admin/listings" },
   tabs: [
     overviewTab,
     {

--- a/src/features/admin/servicing.tsx
+++ b/src/features/admin/servicing.tsx
@@ -182,7 +182,7 @@ const renderServicingPage = ({
     : "/admin/servicing/new";
   return String(
     <AdminPage
-      active={event ? "/admin/servicing" : "/admin/servicing/new"}
+      active={event ? { section: "/admin/servicing" } : "/admin/servicing/new"}
       session={session}
       title={title}
     >

--- a/src/ui/templates/admin/admin-page.tsx
+++ b/src/ui/templates/admin/admin-page.tsx
@@ -17,14 +17,14 @@
 import { CsrfForm, Flash } from "#shared/forms.tsx";
 import type { Child } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession, Theme } from "#shared/types.ts";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, type NavActive } from "#templates/admin/nav.tsx";
 import { Layout } from "#templates/layout.tsx";
 /* jscpd:ignore-end */
 
 export type AdminPageProps = {
   title: string;
   session: AdminSession;
-  active: string;
+  active: NavActive;
   /** Optional page theme forwarded to <Layout> — the settings/debug pages
    *  preview the site's saved theme (`s.theme`) rather than the viewer's. */
   theme?: Theme;
@@ -73,7 +73,7 @@ export const adminFormPage = ({
   children,
 }: {
   title: string;
-  active: string;
+  active: NavActive;
   session: AdminSession;
   action: string;
   error?: string | undefined;

--- a/src/ui/templates/admin/attendee-notes.tsx
+++ b/src/ui/templates/admin/attendee-notes.tsx
@@ -183,7 +183,7 @@ export const adminAddNotePage = ({
 }): string =>
   String(
     <AdminPage
-      active="/admin/attendees"
+      active={{ section: "/admin/attendees" }}
       flash={<Flash error={error} />}
       session={session}
       title={t("notes.add_title")}
@@ -231,7 +231,7 @@ export const adminDeleteNotePage = ({
 }): string =>
   ConfirmPage({
     action: `/admin/attendee/${note.attendee_id}/note/${note.id}/delete`,
-    active: "/admin/attendees",
+    active: { section: "/admin/attendees" },
     buttonText: t("notes.delete_submit"),
     children: (
       <>

--- a/src/ui/templates/admin/bulk-actions.tsx
+++ b/src/ui/templates/admin/bulk-actions.tsx
@@ -83,7 +83,7 @@ export const adminBulkActionsPage = (
   const allDeactivated = listings.length > 0 && !hasActive;
   return String(
     <AdminPage
-      active="/admin/groups"
+      active={{ section: "/admin/groups" }}
       session={session}
       title={t("bulk_actions.title_bulk", { name: group.name })}
     >
@@ -306,7 +306,7 @@ const bulkConfirmPage = (
   const count = listings.filter(config.countPredicate).length;
   return ConfirmPage({
     action: config.action,
-    active: "/admin/groups",
+    active: { section: "/admin/groups" },
     buttonText: config.buttonText,
     children: config.children(count, group),
     danger: config.danger,

--- a/src/ui/templates/admin/confirm-page.tsx
+++ b/src/ui/templates/admin/confirm-page.tsx
@@ -14,6 +14,7 @@ import type { Child } from "#shared/jsx/jsx-runtime.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminPage } from "#templates/admin/admin-page.tsx";
+import type { NavActive } from "#templates/admin/nav.tsx";
 
 /* jscpd:ignore-end */
 
@@ -22,7 +23,7 @@ export type TCall = { key: string; args?: Record<string, unknown> };
 
 export type ConfirmPageProps = {
   title: string;
-  active: string;
+  active: NavActive;
   session: AdminSession;
   error?: string | undefined;
   /** Optional content rendered between AdminPage's header and the Flash/error

--- a/src/ui/templates/admin/entity-pages.tsx
+++ b/src/ui/templates/admin/entity-pages.tsx
@@ -17,7 +17,7 @@ import type { ActivityLogEntry } from "#shared/db/activityLog.ts";
 import type { TabLink } from "#shared/entity-pages/core.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { ActivityLogTable } from "#templates/admin/activityLog.tsx";
-import { AdminNav } from "#templates/admin/nav.tsx";
+import { AdminNav, type NavActive } from "#templates/admin/nav.tsx";
 import { ActionButton, type IconName } from "#templates/components/actions.tsx";
 import { DetailTable } from "#templates/components/detail-table.tsx";
 import { Layout } from "#templates/layout.tsx";
@@ -187,7 +187,7 @@ const TabStrip = ({ tabs }: { tabs: TabLink[] }): JSX.Element => (
 /** Everything the page shell needs, all IO already done. */
 export interface EntityPageView {
   title: string;
-  navActive: string;
+  navActive: NavActive;
   session: AdminSession;
   /** Optional extra content rendered inside the prose block, right after the
    *  `<h1>` (e.g. the attendee page's "Add a note" link). */

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -273,7 +273,7 @@ export const adminGroupDeletePage = (
 ): string =>
   ConfirmPage({
     action: `/admin/groups/${group.id}/delete`,
-    active: "/admin/groups",
+    active: { section: "/admin/groups" },
     buttonText: t("groups.delete.submit"),
     children: (
       <>

--- a/src/ui/templates/admin/images.tsx
+++ b/src/ui/templates/admin/images.tsx
@@ -241,7 +241,7 @@ export const adminImageDeletePage = (
 ): string =>
   ConfirmPage({
     action: `/admin/images/${image.id}/delete`,
-    active: "/admin/images",
+    active: { section: "/admin/images" },
     buttonText: t("images.delete.submit"),
     danger: true,
     error,

--- a/src/ui/templates/admin/modifiers/aggregates.tsx
+++ b/src/ui/templates/admin/modifiers/aggregates.tsx
@@ -72,7 +72,7 @@ const modifierRecalculateRenderer = (
 ) =>
   recalculatePageRenderer({
     action: `/admin/modifiers/recalculate/${modifier.id}`,
-    active: "/admin/modifiers",
+    active: { section: "/admin/modifiers" },
     currentLabel: t("modifiers.recalculate.current"),
     description: t("modifiers.recalculate.description"),
     recalculatedLabel: t("modifiers.recalculate.from_attendees"),

--- a/src/ui/templates/admin/modifiers/pages.tsx
+++ b/src/ui/templates/admin/modifiers/pages.tsx
@@ -141,7 +141,7 @@ export const adminModifierEditPage = (
 ): string =>
   String(
     <AdminPage
-      active="/admin/modifiers"
+      active={{ section: "/admin/modifiers" }}
       session={session}
       title={t("modifiers.edit.heading")}
     >
@@ -179,7 +179,7 @@ export const adminModifierDeletePage = (
 ): string =>
   ConfirmPage({
     action: `/admin/modifiers/${modifier.id}/delete`,
-    active: "/admin/modifiers",
+    active: { section: "/admin/modifiers" },
     buttonText: t("modifiers.delete.submit"),
     children: (
       <>

--- a/src/ui/templates/admin/nav.tsx
+++ b/src/ui/templates/admin/nav.tsx
@@ -31,6 +31,40 @@ import {
   nodeLis,
 } from "#templates/components/nav.tsx";
 
+/**
+ * What the admin nav should mark active for the current page.
+ *
+ * - A plain route string — the page *is* this route: a section's landing page
+ *   (`/admin/attendees`), an "Add X" create page (`/admin/attendees/new`), or a
+ *   settings/site sub-page (`/admin/privacy`). The nav highlights the matching
+ *   link and, when the route is a section's landing route or one of its sub-nav
+ *   items, opens that section's sub-nav (current sub-page highlighted).
+ * - `{ section }` — the page merely lives *within* a section: a detail or child
+ *   view of one item (one attendee, one listing, the add-note form). The nav
+ *   highlights the section's top-level link but never opens its sub-nav.
+ *
+ * The `{ section }` form is the *only* way to highlight a section without also
+ * surfacing its sub-nav. It exists because a single-item page is not the
+ * section's landing page, so the section's "Add" create link has no business
+ * appearing beside it — and the sub-nav resolves purely from the active route,
+ * so a detail page that reuses the section's landing route as a bare `active`
+ * string (to get the top link highlighted) would silently re-trigger that "Add"
+ * affordance. Naming the section explicitly makes that impossible to do by
+ * accident: a section a page is *in* can never be mistaken for the section's
+ * landing route the page is *on*.
+ */
+export type NavActive = string | { readonly section: string };
+
+/** The route to resolve highlighting from, for either `NavActive` shape. */
+const activeRoute = (active: NavActive): string =>
+  typeof active === "string" ? active : active.section;
+
+/** True when a page is merely *within* a section (a single-item detail/child
+ * page) rather than on a real section route — so it highlights the section's
+ * top link but shows no sub-nav. */
+const isWithinSection = (active: NavActive): boolean =>
+  typeof active !== "string";
+
 /** One navigation link. */
 interface NavItem {
   href: string;
@@ -374,7 +408,7 @@ const sectionLevels = (
 };
 
 interface AdminNavProps {
-  active: string;
+  active: NavActive;
   session: AdminSession;
 }
 
@@ -387,9 +421,16 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => {
   // Flag this render as an admin page so the Layout emits the admin footer
   // (Chobble link, optional debug menu, and the logout button).
   markAdminFooter(session.adminLevel);
-  const activeSection = resolveSection(active, session.adminLevel);
-  const highlight = activeSection?.topHref ?? active;
-  const rootNodes = toNodes(topLevelItems(session, active), highlight);
+  const route = activeRoute(active);
+  const activeSection = resolveSection(route, session.adminLevel);
+  const highlight = activeSection?.topHref ?? route;
+  const rootNodes = toNodes(topLevelItems(session, route), highlight);
+  // A page merely *within* a section highlights its top link but shows no
+  // sub-nav — the section's "Add" create link is not an affordance for a
+  // single-item detail page.
+  const levels = isWithinSection(active)
+    ? []
+    : sectionLevels(activeSection, route);
   return (
     <>
       {renderReadOnlyBanner(
@@ -408,7 +449,7 @@ export const AdminNav = ({ session, active }: AdminNavProps): JSX.Element => {
       {leveledNav({
         id: "main-nav",
         label: t("nav.admin"),
-        levels: sectionLevels(activeSection, active),
+        levels,
         rootLis: (nested) => nodeLis(rootNodes, nested),
       })}
     </>

--- a/src/ui/templates/admin/recalculate.tsx
+++ b/src/ui/templates/admin/recalculate.tsx
@@ -2,6 +2,7 @@
 import { RECALCULATE_FIELD_NAME } from "#shared/recalculate-fields.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { adminFormPage } from "#templates/admin/admin-page.tsx";
+import type { NavActive } from "#templates/admin/nav.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
 /* jscpd:ignore-end */
@@ -27,7 +28,7 @@ export const adminRecalculatePage = ({
   title,
 }: {
   action: string;
-  active: string;
+  active: NavActive;
   currentLabel: string;
   description: string;
   error?: string | undefined;

--- a/test/lib/server-attendees.test.ts
+++ b/test/lib/server-attendees.test.ts
@@ -1153,6 +1153,27 @@ describeWithEnv("server (admin attendees)", { db: true }, () => {
       expect(response.status).toBe(404);
     });
 
+    // Regression: looking at one attendee wrongly rendered the Attendees
+    // section's "Add" sub-nav (the page passed the section landing route as its
+    // nav-active value, which re-opened the create sub-nav). A single-attendee
+    // page must highlight the Attendees top-level link but show no "Add"
+    // sub-nav beside it.
+    test("the attendee page highlights Attendees but shows no Add sub-nav", async () => {
+      const listing = await createTestListing({ maxAttendees: 100 });
+      const attendee = await createTestAttendee(
+        listing.id,
+        listing.slug,
+        "John Doe",
+        "john@example.com",
+      );
+      const response = await adminGet(`/admin/attendees/${attendee.id}`);
+      const html = await response.text();
+      expect(response.status).toBe(200);
+      expect(html).toContain('class="active" href="/admin/attendees"');
+      expect(html).not.toContain('href="/admin/attendees/new"');
+      expect(html).not.toContain("admin-subnav");
+    });
+
     test("shows edit form with prefilled attendee data", async () => {
       const listing = await createTestListing({ maxAttendees: 100 });
       const result = await bookAttendee(listing, {

--- a/test/ui/templates/admin/nav.test.tsx
+++ b/test/ui/templates/admin/nav.test.tsx
@@ -311,6 +311,47 @@ describeWithEnv("AdminNav", {}, () => {
     expect(html).toContain('class="active" href="/admin/attendees"');
   });
 
+  // Regression: an individual attendee page (and every other single-item page)
+  // used to pass the *section landing route* as its `active` value just to get
+  // the top-level link highlighted — which also re-opened the section's "Add"
+  // sub-nav beside a page that is not the section's landing page. A page that
+  // merely lives *within* a section now says so with `{ section }`: the section
+  // still highlights, but its sub-nav (here, the "Add" create link) must not
+  // appear. Verified for every section that carries an "Add X"-style sub-nav.
+  const withinSectionCases = [
+    { addHref: "/admin/attendees/new", section: "/admin/attendees" },
+    { addHref: "/admin/groups/new", section: "/admin/groups" },
+    { addHref: "/admin/servicing/new", section: "/admin/servicing" },
+    { addHref: "/admin/modifiers/new", section: "/admin/modifiers" },
+    { addHref: "/admin/listing/new", section: "/admin/listings" },
+  ] as const;
+
+  test("a page within a section highlights the section but shows no sub-nav", () => {
+    for (const { section, addHref } of withinSectionCases) {
+      const html = String(
+        AdminNav({ active: { section }, session: { adminLevel: "owner" } }),
+      );
+      // The section's top-level link is highlighted…
+      expect(html, section).toContain(`class="active" href="${section}"`);
+      // …but its sub-nav (the "Add" create link, and the whole desktop
+      // sub-nav level) is absent — a detail page is not the landing page.
+      expect(html, section).not.toContain(`href="${addHref}"`);
+      expect(html, section).not.toContain("admin-subnav");
+    }
+  });
+
+  // The contrast that proves the distinction is real: the SAME section, passed
+  // as a bare route string (the landing list page), DOES open the sub-nav.
+  test("the same section as a bare route string still opens its sub-nav", () => {
+    for (const { section, addHref } of withinSectionCases) {
+      const html = String(
+        AdminNav({ active: section, session: { adminLevel: "owner" } }),
+      );
+      expect(html, section).toContain(`href="${addHref}"`);
+      expect(html, section).toContain("admin-subnav");
+    }
+  });
+
   test("AdminNav marks the servicing link active on servicing pages", () => {
     const html = String(
       AdminNav({


### PR DESCRIPTION
## What was wrong

When you opened one attendee's page, the Attendees menu wrongly showed its
"Add" sub-menu right beside the attendee — the create shortcut you only want
on the attendee *list*, not while you're looking at one person.

## Why it happened

The admin menu works out a section's sub-menu purely from the page's
"which route am I on?" value. The attendee page (and several other
single-item pages) handed it the section's *own landing route*
(`/admin/attendees`) just to light up the top-level "Attendees" link — and
that same value is what tells the menu "you're on the Attendees list page,
so show its Add shortcut". The list page and a single attendee page looked
identical to the menu, so the Add shortcut leaked onto the attendee page.

## The fix

The page's menu value can now say one of two things instead of just a route:

- a plain route — "this page **is** this route" (a list page, an Add page, a
  settings sub-page): unchanged behaviour.
- `{ section }` — "this page lives **within** this section" (one attendee,
  one listing, the add-a-note form): the top-level link still lights up, but
  the section's sub-menu never opens.

Because a page now names the section it's *inside*, it can never be mistaken
for the section's landing page — so the Add shortcut can't sneak back in by
accident. This is applied to every single-item page that was showing an
Add-only sub-menu it shouldn't: the attendee, group and listing pages, the
add-note and delete-note pages, the modifier edit / delete / recalculate
pages, the servicing edit form, image delete, and the group bulk-actions
pages. (The listing page used to point its menu at Home just to dodge this
very sub-menu; it now names its real section and highlights correctly.)

## Tests

- A menu rendered "within a section" lights the section but shows no
  sub-menu, while the same section as a plain route still shows it — proving
  the two are genuinely distinct.
- End-to-end: opening `/admin/attendees/:id` highlights Attendees and shows
  no "Add" sub-menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iH4VNK61igSEVgKWuRV9B

---
_Generated by [Claude Code](https://claude.ai/code/session_018iH4VNK61igSEVgKWuRV9B)_