### PR TITLE
Use a test-mode Stripe key in the payment dashboard-link test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -230,14 +230,6 @@ a small, isolated assertion-strength improvement.*
   validation error text (or another specific error contract) so the negative path
   is genuine. (Original monolith line 990.)
 
-- **`payment.test.ts` — Stripe fixture uses a `live` key prefix.** The
-  "links the payment id to the configured provider dashboard" test sets
-  `stripe_secret_key: "sk_live_abc"`. The value is synthetic, but the `live`
-  prefix models a production credential and can trip secret scanners. Switch to a
-  `sk_test_...` fixture — note the test also asserts the live dashboard URL
-  (`dashboard.stripe.com/payments/...`), so verify that still holds after the
-  change. (Original monolith line 2092.)
-
 - **`payment.test.ts` — assert payment stays unrefunded after ledger failure.**
   The "surfaces a Stripe refund the ledger could not record" test only checks the
   error flash; its comment says the payment must remain visibly un-refunded. Add a

--- a/test/lib/server-attendees/payment.test.ts
+++ b/test/lib/server-attendees/payment.test.ts
@@ -67,7 +67,7 @@ describeWithEnv(
       test("links the payment id to the configured provider dashboard", async () => {
         settings.setForTest({
           payment_provider: "stripe",
-          stripe_secret_key: "sk_live_abc",
+          stripe_secret_key: "sk_test_abc",
         });
         try {
           const listing = await createTestListing(paidListing());
@@ -84,7 +84,7 @@ describeWithEnv(
           await expectHtmlResponse(
             response,
             200,
-            'href="https://dashboard.stripe.com/payments/pi_linked_123"',
+            'href="https://dashboard.stripe.com/test/payments/pi_linked_123"',
             'target="_blank"',
           );
         } finally {


### PR DESCRIPTION
## What changed

One of the payment tests used a fake Stripe secret key that started with `sk_live_` — the prefix real, production Stripe keys use. Even though the value was made up, that "live" shape can set off automated secret scanners and reads like a leaked credential. This swaps it for a `sk_test_` key, the harmless test-mode equivalent.

## Why the assertion also changed

The link the app builds to open a payment in Stripe's dashboard depends on whether the key is a live or test key: live keys link to `dashboard.stripe.com/payments/…`, test keys link to `dashboard.stripe.com/test/payments/…`. Because the fixture is now a test key, the test's expected URL is updated to the `/test/` version so it still checks the exact link the app produces.

## Notes

- Test-only change; no product behaviour is affected.
- Verified locally: all 17 tests in `test/lib/server-attendees/payment.test.ts` pass.
- Removes the corresponding follow-up item from `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S

---
_Generated by [Claude Code](https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S)_