### PR TITLE
Fix hidden sole-child listing attributes leaking on public ticket pages

### DIFF
--- a/src/ui/templates/public/reservations.tsx
+++ b/src/ui/templates/public/reservations.tsx
@@ -662,7 +662,7 @@ const renderSoleChildOption = (
     parentId,
     child,
     childDatesById,
-  )}>${label}</p>${priceHtml}${attributesHtml}`;
+  )}>${label}</p>${priceHtml}${visible ? attributesHtml : ""}`;
 };
 
 /**

--- a/test/lib/server-parents-gate/render-selector.test.ts
+++ b/test/lib/server-parents-gate/render-selector.test.ts
@@ -4,8 +4,10 @@ import { it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { settings } from "#shared/db/settings.ts";
 import {
+  assignTestAttributeOptions,
   bookingPageHtml,
   childField,
+  createTestAttributeWithOptions,
   deactivateTestListing,
   describeWithEnv,
   followRedirectWithFlash,
@@ -240,6 +242,63 @@ describeWithEnv(
       expect(html).not.toContain("Hidden add-on");
       expect(html).not.toContain("Includes");
       expect(html).not.toContain("Choose an option for");
+    });
+
+    test("a sole bookable child shows its selected attributes", async () => {
+      // A visible sole child renders informationally (auto-filled by the fold)
+      // but still surfaces its selected attributes beside its name — the parent
+      // ticket page is the only place a buyer sees them for an auto-selected
+      // add-on. Pairs with the hidden-leak test below: a mutant that always
+      // suppresses attributes fails here, and one that always shows them fails
+      // there.
+      const { parent, child } = await makeParent({
+        children: [{ name: "Visible add-on", unitPrice: 1000 }],
+      });
+      const audience = await createTestAttributeWithOptions("Audience", [
+        "Adults",
+      ]);
+      await assignTestAttributeOptions(child.id, audience.options);
+
+      const html = await bookingPageHtml(parent.slug);
+      expect(html).toContain(`data-sole-child="${child.id}"`);
+      expect(html).toContain("listing-attributes");
+      expect(html).toContain("Audience");
+      expect(html).toContain("Adults");
+    });
+
+    test("a sole hidden child does not leak its attributes", async () => {
+      // A hidden add-on shows nothing identifying — not its name, price, OR its
+      // selected attributes — even though its data markers and pay-more price
+      // input stay in the DOM for the fold/compat scripts. Before the fix the
+      // attributes block was appended unconditionally after the suppressed
+      // label, leaking the hidden child's attribute names and option text to
+      // the public page.
+      const { parent, child } = await makeParent({
+        children: [
+          {
+            canPayMore: true,
+            hidden: true,
+            maxPrice: 5000,
+            name: "Hidden add-on",
+            unitPrice: 1500,
+          },
+        ],
+      });
+      const audience = await createTestAttributeWithOptions("Audience", [
+        "Adults",
+      ]);
+      await assignTestAttributeOptions(child.id, audience.options);
+
+      const html = await bookingPageHtml(parent.slug);
+      // Functional markers + price input remain so the fold and client
+      // scripts still drive off them.
+      expect(html).toContain(`data-sole-child="${child.id}"`);
+      expect(html).toContain(`name="child_price_${parent.id}_${child.id}"`);
+      // Nothing visible identifies the hidden child — including its
+      // attributes.
+      expect(html).not.toContain("Hidden add-on");
+      expect(html).not.toContain("Audience");
+      expect(html).not.toContain("Adults");
     });
 
     test("a multi-child selector hides every price when all bookable children are free", async () => {


### PR DESCRIPTION
## What changed

A hidden add-on that is the sole bookable child of a parent listing was leaking its selected attribute names and option text onto the public ticket page.

`renderSoleChildOption` already suppressed the child name and price label when the child was hidden (the `visible ? … : ""` gate), but the newly added `attributesHtml` block was appended **unconditionally** after the suppressed label. So a hidden child kept its data markers and pay-more price input (which the booking fold and the compatibility scripts still need) but also published its attribute labels to buyers — breaking the "a hidden child shows nothing identifying" contract.

This gates `attributesHtml` on the same `visible` flag, so hidden sole children show nothing identifying while still keeping the functional markers the scripts depend on.

## Why

This slipped through #1683 (merged as `09e63164`): the thread that introduced attribute rendering on sole-child add-on options did not account for the hidden-child branch. A follow-up review comment flagged it after merge.

## What this means for users

A hidden add-on with selected listing attributes no longer exposes those attributes on the parent ticket page. Visitors see exactly what the operator intended to hide. No booking, pricing, or capacity behaviour changes.

## Checks

- `deno task precommit` (typecheck, lint, jscpd, full test suite)
- Regression tests in `test/lib/server-parents-gate/render-selector.test.ts`:
  - "a sole bookable child shows its selected attributes" (positive — fixes must not suppress attributes for visible children)
  - "a sole hidden child does not leak its attributes" (the bug — fails before the fix, passes after)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed public reservation pages so hidden sole-child listings no longer display their selected attributes or options.
  * Visible auto-selected sole-child listings continue to show the appropriate attribute details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->