### PR TITLE
Guard the allocations metadata field against the provider length cap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -260,13 +260,6 @@ keeps the bundles honest by failing when a route reads a key it didn't declare.
   with no save-time warning. Fix: reject (or warn on) a parent package member
   whose per-order cap is below its pick count.
 
-- **`allocations` metadata length limit.** `enforceMetadataLimits`
-  length-checks `items`, answers, `modifiers`, the entry count and the packed
-  field, but not `allocations` — the fastest-growing field once every pick adds
-  an allocation. A large multi-slot checkout can fail with a raw payment-provider
-  error instead of the app's "book in smaller batches" message. Add
-  `allocations` to the same length guard.
-
 - **Capacity edge cases beyond the shipped model.** The shipped bundle-cap model
   (per-member child caps, sole-child pools, all-children forced demand) covers
   the common configurations but is not a full per-candidate feasibility solver:

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -489,11 +489,12 @@ const parsePackedFields = (raw: string): Partial<Record<string, string>> => {
 /**
  * Enforce a payment provider's metadata limits.
  *
- * Only items, answer_ids and modifiers can realistically exceed the per-value
- * length limit — they grow with the number of listings/options/modifiers
- * selected (answer-triggered modifiers ride the modifiers refs). All other
- * fields (name, email, address, etc.) are already constrained by form
- * validation to lengths well below the smallest provider limit (255).
+ * Only items, answer_ids, modifiers and allocations can realistically exceed
+ * the per-value length limit — they grow with the number of
+ * listings/options/modifiers/package-picks selected (answer-triggered modifiers
+ * ride the modifiers refs). All other fields (name, email, address, etc.) are
+ * already constrained by form validation to lengths well below the smallest
+ * provider limit (255).
  *
  * Square also caps the *number* of entries: a customisable-day checkout that
  * fills its optional fields (date, day_count, answer_ids, …) plus a modifiers
@@ -524,10 +525,14 @@ export const enforceMetadataLimits = (
   const answerIds = metadata.answer_ids;
   const textAnswerIds = metadata.text_answer_ids;
   const modifiers = metadata.modifiers;
+  // `allocations` grows with every package pick, so it can outrun the per-value
+  // cap just like the other option refs — guard it the same way.
+  const allocations = metadata.allocations;
   if (
     (answerIds && answerIds.length > maxValueLength) ||
     (textAnswerIds && textAnswerIds.length > maxValueLength) ||
     (modifiers && modifiers.length > maxValueLength) ||
+    (allocations && allocations.length > maxValueLength) ||
     (maxEntries !== undefined && Object.keys(metadata).length > maxEntries)
   ) {
     throw new PaymentUserError(

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -522,17 +522,22 @@ export const enforceMetadataLimits = (
     );
   }
 
-  const answerIds = metadata.answer_ids;
-  const textAnswerIds = metadata.text_answer_ids;
-  const modifiers = metadata.modifiers;
-  // `allocations` grows with every package pick, so it can outrun the per-value
-  // cap just like the other option refs — guard it the same way.
-  const allocations = metadata.allocations;
+  // Every option-ref field grows with the number of listings / options /
+  // modifiers / package-picks selected, so any of them can outrun the per-value
+  // cap. Check them uniformly, so a new ref field is one more list entry rather
+  // than another near-identical OR-clause. `allocations` is the newest — it
+  // grows with every package pick.
+  const OPTION_REF_FIELDS = [
+    "answer_ids",
+    "text_answer_ids",
+    "modifiers",
+    "allocations",
+  ] as const;
+  const oversizedOptionRef = OPTION_REF_FIELDS.some(
+    (field) => (metadata[field]?.length ?? 0) > maxValueLength,
+  );
   if (
-    (answerIds && answerIds.length > maxValueLength) ||
-    (textAnswerIds && textAnswerIds.length > maxValueLength) ||
-    (modifiers && modifiers.length > maxValueLength) ||
-    (allocations && allocations.length > maxValueLength) ||
+    oversizedOptionRef ||
     (maxEntries !== undefined && Object.keys(metadata).length > maxEntries)
   ) {
     throw new PaymentUserError(

--- a/test/lib/payment-helpers/limits.test.ts
+++ b/test/lib/payment-helpers/limits.test.ts
@@ -103,6 +103,36 @@ describe("payment-helpers", () => {
       );
     });
 
+    test("throws PaymentUserError when allocations exceeds limit", () => {
+      // Every package pick adds an allocation, so this field grows fastest; a
+      // large multi-slot checkout must surface the app's batching message, not a
+      // raw provider rejection.
+      const longAllocations = JSON.stringify(
+        Array.from({ length: 40 }, (_, i) => ({ childId: i, parentId: 1 })),
+      );
+      const metadata = {
+        allocations: longAllocations,
+        email: "john@example.com",
+        items: '[{"e":1,"q":1,"p":0}]',
+        name: "John",
+      };
+      expectThrows(
+        () => enforceMetadataLimits(metadata, 255),
+        PaymentUserError,
+        /too many options/i,
+      );
+    });
+
+    test("passes through allocations within the limit", () => {
+      const metadata = {
+        allocations: JSON.stringify([{ childId: 2, parentId: 1 }]),
+        email: "j@x.com",
+        items: '[{"e":1,"q":1,"p":0}]',
+        name: "John",
+      };
+      expect(enforceMetadataLimits(metadata, 255)).toEqual(metadata);
+    });
+
     test("items within Stripe limit (500) but over Square limit (255)", () => {
       const items = JSON.stringify(
         Array.from({ length: 15 }, (_, i) => ({ e: i, p: 100, q: 1 })),


### PR DESCRIPTION
## What changed

When a customer checks out, the booking details are packed into "metadata" sent to the payment provider (Stripe/Square). Each provider caps how long any single metadata value can be. Before handing the booking off, the app checks the fields that can realistically get long and, if one is over the cap, stops with a friendly message: *"…please book in smaller batches."*

That check covered the item list, the question answers, and the modifiers — but **not** `allocations`, the field that records each package pick. Allocations grow with every pick a customer makes, so it's actually the fastest-growing field. A big multi-slot package order could push it past the cap and fail with a raw, confusing payment-provider error instead of the app's clear "book in smaller batches" message.

## The fix

`allocations` is now length-checked alongside the other option fields, so an over-long value surfaces the same friendly "too many options" batching message rather than a provider rejection.

## Tests

- Added a regression test: an over-cap `allocations` value now raises the app's `PaymentUserError`. It **fails without this change** (confirmed by reverting the fix) and passes with it.
- Added a companion test that an allocations value within the cap passes through untouched.
- All 24 tests in `test/lib/payment-helpers/limits.test.ts` pass; lint, typecheck, and duplication (0%) all clean.
- Removes the corresponding follow-up item from `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S

---
_Generated by [Claude Code](https://claude.ai/code/session_013jDnHypgnzR8SWzcoasw6S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payment metadata validation to include allocation metadata alongside other option-related fields.
  * Oversized allocations now produce the standard app-facing “too many options” guidance instead of a raw payment-provider error.
  * Valid allocation metadata is processed as before.
* **Documentation**
  * Clarified that allocations may exceed the provider’s per-value metadata length limit in realistic scenarios.
* **Tests**
  * Added test coverage to verify oversized allocations are rejected and in-limit allocations pass unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->