### PR TITLE
Keep modifier form options off the cold-start path

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -321,14 +321,14 @@ src/shared/images/codecs.ts:84:3  await ensureCodecs(); → (removed)   # encode
 # modifiers.ts — several returns feed truthiness checks or the router's
 # `?? notFoundResponse()` fallthrough, so null/undefined and a 404-vs-undefined
 # return are indistinguishable through every reachable caller.
-src/features/admin/modifiers.ts:207:69  return null → return undefined    # childAddOnInputError "no error"; caller uses truthiness, so null and undefined agree
-src/features/admin/modifiers.ts:294:14  name → ""    # modifiersResource.nameField; the CRUD delete verifies the name via cfg.getName (owner-crud.ts), never resource.verifyName, so nameField is unobservable
-src/features/admin/modifiers.ts:342:10  return null → return undefined    # scopeLinksFor "no links"; edit template renders via `links && …` truthiness, so null and undefined agree
-src/features/admin/modifiers.ts:351:45  return null → return undefined    # answerLinksFor "no links"; rendered via truthiness, so null and undefined agree
-src/features/admin/modifiers.ts:370:46  return Promise.resolve(undefined) → return undefined    # non-owner ledger; awaited in Promise.all where undefined and Promise.resolve(undefined) both resolve to undefined
-src/features/admin/modifiers.ts:408:27  return notFoundResponse() → return undefined    # a handler returning undefined hits routeMainApp's `?? notFoundResponse()` → the same 404
-src/features/admin/modifiers.ts:424:38  return notFoundResponse() → return undefined    # same as 400: undefined → routeMainApp `?? notFoundResponse()` → 404
-src/features/admin/modifiers.ts:535:10  return Promise.resolve() → return undefined    # whole-order modifier writes no links; awaited by caller, so undefined and Promise.resolve() agree
+src/features/admin/modifiers.ts:208:69  return null → return undefined    # childAddOnInputError "no error"; caller uses truthiness, so null and undefined agree
+src/features/admin/modifiers.ts:294:16  name → ""    # modifiersResource.nameField; the CRUD delete verifies the name via cfg.getName (owner-crud.ts), never resource.verifyName, so nameField is unobservable
+src/features/admin/modifiers.ts:343:10  return null → return undefined    # scopeLinksFor "no links"; edit template renders via `links && …` truthiness, so null and undefined agree
+src/features/admin/modifiers.ts:352:45  return null → return undefined    # answerLinksFor "no links"; rendered via truthiness, so null and undefined agree
+src/features/admin/modifiers.ts:371:46  return Promise.resolve(undefined) → return undefined    # non-owner ledger; awaited in Promise.all where undefined and Promise.resolve(undefined) both resolve to undefined
+src/features/admin/modifiers.ts:409:27  return notFoundResponse() → return undefined    # a handler returning undefined hits routeMainApp's `?? notFoundResponse()` → the same 404
+src/features/admin/modifiers.ts:425:38  return notFoundResponse() → return undefined    # same as 400: undefined → routeMainApp `?? notFoundResponse()` → 404
+src/features/admin/modifiers.ts:536:10  return Promise.resolve() → return undefined    # whole-order modifier writes no links; awaited by caller, so undefined and Promise.resolve() agree
 
 # attendees-route-helpers.ts — loadAttendeeForListing's "not found" returns feed
 # orNotFound's truthiness check (`data ? handler : notFoundResponse()`), so a

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -3,6 +3,7 @@
  */
 
 /* jscpd:ignore-start */
+import { once } from "#fp";
 import { t } from "#i18n";
 import {
   createRecalculatePageRenderer,
@@ -82,8 +83,8 @@ import {
 } from "#templates/admin/modifiers/pages.tsx";
 import { modifierAggregateFields } from "#templates/fields/aggregate.ts";
 import {
+  getModifierFields,
   type ModifierFormValues,
-  modifierFields,
 } from "#templates/fields/modifier.ts";
 import { withEntityLoader } from "./entity-handlers.ts";
 import { makeMoneyAdjustHandler } from "./money-adjust.ts";
@@ -284,19 +285,19 @@ const modifierValuesError = (values: ModifierFormValues): string | null =>
     ? modifierValueError(values.calc_kind, values.calc_value)
     : null;
 
-const modifiersResource = defineNamedResource<
-  ModifierRow,
-  ModifierInput,
-  number,
-  ModifierFormValues
->({
-  fields: modifierFields,
-  nameField: "name",
-  table: modifiersTable,
-  toInput: extractModifierInput,
-  validate: validateModifier,
-  validateValues: modifierValuesError,
-});
+// Built lazily on first use (never at module load), so `getModifierFields()` —
+// whose picklist option labels resolve through `t()` — stays off the admin
+// routes' cold-start path. `once` caches the resource after the first build.
+const getModifiersResource = once(() =>
+  defineNamedResource<ModifierRow, ModifierInput, number, ModifierFormValues>({
+    fields: getModifierFields(),
+    nameField: "name",
+    table: modifiersTable,
+    toInput: extractModifierInput,
+    validate: validateModifier,
+    validateValues: modifierValuesError,
+  }),
+);
 
 // The list renders the projected total_revenue (Display = Modifier from
 // getAllModifiers), while the resource and the delete page load the stored row
@@ -309,7 +310,7 @@ const crud = createCrudHandlers({
   renderDelete: adminModifierDeletePage,
   renderList: adminModifiersPage,
   renderNew: adminModifierNewPage,
-  resource: modifiersResource,
+  resource: getModifiersResource,
   singular: "Modifier",
 });
 
@@ -413,7 +414,7 @@ const handleEditPost: TypedRouteHandler<"POST /admin/modifiers/:id/edit"> = (
     if (!aggregates.ok) {
       return errorRedirect(`/admin/modifiers/${id}/edit`, aggregates.error);
     }
-    const result = await modifiersResource.update(id, form);
+    const result = await getModifiersResource().update(id, form);
     if (result.ok) {
       if (aggregates.input) {
         await updateModifierAggregateValues(id, aggregates.input);

--- a/src/features/admin/owner-crud.ts
+++ b/src/features/admin/owner-crud.ts
@@ -45,7 +45,11 @@ type CrudConfig<Row, Input, Display = Row> = {
    * who can't open the staff detail page, return to the edit form instead). */
   getRowPath?: (row: Row, session: AdminSession) => string;
   getAll: () => Promise<Display[]>;
-  resource: NamedResource<Row, Input>;
+  /** The resource, or a factory that builds it. A factory lets a resource whose
+   * fields are a per-request builder (e.g. modifiers, whose picklist options
+   * resolve through `t()`) stay off the module-load / cold-start path — it is
+   * only invoked inside the per-request handlers below, never at setup. */
+  resource: NamedResource<Row, Input> | (() => NamedResource<Row, Input>);
   renderList: (
     rows: Display[],
     session: AdminSession,
@@ -93,6 +97,12 @@ function createCrudHandlersWithAuth(auth: AuthGuards) {
       form: FormParams,
     ) => Response | Promise<Response>;
 
+    // Resolve the resource per-request. When `cfg.resource` is a factory, this
+    // defers building its fields until a handler actually runs (see the type
+    // note above); an already-built resource is returned as-is.
+    const resource = (): NamedResource<Row, Input> =>
+      typeof cfg.resource === "function" ? cfg.resource() : cfg.resource;
+
     const authForm =
       (handler: FormHandler) =>
       (request: Request): Promise<Response> =>
@@ -109,7 +119,7 @@ function createCrudHandlersWithAuth(auth: AuthGuards) {
           const flash = applyFlash(request);
           return withEntity<Row>((row) =>
             htmlResponse(render(row, session, flash.error)),
-          )(() => cfg.resource.table.findById(id));
+          )(() => resource().table.findById(id));
         });
 
     const logAndRedirect = async (
@@ -139,7 +149,7 @@ function createCrudHandlersWithAuth(auth: AuthGuards) {
     );
 
     const createHandler: FormHandler = async (session, form) => {
-      const result = await cfg.resource.create(form);
+      const result = await resource().create(form);
       return result.ok
         ? await logAndRedirect("created", result.row, session)
         : errorRedirect(`${cfg.listPath}/new`, result.error);
@@ -151,7 +161,7 @@ function createCrudHandlersWithAuth(auth: AuthGuards) {
 
     const editPost: IdRouteHandler = (request, { id }) =>
       auth.withForm(request, async (session, form) => {
-        const result = await cfg.resource.update(id, form);
+        const result = await resource().update(id, form);
         if (result.ok) {
           return logAndRedirect("updated", result.row, session);
         }
@@ -166,9 +176,9 @@ function createCrudHandlersWithAuth(auth: AuthGuards) {
         : {}),
       identifier: cfg.getName,
       identifierLabel: `${cfg.singular} name`,
-      load: (id) => cfg.resource.table.findById(id),
+      load: (id) => resource().table.findById(id),
       onConfirm: async (row, id) => {
-        await cfg.resource.delete(id);
+        await resource().delete(id);
         await logActivity(`${cfg.singular} '${cfg.getName(row)}' deleted`);
       },
       path: `${cfg.listPath}/:id/delete`,

--- a/src/ui/templates/admin/modifiers/pages.tsx
+++ b/src/ui/templates/admin/modifiers/pages.tsx
@@ -33,6 +33,14 @@ import {
 } from "./links.tsx";
 import { modifierToFieldValues, ruleSummary } from "./values.ts";
 
+/** Render the modifier form inputs, building the field list once and threading
+ * it through both the value map and the renderer so a single page render does
+ * not reconstruct the fields (and re-run their picklist i18n) twice. */
+const renderModifierFormFields = (modifier?: Modifier): string => {
+  const fields = getModifierFields();
+  return renderFields(fields, modifierToFieldValues(modifier, fields));
+};
+
 /** The modifier guide link, rendered at the bottom of every modifier page. */
 const ModifiersGuideFooter = (): JSX.Element => (
   <GuideFooter href="/admin/guide#modifiers">
@@ -118,9 +126,7 @@ export const adminModifierNewPage = (
     <>
       <CsrfForm action="/admin/modifiers">
         <h1>{t("modifiers.add.heading")}</h1>
-        <Raw
-          html={renderFields(getModifierFields(), modifierToFieldValues())}
-        />
+        <Raw html={renderModifierFormFields()} />
         <SubmitButton icon="plus">{t("modifiers.add.submit")}</SubmitButton>
       </CsrfForm>
       <ModifiersGuideFooter />
@@ -150,12 +156,7 @@ export const adminModifierEditPage = (
       <CsrfForm action={`/admin/modifiers/${modifier.id}/edit`}>
         <h1>{t("modifiers.edit.heading")}</h1>
         <Flash error={error} success={success} />
-        <Raw
-          html={renderFields(
-            getModifierFields(),
-            modifierToFieldValues(modifier),
-          )}
-        />
+        <Raw html={renderModifierFormFields(modifier)} />
         <ModifierRunningTotalsSection modifier={modifier} />
         {SaveChangesButton()}
       </CsrfForm>

--- a/src/ui/templates/admin/modifiers/pages.tsx
+++ b/src/ui/templates/admin/modifiers/pages.tsx
@@ -23,7 +23,7 @@ import {
   SubmitButton,
 } from "#templates/components/actions.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
-import { modifierFields } from "#templates/fields/modifier.ts";
+import { getModifierFields } from "#templates/fields/modifier.ts";
 import { ModifierRunningTotalsSection } from "./aggregates.tsx";
 import {
   type AnswerLinks,
@@ -118,7 +118,9 @@ export const adminModifierNewPage = (
     <>
       <CsrfForm action="/admin/modifiers">
         <h1>{t("modifiers.add.heading")}</h1>
-        <Raw html={renderFields(modifierFields, modifierToFieldValues())} />
+        <Raw
+          html={renderFields(getModifierFields(), modifierToFieldValues())}
+        />
         <SubmitButton icon="plus">{t("modifiers.add.submit")}</SubmitButton>
       </CsrfForm>
       <ModifiersGuideFooter />
@@ -149,7 +151,10 @@ export const adminModifierEditPage = (
         <h1>{t("modifiers.edit.heading")}</h1>
         <Flash error={error} success={success} />
         <Raw
-          html={renderFields(modifierFields, modifierToFieldValues(modifier))}
+          html={renderFields(
+            getModifierFields(),
+            modifierToFieldValues(modifier),
+          )}
         />
         <ModifierRunningTotalsSection modifier={modifier} />
         {SaveChangesButton()}

--- a/src/ui/templates/admin/modifiers/values.ts
+++ b/src/ui/templates/admin/modifiers/values.ts
@@ -5,7 +5,11 @@
 
 import { t } from "#i18n";
 import { toMajorUnits } from "#shared/currency.ts";
-import { booleanToCheckbox, entityToFieldValues } from "#shared/forms.tsx";
+import {
+  booleanToCheckbox,
+  entityToFieldValues,
+  type Field,
+} from "#shared/forms.tsx";
 import type { Modifier } from "#shared/types.ts";
 import { getModifierFields } from "#templates/fields/modifier.ts";
 
@@ -28,13 +32,17 @@ export const ruleSummary = (m: Modifier): string => {
   );
 };
 
-/** Pre-fill form values from a modifier; new modifiers default to active. */
+/** Pre-fill form values from a modifier; new modifiers default to active. The
+ * caller can pass the already-built `fields` so a single render doesn't
+ * reconstruct them (and re-run the picklist i18n) once here and once for
+ * `renderFields`; it defaults to a fresh build for standalone callers. */
 export const modifierToFieldValues = (
   modifier?: Modifier,
+  fields: Field[] = getModifierFields(),
 ): Record<string, string | number | null> =>
   entityToFieldValues(
     modifier,
-    getModifierFields(),
+    fields,
     {
       active: (m) => booleanToCheckbox(m.active),
       min_subtotal: (m) =>

--- a/src/ui/templates/admin/modifiers/values.ts
+++ b/src/ui/templates/admin/modifiers/values.ts
@@ -7,7 +7,7 @@ import { t } from "#i18n";
 import { toMajorUnits } from "#shared/currency.ts";
 import { booleanToCheckbox, entityToFieldValues } from "#shared/forms.tsx";
 import type { Modifier } from "#shared/types.ts";
-import { modifierFields } from "#templates/fields/modifier.ts";
+import { getModifierFields } from "#templates/fields/modifier.ts";
 
 /** Human-readable summary of a modifier's rule, e.g. "Discount · 10%". */
 export const ruleSummary = (m: Modifier): string => {
@@ -34,7 +34,7 @@ export const modifierToFieldValues = (
 ): Record<string, string | number | null> =>
   entityToFieldValues(
     modifier,
-    modifierFields,
+    getModifierFields(),
     {
       active: (m) => booleanToCheckbox(m.active),
       min_subtotal: (m) =>

--- a/src/ui/templates/fields/modifier.ts
+++ b/src/ui/templates/fields/modifier.ts
@@ -25,7 +25,13 @@ export type ModifierFormValues = {
   active: string;
 };
 
-export const modifierFields: Field[] = [
+/**
+ * Modifier form fields (per-request builder). Built on demand rather than at
+ * module load so the picklist option labels — which resolve through `t()` and
+ * compile their ICU messages — stay off the admin routes' cold-start path, the
+ * same way the listing and invite field builders do.
+ */
+export const getModifierFields = (): Field[] => [
   {
     label: "Name",
     name: "name",

--- a/test/ui/templates/fields/field-behaviour.test.ts
+++ b/test/ui/templates/fields/field-behaviour.test.ts
@@ -11,7 +11,7 @@ import {
   getMonthsPerUnitField,
   logisticsAgentFields,
 } from "#templates/fields/listing.ts";
-import { modifierFields } from "#templates/fields/modifier.ts";
+import { getModifierFields } from "#templates/fields/modifier.ts";
 import { getTicketFields } from "#templates/fields/ticket.ts";
 import { getSlugField } from "#templates/fields/validators.ts";
 import { byName } from "#test-utils/fields.ts";
@@ -52,6 +52,13 @@ describe("fields behaviour", () => {
   });
 
   describe("modifier fields", () => {
+    const modifierFields = getModifierFields();
+    test("is a per-request builder, not a shared module-load array", () => {
+      // Each call builds a fresh array, so the picklist option labels (which
+      // resolve through t()) are compiled per request rather than at module
+      // load — keeping that work off the admin routes' cold-start path.
+      expect(getModifierFields()).not.toBe(getModifierFields());
+    });
     test("name is required", () => {
       expect(byName(modifierFields, "name").required).toBe(true);
     });


### PR DESCRIPTION
## What changed

Follow-up to #1699. That change made the price-modifier form's dropdown options come from their schemas, which means each option's label is now looked up from the translations file. But the modifier field list was built once when the code first loads, so that translation work happened at start-up — every time the app boots, even for a page that has nothing to do with modifiers.

This moves that work to where it belongs: the modifier fields are now built fresh each time a modifier form is actually shown or submitted, exactly like the listing and invite-user forms already are. The list of modifier options is no longer assembled at start-up, so booting the app stays lean.

To make that possible without disturbing the modifier save/edit flow, the shared admin CRUD helper now also accepts a "build it when needed" resource, not only a ready-made one — it already only reaches for the resource while handling a request, so nothing runs early. The modifier resource uses that, building itself on first use and caching the result.

## Why

- Removes avoidable start-up work from every app boot that loads the admin routes — the cold-start budget on the edge runtime is tight.
- Brings the modifier form in line with the listing and invite forms, which are already per-request builders.
- Picked up from an automated review note on #1699.

## Notes

- Behaviour is unchanged for anyone using the site; this is purely about *when* the option list is built.
- `deno task precommit` passes (lint, typecheck of source and tests, full test suite, 100% coverage). Adds a regression test that the modifier fields are a fresh per-request build rather than a shared start-up array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7mYBmhzfJbm4wfZH25Fxa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved admin modifier pages by generating modifier form options on demand to reduce initial page-load overhead.

* **Bug Fixes**
  * Fixed modifier edit pages to correctly populate existing modifier values.
  * Improved modifier create, update, and delete handling by ensuring CRUD actions use the correct per-request behavior.

* **Tests**
  * Updated and expanded tests to verify modifier fields are generated independently per call/request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->