### PR TITLE
Add a direct unit test for anyPackageBundleMismatch

### DIFF
--- a/test/features/api/payment-processing/packages.test.ts
+++ b/test/features/api/payment-processing/packages.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  anyPackageBundleMismatch,
   expectedItemPrice,
   type PackagePricing,
   packageBundleMismatch,
@@ -205,5 +206,75 @@ describe("packageBundleMismatch (order-level revalidation)", () => {
       quantityMap: new Map([[1, 1]]),
     };
     expect(packageBundleMismatch(solo, [item(1, 0)])).toBe(true);
+  });
+});
+
+describe("anyPackageBundleMismatch (multi-group revalidation)", () => {
+  // Group 10 bundles members 1 & 2 (one each per package); group 20 bundles
+  // member 3. Each group is revalidated against only its own tagged lines.
+  const groupA: PackagePricing = {
+    dayPriceMap: new Map(),
+    memberIds: new Set([1, 2]),
+    priceMap: new Map(),
+    quantityMap: new Map([
+      [1, 1],
+      [2, 1],
+    ]),
+  };
+  const groupB: PackagePricing = {
+    dayPriceMap: new Map(),
+    memberIds: new Set([3]),
+    priceMap: new Map(),
+    quantityMap: new Map([[3, 1]]),
+  };
+  /** A signed line tagged as a package member of `groupId` (k:"p", r:groupId),
+   *  which is how lineGroupId assigns a line to its group. */
+  const line = (e: number, groupId: number, q = 1) =>
+    ({ e, k: "p", p: 0, q, r: groupId }) as const;
+
+  test("no packages means nothing can have drifted", () => {
+    expect(anyPackageBundleMismatch(new Map(), [])).toBe(false);
+  });
+
+  test("a single group whose lines still match is not a mismatch", () => {
+    expect(
+      anyPackageBundleMismatch(new Map([[10, groupA]]), [
+        line(1, 10),
+        line(2, 10),
+      ]),
+    ).toBe(false);
+  });
+
+  test("a single group missing a member is a mismatch", () => {
+    expect(
+      anyPackageBundleMismatch(new Map([[10, groupA]]), [line(1, 10)]),
+    ).toBe(true);
+  });
+
+  test("one drifted group among several fails the whole order", () => {
+    // Group 10's lines match, but group 20 has no lines at all → mismatch.
+    const pricing = new Map([
+      [10, groupA],
+      [20, groupB],
+    ]);
+    expect(anyPackageBundleMismatch(pricing, [line(1, 10), line(2, 10)])).toBe(
+      true,
+    );
+  });
+
+  test("each group is revalidated against only its OWN tagged lines", () => {
+    // Interleaved lines for both groups; filtered per group, both bundles match,
+    // so mixing another group's lines in must not trip a mismatch.
+    const pricing = new Map([
+      [10, groupA],
+      [20, groupB],
+    ]);
+    expect(
+      anyPackageBundleMismatch(pricing, [
+        line(1, 10),
+        line(2, 10),
+        line(3, 20),
+      ]),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What

`src/features/api/payment-processing.ts` scores as the repo's "thinnest-tested" file (src:test ratio ~8), but that's a **coverage-attribution artifact, not a real gap**: the module is one of the most-tested in the codebase — ~9,500 LOC across ~35 suites — but almost all of it drives the module through the `/payment/success`, `/webhook`, and `/payment/cancel` **routes** (via `handleRequest`), so the coverage report only credits the ~250 LOC of pure-helper unit tests at the mirror path.

Auditing the 11 exports against that coverage, every one is exercised **except `anyPackageBundleMismatch`** (line 769) — the multi-group aggregator over `packageBundleMismatch` — which had no test that referenced it by name (only possibly-transitive coverage through the price-signature webhook scenarios).

This adds a direct unit test for it at the mirror path, as a sibling to the existing `packageBundleMismatch` tests.

## Coverage
`anyPackageBundleMismatch` filters the order's lines per group (by each line's `k`/`r` edge tag → `lineGroupId`) and returns true if **any** group's bundle drifted. The new cases pin both halves of that:

- **no packages** → not a mismatch (empty aggregate is `false`, not `true`)
- a single group **missing a member** → mismatch
- **one drifted group among several** → fails the whole order (the "any" semantics)
- **each group is revalidated against only its own tagged lines** → interleaving another group's lines must not trip a mismatch (pins the per-group filter)

## Notes
- No production changes; one pure-function unit test added (`packages.test.ts`, +5 cases).
- The rest of `payment-processing.ts` is thoroughly covered by the webhook/success integration suites — the low mirror-path ratio reflects where those tests live (route-level), not a coverage gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MeqQm2dPU3Zja5azPyHAx)_