### PR TITLE
Harden OpenCode comment workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,22 +8,104 @@ on:
 
 jobs:
   opencode:
-    if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
     runs-on: ubicloud-standard-16
     permissions:
+      contents: read
       id-token: write
+      pull-requests: read
     steps:
+      - name: Check OpenCode request
+        id: gate
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            const command = (context.payload.comment?.body ?? "")
+              .trimStart()
+              .split(/\s+/, 1)[0] ?? "";
+            const isOpenCodeCommand = command === "/oc" || command === "/opencode";
+
+            if (!isOpenCodeCommand) {
+              core.info("No OpenCode command token found.");
+              core.setOutput("should_run", "false");
+              return;
+            }
+
+            const trustedAuthors = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const authorAssociation = context.payload.comment?.author_association;
+            if (!trustedAuthors.has(authorAssociation)) {
+              core.info(`Ignoring OpenCode command from ${authorAssociation ?? "unknown"} author.`);
+              core.setOutput("should_run", "false");
+              return;
+            }
+
+            const pullNumber = context.payload.issue?.pull_request
+              ? context.payload.issue.number
+              : context.payload.pull_request?.number;
+            if (!pullNumber) {
+              core.info("OpenCode commands only run on pull requests.");
+              core.setOutput("should_run", "false");
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: pullNumber,
+            });
+            const sameRepository =
+              pull.head.repo?.full_name === pull.base.repo?.full_name;
+
+            if (!sameRepository) {
+              core.info("OpenCode commands do not run on fork pull requests.");
+              core.setOutput("should_run", "false");
+              return;
+            }
+
+            core.setOutput("should_run", "true");
+
       - name: Checkout repository
-        uses: actions/checkout@v6
+        if: steps.gate.outputs.should_run == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+      - name: Install OpenCode
+        if: steps.gate.outputs.should_run == 'true'
         env:
+          OPENCODE_VERSION: 1.17.15
+        run: |
+          set -euo pipefail
+
+          arch="$(uname -m)"
+          case "$arch" in
+            x86_64) arch="x64" ;;
+            aarch64 | arm64) arch="arm64" ;;
+            *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+          esac
+
+          target="linux-${arch}"
+          if [ "$arch" = "x64" ] && ! grep -qwi avx2 /proc/cpuinfo 2>/dev/null; then
+            target="${target}-baseline"
+          fi
+          if [ -f /etc/alpine-release ] || ldd --version 2>&1 | grep -qi musl; then
+            target="${target}-musl"
+          fi
+
+          file="opencode-${target}.tar.gz"
+          url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${file}"
+          install_dir="${HOME}/.opencode/bin"
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "${tmp_dir}"' EXIT
+
+          mkdir -p "${install_dir}"
+          curl -fsSL "${url}" -o "${tmp_dir}/${file}"
+          tar -xzf "${tmp_dir}/${file}" -C "${tmp_dir}"
+          install -m 755 "${tmp_dir}/opencode" "${install_dir}/opencode"
+          echo "${install_dir}" >> "${GITHUB_PATH}"
+
+      - name: Run OpenCode
+        if: steps.gate.outputs.should_run == 'true'
+        env:
+          MODEL: neuralwatt/glm-5.2-flex
           NEURALWATT_API_KEY: ${{ secrets.NEURALWATT_API_KEY }}
-        with:
-          model: neuralwatt/glm-5.2-flex
+        run: opencode github run

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,13 +19,11 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
-            const command = (context.payload.comment?.body ?? "")
-              .trimStart()
-              .split(/\s+/, 1)[0] ?? "";
-            const isOpenCodeCommand = command === "/oc" || command === "/opencode";
+            const OPEN_CODE_COMMAND = /(^|\s)\/(?:oc|opencode)(?=\s|$)/;
+            const commentBody = context.payload.comment?.body ?? "";
 
-            if (!isOpenCodeCommand) {
-              core.info("No OpenCode command token found.");
+            if (!OPEN_CODE_COMMAND.test(commentBody)) {
+              core.info("No OpenCode command mention found.");
               core.setOutput("should_run", "false");
               return;
             }
@@ -41,21 +39,27 @@ jobs:
             const pullNumber = context.payload.issue?.pull_request
               ? context.payload.issue.number
               : context.payload.pull_request?.number;
-            if (!pullNumber) {
-              core.info("OpenCode commands only run on pull requests.");
-              core.setOutput("should_run", "false");
+
+            if (pullNumber) {
+              const { data: pull } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: pullNumber,
+              });
+              const sameRepository =
+                pull.head.repo?.full_name === pull.base.repo?.full_name;
+
+              if (!sameRepository) {
+                core.info("OpenCode commands do not run on fork pull requests.");
+                core.setOutput("should_run", "false");
+                return;
+              }
+
+              core.setOutput("should_run", "true");
               return;
             }
 
-            const { data: pull } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: pullNumber,
-            });
-            const sameRepository =
-              pull.head.repo?.full_name === pull.base.repo?.full_name;
-
-            if (!sameRepository) {
-              core.info("OpenCode commands do not run on fork pull requests.");
+            if (!context.payload.issue?.number) {
+              core.info("OpenCode commands only run on issues or pull requests.");
               core.setOutput("should_run", "false");
               return;
             }

--- a/test/lib/opencode-workflow.test.ts
+++ b/test/lib/opencode-workflow.test.ts
@@ -3,6 +3,70 @@ import { describe, it as test } from "@std/testing/bdd";
 
 const WORKFLOW_PATH = ".github/workflows/opencode.yml";
 const SHA = "[a-f0-9]{40}";
+const GATE_SCRIPT_MARKER = "          script: |\n";
+const GATE_SCRIPT_INDENT = "            ";
+
+type GatePayload = {
+  comment?: {
+    author_association?: string;
+    body?: string;
+  };
+  issue?: {
+    number?: number;
+    pull_request?: unknown;
+  };
+  pull_request?: {
+    number?: number;
+  };
+};
+
+type GateContext = {
+  eventName: string;
+  payload: GatePayload;
+  repo: {
+    owner: string;
+    repo: string;
+  };
+};
+
+type PullCheck = {
+  owner: string;
+  pull_number: number;
+  repo: string;
+};
+
+type Pull = {
+  base: {
+    repo?: { full_name?: string } | null;
+  };
+  head: {
+    repo?: { full_name?: string } | null;
+  };
+};
+
+type GateGithub = {
+  rest: {
+    pulls: {
+      get: (check: PullCheck) => Promise<{ data: Pull }>;
+    };
+  };
+};
+
+type GateCore = {
+  info: (message: string) => void;
+  setOutput: (name: string, value: string) => void;
+};
+
+type GateFunction = (
+  context: GateContext,
+  github: GateGithub,
+  core: GateCore,
+) => Promise<void>;
+
+const AsyncFunction = Object.getPrototypeOf(async () => undefined)
+  .constructor as new (
+  ...args: string[]
+) => GateFunction;
 
 const readWorkflow = (): Promise<string> => Deno.readTextFile(WORKFLOW_PATH);
 
@@ -10,6 +74,65 @@ const positionOf = (text: string, phrase: string): number => {
   const position = text.indexOf(phrase);
   expect(position).toBeGreaterThanOrEqual(0);
   return position;
+};
+
+const gateScriptFrom = (workflow: string): string => {
+  const start =
+    positionOf(workflow, GATE_SCRIPT_MARKER) + GATE_SCRIPT_MARKER.length;
+  const lines = workflow.slice(start).split("\n");
+  const end = lines.findIndex(
+    (line) => line.length > 0 && !line.startsWith(GATE_SCRIPT_INDENT),
+  );
+  return lines
+    .slice(0, end === -1 ? lines.length : end)
+    .map((line) =>
+      line.startsWith(GATE_SCRIPT_INDENT)
+        ? line.slice(GATE_SCRIPT_INDENT.length)
+        : line,
+    )
+    .join("\n");
+};
+
+const sameRepositoryPull: Pull = {
+  base: { repo: { full_name: "chobbledotcom/tickets" } },
+  head: { repo: { full_name: "chobbledotcom/tickets" } },
+};
+
+const runGate = async (
+  payload: GatePayload,
+  eventName = "issue_comment",
+  pull = sameRepositoryPull,
+) => {
+  const outputs = new Map<string, string>();
+  const pullNumbers: number[] = [];
+  const script = gateScriptFrom(await readWorkflow());
+  const gate = new AsyncFunction("context", "github", "core", script);
+  const context: GateContext = {
+    eventName,
+    payload,
+    repo: { owner: "chobbledotcom", repo: "tickets" },
+  };
+  const github: GateGithub = {
+    rest: {
+      pulls: {
+        get: (check) => {
+          pullNumbers.push(check.pull_number);
+          return Promise.resolve({ data: pull });
+        },
+      },
+    },
+  };
+  const core: GateCore = {
+    info: () => undefined,
+    setOutput: (name, value) => outputs.set(name, value),
+  };
+
+  await gate(context, github, core);
+
+  return {
+    pullNumbers,
+    shouldRun: outputs.get("should_run") === "true",
+  };
 };
 
 describe("OpenCode workflow", () => {
@@ -25,8 +148,7 @@ describe("OpenCode workflow", () => {
     const workflow = await readWorkflow();
 
     expect(workflow).not.toContain("contains(github.event.comment.body");
-    expect(workflow).toContain('command === "/oc"');
-    expect(workflow).toContain('command === "/opencode"');
+    expect(workflow).toContain("OPEN_CODE_COMMAND");
     expect(workflow).toContain("github.rest.pulls.get");
     expect(workflow).toContain("pull.head.repo?.full_name");
     expect(workflow).toContain("pull.base.repo?.full_name");
@@ -40,6 +162,32 @@ describe("OpenCode workflow", () => {
     expect(gatePosition).toBeLessThan(checkoutPosition);
     expect(checkoutPosition).toBeLessThan(installPosition);
     expect(gatePosition).toBeLessThan(keyPosition);
+  });
+
+  test("runs when a trusted PR comment mentions OpenCode inline", async () => {
+    const result = await runGate({
+      comment: {
+        author_association: "OWNER",
+        body: "Delete the stale branch /oc",
+      },
+      issue: { number: 42, pull_request: {} },
+    });
+
+    expect(result.shouldRun).toBe(true);
+    expect(result.pullNumbers).toEqual([42]);
+  });
+
+  test("runs for trusted OpenCode comments on normal issues", async () => {
+    const result = await runGate({
+      comment: {
+        author_association: "MEMBER",
+        body: "/opencode summarize the problem",
+      },
+      issue: { number: 84 },
+    });
+
+    expect(result.shouldRun).toBe(true);
+    expect(result.pullNumbers).toEqual([]);
   });
 
   test("pins actions and the OpenCode binary to immutable commits and releases", async () => {

--- a/test/lib/opencode-workflow.test.ts
+++ b/test/lib/opencode-workflow.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+
+const WORKFLOW_PATH = ".github/workflows/opencode.yml";
+const SHA = "[a-f0-9]{40}";
+
+const readWorkflow = (): Promise<string> => Deno.readTextFile(WORKFLOW_PATH);
+
+const positionOf = (text: string, phrase: string): number => {
+  const position = text.indexOf(phrase);
+  expect(position).toBeGreaterThanOrEqual(0);
+  return position;
+};
+
+describe("OpenCode workflow", () => {
+  test("grants the token scopes needed before checkout and PR checks", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toContain("contents: read");
+    expect(workflow).toContain("id-token: write");
+    expect(workflow).toContain("pull-requests: read");
+  });
+
+  test("checks the command token and same-repository PR before using secrets", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).not.toContain("contains(github.event.comment.body");
+    expect(workflow).toContain('command === "/oc"');
+    expect(workflow).toContain('command === "/opencode"');
+    expect(workflow).toContain("github.rest.pulls.get");
+    expect(workflow).toContain("pull.head.repo?.full_name");
+    expect(workflow).toContain("pull.base.repo?.full_name");
+    expect(workflow).toContain("steps.gate.outputs.should_run == 'true'");
+
+    const gatePosition = positionOf(workflow, "name: Check OpenCode request");
+    const checkoutPosition = positionOf(workflow, "name: Checkout repository");
+    const installPosition = positionOf(workflow, "name: Install OpenCode");
+    const keyPosition = positionOf(workflow, "NEURALWATT_API_KEY");
+
+    expect(gatePosition).toBeLessThan(checkoutPosition);
+    expect(checkoutPosition).toBeLessThan(installPosition);
+    expect(gatePosition).toBeLessThan(keyPosition);
+  });
+
+  test("pins actions and the OpenCode binary to immutable commits and releases", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toMatch(new RegExp(`uses: actions/github-script@${SHA}`));
+    expect(workflow).toMatch(new RegExp(`uses: actions/checkout@${SHA}`));
+    expect(workflow).toContain("OPENCODE_VERSION: 1.17.15");
+    expect(workflow).toContain(
+      "github.com/anomalyco/opencode/releases/download/v$" +
+        "{OPENCODE_VERSION}",
+    );
+    expect(workflow).toContain("opencode github run");
+    expect(workflow).not.toContain("anomalyco/opencode/github@");
+    expect(workflow).not.toMatch(/uses: .+@latest/);
+  });
+});


### PR DESCRIPTION
## What changed

This hardens the OpenCode comment workflow added in #1663.

- Adds the missing `contents: read` permission so checkout can read the repository when the job has an explicit permissions block.
- Replaces substring command matching with a boundary-aware gate that accepts `/oc` or `/opencode` as its own command token anywhere in the comment.
- Keeps trusted normal issue comments working, so `/oc` can still summarize or work on issues that are not pull requests.
- Checks that pull request commands target a same-repository pull request before checkout, install, or model-key use.
- Removes the mutable third-party OpenCode action ref and installs OpenCode `v1.17.15` directly from its GitHub release before the secret-bearing run step.
- Pins the remaining GitHub actions to commit SHAs.
- Adds regression tests that execute the embedded workflow gate script against PR and normal-issue payloads.

## Why

The workflow needs to reject unsafe or accidental commands without breaking the issue-comment flow OpenCode already supported. Trusted users can now mention OpenCode inline, normal issue comments still run, and fork pull requests are still blocked before secrets are available.

## Validation

- `deno task test:files test/lib/opencode-workflow.test.ts`
- `deno check test/lib/opencode-workflow.test.ts`
- `deno run -A scripts/biome.ts check --write --error-on-warnings test/lib/opencode-workflow.test.ts .github/workflows/opencode.yml`
- `git diff --check`

Full `deno task precommit` was not run after the requested battery-saving note.