### PR TITLE
Keep return_url when an attendee action's typed name doesn't match

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,12 +243,6 @@ a small, isolated assertion-strength improvement.*
   or make the fetch stub resolve through a deferred promise, then await it
   deterministically before asserting the payload. (Original monolith line 2040.)
 
-- **`delete.test.ts` — `return_url` preservation not asserted.** The "preserves
-  return_url on mismatched attendee name" test only checks the flash message — it
-  never verifies the redirect's Location header actually carries `return_url`. Add
-  a Location-header assertion so a regression that drops `return_url` on the
-  mismatch-name error path cannot pass silently. (Original monolith lines 195–202.)
-
 ---
 
 ## Settings on-demand loading — generation counter

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -330,6 +330,12 @@ src/features/admin/modifiers.ts:400:27  return notFoundResponse() → return und
 src/features/admin/modifiers.ts:416:38  return notFoundResponse() → return undefined    # same as 400: undefined → routeMainApp `?? notFoundResponse()` → 404
 src/features/admin/modifiers.ts:527:10  return Promise.resolve() → return undefined    # whole-order modifier writes no links; awaited by caller, so undefined and Promise.resolve() agree
 
+# attendees-route-helpers.ts — loadAttendeeForListing's "not found" returns feed
+# orNotFound's truthiness check (`data ? handler : notFoundResponse()`), so a
+# null and an undefined both take the 404 arm through every reachable caller.
+src/features/admin/attendees-route-helpers.ts:49:23  return null → return undefined    # missing attendee row; orNotFound uses truthiness, so null and undefined agree
+src/features/admin/attendees-route-helpers.ts:52:62  return null → return undefined    # undecryptable / wrong-listing attendee; orNotFound uses truthiness, so null and undefined agree
+
 # group-page-data: groupHasPaidListing's result is consumed only in boolean
 # context (decryptAttendees's paidListing flag and the revenue-row gate), so a
 # false vs undefined early-return is indistinguishable; the two `?? →  ||` are

--- a/src/features/admin/attendee-refunds.ts
+++ b/src/features/admin/attendee-refunds.ts
@@ -34,7 +34,7 @@ import {
 } from "#templates/admin/attendees.tsx";
 import {
   attendeeActionPage,
-  attendeeActionUrl,
+  attendeeActionUrlWithReturn,
   type ListingRouteParams,
   NO_PROVIDER_ERROR,
   verifiedAttendeeAction,
@@ -51,9 +51,7 @@ const refundError = (
   returnUrl = "",
 ): Response =>
   errorRedirect(
-    `${attendeeActionUrl(attendeeId, "refund")}${
-      returnUrl ? `?return_url=${encodeURIComponent(returnUrl)}` : ""
-    }`,
+    attendeeActionUrlWithReturn(attendeeId, "refund", returnUrl),
     msg,
   );
 

--- a/src/features/admin/attendees-route-helpers.ts
+++ b/src/features/admin/attendees-route-helpers.ts
@@ -104,6 +104,18 @@ const attendeeActionHandlers = createEntityRouteHandlers(
 export const attendeeActionUrl = (attendeeId: number, action: string): string =>
   `/admin/attendees/${attendeeId}/${action}`;
 
+/** The action URL with the caller's return_url threaded on, so bouncing back
+ *  to the confirm page keeps its "return here when done" link (and hidden
+ *  field) for a corrected retry. Empty return_url yields the plain action URL. */
+export const attendeeActionUrlWithReturn = (
+  attendeeId: number,
+  action: string,
+  returnUrl: string,
+): string =>
+  `${attendeeActionUrl(attendeeId, action)}${
+    returnUrl ? `?return_url=${encodeURIComponent(returnUrl)}` : ""
+  }`;
+
 /** An attendee-action confirm page renderer's shape. */
 type AttendeeActionRenderer = (
   data: AttendeeWithListing,
@@ -144,7 +156,11 @@ export const verifiedAttendeeAction = (
     const error = verifyOrRedirect(
       form,
       data.attendee.name,
-      attendeeActionUrl(data.attendee.id, action),
+      attendeeActionUrlWithReturn(
+        data.attendee.id,
+        action,
+        form.getString("return_url"),
+      ),
       "Attendee name",
       actionLabel,
     );

--- a/test/lib/server-attendees/delete.test.ts
+++ b/test/lib/server-attendees/delete.test.ts
@@ -167,7 +167,7 @@ describeWithEnv("server (admin attendees) > delete", { db: true }, () => {
       expect(response.status).toBe(302);
       expectFlash(
         response,
-        expect.stringContaining("Attendee name does not match"),
+        "Attendee name does not match. Please type the exact attendee name to confirm deletion.",
         false,
       );
       // The bounce-back confirm page must keep the caller's return_url so a

--- a/test/lib/server-attendees/delete.test.ts
+++ b/test/lib/server-attendees/delete.test.ts
@@ -165,7 +165,17 @@ describeWithEnv("server (admin attendees) > delete", { db: true }, () => {
         return_url: "/admin/calendar#attendees",
       })();
       expect(response.status).toBe(302);
-      expectFlash(response, expect.stringContaining("does not match"), false);
+      expectFlash(
+        response,
+        expect.stringContaining("Attendee name does not match"),
+        false,
+      );
+      // The bounce-back confirm page must keep the caller's return_url so a
+      // corrected retry still lands where the operator came from.
+      const location = response.headers.get("location") ?? "";
+      expect(location).toContain(
+        `return_url=${encodeURIComponent("/admin/calendar#attendees")}`,
+      );
     });
 
     test("deletes attendee with matching name (case insensitive)", async () => {


### PR DESCRIPTION
## What changed

Destructive attendee actions (delete, refund, resend) ask the operator to confirm by typing the attendee's name. If the typed name doesn't match, the app bounces them back to the confirmation page so they can try again.

That bounce-back was **losing the "return here when you're done" link** (`return_url`). So an operator who came from, say, the calendar's attendee view, mistyped the name, then corrected it, would end up back on the generic attendees list instead of the calendar — quietly dropped where they started from.

## The fix

The name-mismatch redirect built its URL without carrying `return_url`. It now threads the submitted `return_url` back onto that URL, so the re-shown confirmation page keeps its hidden field and a corrected second attempt lands back where the operator began.

The exact same "action URL plus optional return_url" string was already being assembled by hand in the refund code, so both now share one small helper (`attendeeActionUrlWithReturn`) instead of two copies.

## Why this was more than a test tweak

The `TODO.md` item that prompted this asked only to *assert* that `return_url` survives on the mismatch path. Writing that assertion revealed the behaviour didn't actually hold — the redirect really was dropping it. So this is a genuine bug fix, not just a stronger test.

## Tests

- Wrote the failing test first: the delete mismatch test now checks the redirect's `Location` header actually carries the encoded `return_url` (it didn't before the fix), and tightens the flash check to the full "Attendee name does not match" message.
- All affected suites pass (`delete`, `server-refunds`).
- Lint, typecheck, and duplication (0%) all clean.
- Mutation testing is at 100% on the changed helper; two unrelated pre-existing `null → undefined` returns in the attendee loader (indistinguishable because they only ever feed a truthiness/404 check) are recorded in the known-equivalent-mutants list with that proof.
- Removes the corresponding follow-up item from `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S

---
_Generated by [Claude Code](https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the original return destination when attendee name verification fails, ensuring users are redirected back to the correct page.
  - Preserved return destinations when an attendee refund action encounters an error.
  - Improved the specificity of the attendee name mismatch message shown during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->