### PR TITLE
Consult capacity rules for feature-layer capacity dates (stage 3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -370,16 +370,15 @@ Stages 1–2 shipped: the declarative `CAPACITY_RULES` table exists, and the SQL
 guard (`src/shared/db/capacity.ts`), the JS preflight
 (`src/shared/db/attendees/capacity.ts`, `update.ts`), and the booking-page
 limits (`booking/model.ts`, `booking/package-cap.ts`) all derive their
-per-date-vs-running-total decisions from it. A handful of **feature-layer**
-call sites still decide the capacity date by hand with
-`listing_type === "daily"` and could consult `capacityDateFor`/`countsPerDate`
-instead (behaviour-identical, one file each):
-`src/features/public/ticket-payment.ts` (~line 219, the stored booking date),
-`src/features/public/qr-book.ts` (~line 99), `src/features/api/listings.ts`
-(the per-child availability dates, ~lines 122–157), and
-`src/features/api/booking.ts` (~line 64). Only the *capacity-date* decisions
-belong to the table — calendar/UI daily branches (date pickers, sorting,
-display) are date-selection logic and should stay as they are.
+per-date-vs-running-total decisions from it. Stage 3 shipped too: the
+feature-layer capacity-date call sites (`ticket-payment.ts` `bookingDateFields`,
+`qr-book.ts` `buildCheckoutIntent`, `api/listings.ts` child availability,
+`api/booking.ts` `resolveBookingDate`) consult
+`capacityDateFor`/`countsPerDate` instead of branching on
+`listing_type === "daily"` by hand. Only the *capacity-date* decisions belong
+to the table — the remaining calendar/UI daily branches (date pickers,
+sorting, display, duration spans) are date-selection logic and should stay as
+they are. Nothing further planned here.
 
 ---
 

--- a/src/features/api/booking.ts
+++ b/src/features/api/booking.ts
@@ -12,6 +12,7 @@ import { isRegistrationClosed } from "#routes/format.ts";
 import { parentRequiresChild } from "#routes/public/ticket-payment.ts";
 import { getBaseUrl } from "#routes/url.ts";
 import { processBooking } from "#shared/booking.ts";
+import { countsPerDate } from "#shared/capacity-rules.ts";
 import { getAvailableDates } from "#shared/dates.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { anyNonStandaloneChild } from "#shared/db/listing-parents.ts";
@@ -53,15 +54,16 @@ const bookingResultToResponse = (
 };
 
 /**
- * Resolve and validate the booking date for daily listings (a no-op for other
- * listing types). Returns the submitted date, null for non-daily listings, or a
- * 400 response when the date is missing or unavailable.
+ * Resolve and validate the booking date for listings booked per date (a no-op
+ * for date-less listings, whose capacity is one running total). Returns the
+ * submitted date, null for date-less listings, or a 400 response when the date
+ * is missing or unavailable.
  */
 const resolveBookingDate = async (
   listing: ListingWithCount,
   body: Record<string, unknown>,
 ): Promise<string | null | Response> => {
-  if (listing.listing_type !== "daily") return null;
+  if (!countsPerDate(listing.listing_type)) return null;
   const submittedDate = String(body.date ?? "");
   const availableDates = getAvailableDates(listing, await getActiveHolidays());
   if (!submittedDate || !availableDates.includes(submittedDate)) {

--- a/src/features/api/listings.ts
+++ b/src/features/api/listings.ts
@@ -14,6 +14,7 @@ import {
   loadBookablePackages,
 } from "#routes/public/discovery.ts";
 import { keepParentDailyDatesChildrenCanServe } from "#routes/public/ticket-payment.ts";
+import { capacityDateFor } from "#shared/capacity-rules.ts";
 import { getAvailableDates, getBookableStartDates } from "#shared/dates.ts";
 import { getGroupRemainingByListingId } from "#shared/db/attendees/capacity.ts";
 import { hasAvailableSpots } from "#shared/db/attendees.ts";
@@ -133,7 +134,7 @@ const buildChildAvailability = (
         (await hasAvailableSpots(
           child.id,
           quantity,
-          child.listing_type === "daily" ? (date ?? null) : null,
+          capacityDateFor(child.listing_type, date),
           child.duration_days,
         )),
       slug: child.slug,

--- a/src/features/public/qr-book.ts
+++ b/src/features/public/qr-book.ts
@@ -10,6 +10,7 @@
 import { isRegistrationClosed } from "#routes/format.ts";
 import { htmlResponse } from "#routes/response.ts";
 import { buildTicketListing } from "#shared/booking/model.ts";
+import { capacityDateFor } from "#shared/capacity-rules.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
 import { getGroupRemainingForListing } from "#shared/db/attendees/capacity.ts";
 import { isHiddenPackageMember } from "#shared/db/groups.ts";
@@ -96,7 +97,7 @@ const buildCheckoutIntent = (
   payload: QrBookPayload,
 ): CheckoutIntent => ({
   address: "",
-  date: listing.listing_type === "daily" ? payload.d : null,
+  date: capacityDateFor(listing.listing_type, payload.d),
   email: "",
   items: [
     {

--- a/src/features/public/ticket-payment.ts
+++ b/src/features/public/ticket-payment.ts
@@ -38,6 +38,7 @@ import {
   stampChildRowPackages,
 } from "#shared/booking/page-packages.ts";
 import type { BookingTree } from "#shared/booking/tree.ts";
+import { capacityDateFor } from "#shared/capacity-rules.ts";
 import { bookingBatchPlan } from "#shared/checkout-complete.ts";
 import type { PricedOrder } from "#shared/checkout-pricing.ts";
 import { getBookableStartDates, isBookingRangeValid } from "#shared/dates.ts";
@@ -216,7 +217,7 @@ export const bookingDateFields = (
   date: string | null,
   dayCount = 1,
 ): { date: string | null; durationDays: number } => ({
-  date: listing.listing_type === "daily" ? date : null,
+  date: capacityDateFor(listing.listing_type, date),
   durationDays: listing.customisable_days
     ? normalizeDurationDays(dayCount)
     : listing.listing_type === "daily"

--- a/test/lib/db/attendees/check-batch-availability.test.ts
+++ b/test/lib/db/attendees/check-batch-availability.test.ts
@@ -43,6 +43,46 @@ describeWithEnv("db > attendees > checkBatchAvailability", { db: true }, () => {
     ).toBe(true);
   });
 
+  test("a dated batch still counts a standard listing's demand as a running total", async () => {
+    const standard = await createTestListing({ maxAttendees: 2 });
+    const daily = await createDailyTestListing({ maxAttendees: 5 });
+    // The standard listing's prior booking lives only in its running total —
+    // its rows carry no booking range, so a per-day count would never see it.
+    await bookAttendee(standard, { quantity: 1 });
+    // The date belongs to the daily item; the standard listing's demand must
+    // still land on its running total (1 booked + 2 > 2), not in a per-day
+    // bucket where the existing booking is invisible.
+    expect(
+      await checkBatchAvailability(
+        [
+          { listingId: standard.id, quantity: 2 },
+          { listingId: daily.id, quantity: 1 },
+        ],
+        "2026-05-01",
+      ),
+    ).toBe(false);
+    expect(
+      await checkBatchAvailability(
+        [
+          { listingId: standard.id, quantity: 1 },
+          { listingId: daily.id, quantity: 1 },
+        ],
+        "2026-05-01",
+      ),
+    ).toBe(true);
+  });
+
+  test("a date-less batch counts a daily listing's running total", async () => {
+    const daily = await createDailyTestListing({ maxAttendees: 2 });
+    await bookAttendee(daily, { date: "2026-05-01", quantity: 2 });
+    // With no anchor date the daily listing's demand must fall back to the
+    // date-less running total (2 booked + 1 > 2), not a per-day expansion of
+    // a date that does not exist.
+    expect(
+      await checkBatchAvailability([{ listingId: daily.id, quantity: 1 }]),
+    ).toBe(false);
+  });
+
   test("rejects a multi-day booking when any day in the range is at capacity", async () => {
     const listing = await createDailyTestListing({
       durationDays: 3,

--- a/test/lib/db/attendees/dateless-group-remaining.test.ts
+++ b/test/lib/db/attendees/dateless-group-remaining.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { getDatelessGroupRemaining } from "#shared/db/attendees.ts";
+import { getGroupIdsByListingIds } from "#shared/db/groups.ts";
+import {
+  createDailyTestListing,
+  createTestGroup,
+  createTestListing,
+  describeWithEnv,
+} from "#test-utils";
+
+describeWithEnv(
+  "db > attendees > getDatelessGroupRemaining",
+  { db: true },
+  () => {
+    test("includes only groups reachable from dateLessCap members", async () => {
+      const standardGroup = await createTestGroup({
+        maxAttendees: 5,
+        name: "Standard Pool",
+      });
+      const dailyGroup = await createTestGroup({
+        maxAttendees: 5,
+        name: "Daily Pool",
+      });
+      const standard = await createTestListing({
+        groupId: standardGroup.id,
+        maxAttendees: 5,
+      });
+      const daily = await createDailyTestListing({
+        groupId: dailyGroup.id,
+        maxAttendees: 5,
+      });
+      const membership = await getGroupIdsByListingIds([standard.id, daily.id]);
+      // A perDateCap member's group remaining is a per-date fact, so the
+      // date-less read must include the standard member's group and exclude
+      // the daily member's — not the other way round.
+      const remaining = await getDatelessGroupRemaining(
+        [standard, daily].map(({ id, listing_type }) => ({
+          id,
+          listing_type,
+        })),
+        membership,
+      );
+      expect(remaining.has(standardGroup.id)).toBe(true);
+      expect(remaining.has(dailyGroup.id)).toBe(false);
+    });
+  },
+);


### PR DESCRIPTION
## What changed

Follow-up to #1704, completing stage 3 of the capacity-rules adoption. The four remaining feature-layer call sites that decided the *capacity date* by hand with `listing_type === "daily"` now consult the shared rules table instead:

- `src/features/api/booking.ts` — `resolveBookingDate` uses `countsPerDate` to decide whether a booking carries a date at all.
- `src/features/public/ticket-payment.ts` — `bookingDateFields` derives the stored booking date via `capacityDateFor`.
- `src/features/public/qr-book.ts` — `buildCheckoutIntent` derives the checkout date via `capacityDateFor`.
- `src/features/api/listings.ts` — the per-child availability check passes `capacityDateFor(child.listing_type, date)` to `hasAvailableSpots`.

**Behaviour is identical** — `capacityDateFor` keeps the date for per-date-capped listings and drops it for running-total listings, exactly what each hand-written branch did. The gain is that a listing-type capacity change is now a single row in `CAPACITY_RULES` with no feature-layer hunt.

The calendar/UI daily branches (date pickers, duration spans, sorting, display) deliberately keep their explicit `listing_type` checks — they are date-*selection* logic, not capacity counting, and don't belong to this table. The TODO.md stage-3 section is updated to record that this adoption is complete and nothing further is planned.

## Tests

- All 110 tests across the six suites covering these flows pass (`ticket-payment`, `server-qr-book`, `server-parents-booking/{api-detail,api-availability,qr-book}`, `routes/api/book-basics`).
- `deno task lint` clean; `deno check` clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfHkTVTpFGAFMzc8ggB7me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized “capacity date” handling across listings availability checks, booking date validation, and booking-related payment flows (including QR checkout and ticket payments).
  - Booking requests now require/derive dates according to each listing’s capacity rules rather than relying on daily-only logic.
  - Preserved existing calendar/UI date-selection behavior where applicable.
- **Bug Fixes**
  - Corrected capacity-date derivation for child availability by using capacity-date rules consistently.
- **Tests**
  - Added coverage for mixed running-total/demand scenarios and for dateless group remaining behavior with daily vs standard pools.
- **Documentation**
  - Updated stage 3 capacity-rule guidance to reflect completed feature-layer adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->