### PR TITLE
[codex] Use shared Deno cache setup

### DIFF
--- a/.github/actions/build-bunny-script/action.yml
+++ b/.github/actions/build-bunny-script/action.yml
@@ -7,19 +7,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-
-    - name: Setup Deno
-      uses: denoland/setup-deno@v2
-      with:
-        deno-version: v2.5.6
-
-    - name: Install dependencies
-      shell: bash
-      run: deno install --allow-scripts
+    - name: Set up Deno
+      uses: ./.github/actions/setup-deno
 
     - name: Build edge script
       shell: bash

--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -1,0 +1,36 @@
+name: Set up Deno
+description: >-
+  Set up Node.js, install the pinned Deno version, restore the shared Deno
+  dependency cache, and optionally install project dependencies.
+inputs:
+  install_dependencies:
+    description: Run deno install --allow-scripts after restoring the cache.
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+
+    - name: Setup Deno
+      id: deno
+      uses: denoland/setup-deno@v2
+      with:
+        deno-version-file: .tool-versions
+
+    # Keep one repo-wide dependency cache instead of one cache per workflow/job.
+    - name: Cache Deno dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/deno
+        key: deno-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno.outputs.deno-version }}-${{ hashFiles('deno.lock', 'deno.json', 'e2e-payments/deno.json') }}
+        restore-keys: |
+          deno-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno.outputs.deno-version }}-
+
+    - name: Install Deno dependencies
+      if: inputs.install_dependencies == 'true'
+      shell: bash
+      run: deno install --allow-scripts

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -31,18 +31,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
-
-      - name: Install dependencies
-        run: deno install --allow-scripts
+      - name: Set up Deno
+        uses: ./.github/actions/setup-deno
 
       - name: Create database backup
         # `deno task backup` passes --env-file, so Deno logs a harmless

--- a/.github/workflows/biome-fix.yml
+++ b/.github/workflows/biome-fix.yml
@@ -54,18 +54,8 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
-
-      - name: Install dependencies
-        run: deno install --allow-scripts
+      - name: Set up Deno
+        uses: ./.github/actions/setup-deno
 
       - name: Close existing Biome pull request
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,15 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Set up Deno
+        uses: ./.github/actions/setup-deno
         with:
-          node-version: 24
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
+          install_dependencies: "false"
 
       - name: Generate docs
         run: >-

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -45,15 +45,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
+      - name: Set up Deno
+        uses: ./.github/actions/setup-deno
 
       # Only needed under --harness, but caching .bin is harmless otherwise and
       # saves re-downloading stripe-mock when the harness is used.
@@ -62,9 +55,6 @@ jobs:
         with:
           path: .bin
           key: stripe-mock-${{ env.STRIPE_MOCK_VERSION }}-linux-amd64
-
-      - name: Install dependencies
-        run: deno install --allow-scripts
 
       # The runner streams one coloured glyph per mutant as it goes — "." killed,
       # "S" survived, "T" timed out — then prints a summary, and writes a Markdown

--- a/.github/workflows/payment-sandbox-e2e.yml
+++ b/.github/workflows/payment-sandbox-e2e.yml
@@ -52,10 +52,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
+      - name: Set up Deno
+        uses: ./.github/actions/setup-deno
 
       - name: Install cloudflared
         run: |
@@ -67,16 +65,6 @@ jobs:
           # $GITHUB_PATH only affects later steps, so verify via the full path here.
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/bin/cloudflared" --version
-
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/deno
-          key: deno-${{ runner.os }}-${{ hashFiles('deno.lock', 'e2e-payments/deno.json') }}
-
-      - name: Install Deno dependencies
-        run: deno install --allow-scripts
 
       - name: Resolve Playwright version
         id: pw

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,23 +19,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Build Bunny edge script
+        uses: ./.github/actions/build-bunny-script
         with:
-          node-version: 24
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
-
-      - name: Install dependencies
-        run: deno install --allow-scripts
-
-      - name: Build edge script
-        run: deno task build:edge
-        env:
-          BUILD_COMMIT: ${{ github.sha }}
+          build_commit: ${{ github.sha }}
 
       - name: Create release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.5.6
+      - name: Set up Deno
+        uses: ./.github/actions/setup-deno
 
       # stripe-mock is downloaded, started, and stopped by scripts/run-tests.ts
       # (invoked via the test:coverage step inside precommit). Caching .bin just
@@ -34,9 +27,6 @@ jobs:
         with:
           path: .bin
           key: stripe-mock-${{ env.STRIPE_MOCK_VERSION }}-linux-amd64
-
-      - name: Install dependencies
-        run: deno install --allow-scripts
 
       # Run each precommit check as a separate step so failures are attributed
       # individually in the Actions UI. The set of steps mirrors `getSteps()` in


### PR DESCRIPTION
## What changed

Added one shared GitHub Actions setup action for Deno. It installs the pinned Deno version from `.tool-versions`, restores `~/.cache/deno` with one repo-wide cache key, and optionally runs `deno install --allow-scripts`.

Updated the test, mutation, backup, biome-fix, release, docs, payment sandbox e2e, and Bunny build workflows to use that shared setup path.

## Why

Several workflows were reinstalling Deno dependencies without restoring the package cache first, so CI was reaching out to JSR/npm more often than necessary. The shared cache key lets normal CI, deployment, release, docs, and e2e jobs reuse the same Deno package archive, with a restore prefix so lockfile changes can still reuse the previous cache contents.

## Impact

CI should spend less time and network work fetching Deno, JSR, and npm dependencies, while keeping dependency invalidation tied to the pinned Deno version and Deno config/lock inputs.

## Validation

- `deno fmt --check .github/actions/setup-deno/action.yml .github/actions/build-bunny-script/action.yml .github/workflows/test.yml .github/workflows/mutation.yml .github/workflows/backup.yml .github/workflows/biome-fix.yml .github/workflows/release.yml .github/workflows/docs.yml .github/workflows/payment-sandbox-e2e.yml`
- `deno task precommit`