### PR TITLE
Fix payment sandbox browser regression

### DIFF
--- a/.github/workflows/payment-sandbox-e2e.yml
+++ b/.github/workflows/payment-sandbox-e2e.yml
@@ -68,7 +68,19 @@ jobs:
 
       - name: Resolve Playwright version
         id: pw
-        run: echo "version=1.49.1" >> "$GITHUB_OUTPUT"
+        run: |
+          version="$(
+            deno eval '
+          const config = JSON.parse(await Deno.readTextFile("e2e-payments/deno.json"));
+          const spec = config.imports?.playwright;
+          const version = spec?.match(/^npm:playwright@(.+)$/)?.[1];
+          if (!version) {
+            throw new Error(`Expected imports.playwright to be npm:playwright@<version>; got ${spec}`);
+          }
+          console.log(version);
+          '
+          )"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         id: pw-cache
@@ -82,11 +94,11 @@ jobs:
       # a miss, download the browser and its OS deps in one go.
       - name: Install Playwright Chromium (cache miss)
         if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: deno run -A npm:playwright@1.49.1 install --with-deps chromium
+        run: deno run -A npm:playwright@${{ steps.pw.outputs.version }} install --with-deps chromium
 
       - name: Install Playwright OS dependencies (cache hit)
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: deno run -A npm:playwright@1.49.1 install-deps chromium
+        run: deno run -A npm:playwright@${{ steps.pw.outputs.version }} install-deps chromium
 
       - name: Run ${{ matrix.target }} payment e2e
         env:

--- a/deno.lock
+++ b/deno.lock
@@ -67,7 +67,7 @@
     "npm:marked@18": "18.0.2",
     "npm:node-forge@^1.4.0": "1.4.0",
     "npm:oxc-parser@0.132.0": "0.132.0",
-    "npm:playwright@1.49.1": "1.49.1",
+    "npm:playwright@1.61.1": "1.61.1",
     "npm:postmark@*": "4.0.7",
     "npm:prosemirror-commands@^1.7.0": "1.7.1",
     "npm:prosemirror-history@^1.4.1": "1.5.0",
@@ -1767,12 +1767,12 @@
     "picomatch@4.0.4": {
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
     },
-    "playwright-core@1.49.1": {
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+    "playwright-core@1.61.1": {
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "bin": true
     },
-    "playwright@1.49.1": {
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+    "playwright@1.61.1": {
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dependencies": [
         "playwright-core"
       ],
@@ -2283,7 +2283,7 @@
     "members": {
       "e2e-payments": {
         "dependencies": [
-          "npm:playwright@1.49.1"
+          "npm:playwright@1.61.1"
         ]
       }
     }

--- a/e2e-payments/deno.json
+++ b/e2e-payments/deno.json
@@ -7,7 +7,7 @@
     "e2e": "deno run -A src/main.ts"
   },
   "imports": {
-    "playwright": "npm:playwright@1.49.1"
+    "playwright": "npm:playwright@1.61.1"
   },
   "compilerOptions": {
     "strict": true,

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -45,6 +45,13 @@ export const login = async (session: BrowserSession): Promise<void> => {
   if ((await session.bodyText()).includes("Migration complete")) {
     await session.clickLink("Back to dashboard");
   }
+  const loginFields = await session.page
+    .locator('[name="username"], [name="password"]')
+    .count();
+  if (loginFields > 0) {
+    await session.dumpPage("login-did-not-stick");
+    throw new Error("admin login did not stick; still on the login page");
+  }
   log("  logged in");
 };
 

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -14,6 +14,7 @@ const LISTING_NAME = "E2E Payment Concert";
 // invalid email before redirecting, failing the booking pre-checkout.
 const BOOKER_EMAIL = config.bookerEmail;
 const BOOKER_NAME = "E2E Booker";
+const LOGIN_FIELDS_SELECTOR = '[name="username"], [name="password"]';
 
 /** Run the first-run setup wizard for a fresh install. */
 export const runSetup = async (
@@ -45,10 +46,13 @@ export const login = async (session: BrowserSession): Promise<void> => {
   if ((await session.bodyText()).includes("Migration complete")) {
     await session.clickLink("Back to dashboard");
   }
-  const loginFields = await session.page
-    .locator('[name="username"], [name="password"]')
-    .count();
-  if (loginFields > 0) {
+  try {
+    await session.page.waitForFunction(
+      (selector) => document.querySelectorAll(selector).length === 0,
+      LOGIN_FIELDS_SELECTOR,
+      { timeout: config.actionTimeoutMs },
+    );
+  } catch {
     await session.dumpPage("login-did-not-stick");
     throw new Error("admin login did not stick; still on the login page");
   }

--- a/e2e-payments/src/flow.ts
+++ b/e2e-payments/src/flow.ts
@@ -52,9 +52,11 @@ export const login = async (session: BrowserSession): Promise<void> => {
       LOGIN_FIELDS_SELECTOR,
       { timeout: config.actionTimeoutMs },
     );
-  } catch {
+  } catch (err) {
     await session.dumpPage("login-did-not-stick");
-    throw new Error("admin login did not stick; still on the login page");
+    throw new Error("admin login did not stick; still on the login page", {
+      cause: err,
+    });
   }
   log("  logged in");
 };

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -32,6 +32,10 @@
 src/shared/checkout-pricing.ts:85:35  ?? → ||    # Map<number,number> sum: 0 ?? 0 === 0 || 0
 src/shared/checkout-pricing.ts:334:41  ?? → ||   # intent.modifiers: an array is always truthy
 src/shared/logistics-filter.ts:22:35  ?? → ||    # raw: string|null, only falsy string "" === fallback ""
+src/shared/config.ts:150:39  ?? → ||    # getEnv(): string|undefined, only falsy string "" === fallback ""
+src/shared/config.ts:163:61  ?? → ||    # getEnv(): string|undefined, only falsy string "" === fallback ""
+src/shared/config.ts:170:33  ?? → ||    # getEnv(): string|undefined, only falsy string "" === fallback ""
+src/shared/config.ts:177:33  ?? → ||    # getEnv(): string|undefined, only falsy string "" === fallback ""
 src/shared/qr-token.ts:60:18  ?? → ||    # input.date?: string, only falsy string "" === fallback ""
 src/shared/qr-token.ts:62:18  ?? → ||    # input.name?: string, only falsy string "" === fallback ""
 src/shared/site-assignment.ts:192:57  ?? → ||    # parseReadOnlyFromMs(): number|null, 0 ?? 0 === 0 || 0

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -41,6 +41,25 @@ const DEFAULT_DOMAIN = "localhost";
  */
 const effectiveDomainState = { domain: DEFAULT_DOMAIN };
 
+const isIpv4Loopback = (domain: string): boolean => {
+  const parts = domain.split(".");
+  return (
+    parts.length === 4 &&
+    parts[0] === "127" &&
+    parts.every((part) => {
+      const value = Number(part);
+      return /^\d+$/.test(part) && value >= 0 && value <= 255;
+    })
+  );
+};
+
+const isLocalDevelopmentHost = (domain: string): boolean =>
+  domain === DEFAULT_DOMAIN ||
+  domain.endsWith(".localhost") ||
+  domain === "[::1]" ||
+  domain === "::1" ||
+  isIpv4Loopback(domain);
+
 /** Load the effective domain from DB, falling back to the request URL hostname. */
 export const loadEffectiveDomain = (requestUrl: string): string => {
   const custom = settings.customDomain;
@@ -78,7 +97,7 @@ export const getEffectiveDomain = (): string => effectiveDomainState.domain;
  * must stay off for local development on DEFAULT_DOMAIN.
  */
 export const isSecureMode = (): boolean =>
-  effectiveDomainState.domain !== DEFAULT_DOMAIN;
+  !isLocalDevelopmentHost(effectiveDomainState.domain);
 
 /** Reset effective domain cache back to the default (for testing). */
 export const resetEffectiveDomain = (): void => {

--- a/test/lib/stripe-mock/ports.test.ts
+++ b/test/lib/stripe-mock/ports.test.ts
@@ -181,8 +181,8 @@ describe("startStripeMock ports", () => {
       await withUnusedPort(async (port) => {
         const stripeMock = await startStripeMock({
           confirmDelayMs: 10,
-          delayMs: 1,
-          maxAttempts: 50,
+          delayMs: 10,
+          maxAttempts: 100,
           paths,
           port,
           stopTimeoutMs: 20,

--- a/test/shared/config-env.test.ts
+++ b/test/shared/config-env.test.ts
@@ -1,0 +1,300 @@
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import {
+  getBotpoisonPublicKey,
+  getBotpoisonSecretKey,
+  getBunnyApiKey,
+  getBunnyDnsSubdomainSuffix,
+  getBunnyDnsZoneId,
+  getBunnyScriptId,
+  getDebugKey,
+  getDefaultDbProvider,
+  getDenoDeployOrgId,
+  getDenoDeployToken,
+  getMainInstanceKey,
+  getTursoApiToken,
+  getTursoGroup,
+  getTursoOrganization,
+  isBotpoisonEnabled,
+  isBunnyCdnEnabled,
+  isBunnyDbEnabled,
+  isBunnyDnsEnabled,
+  isDenoDeployEnabled,
+  isInstanceApiEnabled,
+  isSecureMode,
+  isTursoEnabled,
+  resetEffectiveDomain,
+  setEffectiveDomainForTest,
+  slugifyForProvider,
+} from "#shared/config.ts";
+import { setTestEnv } from "#test-utils";
+
+type EnvVars = Record<string, string | undefined>;
+type BoolGetter = () => boolean;
+type StringGetter = () => string;
+type MissingValueCheck = {
+  readonly name: string;
+  readonly check: (getValue: StringGetter, key: string) => void;
+};
+
+const withEnv = <T>(vars: EnvVars, run: () => T): T => {
+  const restore = setTestEnv(vars);
+  try {
+    return run();
+  } finally {
+    restore();
+  }
+};
+
+const expectEnvGetter =
+  (missing: MissingValueCheck) =>
+  (name: string, getValue: StringGetter, key: string, value: string) => {
+    describe(name, () => {
+      test("returns the configured value", () => {
+        withEnv({ [key]: value }, () => {
+          expect(getValue()).toBe(value);
+        });
+      });
+
+      test(missing.name, () => {
+        withEnv({ [key]: undefined }, () => {
+          missing.check(getValue, key);
+        });
+      });
+    });
+  };
+
+const expectRequiredEnvGetter = expectEnvGetter({
+  check: (getValue, key) => {
+    expect(getValue).toThrow(`Required environment variable ${key} is not set`);
+  },
+  name: "throws when the required value is missing",
+});
+
+const expectOptionalEnvGetter = expectEnvGetter({
+  check: (getValue) => {
+    expect(getValue()).toBe("");
+  },
+  name: "returns an empty string when unset",
+});
+
+const expectEnabledByAllKeys = (
+  name: string,
+  isEnabled: BoolGetter,
+  keys: string[],
+) => {
+  describe(name, () => {
+    const allKeysSet = Object.fromEntries(
+      keys.map((key) => [key, `${key.toLowerCase()}_value`]),
+    );
+
+    test("returns true when every required value is set", () => {
+      withEnv(allKeysSet, () => {
+        expect(isEnabled()).toBe(true);
+      });
+    });
+
+    for (const missingKey of keys) {
+      test(`returns false when ${missingKey} is missing`, () => {
+        withEnv({ ...allKeysSet, [missingKey]: undefined }, () => {
+          expect(isEnabled()).toBe(false);
+        });
+      });
+    }
+  });
+};
+
+describe("isSecureMode", () => {
+  afterEach(() => resetEffectiveDomain());
+
+  const localHosts = [
+    "localhost",
+    "admin.localhost",
+    "127.0.0.1",
+    "127.255.255.255",
+    "[::1]",
+    "::1",
+  ];
+
+  for (const host of localHosts) {
+    test(`returns false for ${host}`, () => {
+      setEffectiveDomainForTest(host);
+      expect(isSecureMode()).toBe(false);
+    });
+  }
+
+  const secureHosts = [
+    "example.com",
+    "not-localhost.example",
+    "128.0.0.1",
+    "127.0.0",
+    "127.0.one.1",
+    "127.0.0.256",
+  ];
+
+  for (const host of secureHosts) {
+    test(`returns true for ${host}`, () => {
+      setEffectiveDomainForTest(host);
+      expect(isSecureMode()).toBe(true);
+    });
+  }
+});
+
+expectEnabledByAllKeys("isBunnyCdnEnabled", isBunnyCdnEnabled, [
+  "BUNNY_API_KEY",
+  "BUNNY_SCRIPT_ID",
+]);
+
+expectEnabledByAllKeys("isBunnyDnsEnabled", isBunnyDnsEnabled, [
+  "BUNNY_API_KEY",
+  "BUNNY_DNS_ZONE_ID",
+]);
+
+describe("isBunnyDbEnabled", () => {
+  test("returns true when the API key is set", () => {
+    withEnv({ BUNNY_API_KEY: "bunny_key" }, () => {
+      expect(isBunnyDbEnabled()).toBe(true);
+    });
+  });
+
+  test("returns false when the API key is missing", () => {
+    withEnv({ BUNNY_API_KEY: undefined }, () => {
+      expect(isBunnyDbEnabled()).toBe(false);
+    });
+  });
+});
+
+expectRequiredEnvGetter(
+  "getBunnyApiKey",
+  getBunnyApiKey,
+  "BUNNY_API_KEY",
+  "bunny_key",
+);
+expectRequiredEnvGetter(
+  "getBunnyDnsZoneId",
+  getBunnyDnsZoneId,
+  "BUNNY_DNS_ZONE_ID",
+  "zone_123",
+);
+expectOptionalEnvGetter(
+  "getBunnyDnsSubdomainSuffix",
+  getBunnyDnsSubdomainSuffix,
+  "BUNNY_DNS_SUBDOMAIN_SUFFIX",
+  ".tickets",
+);
+expectRequiredEnvGetter(
+  "getBunnyScriptId",
+  getBunnyScriptId,
+  "BUNNY_SCRIPT_ID",
+  "script_123",
+);
+expectOptionalEnvGetter("getDebugKey", getDebugKey, "DEBUG_KEY", "debug_key");
+
+expectOptionalEnvGetter(
+  "getBotpoisonPublicKey",
+  getBotpoisonPublicKey,
+  "BOTPOISON_PUBLIC_KEY",
+  "botpoison_public",
+);
+expectOptionalEnvGetter(
+  "getBotpoisonSecretKey",
+  getBotpoisonSecretKey,
+  "BOTPOISON_SECRET_KEY",
+  "botpoison_secret",
+);
+expectEnabledByAllKeys("isBotpoisonEnabled", isBotpoisonEnabled, [
+  "BOTPOISON_PUBLIC_KEY",
+  "BOTPOISON_SECRET_KEY",
+]);
+
+describe("isInstanceApiEnabled", () => {
+  test("returns true when the main instance key is set", () => {
+    withEnv({ MAIN_INSTANCE_KEY: "main_key" }, () => {
+      expect(isInstanceApiEnabled()).toBe(true);
+    });
+  });
+
+  test("returns false when the main instance key is missing", () => {
+    withEnv({ MAIN_INSTANCE_KEY: undefined }, () => {
+      expect(isInstanceApiEnabled()).toBe(false);
+    });
+  });
+});
+
+expectRequiredEnvGetter(
+  "getMainInstanceKey",
+  getMainInstanceKey,
+  "MAIN_INSTANCE_KEY",
+  "main_key",
+);
+
+expectEnabledByAllKeys("isDenoDeployEnabled", isDenoDeployEnabled, [
+  "DENO_DEPLOY_TOKEN",
+  "DENO_DEPLOY_ORG_ID",
+]);
+expectRequiredEnvGetter(
+  "getDenoDeployToken",
+  getDenoDeployToken,
+  "DENO_DEPLOY_TOKEN",
+  "deploy_token",
+);
+expectRequiredEnvGetter(
+  "getDenoDeployOrgId",
+  getDenoDeployOrgId,
+  "DENO_DEPLOY_ORG_ID",
+  "deploy_org",
+);
+
+describe("getDefaultDbProvider", () => {
+  test("returns turso only when DEFAULT_DB_HOST is turso", () => {
+    withEnv({ DEFAULT_DB_HOST: "turso" }, () => {
+      expect(getDefaultDbProvider()).toBe("turso");
+    });
+  });
+
+  test("returns bunny when DEFAULT_DB_HOST is missing", () => {
+    withEnv({ DEFAULT_DB_HOST: undefined }, () => {
+      expect(getDefaultDbProvider()).toBe("bunny");
+    });
+  });
+
+  test("returns bunny for any other configured value", () => {
+    withEnv({ DEFAULT_DB_HOST: "bunny" }, () => {
+      expect(getDefaultDbProvider()).toBe("bunny");
+    });
+  });
+});
+
+expectEnabledByAllKeys("isTursoEnabled", isTursoEnabled, [
+  "TURSO_API_TOKEN",
+  "TURSO_ORGANIZATION",
+  "TURSO_GROUP",
+]);
+expectRequiredEnvGetter(
+  "getTursoApiToken",
+  getTursoApiToken,
+  "TURSO_API_TOKEN",
+  "turso_token",
+);
+expectRequiredEnvGetter(
+  "getTursoOrganization",
+  getTursoOrganization,
+  "TURSO_ORGANIZATION",
+  "turso_org",
+);
+expectRequiredEnvGetter(
+  "getTursoGroup",
+  getTursoGroup,
+  "TURSO_GROUP",
+  "turso_group",
+);
+
+describe("slugifyForProvider", () => {
+  test("keeps the start of the provider slug within the length limit", () => {
+    expect(slugifyForProvider("My Long Site Name", 10)).toBe("my-long-si");
+  });
+
+  test("trims a trailing hyphen left by the length limit", () => {
+    expect(slugifyForProvider("Alpha Beta", 6)).toBe("alpha");
+  });
+});

--- a/test/shared/config.test.ts
+++ b/test/shared/config.test.ts
@@ -1,23 +1,17 @@
 import { expect } from "@std/expect";
-import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { afterEach, beforeEach, it as test } from "@std/testing/bdd";
 import {
   getBookingFee,
-  getBotpoisonPublicKey,
-  getBotpoisonSecretKey,
-  getDefaultDbProvider,
   getEffectiveDomain,
   getEmbedHosts,
-  isBotpoisonEnabled,
-  isDenoDeployEnabled,
   isPaymentsEnabled,
-  isTursoEnabled,
   loadEffectiveDomain,
   resetEffectiveDomain,
   seedEffectiveDomainHost,
   setEffectiveDomainForTest,
 } from "#shared/config.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
-import { describeWithEnv, setTestEnv, setupStripe } from "#test-utils";
+import { describeWithEnv, setupStripe } from "#test-utils";
 
 describeWithEnv("isPaymentsEnabled", { db: true }, () => {
   test("returns false when no provider is configured", () => {
@@ -211,156 +205,5 @@ describeWithEnv("getEmbedHosts", { db: true }, () => {
       "two.example.com",
       "three.example.com",
     ]);
-  });
-});
-
-describe("Botpoison config", () => {
-  let restoreEnv: (() => void) | undefined;
-  afterEach(() => {
-    restoreEnv?.();
-    restoreEnv = undefined;
-  });
-
-  test("getBotpoisonPublicKey returns the configured env value", () => {
-    restoreEnv = setTestEnv({ BOTPOISON_PUBLIC_KEY: "pk_live_abc" });
-    expect(getBotpoisonPublicKey()).toBe("pk_live_abc");
-  });
-
-  test("getBotpoisonPublicKey returns an empty string when unset", () => {
-    restoreEnv = setTestEnv({ BOTPOISON_PUBLIC_KEY: undefined });
-    expect(getBotpoisonPublicKey()).toBe("");
-  });
-
-  test("getBotpoisonSecretKey returns the configured env value", () => {
-    restoreEnv = setTestEnv({ BOTPOISON_SECRET_KEY: "sk_live_abc" });
-    expect(getBotpoisonSecretKey()).toBe("sk_live_abc");
-  });
-
-  test("getBotpoisonSecretKey returns an empty string when unset", () => {
-    restoreEnv = setTestEnv({ BOTPOISON_SECRET_KEY: undefined });
-    expect(getBotpoisonSecretKey()).toBe("");
-  });
-
-  test("isBotpoisonEnabled is true only when both keys are set", () => {
-    restoreEnv = setTestEnv({
-      BOTPOISON_PUBLIC_KEY: "pk_live_abc",
-      BOTPOISON_SECRET_KEY: "sk_live_abc",
-    });
-    expect(isBotpoisonEnabled()).toBe(true);
-  });
-
-  test("isBotpoisonEnabled is false when only the public key is set", () => {
-    restoreEnv = setTestEnv({
-      BOTPOISON_PUBLIC_KEY: "pk_live_abc",
-      BOTPOISON_SECRET_KEY: undefined,
-    });
-    expect(isBotpoisonEnabled()).toBe(false);
-  });
-
-  test("isBotpoisonEnabled is false when only the secret key is set", () => {
-    restoreEnv = setTestEnv({
-      BOTPOISON_PUBLIC_KEY: undefined,
-      BOTPOISON_SECRET_KEY: "sk_live_abc",
-    });
-    expect(isBotpoisonEnabled()).toBe(false);
-  });
-});
-
-describe("isDenoDeployEnabled", () => {
-  let restoreEnv: (() => void) | undefined;
-  afterEach(() => {
-    restoreEnv?.();
-    restoreEnv = undefined;
-  });
-
-  test("returns true when both DENO_DEPLOY_TOKEN and DENO_DEPLOY_ORG_ID are set", () => {
-    restoreEnv = setTestEnv({
-      DENO_DEPLOY_ORG_ID: "org123",
-      DENO_DEPLOY_TOKEN: "tok123",
-    });
-    expect(isDenoDeployEnabled()).toBe(true);
-  });
-
-  test("returns false when DENO_DEPLOY_TOKEN is missing", () => {
-    restoreEnv = setTestEnv({
-      DENO_DEPLOY_ORG_ID: "org123",
-      DENO_DEPLOY_TOKEN: undefined,
-    });
-    expect(isDenoDeployEnabled()).toBe(false);
-  });
-
-  test("returns false when DENO_DEPLOY_ORG_ID is missing", () => {
-    restoreEnv = setTestEnv({
-      DENO_DEPLOY_ORG_ID: undefined,
-      DENO_DEPLOY_TOKEN: "tok123",
-    });
-    expect(isDenoDeployEnabled()).toBe(false);
-  });
-});
-
-describe("isTursoEnabled", () => {
-  let restoreEnv: (() => void) | undefined;
-  afterEach(() => {
-    restoreEnv?.();
-    restoreEnv = undefined;
-  });
-
-  test("returns true when all Turso env vars are set", () => {
-    restoreEnv = setTestEnv({
-      TURSO_API_TOKEN: "tok",
-      TURSO_GROUP: "grp",
-      TURSO_ORGANIZATION: "org",
-    });
-    expect(isTursoEnabled()).toBe(true);
-  });
-
-  test("returns false when TURSO_API_TOKEN is missing", () => {
-    restoreEnv = setTestEnv({
-      TURSO_API_TOKEN: undefined,
-      TURSO_GROUP: "grp",
-      TURSO_ORGANIZATION: "org",
-    });
-    expect(isTursoEnabled()).toBe(false);
-  });
-
-  test("returns false when TURSO_ORGANIZATION is missing", () => {
-    restoreEnv = setTestEnv({
-      TURSO_API_TOKEN: "tok",
-      TURSO_GROUP: "grp",
-      TURSO_ORGANIZATION: undefined,
-    });
-    expect(isTursoEnabled()).toBe(false);
-  });
-
-  test("returns false when TURSO_GROUP is missing", () => {
-    restoreEnv = setTestEnv({
-      TURSO_API_TOKEN: "tok",
-      TURSO_GROUP: undefined,
-      TURSO_ORGANIZATION: "org",
-    });
-    expect(isTursoEnabled()).toBe(false);
-  });
-});
-
-describe("getDefaultDbProvider", () => {
-  let restoreEnv: (() => void) | undefined;
-  afterEach(() => {
-    restoreEnv?.();
-    restoreEnv = undefined;
-  });
-
-  test("returns bunny when DEFAULT_DB_HOST is not set", () => {
-    restoreEnv = setTestEnv({ DEFAULT_DB_HOST: undefined });
-    expect(getDefaultDbProvider()).toBe("bunny");
-  });
-
-  test("returns turso when DEFAULT_DB_HOST is turso", () => {
-    restoreEnv = setTestEnv({ DEFAULT_DB_HOST: "turso" });
-    expect(getDefaultDbProvider()).toBe("turso");
-  });
-
-  test("returns bunny when DEFAULT_DB_HOST is set to an unrecognised value", () => {
-    restoreEnv = setTestEnv({ DEFAULT_DB_HOST: "bunny" });
-    expect(getDefaultDbProvider()).toBe("bunny");
   });
 });

--- a/test/shared/cookies.test.ts
+++ b/test/shared/cookies.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { parseCookies } from "#routes/url.ts";
 import {
   resetEffectiveDomain,
+  seedEffectiveDomainHost,
   setEffectiveDomainForTest,
 } from "#shared/config.ts";
 import {
@@ -43,6 +44,14 @@ describe("isSecureMode", () => {
     setEffectiveDomainForTest("localhost");
     expect(isSecureMode()).toBe(false);
   });
+
+  test("returns false for loopback IP hosts", () => {
+    setEffectiveDomainForTest("127.0.0.1");
+    expect(isSecureMode()).toBe(false);
+
+    setEffectiveDomainForTest("[::1]");
+    expect(isSecureMode()).toBe(false);
+  });
 });
 
 describe("getSessionCookieName", () => {
@@ -76,6 +85,13 @@ describe("buildSessionCookie", () => {
     expect(cookie).toContain("session=test-token");
     expectDevCookieAttributes(cookie);
     expect(cookie).toContain("Max-Age=86400");
+  });
+
+  test("keeps loopback request hosts in dev cookie mode", () => {
+    seedEffectiveDomainHost("http://127.0.0.1:38123/admin/");
+    const cookie = buildSessionCookie("test-token");
+    expect(cookie).toContain("session=test-token");
+    expectDevCookieAttributes(cookie);
   });
 
   test("respects custom maxAge", () => {


### PR DESCRIPTION
## Summary

Fixes the payment sandbox e2e regression by restoring the browser version used by the last passing run and by correcting the local-session cookie path that broke the `free` leg on `127.0.0.1`.

## What changed

- Updated the payment e2e harness to Playwright `1.61.1`.
- Made the workflow install/cache the Playwright version declared in `e2e-payments/deno.json`, so the harness and browser install stay in sync.
- Treats loopback and localhost-style hosts as local development hosts for cookie security mode.
- Added regression coverage for loopback session cookies and config environment helpers.
- Replaced the one-shot login field count with a retrying page wait that dumps artifacts only if the login form stays visible, while preserving the original Playwright error as the cause.
- Stabilized the stripe-mock stop test by giving the fake process a realistic startup window while keeping the short stop timeout.

## Validation

- `deno fmt e2e-payments/src/flow.ts --check`
- `deno check --config=e2e-payments/deno.json e2e-payments/src/main.ts`
- `deno task test:files test/lib/stripe-mock/ports.test.ts`
- `deno test --no-check --allow-all --parallel test/shared/config.test.ts test/shared/config-env.test.ts test/shared/cookies.test.ts`
- `deno task mutation src/shared/config.ts '{test/shared/config-env.test.ts,test/shared/cookies.test.ts,test/shared/config.test.ts}' --harness`
- `CHROMIUM_EXECUTABLE=/etc/profiles/per-user/user/bin/chromium deno task e2e free`
- `deno task precommit`

I also manually dispatched the real payment sandbox workflow on this branch: https://github.com/chobbledotcom/tickets/actions/runs/29009770515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected secure-mode and session cookie handling for local development on loopback and localhost-style hosts (including `127.x.x.x` and `::1`), ensuring non-secure rules apply as expected.
* **Chores**
  * Improved end-to-end payment test automation by resolving the Playwright version dynamically at runtime and using it for browser install steps.
  * Updated the Playwright dependency version used for e2e runs.
* **Tests**
  * Strengthened admin login flow checks to fail fast when the login does not advance.
  * Adjusted Stripe mock stop timing and expanded config/cookie coverage for loopback hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->