### PR TITLE
Secure delivery mark-done date scope

### DIFF
--- a/src/features/admin/deliveries.ts
+++ b/src/features/admin/deliveries.ts
@@ -14,7 +14,12 @@
 import { unique } from "#fp";
 import { t } from "#i18n";
 import { getDateFilter, getMonthFilter } from "#routes/admin/actions.ts";
-import { DELIVERY_FORM, deliveryPage, withAuth } from "#routes/auth.ts";
+import {
+  type AuthSession,
+  DELIVERY_FORM,
+  deliveryPage,
+  withAuth,
+} from "#routes/auth.ts";
 import { errorRedirect, redirect } from "#routes/response.ts";
 import { defineRoutes } from "#routes/router.ts";
 import { addDays, formatDateLabel } from "#shared/dates.ts";
@@ -84,6 +89,7 @@ const bookingsForDate = (
     }
     booking.legs.push({
       agentName: lookups.agentNameById.get(leg.agentId)!,
+      date: leg.date,
       done: leg.done,
       kind: leg.kind,
       time: leg.time,
@@ -211,13 +217,24 @@ const handleDeliveriesGet = deliveryPage(async (session, request) => {
   );
 });
 
+/** Whether a mark for `date` is allowed for the marking user. An agent only
+ * ever sees today and tomorrow, so a mark from one may name only those two
+ * days; staff may open any date on the run sheet, so their date is left to the
+ * query's per-day scoping (and agent ownership) to police. */
+const markDateAllowed = (session: AuthSession, date: string): boolean => {
+  if (isStaffRole(session.adminLevel)) return true;
+  const today = todayInTz(settings.timezone);
+  return date === today || date === addDays(today, 1);
+};
+
 /** Handle POST /admin/deliveries/mark — toggle a leg done, scoped to the
- * agent's own logistics agents. */
+ * agent's own logistics agents and to the run-sheet day it was shown on. */
 const handleDeliveriesMark = (request: Request): Promise<Response> =>
   withAuth(request, DELIVERY_FORM, async (session, form) => {
     const attendeeId = form.getOptionalInt("attendee_id");
     const listingId = form.getOptionalInt("listing_id");
     const kind = form.getString("kind");
+    const date = form.getString("date");
     const done = form.getFlag("done");
     if (attendeeId === null || listingId === null) {
       return errorRedirect(
@@ -231,12 +248,19 @@ const handleDeliveriesMark = (request: Request): Promise<Response> =>
         t("deliveries.invalid_request"),
       );
     }
+    if (!markDateAllowed(session, date)) {
+      return errorRedirect(
+        "/admin/deliveries",
+        t("deliveries.invalid_request"),
+      );
+    }
 
     const agentIds = await userAgents.getIds(session.userId);
     const updated = await setLegDone(
       attendeeId,
       listingId,
       kind,
+      date,
       done,
       agentIds,
     );

--- a/src/shared/db/logistics.ts
+++ b/src/shared/db/logistics.ts
@@ -275,26 +275,35 @@ export const getAgentRunSheetDates = async (
 /**
  * Mark a booking leg done/undone, but only when the leg's logistics agent is
  * one of `agentIds` — this enforces that an agent user can only update their
- * own runs. Returns true when a row was updated (i.e. the agent owns the leg).
+ * own runs — and only the row whose leg falls on `date`, so a mark is scoped to
+ * the run-sheet day it was shown on. Returns true when a row was updated (i.e.
+ * the agent owns the leg on that date).
  */
 export const setLegDone = async (
   attendeeId: number,
   listingId: number,
   kind: DeliveryLegKind,
+  date: string,
   done: boolean,
   agentIds: number[],
 ): Promise<boolean> => {
   if (agentIds.length === 0) return false;
   const doneColumn = kind === "start" ? "start_done" : "end_done";
   const agentColumn = kind === "start" ? "start_agent_id" : "end_agent_id";
+  const dateExpression =
+    kind === "start" ? "DATE(start_at)" : "DATE(end_at, '-1 day')";
   const result = await execute(
+    // The date predicate scopes the update to the leg on the claimed run-sheet
+    // day: a listing+attendee can have several rows across dates, so without it
+    // a mark would flip legs on days the user isn't viewing.
     // quantity > 0: refuse to complete a leg on a no-quantity line, so a stale or
     // crafted delivery form can't mark a hidden ghost's drop-off/collection done.
     `UPDATE listing_attendees SET ${doneColumn} = ?
           WHERE attendee_id = ? AND listing_id = ?
+            AND ${dateExpression} = ?
             AND ${agentColumn} IN (${inPlaceholders(agentIds)})
             AND quantity > 0`,
-    [done ? 1 : 0, attendeeId, listingId, ...agentIds],
+    [done ? 1 : 0, attendeeId, listingId, date, ...agentIds],
   );
   return result.rowsAffected > 0;
 };

--- a/src/ui/templates/admin/deliveries.tsx
+++ b/src/ui/templates/admin/deliveries.tsx
@@ -62,6 +62,8 @@ export type DeliveryLegView = {
   kind: "start" | "end";
   /** Name of the logistics agent (van/crew) this leg belongs to. */
   agentName: string;
+  /** Calendar date of this leg (YYYY-MM-DD), matching the run-sheet day. */
+  date: string;
   /** Logistics time label ("" when unset). */
   time: string;
   done: boolean;
@@ -131,6 +133,7 @@ const LegItem = ({
         value={String(booking.listingId)}
       />
       <input name="kind" type="hidden" value={leg.kind} />
+      <input name="date" type="hidden" value={leg.date} />
       <input name="done" type="hidden" value={leg.done ? "0" : "1"} />
       <button type="submit">
         {leg.done ? t("deliveries.mark_not_done") : t("deliveries.mark_done")}

--- a/test/lib/db/logistics-runsheet.test.ts
+++ b/test/lib/db/logistics-runsheet.test.ts
@@ -369,7 +369,7 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
       expect(before.find((l) => l.kind === "start")?.done).toBe(false);
 
       // Ticking the run-sheet leg completes every path row together.
-      await setLegDone(attendeeId, listingId, "start", true, [van]);
+      await setLegDone(attendeeId, listingId, "start", D1, true, [van]);
       const after = await getAgentRunSheet([van], [D1]);
       expect(after.find((l) => l.kind === "start")?.done).toBe(true);
       const rows = await queryAll<{ start_done: number }>(
@@ -437,7 +437,7 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
 
   describe("setLegDone", () => {
     test("returns false for no agent ids", async () => {
-      expect(await setLegDone(1, 1, "start", true, [])).toBe(false);
+      expect(await setLegDone(1, 1, "start", D1, true, [])).toBe(false);
     });
 
     test("marks the start leg done for the owning agent", async () => {
@@ -447,7 +447,9 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
         startAgentId: van,
         startDate: D1,
       });
-      const ok = await setLegDone(attendeeId, listingId, "start", true, [van]);
+      const ok = await setLegDone(attendeeId, listingId, "start", D1, true, [
+        van,
+      ]);
       expect(ok).toBe(true);
       const legs = await getAgentRunSheet([van], [D1]);
       expect(legs[0]?.done).toBe(true);
@@ -461,7 +463,7 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
         startAgentId: van,
         startDate: D1,
       });
-      await setLegDone(attendeeId, listingId, "end", true, [van]);
+      await setLegDone(attendeeId, listingId, "end", D1, true, [van]);
       const legs = await getAgentRunSheet([van], [D1]);
       expect(legs.find((l) => l.kind === "start")?.done).toBe(false);
       expect(legs.find((l) => l.kind === "end")?.done).toBe(true);
@@ -475,7 +477,7 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
         startDate: D1,
         startDone: true,
       });
-      await setLegDone(attendeeId, listingId, "start", false, [van]);
+      await setLegDone(attendeeId, listingId, "start", D1, false, [van]);
       const legs = await getAgentRunSheet([van], [D1]);
       expect(legs[0]?.done).toBe(false);
     });
@@ -488,9 +490,26 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
         startDate: D1,
       });
       const kind: DeliveryLegKind = "start";
-      const ok = await setLegDone(attendeeId, listingId, kind, true, [van]);
+      const ok = await setLegDone(attendeeId, listingId, kind, D1, true, [van]);
       expect(ok).toBe(false);
       const legs = await getAgentRunSheet([other], [D1]);
+      expect(legs[0]?.done).toBe(false);
+    });
+
+    test("refuses to update an owning agent leg on a different date", async () => {
+      // The leg is genuinely the van's, but on D3 — marking it via a D1 form
+      // must not flip a leg on a day the run sheet wasn't showing.
+      const { attendeeId, listingId } = await makeBooking({
+        endAgentId: null,
+        endDate: D4,
+        startAgentId: van,
+        startDate: D3,
+      });
+      const ok = await setLegDone(attendeeId, listingId, "start", D1, true, [
+        van,
+      ]);
+      expect(ok).toBe(false);
+      const legs = await getAgentRunSheet([van], [D3]);
       expect(legs[0]?.done).toBe(false);
     });
   });

--- a/test/lib/no-quantity-audit.test.ts
+++ b/test/lib/no-quantity-audit.test.ts
@@ -196,7 +196,11 @@ describeWithEnv("no-quantity audit > logistics", { db: true }, () => {
     ).toEqual([1]);
 
     // setLegDone refuses the ghost line even with the right agent.
-    expect(await setLegDone(2, listing.id, "start", true, [AGENT])).toBe(false);
-    expect(await setLegDone(1, listing.id, "start", true, [AGENT])).toBe(true);
+    expect(
+      await setLegDone(2, listing.id, "start", "2026-07-01", true, [AGENT]),
+    ).toBe(false);
+    expect(
+      await setLegDone(1, listing.id, "start", "2026-07-01", true, [AGENT]),
+    ).toBe(true);
   });
 });

--- a/test/lib/server-agent-deliveries.test.ts
+++ b/test/lib/server-agent-deliveries.test.ts
@@ -232,6 +232,7 @@ describeWithEnv("server (agent deliveries)", { db: true }, () => {
 
     const markResponse = await markRequest(cookie, {
       attendee_id: String(attendeeId),
+      date: todayInTz(settings.timezone),
       done: "1",
       kind: "start",
       listing_id: String(listingId),
@@ -244,6 +245,7 @@ describeWithEnv("server (agent deliveries)", { db: true }, () => {
     // Toggling it back off takes the "not done" message branch.
     const unmark = await markRequest(cookie, {
       attendee_id: String(attendeeId),
+      date: todayInTz(settings.timezone),
       done: "0",
       kind: "start",
       listing_id: String(listingId),
@@ -268,12 +270,35 @@ describeWithEnv("server (agent deliveries)", { db: true }, () => {
 
     const response = await markRequest(cookie, {
       attendee_id: String(attendeeId),
+      date: todayInTz(settings.timezone),
       done: "1",
       kind: "start",
       listing_id: String(listingId),
     });
     const location = expectRedirect(response, "/admin/deliveries");
     expect(location).toContain("flash");
+  });
+
+  test("marking with a date outside today or tomorrow is rejected", async () => {
+    const van = await makeVan("Van 1");
+    const { cookie } = await createTestAgentSession({
+      agentIds: [van],
+      token: "a15",
+      username: "agent15",
+    });
+    const { attendeeId, listingId } = await makeTodayBooking(van, van);
+
+    const response = await markRequest(cookie, {
+      attendee_id: String(attendeeId),
+      date: addDays(todayInTz(settings.timezone), 2),
+      done: "1",
+      kind: "start",
+      listing_id: String(listingId),
+    });
+    expectRedirect(response, "/admin/deliveries");
+
+    const after = await awaitTestRequest("/admin/deliveries", { cookie });
+    expect(await after.text()).toContain("Mark done");
   });
 
   test("marking with missing ids is rejected", async () => {
@@ -300,6 +325,7 @@ describeWithEnv("server (agent deliveries)", { db: true }, () => {
     });
     const response = await markRequest(cookie, {
       attendee_id: "1",
+      date: todayInTz(settings.timezone),
       done: "1",
       kind: "middle",
       listing_id: "1",
@@ -388,6 +414,34 @@ describeWithEnv("server (agent deliveries)", { db: true }, () => {
     // neither today nor tomorrow).
     expect(html).toContain("Future Castle");
     expect(html).toContain(formatDateLabel(future));
+  });
+
+  test("staff can mark a leg done on a future date they opened", async () => {
+    // Agents are pinned to today/tomorrow, but staff may open any date — so a
+    // mark on a far-future run-sheet day must be accepted, not rejected as an
+    // out-of-window date.
+    const van = await makeVan("Van 1");
+    await assignOwnerAgents([van]);
+    const future = addDays(todayInTz(settings.timezone), 10);
+    const { attendeeId, listingId } = await makeBookingOn(
+      van,
+      van,
+      future,
+      1,
+      "Future Castle",
+    );
+
+    const response = await markRequest(await testCookie(), {
+      attendee_id: String(attendeeId),
+      date: future,
+      done: "1",
+      kind: "start",
+      listing_id: String(listingId),
+    });
+    expectRedirect(response, "/admin/deliveries");
+
+    const html = await fetchDeliveriesForDate(future);
+    expect(html).toContain("Mark not done");
   });
 
   test("staff run sheet offers a date picker linking to their delivery dates", async () => {

--- a/test/ui/templates/admin/deliveries.test.ts
+++ b/test/ui/templates/admin/deliveries.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
 
 const leg = (over: Partial<DeliveryLegView> = {}): DeliveryLegView => ({
   agentName: "Van 1",
+  date: "2026-06-16",
   done: false,
   kind: "start",
   time: "09:00",
@@ -99,6 +100,7 @@ describe("agentDeliveriesPage", () => {
     expect(html).toContain("https://wa.me/447700900000");
     expect(html).toContain('action="/admin/deliveries/mark"');
     expect(html).toContain('value="start"');
+    expect(html).toContain('name="date" type="hidden" value="2026-06-16"');
     expect(html).toContain("Mark done");
     // The ticket token the customer can quote is shown.
     expect(html).toContain("<strong>Token:</strong> TOKEN123");


### PR DESCRIPTION
## What

Scopes the delivery run-sheet "mark done" toggle to the specific calendar day the leg was shown on, so marking a leg can only ever flip the row for that day.

## Why

`setLegDone` matched only on `(attendee_id, listing_id, kind, agent)`. Because a listing+attendee can have several `listing_attendees` rows across dates, that `UPDATE` could tick off legs on days the user wasn't looking at. The mark now carries the run-sheet `date` end-to-end and the query pins the update to the row whose leg actually falls on that day.

## Changes

- `setLegDone` takes a `date` and adds `DATE(start_at) = ?` (drop-off) / `DATE(end_at, '-1 day') = ?` (collection) to the `UPDATE`, alongside the existing agent-ownership and `quantity > 0` guards.
- The mark form submits a hidden `date` input (the leg's calendar day), threaded through the handler.
- Server-side date validation is role-aware: agent users are pinned to today/tomorrow (their only view), while staff — who can now open any date on the run sheet — are left to the query's per-day scoping and agent ownership. Extracted into a small `markDateAllowed` helper to keep the handler under the cognitive-complexity limit.

## Notes

This branch was 359 commits behind `main` with a single unmerged commit. It has been rebased onto the current `main` and brought up to date with the code that landed in the meantime — notably the "staff can open any date" run-sheet feature (which is why the today/tomorrow check is now role-aware rather than flat), the `quantity > 0` no-quantity guard on `setLegDone`, and the restructured `describe("setLegDone")` test block. Added a test covering a staff user marking a leg on a future date they opened.

## Testing

- `deno task typecheck`
- `deno task lint:ci`
- `deno task cpd` (0% duplication)
- Affected suites: `test/lib/db/logistics-runsheet.test.ts`, `test/lib/server-agent-deliveries.test.ts`, `test/ui/templates/admin/deliveries.test.ts`, `test/lib/no-quantity-audit.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVSbXKGo11bcAvVJYar4Vk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delivery run sheets now retain the calendar date for each delivery leg.
  - Staff can mark legs complete or incomplete for any run-sheet date.
  - Agents can mark legs only for today or tomorrow in the configured timezone.

- **Bug Fixes**
  - Completion updates now apply only to the selected run-sheet date, preventing similarly assigned legs on other dates from being changed.
  - Invalid dates are rejected with an appropriate error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->