### PR TITLE
Make price-rule precedence a single declarative table

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -156,9 +156,12 @@ test/test-utils/test-browser.ts:351:58  ?? → ||  # RequestInit.method is omitt
 test/test-utils/test-browser.ts:414:28  ?? → ||  # forms[0] is a FormInfo object when present, otherwise undefined
 src/ui/templates/admin/listing-defaults.tsx:105:19  ?? → ||  # UrlControl value: string|undefined; the only falsy-non-null string is "" which equals the "" fallback, so ?? and || coincide
 src/ui/templates/admin/listing-defaults.tsx:131:38  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
-src/shared/booking/build-tree.ts:132:48  ?? → ||    # childrenByParentId.get(): readonly TicketListing[]|undefined — an array is always truthy
-src/shared/booking/build-tree.ts:172:62  ?? → ||    # packageQuantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
-src/shared/booking/build-tree.ts:205:38  ?? → ||    # input.root: RootRef-minus-listing|undefined — an object literal is always truthy, so ?? and || coincide
+src/shared/booking/build-tree.ts:130:48  ?? → ||    # childrenByParentId?.get(): readonly TicketListing[]|undefined — an array is always truthy, so ?? and || coincide
+src/shared/booking/build-tree.ts:170:52  ?? → ||    # pkg.quantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
+src/shared/booking/build-tree.ts:208:33  ?? → ||    # deriveRootRef input.packages: readonly TreePackage[]|null|undefined — a non-empty array is truthy and [] destructures to the same `first`, so ?? and || coincide
+src/shared/booking/build-tree.ts:212:38  ?? → ||    # standaloneListingIds?.size: number|undefined — a real size is ≥0 and (0 ?? 0)===(0 || 0), undefined too, so ?? and || coincide
+src/shared/booking/build-tree.ts:224:34  ?? → ||    # buildBookingTree input.packages: readonly TreePackage[]|null|undefined — same as the deriveRootRef case, an array/null/undefined makes ?? and || coincide
+src/shared/booking/build-tree.ts:231:56  ?? → ||    # standaloneListingIds?.has(): boolean|undefined — (b ?? false)===(b || false) for any boolean b, and undefined too, so ?? and || coincide
 src/shared/booking/fold-tree.ts:157:4  ?? → ||    # childQtyField: parseNonNegativeInt returns a non-negative int or null; its only falsy result (0) already maps to 0, so ?? and || coincide
 src/shared/booking/fold-tree.ts:280:48  ?? → ||    # foldChild summed: state.quantities.get(childId) is undefined (first fold) or a positive running total, never 0, so ?? and || coincide
 src/shared/booking/fold-tree.ts:424:58  ?? → ||    # foldBookingTree parentQty: base.quantities.get() is undefined or ≥0, and a 0 takes the same `<= 0` skip, so ?? and || coincide

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -157,7 +157,7 @@ test/test-utils/test-browser.ts:414:28  ?? → ||  # forms[0] is a FormInfo obje
 src/ui/templates/admin/listing-defaults.tsx:105:19  ?? → ||  # UrlControl value: string|undefined; the only falsy-non-null string is "" which equals the "" fallback, so ?? and || coincide
 src/ui/templates/admin/listing-defaults.tsx:131:38  ?? → ||  # value?.includes(day): boolean|undefined; for boolean b, b ?? false === b || false, and undefined ?? false === undefined || false
 src/shared/booking/build-tree.ts:130:48  ?? → ||    # childrenByParentId?.get(): readonly TicketListing[]|undefined — an array is always truthy, so ?? and || coincide
-src/shared/booking/build-tree.ts:170:52  ?? → ||    # pkg.quantities.get(): a member's fixed per-package quantity is ≥1 (group_listings.quantity DEFAULT 1), never 0, so ?? and || coincide
+src/shared/booking/build-tree.ts:170:52  ?? → ||    # pkg.quantities.get(): a member's fixed per-package quantity is ≥1 — every save path enforces it (the form's parsePackageQuantity clamps 0→1 in admin/groups.ts, the JSON API's parsePackageMember rejects quantity<1 in admin/api-groups.ts), so the map never holds 0 and (n ?? 1)===(n || 1)
 src/shared/booking/build-tree.ts:208:33  ?? → ||    # deriveRootRef input.packages: readonly TreePackage[]|null|undefined — a non-empty array is truthy and [] destructures to the same `first`, so ?? and || coincide
 src/shared/booking/build-tree.ts:212:38  ?? → ||    # standaloneListingIds?.size: number|undefined — a real size is ≥0 and (0 ?? 0)===(0 || 0), undefined too, so ?? and || coincide
 src/shared/booking/build-tree.ts:224:34  ?? → ||    # buildBookingTree input.packages: readonly TreePackage[]|null|undefined — same as the deriveRootRef case, an array/null/undefined makes ?? and || coincide

--- a/src/shared/booking/build-tree.ts
+++ b/src/shared/booking/build-tree.ts
@@ -4,7 +4,7 @@ import {
   packageByMemberListingId,
   type TreePackage,
 } from "#shared/booking/page-packages.ts";
-import { packageMemberPriceRule } from "#shared/booking/price-tree.ts";
+import { selectPriceRule } from "#shared/booking/price-tree.ts";
 import {
   type BookingNode,
   type BookingTree,
@@ -69,23 +69,19 @@ const derivePriceRule = (
   listing: ListingWithCount,
   overrideMinor: number | undefined,
   dayOverrides?: ReadonlyMap<number, number> | undefined,
-): PriceRule => {
-  // A flat override outranks pay-more, but the two never coexist: packages
-  // cannot contain pay-what-you-want listings, so an overridden line is never
-  // PAY_MORE. Everything else is the shared member/base rule constructor.
-  if (overrideMinor === undefined && listing.can_pay_more) {
-    return {
-      kind: "PAY_MORE",
-      maxMinor: listing.max_price,
-      minMinor: listing.unit_price,
-    };
-  }
-  return packageMemberPriceRule(
-    overrideMinor,
+): PriceRule =>
+  // Map the listing onto the shared precedence inputs and let
+  // {@link selectPriceRule} pick the winning tier. A flat override outranks
+  // pay-more, but the two never coexist: packages cannot contain
+  // pay-what-you-want listings, so an overridden line is never PAY_MORE.
+  selectPriceRule({
+    customisableDays: listing.customisable_days,
     dayOverrides,
-    listing.customisable_days,
-  );
-};
+    overrideMinor,
+    payMore: listing.can_pay_more
+      ? { maxMinor: listing.max_price, minMinor: listing.unit_price }
+      : undefined,
+  });
 
 /** A required child's date facet. Only a child that carries date/span semantics
  * — a daily or customisable listing — `INHERIT`s its parent's resolved span; a

--- a/src/shared/booking/price-tree.ts
+++ b/src/shared/booking/price-tree.ts
@@ -142,17 +142,28 @@ const PRICE_RULES: { [K in PriceRuleKind]: PriceRuleSpec<K> } = {
   },
 };
 
+/** Compile-time assertion that `order` names EVERY {@link PriceRuleKind} — a new
+ * tier added to {@link PriceRule} becomes a type error here until it is given a
+ * place in the precedence, so it can never be silently skipped straight to
+ * `BASE`. `T` is inferred as the literal tuple (the `const` type parameter), and
+ * the conditional collapses the parameter to `never` when a kind is missing. */
+const orderedKinds = <const T extends readonly PriceRuleKind[]>(
+  order: [PriceRuleKind] extends [T[number]] ? T : never,
+): T => order;
+
 /** The price-rule precedence as data, highest first: the FIRST kind whose
  * {@link PriceRuleSpec.appliesTo} accepts the listing wins — `OVERRIDE >
  * PAY_MORE > DAY_PRICE > BASE`. This is the single source of truth for the
  * precedence the app once repeated as a comment, an if-chain, and a switch;
- * `BASE` always applies and sits last, so a match is always found. */
-export const PRICE_RULE_PRECEDENCE: readonly PriceRuleKind[] = [
+ * `BASE` always applies and sits last, so a match is always found. The list is
+ * exhaustive by construction ({@link orderedKinds}), so it can never fall out of
+ * step with the {@link PRICE_RULES} table. */
+const PRICE_RULE_PRECEDENCE = orderedKinds([
   "OVERRIDE",
   "PAY_MORE",
   "DAY_PRICE",
   "BASE",
-];
+]);
 
 /** Choose a listing's {@link PriceRule} by the {@link PRICE_RULE_PRECEDENCE}
  * order — the ONE selector the tree builder and every member-pricing surface

--- a/src/shared/booking/price-tree.ts
+++ b/src/shared/booking/price-tree.ts
@@ -6,6 +6,13 @@ import {
 } from "#shared/booking/tree.ts";
 import { type DayPricedListing, dayPriceFor } from "#shared/types.ts";
 
+/** The discriminant of {@link PriceRule} — the set of price tiers. Their
+ * precedence is NOT this type's business (a union has no order); it lives in
+ * {@link PRICE_RULE_PRECEDENCE}. Deriving it from the union keeps the tier list
+ * in one place: a new tier on {@link PriceRule} is instantly a compile error in
+ * every table below keyed by this type. */
+export type PriceRuleKind = PriceRule["kind"];
+
 /**
  * The unified **unit price** derivation — one evaluation of a node's `priceRule`
  * that replaces the old `itemUnitPrice` + `applyPackageOverrides` pair.
@@ -39,24 +46,144 @@ export type PricedListing = DayPricedListing & {
  * amounts only (webhooks, revalidation, bundle totals). */
 export const NO_CUSTOM_PRICES: ReadonlyMap<number, number> = new Map();
 
+// ---------------------------------------------------------------------------
+// Price rules as data — one table keyed by kind decides *which* tier a listing
+// gets (precedence order) and *how* each tier prices (evaluation).
+// ---------------------------------------------------------------------------
+
+/** The listing facts that decide WHICH price rule a listing gets, checked in
+ * precedence order. `payMore` is present only for a pay-what-you-want listing;
+ * the surfaces that price members outside the tree builder (webhook payloads,
+ * payment revalidation) hold a narrower listing shape with no pay-more fields,
+ * so they omit it and their lines never select `PAY_MORE`. */
+export type PriceRuleInputs = {
+  /** A flat package override (incl. an explicit free `0`); absent for a
+   * non-member line. */
+  readonly overrideMinor: number | undefined;
+  /** A customisable member's per-day overrides (day count → per-unit minor). */
+  readonly dayOverrides: ReadonlyMap<number, number> | undefined;
+  /** Whether the listing prices per booked day count. */
+  readonly customisableDays: boolean;
+  /** Pay-what-you-want bounds, present only for a `can_pay_more` listing. */
+  readonly payMore?:
+    | { readonly minMinor: number; readonly maxMinor: number }
+    | undefined;
+};
+
+/** What an evaluated price rule reads to resolve its per-ticket price. */
+type PriceEvalContext = {
+  readonly listing: PricedListing;
+  readonly customPrices: ReadonlyMap<number, number>;
+  readonly dayCount: number;
+};
+
+/** The buyer's submitted price for this listing, else its fixed unit price. A
+ * genuine `0` (a free pay-more booking, or a `0` QR override) is honoured — the
+ * map holds `0`, and `0` is not nullish, so `??` keeps it. */
+const submittedOrUnitPrice = (ctx: PriceEvalContext): number =>
+  ctx.customPrices.get(ctx.listing.id) ?? ctx.listing.unit_price;
+
+/** Everything one price tier knows about itself: whether it wins for a listing
+ * (`appliesTo`), how to build its concrete rule from the inputs (`build`), and
+ * how to price that rule at checkout (`evaluate`). Each is generic in its own
+ * `kind`, so `build`/`evaluate` see the narrowed {@link PriceRule} variant. */
+type PriceRuleSpec<K extends PriceRuleKind> = {
+  readonly appliesTo: (inputs: PriceRuleInputs) => boolean;
+  readonly build: (inputs: PriceRuleInputs) => Extract<PriceRule, { kind: K }>;
+  readonly evaluate: (
+    rule: Extract<PriceRule, { kind: K }>,
+    ctx: PriceEvalContext,
+  ) => number;
+};
+
+/** Every price tier as data, keyed by {@link PriceRuleKind}. Because it is an
+ * exhaustive map over the union's discriminant, adding a tier to
+ * {@link PriceRule} is a compile error here until it is defined — no silent
+ * fall-through in either the selector or the evaluator. Adding a tier (say an
+ * "early bird") is one new entry here plus one entry in
+ * {@link PRICE_RULE_PRECEDENCE}; nothing else to hand-edit. */
+const PRICE_RULES: { [K in PriceRuleKind]: PriceRuleSpec<K> } = {
+  BASE: {
+    // The terminal fallback: always applies, so selection is total.
+    appliesTo: () => true,
+    build: () => ({ kind: "BASE" }),
+    // A fixed listing, optionally carrying a signed QR-token override.
+    evaluate: (_rule, ctx) => submittedOrUnitPrice(ctx),
+  },
+  DAY_PRICE: {
+    appliesTo: (inputs) => inputs.customisableDays,
+    build: (inputs) => ({ kind: "DAY_PRICE", overrides: inputs.dayOverrides }),
+    // A customisable member's per-day override for the chosen count, else the
+    // listing's own entered day price — NEVER base × days; 0 for an unoffered count.
+    evaluate: (rule, ctx) =>
+      rule.overrides?.get(ctx.dayCount) ??
+      dayPriceFor(ctx.listing, ctx.dayCount) ??
+      0,
+  },
+  OVERRIDE: {
+    appliesTo: (inputs) => inputs.overrideMinor !== undefined,
+    // `appliesTo` guarantees the override is set.
+    build: (inputs) => ({
+      amountMinor: inputs.overrideMinor!,
+      kind: "OVERRIDE",
+    }),
+    // The flat package price, including an explicit free `0`.
+    evaluate: (rule) => rule.amountMinor,
+  },
+  PAY_MORE: {
+    appliesTo: (inputs) => inputs.payMore !== undefined,
+    build: (inputs) => ({
+      kind: "PAY_MORE",
+      maxMinor: inputs.payMore!.maxMinor,
+      minMinor: inputs.payMore!.minMinor,
+    }),
+    // The buyer's pay-what-you-want input (falls back to the minimum unit price).
+    evaluate: (_rule, ctx) => submittedOrUnitPrice(ctx),
+  },
+};
+
+/** The price-rule precedence as data, highest first: the FIRST kind whose
+ * {@link PriceRuleSpec.appliesTo} accepts the listing wins — `OVERRIDE >
+ * PAY_MORE > DAY_PRICE > BASE`. This is the single source of truth for the
+ * precedence the app once repeated as a comment, an if-chain, and a switch;
+ * `BASE` always applies and sits last, so a match is always found. */
+export const PRICE_RULE_PRECEDENCE: readonly PriceRuleKind[] = [
+  "OVERRIDE",
+  "PAY_MORE",
+  "DAY_PRICE",
+  "BASE",
+];
+
+/** Choose a listing's {@link PriceRule} by the {@link PRICE_RULE_PRECEDENCE}
+ * order — the ONE selector the tree builder and every member-pricing surface
+ * share, so the precedence can never fork per surface. */
+export const selectPriceRule = (inputs: PriceRuleInputs): PriceRule => {
+  // `BASE` always applies and is last, so a matching kind is always found.
+  const kind = PRICE_RULE_PRECEDENCE.find((k) =>
+    PRICE_RULES[k].appliesTo(inputs),
+  )!;
+  return PRICE_RULES[kind].build(inputs);
+};
+
 /** A package member's {@link PriceRule} from its configured package pricing:
  * flat override (including an explicit free `0`) > per-day overrides for a
- * customisable member > the listing's own day/base price. The ONE constructor
- * every surface that prices a member outside the tree builder (webhook payloads,
- * payment revalidation) shares with the tree itself, so the precedence can never
- * fork per surface. Pass both overrides `undefined` for a non-member line: the
- * rule falls through to the listing's own pricing. */
+ * customisable member > the listing's own day/base price. The narrower entry
+ * for the surfaces that price a member outside the tree builder (webhook
+ * payloads, payment revalidation): it shares {@link selectPriceRule} with the
+ * tree but omits `payMore` — a package member is never pay-what-you-want
+ * (invariant at save) and these surfaces carry no pay-more fields — so it only
+ * ever yields `OVERRIDE > DAY_PRICE > BASE`. Pass `flatOverrideMinor` undefined
+ * for a non-member line: it falls through to the listing's own pricing. */
 export const packageMemberPriceRule = (
   flatOverrideMinor: number | undefined,
   dayOverrides: ReadonlyMap<number, number> | undefined,
   customisableDays: boolean,
-): PriceRule => {
-  if (flatOverrideMinor !== undefined) {
-    return { amountMinor: flatOverrideMinor, kind: "OVERRIDE" };
-  }
-  if (customisableDays) return { kind: "DAY_PRICE", overrides: dayOverrides };
-  return { kind: "BASE" };
-};
+): PriceRule =>
+  selectPriceRule({
+    customisableDays,
+    dayOverrides,
+    overrideMinor: flatOverrideMinor,
+  });
 
 export const effectivePrice = (
   priceRule: PriceRule,
@@ -64,19 +191,13 @@ export const effectivePrice = (
   customPrices: ReadonlyMap<number, number>,
   dayCount: number,
 ): number => {
-  switch (priceRule.kind) {
-    case "OVERRIDE":
-      return priceRule.amountMinor;
-    case "DAY_PRICE":
-      return (
-        priceRule.overrides?.get(dayCount) ??
-        dayPriceFor(listing, dayCount) ??
-        0
-      );
-    default:
-      // PAY_MORE (buyer's custom price) and BASE (fixed, optionally QR-overridden).
-      return customPrices.get(listing.id) ?? listing.unit_price;
-  }
+  // Dispatch to this rule's evaluator. The cast bridges TS's inability to
+  // correlate `priceRule.kind` with its matching narrowed spec; the map is
+  // exhaustive, so every kind has one.
+  const { evaluate } = PRICE_RULES[
+    priceRule.kind
+  ] as PriceRuleSpec<PriceRuleKind>;
+  return evaluate(priceRule, { customPrices, dayCount, listing });
 };
 
 /** The minimum unavoidable child charge for ONE unit of a parent member: the

--- a/test/lib/price-tree.test.ts
+++ b/test/lib/price-tree.test.ts
@@ -4,7 +4,11 @@ import { buildBookingTree } from "#shared/booking/build-tree.ts";
 import { buildTicketListing } from "#shared/booking/model.ts";
 import {
   effectivePrice,
+  type PriceRuleInputs,
+  packageBundleTotal,
+  packageMemberPriceRule,
   priceRuleByListingId,
+  selectPriceRule,
 } from "#shared/booking/price-tree.ts";
 import type { PriceRule } from "#shared/booking/tree.ts";
 import type { ListingWithCount } from "#shared/types.ts";
@@ -112,6 +116,118 @@ describe("effectivePrice", () => {
         1,
       ),
     ).toBe(1500);
+  });
+});
+
+describe("selectPriceRule", () => {
+  /** A listing that offers none of the higher tiers by default. */
+  const inputs = (over: Partial<PriceRuleInputs> = {}): PriceRuleInputs => ({
+    customisableDays: false,
+    dayOverrides: undefined,
+    overrideMinor: undefined,
+    ...over,
+  });
+
+  test("BASE is the fallback when no higher tier applies", () => {
+    expect(selectPriceRule(inputs())).toEqual({ kind: "BASE" });
+  });
+
+  test("PAY_MORE wins over DAY_PRICE and BASE, carrying its bounds", () => {
+    expect(
+      selectPriceRule(
+        inputs({
+          customisableDays: true,
+          payMore: { maxMinor: 5000, minMinor: 100 },
+        }),
+      ),
+    ).toEqual({ kind: "PAY_MORE", maxMinor: 5000, minMinor: 100 });
+  });
+
+  test("DAY_PRICE wins over BASE and carries its per-day overrides", () => {
+    const dayOverrides = new Map([[2, 1500]]);
+    expect(
+      selectPriceRule(inputs({ customisableDays: true, dayOverrides })),
+    ).toEqual({ kind: "DAY_PRICE", overrides: dayOverrides });
+  });
+
+  test("OVERRIDE outranks every other tier, carrying its amount (incl. free 0)", () => {
+    // Every lower tier is also offered; the flat override must still win.
+    const contested = inputs({
+      customisableDays: true,
+      dayOverrides: new Map([[1, 999]]),
+      payMore: { maxMinor: 5000, minMinor: 100 },
+    });
+    expect(selectPriceRule({ ...contested, overrideMinor: 1200 })).toEqual({
+      amountMinor: 1200,
+      kind: "OVERRIDE",
+    });
+    expect(selectPriceRule({ ...contested, overrideMinor: 0 })).toEqual({
+      amountMinor: 0,
+      kind: "OVERRIDE",
+    });
+  });
+});
+
+describe("packageMemberPriceRule", () => {
+  test("never yields PAY_MORE — a member is never pay-what-you-want", () => {
+    // Even though the shared precedence has a PAY_MORE tier, this member-pricing
+    // entry omits pay-more info, so a customisable member falls to DAY_PRICE.
+    expect(packageMemberPriceRule(undefined, undefined, true)).toEqual({
+      kind: "DAY_PRICE",
+      overrides: undefined,
+    });
+  });
+
+  test("a flat override outranks the day/base price", () => {
+    expect(packageMemberPriceRule(1200, new Map([[1, 999]]), true)).toEqual({
+      amountMinor: 1200,
+      kind: "OVERRIDE",
+    });
+  });
+
+  test("a non-member, non-customisable line falls through to BASE", () => {
+    expect(packageMemberPriceRule(undefined, undefined, false)).toEqual({
+      kind: "BASE",
+    });
+  });
+});
+
+describe("packageBundleTotal", () => {
+  /** A package tree carrying one child (id 9, unit 300) under member 5; the
+   * caller supplies the members and their package pricing. */
+  const bundleTree = (
+    over: Pick<Parameters<typeof buildBookingTree>[0], "listings" | "packages">,
+  ) =>
+    buildBookingTree({
+      childrenByParentId: new Map([
+        [5, [resolved({ id: 9, unit_price: 300 })]],
+      ]),
+      slugs: ["pkg"],
+      ...over,
+    });
+
+  test("sums each member's unit + cheapest bookable child, × its fixed quantity", () => {
+    const tree = bundleTree({
+      listings: [resolved({ id: 5 }), resolved({ id: 6, unit_price: 500 })],
+      packages: [
+        treePackage(3, [5, 6], {
+          prices: new Map([[5, 1000]]),
+          quantities: new Map([[5, 2]]),
+        }),
+      ],
+    });
+    // Member 5: (override 1000 + child 300) × fixed 2 = 2600.
+    // Member 6: (base 500 + no child 0) × fixed 1 = 500.
+    expect(packageBundleTotal(tree, 1, new Set([9]))).toBe(3100);
+  });
+
+  test("a child that is not bookable adds nothing to the minimum charge", () => {
+    const tree = bundleTree({
+      listings: [resolved({ id: 5, unit_price: 1000 })],
+      packages: [treePackage(3, [5])],
+    });
+    // Child 9 is outside the bookable set → filtered out → just the member's 1000.
+    expect(packageBundleTotal(tree, 1, new Set())).toBe(1000);
   });
 });
 


### PR DESCRIPTION
## What changed

Bookings charge one of four prices, and there is a fixed order in which they
win:

1. a **package override** (a flat price the package sets for a member),
2. **pay-what-you-want** (the buyer names the price, within limits),
3. a **customisable day price** (the price depends on how many days are booked),
4. the plain **base price**.

That order used to be written down in three separate places — a note in the
type, an if/else chain in the code that builds a booking, and a switch in the
code that works out each price. Adding a new price tier meant remembering to
edit all three, and if you missed one nothing complained; the price would just
quietly come out wrong.

This change gathers it into one place. Each price tier is now a single entry in
one table that says: how to tell whether this tier applies, how to set it up,
and how to work out its actual price. A separate short list spells out the
winning order. Picking a listing's price is now just walking down that list and
taking the first tier that fits; working out the price is a direct lookup.

## Why it's safer

Because the table has to include every tier, leaving one out is now caught
immediately as a build error rather than slipping through unnoticed. The code
that builds a booking and the code that re-checks prices for webhooks and
refunds all go through the same single chooser, so they can never disagree about
which price wins.

## Scope

This is a refactor — the prices people are charged are exactly the same as
before. New tests cover the price chooser, the winning order, the member-pricing
entry point, and the package bundle total. Both changed source files pass at
100% mutation coverage; the two files' known-equivalent mutant notes were
brought back in sync (their line references had drifted).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdhAdeRgJAPjbdU3Qc3Gj4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized pricing selection across booking scenarios.
  * Ensured overrides, day-based pricing, base prices, and “pay more” options follow consistent precedence.
  * Preserved valid zero-value prices and member-pricing behavior.
  * Improved bundle totals by accurately combining member prices with eligible child items and quantities.

* **Bug Fixes**
  * Corrected handling of missing or non-bookable child items in bundle calculations.
  * Improved pricing behavior for customisable listings and package members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->