### PR TITLE
[codex] clear coverage before test runs

### DIFF
--- a/scripts/coverage-output.ts
+++ b/scripts/coverage-output.ts
@@ -1,10 +1,10 @@
 import { join } from "node:path";
 import { projectRoot } from "./project-root.ts";
 
-export const COVERAGE_DIR = join(projectRoot, "coverage");
+export const COVERAGE_OUTPUT_DIR = join(projectRoot, "coverage");
 
-export const clearCoverageDir = async (
-  coverageDir = COVERAGE_DIR,
+export const removeOldCoverageOutput = async (
+  coverageDir = COVERAGE_OUTPUT_DIR,
 ): Promise<void> => {
   try {
     await Deno.remove(coverageDir, { recursive: true });

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -6,8 +6,8 @@
  * harness once the run completes.
  */
 
+import { COVERAGE_OUTPUT_DIR } from "./coverage-output.ts";
 import { projectRoot } from "./project-root.ts";
-import { COVERAGE_DIR } from "./test-coverage.ts";
 import { JUNIT_PATH, readSlowTestsReport } from "./test-durations.ts";
 import { runTests, withTestHarness } from "./test-harness.ts";
 
@@ -297,7 +297,7 @@ const checkCoverage = async (): Promise<void> => {
   console.log("\nChecking coverage...");
 
   const tableCmd = new Deno.Command(Deno.execPath(), {
-    args: ["coverage", COVERAGE_DIR],
+    args: ["coverage", COVERAGE_OUTPUT_DIR],
     cwd: projectRoot,
     stderr: "inherit",
     stdin: "inherit",
@@ -306,7 +306,7 @@ const checkCoverage = async (): Promise<void> => {
   await tableCmd.output();
 
   const lcovCmd = new Deno.Command(Deno.execPath(), {
-    args: ["coverage", COVERAGE_DIR, "--lcov"],
+    args: ["coverage", COVERAGE_OUTPUT_DIR, "--lcov"],
     cwd: projectRoot,
     stderr: "inherit",
     stdout: "piped",

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -6,8 +6,8 @@
  * harness once the run completes.
  */
 
-import { join } from "node:path";
 import { projectRoot } from "./project-root.ts";
+import { COVERAGE_DIR } from "./test-coverage.ts";
 import { JUNIT_PATH, readSlowTestsReport } from "./test-durations.ts";
 import { runTests, withTestHarness } from "./test-harness.ts";
 
@@ -136,7 +136,12 @@ const checkRecord = (record: string): CoverageFailure | undefined => {
     "BRF",
     extractUncoveredBranchLines(record),
   );
-  return lines || branches ? { ...source, branches, lines } : undefined;
+  if (!lines && !branches) return undefined;
+  return {
+    ...source,
+    ...(branches ? { branches } : {}),
+    ...(lines ? { lines } : {}),
+  };
 };
 
 /** Parse lcov records and return coverage failures */
@@ -290,10 +295,9 @@ const reportCoverageFailures = async (
 /** Run coverage check: print table, parse lcov, enforce 100% */
 const checkCoverage = async (): Promise<void> => {
   console.log("\nChecking coverage...");
-  const coverageDir = join(projectRoot, "coverage");
 
   const tableCmd = new Deno.Command(Deno.execPath(), {
-    args: ["coverage", coverageDir],
+    args: ["coverage", COVERAGE_DIR],
     cwd: projectRoot,
     stderr: "inherit",
     stdin: "inherit",
@@ -302,7 +306,7 @@ const checkCoverage = async (): Promise<void> => {
   await tableCmd.output();
 
   const lcovCmd = new Deno.Command(Deno.execPath(), {
-    args: ["coverage", coverageDir, "--lcov"],
+    args: ["coverage", COVERAGE_DIR, "--lcov"],
     cwd: projectRoot,
     stderr: "inherit",
     stdout: "piped",

--- a/scripts/test-coverage.ts
+++ b/scripts/test-coverage.ts
@@ -1,0 +1,15 @@
+import { join } from "node:path";
+import { projectRoot } from "./project-root.ts";
+
+export const COVERAGE_DIR = join(projectRoot, "coverage");
+
+export const clearCoverageDir = async (
+  coverageDir = COVERAGE_DIR,
+): Promise<void> => {
+  try {
+    await Deno.remove(coverageDir, { recursive: true });
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    throw error;
+  }
+};

--- a/scripts/test-harness.ts
+++ b/scripts/test-harness.ts
@@ -20,8 +20,11 @@ import {
   hasReporterArg,
   runCompactDenoTest,
 } from "./compact-test-reporter.ts";
+import {
+  COVERAGE_OUTPUT_DIR,
+  removeOldCoverageOutput,
+} from "./coverage-output.ts";
 import { projectRoot } from "./project-root.ts";
-import { COVERAGE_DIR, clearCoverageDir } from "./test-coverage.ts";
 
 const STRIPE_MOCK_VERSION = "0.188.0";
 export const STRIPE_MOCK_PORT = 12111;
@@ -183,7 +186,7 @@ const buildDenoTestArgs = (
     "--v8-flags=--expose-gc",
   ];
   if (reporter) args.push("--reporter", reporter);
-  if (useCoverage) args.push(`--coverage=${COVERAGE_DIR}`);
+  if (useCoverage) args.push(`--coverage=${COVERAGE_OUTPUT_DIR}`);
   if (junitPath) args.push("--junit-path", junitPath);
   args.push(...extraArgs);
   return args;
@@ -209,7 +212,7 @@ export const runTests = async (
     STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
   };
 
-  if (useCoverage) await clearCoverageDir();
+  if (useCoverage) await removeOldCoverageOutput();
 
   if (!hasReporterArg(extraArgs)) {
     const estimatedTotal = await estimateTapEventCount(projectRoot, extraArgs);

--- a/scripts/test-harness.ts
+++ b/scripts/test-harness.ts
@@ -21,6 +21,7 @@ import {
   runCompactDenoTest,
 } from "./compact-test-reporter.ts";
 import { projectRoot } from "./project-root.ts";
+import { COVERAGE_DIR, clearCoverageDir } from "./test-coverage.ts";
 
 const STRIPE_MOCK_VERSION = "0.188.0";
 export const STRIPE_MOCK_PORT = 12111;
@@ -182,7 +183,7 @@ const buildDenoTestArgs = (
     "--v8-flags=--expose-gc",
   ];
   if (reporter) args.push("--reporter", reporter);
-  if (useCoverage) args.push("--coverage=coverage");
+  if (useCoverage) args.push(`--coverage=${COVERAGE_DIR}`);
   if (junitPath) args.push("--junit-path", junitPath);
   args.push(...extraArgs);
   return args;
@@ -207,6 +208,8 @@ export const runTests = async (
     STRIPE_MOCK_HOST: "localhost",
     STRIPE_MOCK_PORT: String(STRIPE_MOCK_PORT),
   };
+
+  if (useCoverage) await clearCoverageDir();
 
   if (!hasReporterArg(extraArgs)) {
     const estimatedTotal = await estimateTapEventCount(projectRoot, extraArgs);

--- a/test/scripts/test-coverage.test.ts
+++ b/test/scripts/test-coverage.test.ts
@@ -1,18 +1,19 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { clearCoverageDir } from "../../scripts/test-coverage.ts";
+import { bracket } from "#fp";
+import { removeOldCoverageOutput } from "../../scripts/coverage-output.ts";
 
-const withTempDir = async (
-  useDir: (path: string) => Promise<void>,
-): Promise<void> => {
-  const path = await Deno.makeTempDir();
-  try {
-    await useDir(path);
-  } finally {
-    await Deno.remove(path, { recursive: true }).catch(() => {});
-  }
-};
+const withTempCoverageDir = bracket(
+  async () => join(await Deno.makeTempDir(), "coverage"),
+  (coverageDir: string) =>
+    Deno.remove(dirname(coverageDir), { recursive: true }).catch(() => {}),
+);
+
+const withTempFile = bracket(
+  () => Deno.makeTempFile(),
+  (path: string) => Deno.remove(path).catch(() => {}),
+);
 
 const pathExists = async (path: string): Promise<boolean> => {
   try {
@@ -24,31 +25,32 @@ const pathExists = async (path: string): Promise<boolean> => {
   }
 };
 
-describe("clearCoverageDir", () => {
+describe("removeOldCoverageOutput", () => {
   test("removes stale coverage files before a coverage run", async () => {
-    await withTempDir(async (dir) => {
-      const coverageDir = join(dir, "coverage");
+    await withTempCoverageDir(async (coverageDir) => {
       const staleFile = join(coverageDir, "old.json");
       await Deno.mkdir(coverageDir);
       await Deno.writeTextFile(staleFile, "stale coverage");
 
-      await clearCoverageDir(coverageDir);
+      await removeOldCoverageOutput(coverageDir);
 
       expect(await pathExists(coverageDir)).toBe(false);
     });
   });
 
   test("allows a missing coverage directory on the first run", async () => {
-    await withTempDir(async (dir) => {
-      const coverageDir = join(dir, "coverage");
-
-      await clearCoverageDir(coverageDir);
+    await withTempCoverageDir(async (coverageDir) => {
+      await removeOldCoverageOutput(coverageDir);
 
       expect(await pathExists(coverageDir)).toBe(false);
     });
   });
 
-  test("fails if the coverage directory cannot be removed cleanly", async () => {
-    await expect(clearCoverageDir("\0")).rejects.toThrow();
+  test("surfaces filesystem errors other than missing coverage output", async () => {
+    await withTempFile(async (filePath) => {
+      await expect(
+        removeOldCoverageOutput(join(filePath, "coverage")),
+      ).rejects.toThrow(Deno.errors.NotADirectory);
+    });
   });
 });

--- a/test/scripts/test-coverage.test.ts
+++ b/test/scripts/test-coverage.test.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { clearCoverageDir } from "../../scripts/test-coverage.ts";
+
+const withTempDir = async (
+  useDir: (path: string) => Promise<void>,
+): Promise<void> => {
+  const path = await Deno.makeTempDir();
+  try {
+    await useDir(path);
+  } finally {
+    await Deno.remove(path, { recursive: true }).catch(() => {});
+  }
+};
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+};
+
+describe("clearCoverageDir", () => {
+  test("removes stale coverage files before a coverage run", async () => {
+    await withTempDir(async (dir) => {
+      const coverageDir = join(dir, "coverage");
+      const staleFile = join(coverageDir, "old.json");
+      await Deno.mkdir(coverageDir);
+      await Deno.writeTextFile(staleFile, "stale coverage");
+
+      await clearCoverageDir(coverageDir);
+
+      expect(await pathExists(coverageDir)).toBe(false);
+    });
+  });
+
+  test("allows a missing coverage directory on the first run", async () => {
+    await withTempDir(async (dir) => {
+      const coverageDir = join(dir, "coverage");
+
+      await clearCoverageDir(coverageDir);
+
+      expect(await pathExists(coverageDir)).toBe(false);
+    });
+  });
+
+  test("fails if the coverage directory cannot be removed cleanly", async () => {
+    await expect(clearCoverageDir("\0")).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## What changed

Coverage-enabled test runs now remove old generated coverage output before `deno test --coverage` starts. The coverage output path and cleanup helper live together in `scripts/coverage-output.ts`, so the test harness and coverage checker share one named location instead of carrying parallel `coverage` strings.

The focused regression tests now use the repo's `bracket` cleanup pattern and cover three real behaviours: removing stale coverage files, allowing the first run when the directory is absent, and surfacing filesystem errors that are not a missing coverage directory.

## Why

Deno writes many V8 coverage files into the existing coverage directory. Repeated runs were accumulating stale files, which made local coverage output grow into multiple gigabytes and hundreds of thousands of files.

## Impact

Repeated coverage and precommit runs start from a clean coverage directory, so stale output no longer piles up between runs. The generated coverage directory is still produced for each run and remains available for reports.

## Validation

- `deno task test:files test/scripts/test-coverage.test.ts`
- `deno check scripts/coverage-output.ts scripts/test-harness.ts scripts/run-tests.ts test/scripts/test-coverage.test.ts`
- `deno task lint:ci`
- `deno task precommit`