### PR TITLE
Harden image deletion and payment sandbox e2e

### DIFF
--- a/e2e-payments/src/browser.ts
+++ b/e2e-payments/src/browser.ts
@@ -6,10 +6,10 @@
 
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { type Browser, type Locator, type Page, chromium } from "playwright";
+import { type Browser, chromium, type Locator, type Page } from "playwright";
 import { config } from "./config.ts";
-import { repoRoot } from "./server.ts";
 import { log } from "./log.ts";
+import { repoRoot } from "./server.ts";
 
 export interface BrowserSession {
   browser: Browser;
@@ -31,7 +31,9 @@ export interface BrowserSession {
   stop: () => Promise<void>;
 }
 
-export const launchBrowser = async (baseUrl: string): Promise<BrowserSession> => {
+export const launchBrowser = async (
+  baseUrl: string,
+): Promise<BrowserSession> => {
   log(`Launching Chromium (headless=${config.headless})…`);
   const browser = await chromium.launch({
     headless: config.headless,
@@ -65,7 +67,7 @@ export const launchBrowser = async (baseUrl: string): Promise<BrowserSession> =>
   const dumpPage = async (label: string): Promise<void> => {
     const png = join(artifactsDir, `${label}.png`);
     const html = join(artifactsDir, `${label}.html`);
-    await page.screenshot({ path: png, fullPage: true }).catch(() => {});
+    await page.screenshot({ fullPage: true, path: png }).catch(() => {});
     await page
       .content()
       .then((c) => writeFile(html, c))
@@ -107,28 +109,9 @@ export const launchBrowser = async (baseUrl: string): Promise<BrowserSession> =>
   };
 
   return {
-    browser,
-    page,
     baseUrl,
-    goto: async (path) => {
-      log(`  goto ${path}`);
-      await page.goto(path, { waitUntil: "domcontentloaded" });
-      await logWhere("goto");
-    },
-    // force: bypass the visible/enabled/stable actionability wait — the app's
-    // form controls are styled/validated in ways that make Playwright's default
-    // actionability hang in the CI Chromium. We assert real outcomes elsewhere.
-    fill: async (name, value) => {
-      log(`  fill ${name}`);
-      await page.locator(sel(name)).first().fill(value, { force: true, timeout: T });
-    },
-    select: async (name, value) => {
-      log(`  select ${name}=${value}`);
-      await page
-        .locator(sel(name))
-        .first()
-        .selectOption(value, { force: true, timeout: T });
-    },
+    bodyText: () => page.locator("body").innerText({ timeout: T }),
+    browser,
     check: async (name, value) => {
       const s = value ? `${sel(name)}[value="${value}"]` : sel(name);
       log(`  check ${name}${value ? `=${value}` : ""}`);
@@ -139,13 +122,12 @@ export const launchBrowser = async (baseUrl: string): Promise<BrowserSession> =>
     clickButton: async (text) => {
       log(`  submit "${text}"`);
       await robustSubmit(
-        page.getByRole("button", { name: text, exact: false }).first(),
+        page.getByRole("button", { exact: false, name: text }).first(),
       );
     },
-    submitLocator: (locator) => robustSubmit(locator),
     clickLink: async (text) => {
       log(`  link "${text}"`);
-      const link = page.getByRole("link", { name: text, exact: false }).first();
+      const link = page.getByRole("link", { exact: false, name: text }).first();
       await link.waitFor({ state: "attached", timeout: T });
       const href = await link.getAttribute("href");
       // Navigate by href when possible — avoids click-actionability entirely.
@@ -160,12 +142,35 @@ export const launchBrowser = async (baseUrl: string): Promise<BrowserSession> =>
       }
       await logWhere(`link "${text}"`);
     },
-    bodyText: () => page.locator("body").innerText({ timeout: T }),
-    screenshot: (label) => dumpPage(label),
     dumpPage,
+    // force: bypass the visible/enabled/stable actionability wait — the app's
+    // form controls are styled/validated in ways that make Playwright's default
+    // actionability hang in the CI Chromium. We assert real outcomes elsewhere.
+    fill: async (name, value) => {
+      log(`  fill ${name}`);
+      await page
+        .locator(sel(name))
+        .first()
+        .fill(value, { force: true, timeout: T });
+    },
+    goto: async (path) => {
+      log(`  goto ${path}`);
+      await page.goto(path, { waitUntil: "domcontentloaded" });
+      await logWhere("goto");
+    },
+    page,
+    screenshot: (label) => dumpPage(label),
+    select: async (name, value) => {
+      log(`  select ${name}=${value}`);
+      await page
+        .locator(sel(name))
+        .first()
+        .selectOption(value, { force: true, timeout: T });
+    },
     stop: async () => {
       await browser.close();
     },
+    submitLocator: (locator) => robustSubmit(locator),
   };
 };
 

--- a/e2e-payments/src/config.ts
+++ b/e2e-payments/src/config.ts
@@ -28,26 +28,17 @@ const num = (key: string, fallback: number): number => {
 };
 
 export const config = {
-  /** Deno binary used to boot the app server. */
-  denoBin: env("DENO_BIN") ?? "deno",
-  /** cloudflared binary used for the public webhook/return-URL tunnel. */
-  cloudflaredBin: env("CLOUDFLARED_BIN") ?? "cloudflared",
-  /**
-   * Path to a Chromium executable. The managed environment pre-installs one at
-   * /opt/pw-browsers/chromium; CI installs its own via `playwright install` and
-   * leaves this unset so Playwright resolves the bundled build.
-   */
-  chromiumExecutable: env("CHROMIUM_EXECUTABLE"),
-  headless: bool("HEADLESS", true),
-
-  /** 32-byte base64 key. Defaults to the repo's well-known test key. */
-  dbEncryptionKey:
-    env("DB_ENCRYPTION_KEY") ??
-    "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+  /** Per-element action timeout. Kept short: with force interactions an element
+   * is acted on as soon as it is attached, so a long wait here only delays a
+   * genuine failure (and its screenshot). */
+  actionTimeoutMs: num("E2E_ACTION_TIMEOUT_MS", 15_000),
+  adminPassword: env("ADMIN_PASSWORD") ?? "password",
 
   /** Admin credentials created by the setup wizard. Password must be 8+ chars. */
   adminUsername: env("ADMIN_USERNAME") ?? "admin",
-  adminPassword: env("ADMIN_PASSWORD") ?? "password",
+
+  /** Where to drop screenshots / server logs on failure. */
+  artifactsDir: env("E2E_ARTIFACTS_DIR") ?? "artifacts",
   /**
    * Email used for the booking. NOT a reserved domain: `example.com` is
    * rejected by some payment processors (Square returns "invalid email"), so
@@ -55,12 +46,43 @@ export const config = {
    */
   bookerEmail: env("E2E_BOOKER_EMAIL") ?? "e2e-booker@mailinator.com",
   /**
+   * Path to a Chromium executable. The managed environment pre-installs one at
+   * /opt/pw-browsers/chromium; CI installs its own via `playwright install` and
+   * leaves this unset so Playwright resolves the bundled build.
+   */
+  chromiumExecutable: env("CHROMIUM_EXECUTABLE"),
+  /** cloudflared binary used for the public webhook/return-URL tunnel. */
+  cloudflaredBin: env("CLOUDFLARED_BIN") ?? "cloudflared",
+
+  /** 32-byte base64 key. Defaults to the repo's well-known test key. */
+  dbEncryptionKey: env("DB_ENCRYPTION_KEY") ??
+    "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+  /** Deno binary used to boot the app server. */
+  denoBin: env("DENO_BIN") ?? "deno",
+
+  /** Force the tunnel on/off. Stripe always needs it; default follows target. */
+  forceTunnel: env("E2E_TUNNEL"),
+  headless: bool("HEADLESS", true),
+  navTimeoutMs: num("E2E_NAV_TIMEOUT_MS", 45_000),
+
+  /** Ntfy endpoint pinged on failure (e.g. `https://ntfy.sh/your-topic`). Unset ⇒ no notification. */
+  ntfyUrl: env("NTFY_URL"),
+  paymentConfirmTimeoutMs: num("E2E_PAYMENT_CONFIRM_TIMEOUT_MS", 90_000),
+
+  /** Timeouts (ms). Hosted checkout pages can be slow, so keep these generous. */
+  serverBootTimeoutMs: num("E2E_SERVER_BOOT_TIMEOUT_MS", 60_000),
+  /**
    * ISO country picked in setup — determines the site currency. Must map to a
    * 2-decimal currency (GBP/USD/EUR, as the provider defaults do): the price
    * entry and paid-amount assertion assume minor units are hundredths, so a
    * zero-decimal currency (e.g. JPY via JP) is unsupported.
    */
   setupCountry: env("SETUP_COUNTRY") ?? "GB",
+  /** How many times to (re)spawn cloudflared before giving up. trycloudflare
+   * quick tunnels intermittently fail to register, so retry rather than fail
+   * the whole leg on the first miss. */
+  tunnelAttempts: num("E2E_TUNNEL_ATTEMPTS", 3),
+  tunnelTimeoutMs: num("E2E_TUNNEL_TIMEOUT_MS", 60_000),
 
   /**
    * Ticket price in minor units (e.g. 137 = £1.37 / $1.37). Deliberately a
@@ -69,29 +91,6 @@ export const config = {
    * keeps its decimals, making the paid-amount assertion specific.
    */
   unitPrice: num("E2E_UNIT_PRICE", 137),
-
-  /** Timeouts (ms). Hosted checkout pages can be slow, so keep these generous. */
-  serverBootTimeoutMs: num("E2E_SERVER_BOOT_TIMEOUT_MS", 60_000),
-  tunnelTimeoutMs: num("E2E_TUNNEL_TIMEOUT_MS", 60_000),
-  /** How many times to (re)spawn cloudflared before giving up. trycloudflare
-   * quick tunnels intermittently fail to register, so retry rather than fail
-   * the whole leg on the first miss. */
-  tunnelAttempts: num("E2E_TUNNEL_ATTEMPTS", 3),
-  navTimeoutMs: num("E2E_NAV_TIMEOUT_MS", 45_000),
-  /** Per-element action timeout. Kept short: with force interactions an element
-   * is acted on as soon as it is attached, so a long wait here only delays a
-   * genuine failure (and its screenshot). */
-  actionTimeoutMs: num("E2E_ACTION_TIMEOUT_MS", 15_000),
-  paymentConfirmTimeoutMs: num("E2E_PAYMENT_CONFIRM_TIMEOUT_MS", 90_000),
-
-  /** Force the tunnel on/off. Stripe always needs it; default follows target. */
-  forceTunnel: env("E2E_TUNNEL"),
-
-  /** Where to drop screenshots / server logs on failure. */
-  artifactsDir: env("E2E_ARTIFACTS_DIR") ?? "artifacts",
-
-  /** Ntfy endpoint pinged on failure (e.g. `https://ntfy.sh/your-topic`). Unset ⇒ no notification. */
-  ntfyUrl: env("NTFY_URL"),
 };
 
 /** Whether a public tunnel is required for the given target. */
@@ -136,7 +135,11 @@ export const providerSecrets = (
     const token = env("SQUARE_ACCESS_TOKEN");
     const locationId = env("SQUARE_LOCATION_ID");
     if (!token || !locationId) return null;
-    return { token, locationId, sandbox: bool("SQUARE_SANDBOX", true) ? "true" : "false" };
+    return {
+      locationId,
+      sandbox: bool("SQUARE_SANDBOX", true) ? "true" : "false",
+      token,
+    };
   }
   // sumup
   const apiKey = env("SUMUP_API_KEY");

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -74,7 +74,9 @@ export const createListing = async (
     .locator('a[href*="/ticket/"]')
     .first()
     .getAttribute("href", { timeout: config.navTimeoutMs });
-  if (!href) throw new Error("no public /ticket/ link found on the listing page");
+  if (!href) {
+    throw new Error("no public /ticket/ link found on the listing page");
+  }
   const path = href.startsWith("http") ? new URL(href).pathname : href;
   log(`  public booking path: ${path}`);
   return path;
@@ -127,7 +129,9 @@ export const submitBooking = async (
   await fillIfPresent(session, "name", BOOKER_NAME);
 
   // Quantity field name varies (single `quantity` vs per-listing `quantity_<id>`).
-  const qty = page.locator('input[name^="quantity"], select[name^="quantity"]').first();
+  const qty = page
+    .locator('input[name^="quantity"], select[name^="quantity"]')
+    .first();
   if (await qty.count()) {
     const tag = await qty.evaluate((el) => el.tagName.toLowerCase());
     if (tag === "select") await qty.selectOption("1");
@@ -243,11 +247,15 @@ export const assertPaidBookingConfirmed = async (
     );
   } catch {
     const hostedError = await collectHostedErrors(session);
+    const appBody = await session.bodyText();
     throw new Error(
       `did not land on a success page after checkout.\nURL: ${page.url()}\n` +
+        // Prefer the scraped inline error; only fall back to the raw body when
+        // no error node was found (the body is mostly a huge country <select>
+        // that buries the real message and floods the CI log).
         (hostedError
           ? `Checkout page error(s): ${hostedError}`
-          : (await session.bodyText()).slice(0, 400)),
+          : appBody.slice(0, 400)),
     );
   }
   log(`  ✔ customer saw the success page (${page.url()})`);

--- a/e2e-payments/src/main.ts
+++ b/e2e-payments/src/main.ts
@@ -13,10 +13,8 @@
  */
 
 import { readFileSync } from "node:fs";
-import { config, needsTunnel, type Target, providerSecrets } from "./config.ts";
-import { fail, log, step, warn } from "./log.ts";
 import { launchBrowser } from "./browser.ts";
-import { providers } from "./providers/index.ts";
+import { config, needsTunnel, providerSecrets, type Target } from "./config.ts";
 import {
   assertFreeThankYou,
   assertPaidBookingConfirmed,
@@ -26,10 +24,12 @@ import {
   runSetup,
   submitBooking,
 } from "./flow.ts";
+import { fail, log, step, warn } from "./log.ts";
+import { notifyFailure } from "./notify.ts";
 import { runComplexOrderJourney } from "./order-flow.ts";
+import { providers } from "./providers/index.ts";
 import { buildStaticAssets, startAppServer } from "./server.ts";
 import { noTunnel, startTunnel } from "./tunnel.ts";
-import { notifyFailure } from "./notify.ts";
 
 /**
  * Print the tail of the app server's log to stdout. On CI the server log is
@@ -59,11 +59,22 @@ const dumpServerLog = (logPath: string, lines = 20): void => {
 };
 
 const parseTarget = (): Target => {
-  const raw = (process.argv[2] ?? process.env.E2E_PROVIDER ?? "free").toLowerCase();
-  if (raw === "free" || raw === "stripe" || raw === "square" || raw === "sumup") {
+  const raw = (
+    process.argv[2] ??
+      process.env.E2E_PROVIDER ??
+      "free"
+  ).toLowerCase();
+  if (
+    raw === "free" ||
+    raw === "stripe" ||
+    raw === "square" ||
+    raw === "sumup"
+  ) {
     return raw;
   }
-  throw new Error(`unknown target "${raw}" (expected stripe|square|sumup|free)`);
+  throw new Error(
+    `unknown target "${raw}" (expected stripe|square|sumup|free)`,
+  );
 };
 
 const run = async (): Promise<void> => {
@@ -77,8 +88,9 @@ const run = async (): Promise<void> => {
     return; // exit 0 — a missing-secret leg is a skip, not a failure
   }
 
-  const country =
-    process.env.SETUP_COUNTRY?.trim() || provider?.setupCountry || config.setupCountry;
+  const country = process.env.SETUP_COUNTRY?.trim() ||
+    provider?.setupCountry ||
+    config.setupCountry;
 
   // Resources are declared up front and acquired inside the try, so a failure
   // during startup (tunnel/browser) still tears down whatever was created —
@@ -130,16 +142,18 @@ const run = async (): Promise<void> => {
       paid: provider !== null,
       ...(provider
         ? {
-            payHostedCheckout: async () => {
-              step(`Paying the complex order on the ${provider.name} hosted checkout`);
-              await assertRedirectedToCheckout(activeSession);
-              await provider.payHostedCheckout(activeSession.page, {
-                baseUrl: activeTunnel.publicBaseUrl,
-                secrets: secrets!,
-                serverLogPath: activeServer.logPath,
-              });
-            },
-          }
+          payHostedCheckout: async () => {
+            step(
+              `Paying the complex order on the ${provider.name} hosted checkout`,
+            );
+            await assertRedirectedToCheckout(activeSession);
+            await provider.payHostedCheckout(activeSession.page, {
+              baseUrl: activeTunnel.publicBaseUrl,
+              secrets: secrets!,
+              serverLogPath: activeServer.logPath,
+            });
+          },
+        }
         : {}),
     });
 

--- a/e2e-payments/src/notify.ts
+++ b/e2e-payments/src/notify.ts
@@ -20,7 +20,8 @@ export const notifyFailure = async (target: string): Promise<void> => {
 
   try {
     const res = await fetch(ntfyUrl, {
-      body: `payment sandbox e2e (${target}) failed — see the CI job log/artifacts for details.`,
+      body:
+        `payment sandbox e2e (${target}) failed — see the CI job log/artifacts for details.`,
       headers: {
         Tags: "warning",
         Title: `payment sandbox e2e: ${target} failed`,
@@ -29,11 +30,19 @@ export const notifyFailure = async (target: string): Promise<void> => {
       signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS),
     });
     if (!res.ok) {
-      warn(`ntfy publish rejected: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`);
+      warn(
+        `ntfy publish rejected: HTTP ${res.status} ${
+          (await res.text()).slice(0, 200)
+        }`,
+      );
       return;
     }
     log("  notified ntfy of the failure");
   } catch (err) {
-    warn(`failed to notify ntfy: ${err instanceof Error ? err.message : String(err)}`);
+    warn(
+      `failed to notify ntfy: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 };

--- a/e2e-payments/src/providers/card.ts
+++ b/e2e-payments/src/providers/card.ts
@@ -51,21 +51,31 @@ export const fillFirst = async (
   label: string,
   selectors: string[],
   value: string,
-  { required = true, type = false }: { required?: boolean; type?: boolean } = {},
+  {
+    required = true,
+    type = false,
+  }: { required?: boolean; type?: boolean } = {},
 ): Promise<boolean> => {
-  const filled = await withFirstVisible(page, selectors, async (loc, selector) => {
-    if (type) {
-      // Some hosted fields (Stripe's card iframe) track real keystrokes and
-      // ignore a programmatic .fill(), reporting the field as still "Required" —
-      // so click and type the value character by character.
-      await loc.click({ timeout: FILL_TIMEOUT });
-      await loc.pressSequentially(value, { delay: 25, timeout: FILL_TIMEOUT });
-    } else {
-      await loc.fill(value, { timeout: FILL_TIMEOUT });
-    }
-    log(`  filled ${label} via "${selector}"`);
-    return true;
-  });
+  const filled = await withFirstVisible(
+    page,
+    selectors,
+    async (loc, selector) => {
+      if (type) {
+        // Some hosted fields (Stripe's card iframe) track real keystrokes and
+        // ignore a programmatic .fill(), reporting the field as still "Required" —
+        // so click and type the value character by character.
+        await loc.click({ timeout: FILL_TIMEOUT });
+        await loc.pressSequentially(value, {
+          delay: 25,
+          timeout: FILL_TIMEOUT,
+        });
+      } else {
+        await loc.fill(value, { timeout: FILL_TIMEOUT });
+      }
+      log(`  filled ${label} via "${selector}"`);
+      return true;
+    },
+  );
   if (filled) return true;
   const msg = `could not locate field "${label}" on the hosted checkout page`;
   if (required) throw new Error(msg);
@@ -79,11 +89,15 @@ export const clickFirst = async (
   label: string,
   selectors: string[],
 ): Promise<void> => {
-  const clicked = await withFirstVisible(page, selectors, async (loc, selector) => {
-    await loc.click({ timeout: FILL_TIMEOUT });
-    log(`  clicked ${label} via "${selector}"`);
-    return true;
-  });
+  const clicked = await withFirstVisible(
+    page,
+    selectors,
+    async (loc, selector) => {
+      await loc.click({ timeout: FILL_TIMEOUT });
+      log(`  clicked ${label} via "${selector}"`);
+      return true;
+    },
+  );
   if (!clicked) {
     throw new Error(
       `could not locate "${label}" control on the hosted checkout page`,
@@ -139,17 +153,24 @@ export interface CardDetails {
  * fallbacks. fillFirst also searches child frames, covering SDK iframes.
  */
 const CARD_SELECTORS: Record<string, string[]> = {
-  number: [
-    'input[autocomplete="cc-number"]',
-    'input[name="cardnumber"]',
-    'input[name="cardNumber"]',
-    'input[name="number"]',
-    'input[id*="card-number" i]',
-    'input[id*="cardnumber" i]',
-    'input[name*="cardnumber" i]',
-    'input[placeholder*="card number" i]',
-    'input[aria-label*="card number" i]',
-    "#cardNumber",
+  cvc: [
+    'input[autocomplete="cc-csc"]',
+    'input[name="cvc"]',
+    'input[name="cvv"]',
+    'input[name="cvcNumber"]',
+    'input[name="securityCode"]',
+    'input[id*="cvc" i]',
+    'input[id*="cvv" i]',
+    'input[placeholder*="cvc" i]',
+    'input[placeholder*="cvv" i]',
+    'input[aria-label*="security code" i]',
+    "#cardCvc",
+  ],
+  email: [
+    'input[autocomplete="email"]',
+    'input[type="email"]',
+    'input[name="email"]',
+    "#email",
   ],
   expiry: [
     'input[autocomplete="cc-exp"]',
@@ -165,19 +186,6 @@ const CARD_SELECTORS: Record<string, string[]> = {
     'input[aria-label*="expir" i]',
     "#cardExpiry",
   ],
-  cvc: [
-    'input[autocomplete="cc-csc"]',
-    'input[name="cvc"]',
-    'input[name="cvv"]',
-    'input[name="cvcNumber"]',
-    'input[name="securityCode"]',
-    'input[id*="cvc" i]',
-    'input[id*="cvv" i]',
-    'input[placeholder*="cvc" i]',
-    'input[placeholder*="cvv" i]',
-    'input[aria-label*="security code" i]',
-    "#cardCvc",
-  ],
   name: [
     'input[autocomplete="cc-name"]',
     'input[name="cardholder-name"]',
@@ -189,6 +197,18 @@ const CARD_SELECTORS: Record<string, string[]> = {
     'input[aria-label*="cardholder" i]',
     "#billingName",
   ],
+  number: [
+    'input[autocomplete="cc-number"]',
+    'input[name="cardnumber"]',
+    'input[name="cardNumber"]',
+    'input[name="number"]',
+    'input[id*="card-number" i]',
+    'input[id*="cardnumber" i]',
+    'input[name*="cardnumber" i]',
+    'input[placeholder*="card number" i]',
+    'input[aria-label*="card number" i]',
+    "#cardNumber",
+  ],
   postal: [
     'input[autocomplete="postal-code"]',
     'input[autocomplete="billing postal-code"]',
@@ -199,12 +219,6 @@ const CARD_SELECTORS: Record<string, string[]> = {
     'input[id*="postal" i]',
     'input[id*="zip" i]',
     "#billingPostalCode",
-  ],
-  email: [
-    'input[autocomplete="email"]',
-    'input[type="email"]',
-    'input[name="email"]',
-    "#email",
   ],
 };
 

--- a/e2e-payments/src/providers/index.ts
+++ b/e2e-payments/src/providers/index.ts
@@ -1,12 +1,12 @@
 import type { ProviderName } from "../config.ts";
-import { stripe } from "./stripe.ts";
 import { square } from "./square.ts";
+import { stripe } from "./stripe.ts";
 import { sumup } from "./sumup.ts";
 import type { PaymentProvider } from "./types.ts";
 
 export const providers: Record<ProviderName, PaymentProvider> = {
-  stripe,
   square,
+  stripe,
   sumup,
 };
 

--- a/e2e-payments/src/providers/square.ts
+++ b/e2e-payments/src/providers/square.ts
@@ -39,8 +39,8 @@ import type { HostedCheckoutContext, PaymentProvider } from "./types.ts";
  */
 
 const SQUARE_API = {
-  sandbox: "https://connect.squareupsandbox.com",
   production: "https://connect.squareup.com",
+  sandbox: "https://connect.squareupsandbox.com",
 } as const;
 
 // Match the app's Square-Version so request/response shapes agree.
@@ -55,6 +55,15 @@ type SquareMoney = { amount: number; currency: string };
 
 /** Options for a single Square REST call. */
 type SquareRequest = { method?: string; body?: unknown };
+
+const squareHeaders = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+  "Content-Type": "application/json",
+  "Square-Version": SQUARE_API_VERSION,
+});
+
+const squareBody = (body: unknown): { body: string } | Record<never, never> =>
+  body == null ? {} : { body: JSON.stringify(body) };
 
 /** Recover the Square order id the app created for this booking from its server
  * log (it is logged as `[Square] Payment link created orderId=…`). Polled
@@ -88,13 +97,9 @@ const squareFetch = async (
   init?: SquareRequest,
 ): Promise<unknown> => {
   const res = await fetch(`${base}${path}`, {
+    headers: squareHeaders(token),
     method: init?.method ?? "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "Square-Version": SQUARE_API_VERSION,
-    },
-    ...(init?.body != null ? { body: JSON.stringify(init.body) } : {}),
+    ...squareBody(init?.body),
   });
   const text = await res.text();
   if (!res.ok) {
@@ -116,7 +121,9 @@ const completeViaSandboxApi = async (
   const token = ctx.secrets.token;
 
   const orderId = await readOrderId(ctx.serverLogPath);
-  log(`Square sandbox has no hosted card page; completing order ${orderId} via the Payments API…`);
+  log(
+    `Square sandbox has no hosted card page; completing order ${orderId} via the Payments API…`,
+  );
 
   // Read the order back to pay the exact amount/currency it was created for
   // (matching the app's signed total — a mismatch would be refused).
@@ -138,7 +145,9 @@ const completeViaSandboxApi = async (
   const locationId = order?.location_id ?? ctx.secrets.locationId;
   if (!amountMoney || !locationId) {
     throw new Error(
-      `Square: order ${orderId} missing total/location (got ${JSON.stringify(order)})`,
+      `Square: order ${orderId} missing total/location (got ${
+        JSON.stringify(order)
+      })`,
     );
   }
   log(
@@ -149,13 +158,22 @@ const completeViaSandboxApi = async (
   // taken against an OPEN order ("The order must be OPEN to be paid" → the
   // authorised payment is otherwise voided). Transition DRAFT → OPEN first.
   if (order?.state && order.state !== "OPEN") {
-    await squareFetch(base, token, `/v2/orders/${encodeURIComponent(orderId)}`, {
-      method: "PUT",
-      body: {
-        idempotency_key: crypto.randomUUID(),
-        order: { location_id: locationId, version: order.version, state: "OPEN" },
+    await squareFetch(
+      base,
+      token,
+      `/v2/orders/${encodeURIComponent(orderId)}`,
+      {
+        body: {
+          idempotency_key: crypto.randomUUID(),
+          order: {
+            location_id: locationId,
+            state: "OPEN",
+            version: order.version,
+          },
+        },
+        method: "PUT",
       },
-    });
+    );
     log(`  transitioned order ${orderId} ${order.state} → OPEN`);
   }
 
@@ -163,15 +181,15 @@ const completeViaSandboxApi = async (
   // auto-completed → the order gains a COMPLETED card tender, which is exactly
   // what the app's retrieveSession treats as "paid".
   const payResp = (await squareFetch(base, token, "/v2/payments", {
-    method: "POST",
     body: {
-      source_id: SANDBOX_CARD_NONCE,
-      idempotency_key: crypto.randomUUID(),
       amount_money: amountMoney,
-      order_id: orderId,
-      location_id: locationId,
       autocomplete: true,
+      idempotency_key: crypto.randomUUID(),
+      location_id: locationId,
+      order_id: orderId,
+      source_id: SANDBOX_CARD_NONCE,
     },
+    method: "POST",
   })) as { payment?: { id?: string; status?: string } };
   log(`  payment ${payResp.payment?.id} status=${payResp.payment?.status}`);
   if (payResp.payment?.status !== "COMPLETED") {
@@ -182,26 +200,21 @@ const completeViaSandboxApi = async (
 
   // Drive the browser to the app's real return URL, exactly as Square would on
   // a live redirect (the app reads orderId → validates the now-paid order).
-  const returnUrl = `${ctx.baseUrl}/payment/success?orderId=${encodeURIComponent(orderId)}`;
+  const returnUrl = `${ctx.baseUrl}/payment/success?orderId=${
+    encodeURIComponent(orderId)
+  }`;
   log(`  navigating the browser to the app return URL: ${returnUrl}`);
   await page.goto(returnUrl, { waitUntil: "domcontentloaded" });
 };
 
 export const square: PaymentProvider = {
-  name: "square",
-  // The Square sandbox account/location has a FIXED currency and rejects a
-  // payment link whose amount is in any other currency ("This business can only
-  // process payments in GBP but amount was provided in USD"). This sandbox is
-  // GBP, so set the site up as GB. Override with SETUP_COUNTRY to match a
-  // differently-configured Square sandbox location.
-  setupCountry: "GB",
-
   configure: configureProvider("square", async (session, secrets) => {
     await session.fill("square_access_token", secrets.token);
     await session.fill("square_location_id", secrets.locationId);
     if (secrets.sandbox === "true") await session.check("square_sandbox");
     await session.clickButton("Update Square Credentials");
   }),
+  name: "square",
 
   payHostedCheckout: async (
     page: Page,
@@ -210,4 +223,10 @@ export const square: PaymentProvider = {
     await page.waitForLoadState("domcontentloaded");
     await completeViaSandboxApi(page, ctx);
   },
+  // The Square sandbox account/location has a FIXED currency and rejects a
+  // payment link whose amount is in any other currency ("This business can only
+  // process payments in GBP but amount was provided in USD"). This sandbox is
+  // GBP, so set the site up as GB. Override with SETUP_COUNTRY to match a
+  // differently-configured Square sandbox location.
+  setupCountry: "GB",
 };

--- a/e2e-payments/src/providers/stripe.ts
+++ b/e2e-payments/src/providers/stripe.ts
@@ -20,13 +20,48 @@ import type { PaymentProvider } from "./types.ts";
  * Docs: https://docs.stripe.com/testing
  */
 export const stripe: PaymentProvider = {
-  name: "stripe",
-  setupCountry: "US",
+  // Each run registers a webhook endpoint for its ephemeral *.trycloudflare.com
+  // URL, and the throwaway DB forgets the id — so without cleanup they pile up
+  // and Stripe eventually rejects new ones (accounts cap webhook endpoints).
+  // Delete every endpoint pointing at a trycloudflare tunnel, which also sweeps
+  // up any orphans left by earlier runs.
+  cleanup: async (secrets): Promise<void> => {
+    const headers = { Authorization: `Bearer ${secrets.secretKey}` };
+    try {
+      const res = await fetch(
+        "https://api.stripe.com/v1/webhook_endpoints?limit=100",
+        { headers },
+      );
+      if (!res.ok) {
+        warn(`  Stripe webhook cleanup: list failed (HTTP ${res.status})`);
+        return;
+      }
+      const body = (await res.json()) as {
+        data?: { id: string; url?: string }[];
+      };
+      const stale = (body.data ?? []).filter((e) =>
+        e.url?.includes("trycloudflare.com")
+      );
+      for (const endpoint of stale) {
+        await fetch(
+          `https://api.stripe.com/v1/webhook_endpoints/${endpoint.id}`,
+          { headers, method: "DELETE" },
+        ).catch(() => {});
+        log(`  deleted stale Stripe webhook endpoint ${endpoint.id}`);
+      }
+      if (stale.length === 0) {
+        log("  no stale Stripe webhook endpoints to clean");
+      }
+    } catch (err) {
+      warn(`  Stripe webhook cleanup skipped: ${String(err)}`);
+    }
+  },
 
   configure: configureProvider("stripe", async (session, secrets) => {
     await session.fill("stripe_secret_key", secrets.secretKey);
     await session.clickButton("Update Stripe Key");
   }),
+  name: "stripe",
 
   payHostedCheckout: async (page: Page): Promise<void> => {
     log("Filling Stripe Checkout hosted page…");
@@ -84,39 +119,5 @@ export const stripe: PaymentProvider = {
       'button:has-text("Pay")',
     ]);
   },
-
-  // Each run registers a webhook endpoint for its ephemeral *.trycloudflare.com
-  // URL, and the throwaway DB forgets the id — so without cleanup they pile up
-  // and Stripe eventually rejects new ones (accounts cap webhook endpoints).
-  // Delete every endpoint pointing at a trycloudflare tunnel, which also sweeps
-  // up any orphans left by earlier runs.
-  cleanup: async (secrets): Promise<void> => {
-    const headers = { Authorization: `Bearer ${secrets.secretKey}` };
-    try {
-      const res = await fetch(
-        "https://api.stripe.com/v1/webhook_endpoints?limit=100",
-        { headers },
-      );
-      if (!res.ok) {
-        warn(`  Stripe webhook cleanup: list failed (HTTP ${res.status})`);
-        return;
-      }
-      const body = (await res.json()) as {
-        data?: { id: string; url?: string }[];
-      };
-      const stale = (body.data ?? []).filter((e) =>
-        e.url?.includes("trycloudflare.com"),
-      );
-      for (const endpoint of stale) {
-        await fetch(
-          `https://api.stripe.com/v1/webhook_endpoints/${endpoint.id}`,
-          { method: "DELETE", headers },
-        ).catch(() => {});
-        log(`  deleted stale Stripe webhook endpoint ${endpoint.id}`);
-      }
-      if (stale.length === 0) log("  no stale Stripe webhook endpoints to clean");
-    } catch (err) {
-      warn(`  Stripe webhook cleanup skipped: ${String(err)}`);
-    }
-  },
+  setupCountry: "US",
 };

--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -4,6 +4,7 @@ import { log, warn } from "../log.ts";
 import { clickFirst, fillCard, fillFirst, fillFrameInput } from "./card.ts";
 import { configureProvider } from "./shared.ts";
 import type { PaymentProvider } from "./types.ts";
+
 /* jscpd:ignore-end */
 
 /**
@@ -24,21 +25,19 @@ import type { PaymentProvider } from "./types.ts";
 // authentication. 4000…0002 is a DECLINE card ("Payment Declined").
 // Docs: https://developer.sumup.com/online-payments/testing
 const CARD = {
-  number: "4200000000000091",
-  expiry: "12/34",
   cvc: "123",
+  expiry: "12/34",
   name: "E2E Tester",
+  number: "4200000000000091",
 } as const;
 
 export const sumup: PaymentProvider = {
-  name: "sumup",
-  setupCountry: "GB",
-
   configure: configureProvider("sumup", async (session, secrets) => {
     await session.fill("sumup_api_key", secrets.apiKey);
     await session.fill("sumup_merchant_code", secrets.merchantCode);
     await session.clickButton("Update SumUp Credentials");
   }),
+  name: "sumup",
 
   payHostedCheckout: async (page: Page): Promise<void> => {
     log("Filling SumUp hosted checkout…");
@@ -68,7 +67,13 @@ export const sumup: PaymentProvider = {
         "input",
         CARD.expiry,
       );
-      const filledCvc = await fillFrameInput(page, "cvc", ["CVV", "CVC"], "input", CARD.cvc);
+      const filledCvc = await fillFrameInput(
+        page,
+        "cvc",
+        ["CVV", "CVC"],
+        "input",
+        CARD.cvc,
+      );
       if (!filledExpiry || !filledCvc) {
         const missing = [
           ...(filledExpiry ? [] : ["expiry"]),
@@ -100,10 +105,10 @@ export const sumup: PaymentProvider = {
     } else {
       warn("  Braintree hosted fields not found — trying generic card fill");
       await fillCard(page, {
-        number: CARD.number,
-        expiry: CARD.expiry,
         cvc: CARD.cvc,
+        expiry: CARD.expiry,
         name: CARD.name,
+        number: CARD.number,
       });
     }
 
@@ -116,6 +121,7 @@ export const sumup: PaymentProvider = {
 
     await returnToMerchant(page);
   },
+  setupCountry: "GB",
 };
 
 /**
@@ -157,7 +163,9 @@ const returnToMerchant = async (page: Page): Promise<void> => {
     try {
       if (await link.isVisible({ timeout: 500 })) {
         await link.click({ timeout: 5_000 });
-        log("  clicked SumUp's 'Back to merchant website' to return to the app");
+        log(
+          "  clicked SumUp's 'Back to merchant website' to return to the app",
+        );
         return;
       }
     } catch {

--- a/e2e-payments/src/server.ts
+++ b/e2e-payments/src/server.ts
@@ -6,13 +6,13 @@
 
 /* jscpd:ignore-start */
 import { type ChildProcess, spawn } from "node:child_process";
-import { mkdirSync, rmSync } from "node:fs";
-import { createWriteStream } from "node:fs";
+import { createWriteStream, mkdirSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { config } from "./config.ts";
 import { log, warn } from "./log.ts";
 import { sleep, stopChild } from "./util.ts";
+
 /* jscpd:ignore-end */
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -39,8 +39,12 @@ export const buildStaticAssets = async (): Promise<void> => {
       stdio: "inherit",
     });
     child.on("error", reject);
-    child.on("exit", (code) =>
-      code === 0 ? resolveP() : reject(new Error(`build:static exited ${code}`)),
+    child.on(
+      "exit",
+      (code) =>
+        code === 0
+          ? resolveP()
+          : reject(new Error(`build:static exited ${code}`)),
     );
   });
 };
@@ -51,7 +55,7 @@ export const startAppServer = async (): Promise<AppServer> => {
   mkdirSync(artifactsDir, { recursive: true });
 
   const dbDir = join(repoRoot, "e2e-payments", ".tmp");
-  rmSync(dbDir, { recursive: true, force: true });
+  rmSync(dbDir, { force: true, recursive: true });
   mkdirSync(dbDir, { recursive: true });
   const dbUrl = `file:${join(dbDir, "e2e.db")}`;
 
@@ -75,9 +79,9 @@ export const startAppServer = async (): Promise<AppServer> => {
       cwd: repoRoot,
       env: {
         ...process.env,
-        PORT: String(port),
-        DB_URL: dbUrl,
         DB_ENCRYPTION_KEY: config.dbEncryptionKey,
+        DB_URL: dbUrl,
+        PORT: String(port),
       },
     },
   );
@@ -97,8 +101,8 @@ export const startAppServer = async (): Promise<AppServer> => {
         log(`App server is up at ${localBaseUrl} (log: ${logPath})`);
         return {
           localBaseUrl,
-          port,
           logPath,
+          port,
           stop: stopChild(child),
         };
       }

--- a/src/features/admin/image-upload.ts
+++ b/src/features/admin/image-upload.ts
@@ -4,6 +4,7 @@
 
 import { t } from "#i18n";
 import { formDataToParams } from "#routes/csrf.ts";
+import { redirect } from "#routes/response.ts";
 import { imagesTable } from "#shared/db/images.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import {
@@ -107,4 +108,15 @@ export const createImageFromUpload = async (
     );
     throw err;
   }
+};
+
+export const withUploadedImage = async (
+  formData: FormData,
+  failurePath: string,
+  useImage: (image: Image) => Promise<Response>,
+): Promise<Response> => {
+  const result = await createImageFromUpload(formData);
+  return result.ok
+    ? useImage(result.value)
+    : redirect(failurePath, result.error, false);
 };

--- a/src/features/admin/images.ts
+++ b/src/features/admin/images.ts
@@ -20,15 +20,18 @@ import {
   getAllImages,
   getImageById,
   getImageUsesForImage,
-  type ImageUseTarget,
   imagesTable,
+  type ImageUseTarget,
   setItemsForImage,
 } from "#shared/db/images.ts";
 import { getAllListingOptions } from "#shared/db/listings.ts";
 import { getNewsPostNames } from "#shared/db/news-posts.ts";
 import { sitePages } from "#shared/db/site-pages.ts";
 import type { FormParams } from "#shared/form-data.ts";
-import { deleteImageStorageFiles, isStorageEnabled } from "#shared/storage.ts";
+import {
+  deleteImageStorageFilesStrict,
+  isStorageEnabled,
+} from "#shared/storage.ts";
 import {
   type AdminLevel,
   type Image,
@@ -44,10 +47,7 @@ import {
   type ImageItemOption,
 } from "#templates/admin/images.tsx";
 import { withEntityFromParam } from "./entity-handlers.ts";
-import {
-  createImageFromUpload,
-  imageMetadataFromForm,
-} from "./image-upload.ts";
+import { imageMetadataFromForm, withUploadedImage } from "./image-upload.ts";
 
 // jscpd:ignore-end
 
@@ -77,13 +77,16 @@ const handleImageNewGet: TypedRouteHandler<"GET /admin/images/new"> = (
 const handleImageCreatePost: TypedRouteHandler<"POST /admin/images"> = (
   request,
 ) =>
-  withAuth(request, CONTENT_MULTIPART, (_session, formData) =>
-    withStorageEnabled(async () => {
-      const result = await createImageFromUpload(formData);
-      if (!result.ok) return redirect("/admin/images/new", result.error, false);
-      await logActivity(`Image '${result.value.name}' uploaded`);
-      return redirect(imagePath(result.value.id), t("images.created"), true);
-    }),
+  withAuth(
+    request,
+    CONTENT_MULTIPART,
+    (_session, formData) =>
+      withStorageEnabled(() =>
+        withUploadedImage(formData, "/admin/images/new", async (image) => {
+          await logActivity(`Image '${image.name}' uploaded`);
+          return redirect(imagePath(image.id), t("images.created"), true);
+        })
+      ),
   );
 
 const listingImageItemOptions = async (): Promise<ImageItemOption[]> =>
@@ -139,19 +142,21 @@ const handleImageEditGet: TypedRouteHandler<"GET /admin/images/:id/edit"> = (
   request,
   { id },
 ) =>
-  requireContentOr(request, (session) =>
-    withEntityFromParam(id, getImageById, async (image) => {
-      applyFlash(request);
-      return withStorageEnabled(async () => {
-        const [options, selected] = await Promise.all([
-          imageItemOptions(session.adminLevel),
-          selectedUses(image.id),
-        ]);
-        return htmlResponse(
-          adminImageEditPage({ image, options, selected, session }),
-        );
-      });
-    }),
+  requireContentOr(
+    request,
+    (session) =>
+      withEntityFromParam(id, getImageById, async (image) => {
+        applyFlash(request);
+        return withStorageEnabled(async () => {
+          const [options, selected] = await Promise.all([
+            imageItemOptions(session.adminLevel),
+            selectedUses(image.id),
+          ]);
+          return htmlResponse(
+            adminImageEditPage({ image, options, selected, session }),
+          );
+        });
+      }),
   );
 
 const parseImageTargets = (form: FormParams): ImageUseTarget[] =>
@@ -175,10 +180,14 @@ const withStorageImageForm = (
     adminLevel: AdminLevel,
   ) => Response | Promise<Response>,
 ): Promise<Response> =>
-  withAuth(request, CONTENT_FORM, (session, form) =>
-    withEntityFromParam(id, getImageById, (image) =>
-      withStorageEnabled(() => action(image, form, session.adminLevel)),
-    ),
+  withAuth(
+    request,
+    CONTENT_FORM,
+    (session, form) =>
+      withEntityFromParam(id, getImageById, (image) =>
+        withStorageEnabled(() =>
+          action(image, form, session.adminLevel)
+        )),
   );
 
 /** The image-use item types that are public Site content (owner + editor):
@@ -192,7 +201,7 @@ const isSiteContentImageType = (type: ImageUseItemType): boolean =>
  * changing or removing it is a Site-gated action a manager may not take. */
 const imageHasSiteContentUse = async (imageId: number): Promise<boolean> =>
   (await getImageUsesForImage(imageId)).some((use) =>
-    isSiteContentImageType(use.item_type),
+    isSiteContentImageType(use.item_type)
   );
 
 /** Block a non-Site session (a manager) from a save that would change an image
@@ -248,13 +257,15 @@ const handleImageEditPost: TypedRouteHandler<"POST /admin/images/:id/edit"> = (
 const handleImageDeleteGet: TypedRouteHandler<
   "GET /admin/images/:id/delete"
 > = (request, { id }) =>
-  requireContentOr(request, (session) =>
-    withEntityFromParam(id, getImageById, (image) => {
-      applyFlash(request);
-      return withStorageEnabled(() =>
-        htmlResponse(adminImageDeletePage(image, session)),
-      );
-    }),
+  requireContentOr(
+    request,
+    (session) =>
+      withEntityFromParam(id, getImageById, (image) => {
+        applyFlash(request);
+        return withStorageEnabled(() =>
+          htmlResponse(adminImageDeletePage(image, session))
+        );
+      }),
   );
 
 const confirmDelete = (form: FormParams, image: Image): string | null =>
@@ -277,8 +288,19 @@ const handleImageDeletePost: TypedRouteHandler<
     if (blocked) return blocked;
     const mismatch = confirmDelete(form, image);
     if (mismatch) return redirect(deletePath, mismatch, false);
+    // Delete the stored files first: if storage cleanup fails, keep the DB
+    // record so the admin can retry, rather than orphaning the files under a
+    // deleted record with no library entry to delete them from.
+    try {
+      await deleteImageStorageFilesStrict(image);
+    } catch {
+      return redirect(
+        deletePath,
+        t("images.delete.storage_failed"),
+        false,
+      );
+    }
     await deleteImageRecord(image.id);
-    await deleteImageStorageFiles(image, "image deletion");
     await logActivity(`Image '${image.name}' deleted`);
     return redirect("/admin/images", t("images.deleted"), true);
   });

--- a/src/features/admin/images.ts
+++ b/src/features/admin/images.ts
@@ -20,8 +20,8 @@ import {
   getAllImages,
   getImageById,
   getImageUsesForImage,
-  imagesTable,
   type ImageUseTarget,
+  imagesTable,
   setItemsForImage,
 } from "#shared/db/images.ts";
 import { getAllListingOptions } from "#shared/db/listings.ts";
@@ -77,16 +77,13 @@ const handleImageNewGet: TypedRouteHandler<"GET /admin/images/new"> = (
 const handleImageCreatePost: TypedRouteHandler<"POST /admin/images"> = (
   request,
 ) =>
-  withAuth(
-    request,
-    CONTENT_MULTIPART,
-    (_session, formData) =>
-      withStorageEnabled(() =>
-        withUploadedImage(formData, "/admin/images/new", async (image) => {
-          await logActivity(`Image '${image.name}' uploaded`);
-          return redirect(imagePath(image.id), t("images.created"), true);
-        })
-      ),
+  withAuth(request, CONTENT_MULTIPART, (_session, formData) =>
+    withStorageEnabled(() =>
+      withUploadedImage(formData, "/admin/images/new", async (image) => {
+        await logActivity(`Image '${image.name}' uploaded`);
+        return redirect(imagePath(image.id), t("images.created"), true);
+      }),
+    ),
   );
 
 const listingImageItemOptions = async (): Promise<ImageItemOption[]> =>
@@ -142,21 +139,19 @@ const handleImageEditGet: TypedRouteHandler<"GET /admin/images/:id/edit"> = (
   request,
   { id },
 ) =>
-  requireContentOr(
-    request,
-    (session) =>
-      withEntityFromParam(id, getImageById, async (image) => {
-        applyFlash(request);
-        return withStorageEnabled(async () => {
-          const [options, selected] = await Promise.all([
-            imageItemOptions(session.adminLevel),
-            selectedUses(image.id),
-          ]);
-          return htmlResponse(
-            adminImageEditPage({ image, options, selected, session }),
-          );
-        });
-      }),
+  requireContentOr(request, (session) =>
+    withEntityFromParam(id, getImageById, async (image) => {
+      applyFlash(request);
+      return withStorageEnabled(async () => {
+        const [options, selected] = await Promise.all([
+          imageItemOptions(session.adminLevel),
+          selectedUses(image.id),
+        ]);
+        return htmlResponse(
+          adminImageEditPage({ image, options, selected, session }),
+        );
+      });
+    }),
   );
 
 const parseImageTargets = (form: FormParams): ImageUseTarget[] =>
@@ -180,14 +175,10 @@ const withStorageImageForm = (
     adminLevel: AdminLevel,
   ) => Response | Promise<Response>,
 ): Promise<Response> =>
-  withAuth(
-    request,
-    CONTENT_FORM,
-    (session, form) =>
-      withEntityFromParam(id, getImageById, (image) =>
-        withStorageEnabled(() =>
-          action(image, form, session.adminLevel)
-        )),
+  withAuth(request, CONTENT_FORM, (session, form) =>
+    withEntityFromParam(id, getImageById, (image) =>
+      withStorageEnabled(() => action(image, form, session.adminLevel)),
+    ),
   );
 
 /** The image-use item types that are public Site content (owner + editor):
@@ -201,7 +192,7 @@ const isSiteContentImageType = (type: ImageUseItemType): boolean =>
  * changing or removing it is a Site-gated action a manager may not take. */
 const imageHasSiteContentUse = async (imageId: number): Promise<boolean> =>
   (await getImageUsesForImage(imageId)).some((use) =>
-    isSiteContentImageType(use.item_type)
+    isSiteContentImageType(use.item_type),
   );
 
 /** Block a non-Site session (a manager) from a save that would change an image
@@ -257,15 +248,13 @@ const handleImageEditPost: TypedRouteHandler<"POST /admin/images/:id/edit"> = (
 const handleImageDeleteGet: TypedRouteHandler<
   "GET /admin/images/:id/delete"
 > = (request, { id }) =>
-  requireContentOr(
-    request,
-    (session) =>
-      withEntityFromParam(id, getImageById, (image) => {
-        applyFlash(request);
-        return withStorageEnabled(() =>
-          htmlResponse(adminImageDeletePage(image, session))
-        );
-      }),
+  requireContentOr(request, (session) =>
+    withEntityFromParam(id, getImageById, (image) => {
+      applyFlash(request);
+      return withStorageEnabled(() =>
+        htmlResponse(adminImageDeletePage(image, session)),
+      );
+    }),
   );
 
 const confirmDelete = (form: FormParams, image: Image): string | null =>
@@ -294,11 +283,7 @@ const handleImageDeletePost: TypedRouteHandler<
     try {
       await deleteImageStorageFilesStrict(image);
     } catch {
-      return redirect(
-        deletePath,
-        t("images.delete.storage_failed"),
-        false,
-      );
+      return redirect(deletePath, t("images.delete.storage_failed"), false);
     }
     await deleteImageRecord(image.id);
     await logActivity(`Image '${image.name}' deleted`);

--- a/src/features/admin/item-images.ts
+++ b/src/features/admin/item-images.ts
@@ -81,21 +81,14 @@ export const createItemImageHandlers = <T>(
   upload: RouteHandlerFn;
 } => ({
   set: (request, { id }) =>
-    withAuth(
-      request,
-      config.auth?.form ?? CONTENT_FORM,
-      (_session, form) =>
-        withStorageBackedItem(id, config, async (item, itemId) => {
-          await setImagesForItem(
-            config.itemType,
-            itemId,
-            selectedImageIds(form),
-          );
-          await logActivity(
-            `Images updated for ${config.itemType} '${config.nameOf(item)}'`,
-          );
-          return redirect(config.path(itemId), t("images.item.saved"), true);
-        }),
+    withAuth(request, config.auth?.form ?? CONTENT_FORM, (_session, form) =>
+      withStorageBackedItem(id, config, async (item, itemId) => {
+        await setImagesForItem(config.itemType, itemId, selectedImageIds(form));
+        await logActivity(
+          `Images updated for ${config.itemType} '${config.nameOf(item)}'`,
+        );
+        return redirect(config.path(itemId), t("images.item.saved"), true);
+      }),
     ),
   upload: (request, { id }) =>
     withAuth(
@@ -110,11 +103,9 @@ export const createItemImageHandlers = <T>(
               itemType: config.itemType,
             });
             await logActivity(
-              `Image '${image.name}' uploaded for ${config.itemType} '${
-                config.nameOf(
-                  item,
-                )
-              }'`,
+              `Image '${image.name}' uploaded for ${config.itemType} '${config.nameOf(
+                item,
+              )}'`,
             );
             return redirect(itemPath, t("images.item.uploaded"), true);
           });

--- a/src/features/admin/item-images.ts
+++ b/src/features/admin/item-images.ts
@@ -23,7 +23,7 @@ import { isStorageEnabled } from "#shared/storage.ts";
 import type { ImageUseItemType } from "#shared/types.ts";
 import { ItemImagesPanel } from "#templates/admin/images.tsx";
 import { withEntityFromParam } from "./entity-handlers.ts";
-import { createImageFromUpload } from "./image-upload.ts";
+import { withUploadedImage } from "./image-upload.ts";
 
 type ItemImageConfig<T> = {
   /** Who may edit this entity's images. Defaults to the content gates; entities
@@ -81,14 +81,21 @@ export const createItemImageHandlers = <T>(
   upload: RouteHandlerFn;
 } => ({
   set: (request, { id }) =>
-    withAuth(request, config.auth?.form ?? CONTENT_FORM, (_session, form) =>
-      withStorageBackedItem(id, config, async (item, itemId) => {
-        await setImagesForItem(config.itemType, itemId, selectedImageIds(form));
-        await logActivity(
-          `Images updated for ${config.itemType} '${config.nameOf(item)}'`,
-        );
-        return redirect(config.path(itemId), t("images.item.saved"), true);
-      }),
+    withAuth(
+      request,
+      config.auth?.form ?? CONTENT_FORM,
+      (_session, form) =>
+        withStorageBackedItem(id, config, async (item, itemId) => {
+          await setImagesForItem(
+            config.itemType,
+            itemId,
+            selectedImageIds(form),
+          );
+          await logActivity(
+            `Images updated for ${config.itemType} '${config.nameOf(item)}'`,
+          );
+          return redirect(config.path(itemId), t("images.item.saved"), true);
+        }),
     ),
   upload: (request, { id }) =>
     withAuth(
@@ -96,20 +103,21 @@ export const createItemImageHandlers = <T>(
       config.auth?.multipart ?? CONTENT_MULTIPART,
       async (_session, formData) =>
         withStorageBackedItem(id, config, async (item, itemId) => {
-          const result = await createImageFromUpload(formData);
-          if (!result.ok) {
-            return redirect(config.path(itemId), result.error, false);
-          }
-          await appendImageToItem(result.value.id, {
-            itemId,
-            itemType: config.itemType,
+          const itemPath = config.path(itemId);
+          return withUploadedImage(formData, itemPath, async (image) => {
+            await appendImageToItem(image.id, {
+              itemId,
+              itemType: config.itemType,
+            });
+            await logActivity(
+              `Image '${image.name}' uploaded for ${config.itemType} '${
+                config.nameOf(
+                  item,
+                )
+              }'`,
+            );
+            return redirect(itemPath, t("images.item.uploaded"), true);
           });
-          await logActivity(
-            `Image '${result.value.name}' uploaded for ${config.itemType} '${config.nameOf(
-              item,
-            )}'`,
-          );
-          return redirect(config.path(itemId), t("images.item.uploaded"), true);
         }),
     ),
 });

--- a/src/features/api/index.ts
+++ b/src/features/api/index.ts
@@ -141,7 +141,13 @@ export type PublicListing = {
   description: string;
   date: string | null;
   location: string | null;
-  imageUrl: string;
+  /** Filename of the listing's primary image, or `null` when it has none. Like
+   * `date`/`location`, the model's empty-string convention is normalised to
+   * `null` at this API boundary so clients can branch on absence uniformly. */
+  imageUrl: string | null;
+  /** Operator-provided alt text for `imageUrl`, or `null` when unset. Lets
+   * API-driven storefronts render the image accessibly. */
+  imageAltText: string | null;
   unitPrice: number;
   canPayMore: boolean;
   maxPrice: number;
@@ -195,7 +201,8 @@ export const resolvedToPublicListing = (
     date: listing.date || null,
     description: listing.description,
     fields: listing.fields,
-    imageUrl: listing.image_url,
+    imageAltText: listing.image_alt_text || null,
+    imageUrl: listing.image_url || null,
     isClosed: closed,
     isSoldOut,
     listingType: listing.listing_type,

--- a/src/locales/en/images.json
+++ b/src/locales/en/images.json
@@ -7,6 +7,7 @@
   "images.delete.link": "Delete image",
   "images.delete.mismatch": "Confirmation did not match the image name",
   "images.news_gated": "This image is used by public site content — only site editors can manage it.",
+  "images.delete.storage_failed": "Could not delete the image files from storage. The image was kept so you can try again.",
   "images.delete.submit": "Delete image",
   "images.edit.heading": "Edit {name}",
   "images.empty": "No images yet.",

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -257,6 +257,33 @@ export const deleteImageStorageFiles = async (
   await tryDeleteFile(image.filename_thumb, image.id, reason);
 };
 
+/** True for a "the file is already gone" deletion error from either backend, so
+ * a retried delete treats an already-removed file as success. */
+const isAlreadyDeleted = (err: unknown): boolean =>
+  err instanceof Error &&
+  (err.message.startsWith("File not found:") || err.name === "NotFound");
+
+/**
+ * Delete an image's storage files, throwing if any file could not be removed
+ * (a file that is already gone counts as success, so retries are safe). Unlike
+ * {@link deleteImageStorageFiles}, this surfaces failures so the caller can
+ * keep the image's DB record for a later retry instead of orphaning the stored
+ * files under a deleted record.
+ */
+export const deleteImageStorageFilesStrict = async (
+  image: ImageWithStorage,
+): Promise<void> => {
+  const results = await Promise.allSettled([
+    deleteFile(image.filename),
+    deleteFile(image.filename_thumb),
+  ]);
+  const failure = results
+    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+    .map((r) => r.reason)
+    .find((reason) => !isAlreadyDeleted(reason));
+  if (failure) throw failure;
+};
+
 /** Delete all first-class image files. */
 export const deleteAllImageStorageFiles = async (
   images: ReadonlyArray<ImageWithStorage>,

--- a/src/ui/templates/components/actions.tsx
+++ b/src/ui/templates/components/actions.tsx
@@ -8,7 +8,7 @@
  */
 
 import { t } from "#i18n";
-import type { Child, SafeHtml } from "#jsx/jsx-runtime.ts";
+import { type Child, SafeHtml } from "#jsx/jsx-runtime.ts";
 import { ICONS_PATH } from "#shared/asset-paths.ts";
 import { type AdminLevel, isStaffRole } from "#shared/types.ts";
 
@@ -231,7 +231,7 @@ export const GuideFooter = ({
   children?: Child;
 }): SafeHtml =>
   adminLevel !== undefined && !isStaffRole(adminLevel) ? (
-    <></>
+    new SafeHtml("")
   ) : (
     <p class="guide-footer">
       <GuideLink href={href}>{children}</GuideLink>

--- a/test/lib/server-admin-image-edit-delete.test.ts
+++ b/test/lib/server-admin-image-edit-delete.test.ts
@@ -28,7 +28,6 @@ import {
   imageNamesForItem,
   makeImage,
 } from "#test-utils/admin-images.ts";
-import { setupErrorSpy } from "#test-utils/error-spy.ts";
 
 describeWithEnv(
   "admin image edit and delete routes",
@@ -230,8 +229,6 @@ describeWithEnv(
     });
 
     describe("POST /admin/images/:id/delete", () => {
-      const errors = setupErrorSpy();
-
       test("redirects away from delete confirmation when storage is disabled", async () => {
         const image = await makeImage("Disabled delete");
 

--- a/test/lib/server-admin-image-edit-delete.test.ts
+++ b/test/lib/server-admin-image-edit-delete.test.ts
@@ -19,7 +19,6 @@ import {
   testCookie,
   testCsrfToken,
   withCdnRejecting,
-  withExpectedError,
   withStorageDisabled,
   withStorageMock,
 } from "#test-utils";
@@ -316,35 +315,29 @@ describeWithEnv(
         expect(messages).toContain("Image 'Discard' deleted");
       });
 
-      test("deletes the image row even when storage cleanup fails", async () => {
+      test("keeps the image row when storage cleanup fails", async () => {
         const image = await makeImage("Storage failure");
         const cookie = await testCookie();
         const csrfToken = await testCsrfToken();
 
-        await withExpectedError(async () => {
-          await withCdnRejecting(new Error("delete down"), async () => {
-            const response = await handleRequest(
-              mockFormRequest(
-                `/admin/images/${image.id}/delete`,
-                { confirm_identifier: image.name, csrf_token: csrfToken },
-                cookie,
-              ),
-            );
-            await expectFlashRedirect(
-              "/admin/images",
-              "Image deleted",
-              true,
+        await withCdnRejecting(new Error("delete down"), async () => {
+          const response = await handleRequest(
+            mockFormRequest(
+              `/admin/images/${image.id}/delete`,
+              { confirm_identifier: image.name, csrf_token: csrfToken },
               cookie,
-            )(response);
-          });
+            ),
+          );
+          await expectFlashRedirect(
+            `/admin/images/${image.id}/delete`,
+            "Could not delete the image files from storage. The image was kept so you can try again.",
+            false,
+            cookie,
+          )(response);
         });
-        expect(await getImageById(image.id)).toBeNull();
-        // Both files (full-size + thumbnail) log their failed cleanup with the
-        // "image deletion" context so an operator can trace the orphaned files.
-        const cleanupFailures = errors.calls
-          .map((call) => String(call.args[0]))
-          .filter((message) => message.includes('detail="image deletion"'));
-        expect(cleanupFailures.length).toBe(2);
+        // The record survives so the admin can retry rather than orphaning the
+        // stored files under a deleted library entry.
+        expect(await getImageById(image.id)).not.toBeNull();
       });
     });
   },

--- a/test/routes/api/listings.test.ts
+++ b/test/routes/api/listings.test.ts
@@ -2,7 +2,9 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import * as v from "valibot";
 import { addDays } from "#shared/dates.ts";
+import { imagesTable, setImagesForItem } from "#shared/db/images.ts";
 import { todayInTz } from "#shared/timezone.ts";
+import { nonEmptyString } from "#shared/validation/string.ts";
 import {
   bookAttendee,
   createDailyTestListing,
@@ -206,6 +208,29 @@ describePublicApi(() => {
       const { body } = await fetchListingBySlug(listing.slug);
       const apiListing = v.parse(PublicListingSchema, body.listing);
       expect(apiListing.availableDates).toBeUndefined();
+    });
+
+    test("returns null image fields for a listing with no image", async () => {
+      const listing = await createTestListing();
+      const { body } = await fetchListingBySlug(listing.slug);
+      const apiListing = v.parse(PublicListingSchema, body.listing);
+      expect(apiListing.imageUrl).toBeNull();
+      expect(apiListing.imageAltText).toBeNull();
+    });
+
+    test("exposes the primary image filename and alt text", async () => {
+      const listing = await createTestListing();
+      const image = await imagesTable.insert({
+        altText: "A watercolour workshop",
+        filename: nonEmptyString("primary.webp", "test filename"),
+        filenameThumb: nonEmptyString("primary-thumb.webp", "test thumb"),
+        name: "Primary",
+      });
+      await setImagesForItem("listing", listing.id, [image.id]);
+      const { body } = await fetchListingBySlug(listing.slug);
+      const apiListing = v.parse(PublicListingSchema, body.listing);
+      expect(apiListing.imageUrl).toBe("primary.webp");
+      expect(apiListing.imageAltText).toBe("A watercolour workshop");
     });
   });
 

--- a/test/test-utils/api-schemas.ts
+++ b/test/test-utils/api-schemas.ts
@@ -30,8 +30,10 @@ export const PublicListingSchema = v.strictObject({
     ],
     v.boolean(),
   ),
-  imageUrl: v.string(),
-  ...v.entriesFromList(["date", "location"], v.nullable(v.string())),
+  ...v.entriesFromList(
+    ["date", "imageAltText", "imageUrl", "location"],
+    v.nullable(v.string()),
+  ),
   availableDates: v.optional(v.array(v.string())),
   dayPrices: v.optional(v.record(v.string(), v.number())),
 });

--- a/test/ui/templates/components/actions.test.ts
+++ b/test/ui/templates/components/actions.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { jsx } from "#jsx/jsx-runtime.ts";
 import { ICONS_PATH } from "#shared/asset-paths.ts";
+import type { AdminLevel } from "#shared/types.ts";
 import {
   ActionButton,
   BackButton,
@@ -117,13 +119,14 @@ describe("GuideLink", () => {
 });
 
 describe("GuideFooter", () => {
+  const guideFooterProps = (adminLevel?: AdminLevel) => ({
+    children: "Listings guide",
+    href: "/admin/guide#listings",
+    ...(adminLevel === undefined ? {} : { adminLevel }),
+  });
+
   test("renders the bottom-of-page guide link when no role is given", () => {
-    const html = String(
-      GuideFooter({
-        children: "Listings guide",
-        href: "/admin/guide#listings",
-      }),
-    );
+    const html = String(GuideFooter(guideFooterProps()));
     expect(html).toContain('class="guide-footer"');
     expect(html).toContain('href="/admin/guide#listings"');
     expect(html).toContain("<span>Listings guide</span>");
@@ -131,28 +134,23 @@ describe("GuideFooter", () => {
 
   test("renders for staff roles (owner/manager) when a role is given", () => {
     for (const adminLevel of ["owner", "manager"] as const) {
-      const html = String(
-        GuideFooter({
-          adminLevel,
-          children: "Listings guide",
-          href: "/admin/guide#listings",
-        }),
-      );
+      const html = String(GuideFooter(guideFooterProps(adminLevel)));
       expect(html).toContain('class="guide-footer"');
     }
   });
 
   test("renders nothing for non-staff roles (the guide is staff-only, 403s them)", () => {
     for (const adminLevel of ["editor", "agent"] as const) {
-      const html = String(
-        GuideFooter({
-          adminLevel,
-          children: "Listings guide",
-          href: "/admin/guide#listings",
-        }),
-      );
-      expect(html).not.toContain("guide-footer");
-      expect(html).not.toContain("/admin/guide#listings");
+      expect(String(GuideFooter(guideFooterProps(adminLevel)))).toBe("");
     }
+  });
+
+  test("renders empty HTML for hidden footers used as JSX components", () => {
+    const html = String(
+      jsx("div", {
+        children: jsx(() => GuideFooter(guideFooterProps("editor")), null),
+      }),
+    );
+    expect(html).toBe("<div></div>");
   });
 });


### PR DESCRIPTION
## Summary

- keep image records when storage cleanup fails so admins can retry deletion instead of orphaning files
- expose nullable listing image fields in the public API and cover them in the split API route tests
- tune the payment sandbox e2e harness diagnostics/provider handling while preserving the current complex-order run
- make hidden `GuideFooter` output explicit empty HTML so non-staff JSX component usage does not render literal `null`

## Validation

- `deno run -A scripts/biome.ts check --error-on-warnings src/ui/templates/components/actions.tsx test/ui/templates/components/actions.test.ts`
- `deno check src/ui/templates/components/actions.tsx test/ui/templates/components/actions.test.ts`
- `deno task test:files test/ui/templates/components/actions.test.ts`
- `deno task precommit` passed lint, typecheck, CPD, build:edge, and test:coverage
- mutation phase produced no output for several minutes and was interrupted; this matches the amended commit's WIP/NOT GREEN state