### PR TITLE
Assert the real validation error in the add-attendee failure test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -223,13 +223,6 @@ was pure relocation + cpd dedup (the task explicitly required "do NOT change wha
 any test asserts"), so these were left untouched and tracked here instead. Each is
 a small, isolated assertion-strength improvement.*
 
-- **`add-attendee.test.ts` — `expect.stringContaining("")` is vacuous.** The
-  "redirects with error on validation failure" test asserts
-  `expectFlash(response, expect.stringContaining(""), false)`, which matches every
-  string and passes even if the flash carries the wrong message. Assert the actual
-  validation error text (or another specific error contract) so the negative path
-  is genuine. (Original monolith line 990.)
-
 - **`payment.test.ts` — assert payment stays unrefunded after ledger failure.**
   The "surfaces a Stripe refund the ledger could not record" test only checks the
   error flash; its comment says the payment must remain visibly un-refunded. Add a

--- a/test/lib/server-attendees/add-attendee.test.ts
+++ b/test/lib/server-attendees/add-attendee.test.ts
@@ -218,7 +218,8 @@ describeWithEnv("server (admin attendees) > add attendee", { db: true }, () => {
         quantity: "1",
       });
       expect(response.status).toBe(302);
-      expectFlash(response, expect.stringContaining(""), false);
+      // Empty name is the first required field to fail, so the flash names it.
+      expectFlash(response, "Your Name is required", false);
     });
 
     test("redirects with error when capacity exceeded", async () => {


### PR DESCRIPTION
## What changed

A test that was meant to prove the "add attendee" form rejects bad input wasn't actually checking anything meaningful.

The test submitted an attendee with an empty name and email, then asserted the error message with `expect.stringContaining("")` — an empty substring, which every possible string contains. So the test would have passed even if the app flashed the *wrong* message, the wrong field's error, or an empty one. The negative path was untested in practice.

## The fix

It now asserts the **exact** message the app produces: submitting an empty name makes the name (the first required contact field) fail first, so the flash is `"Your Name is required"`. A regression that changed or dropped that message will now fail the test.

## Notes

- Test-only change; no product behaviour is affected.
- Verified locally: all 18 tests in `test/lib/server-attendees/add-attendee.test.ts` pass, and the asserted string matches the app's real output (the required-field error is built as `"${label} is required"` in `forms.tsx`, with the name field labelled "Your Name").
- Lint clean.
- Removes the corresponding follow-up item from `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S

---
_Generated by [Claude Code](https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation feedback coverage by verifying that an empty name displays the specific message “Your Name is required.”
* **Tests**
  * Strengthened validation testing to prevent overly broad assertions.
  * Removed the completed test-quality follow-up item from the project checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->