### PR TITLE
Read only the listings an attribute uses, in one query

### DIFF
--- a/src/features/admin/attributes.ts
+++ b/src/features/admin/attributes.ts
@@ -34,7 +34,7 @@ import {
   getAllAttributesWithOptions,
   getAttributeId,
   getAttributeIdsOrdered,
-  getAttributeOptionListingIds,
+  getAttributeListingUse,
   getAttributeWithOptions,
   getNextAttributeOptionSortOrder,
   pruneInvalidAttributeOptionIds,
@@ -42,7 +42,6 @@ import {
   swapAttributeOptionOrder,
   swapAttributeOrder,
 } from "#shared/db/attributes.ts";
-import { getAllListingOptions } from "#shared/db/listings.ts";
 import { getFlash } from "#shared/flash-context.ts";
 import { defineForm } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
@@ -116,14 +115,12 @@ const handleAttributesPost = createAuthedFormRoute({
  * the attribute's options, as per-option counts plus a builder that turns any
  * subset of the options into "listings using this" table rows. */
 const loadAttributeListingUse = async (attributeId: number) => {
-  const [listingIdsByOption, listingOptions] = await Promise.all([
-    getAttributeOptionListingIds(attributeId),
-    getAllListingOptions(),
-  ]);
+  const { listingIdsByOption, listings } =
+    await getAttributeListingUse(attributeId);
   return {
     listingCounts: optionListingCounts(listingIdsByOption),
     rowsFor: (options: AttributeOption[]) =>
-      attributeListingRows(options, listingIdsByOption, listingOptions),
+      attributeListingRows(options, listingIdsByOption, listings),
   };
 };
 

--- a/src/shared/db/attributes.ts
+++ b/src/shared/db/attributes.ts
@@ -5,8 +5,10 @@
  * ids only; display code resolves those ids back to ordered attribute groups.
  */
 
-import { filter, map, reduce, unique } from "#fp";
+/* jscpd:ignore-start */
+import { filter, map, mapParallel, reduce, sort, unique, uniqueBy } from "#fp";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
+import type { EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
 import {
   executeBatch,
   inPlaceholders,
@@ -15,8 +17,10 @@ import {
   type TxScope,
 } from "#shared/db/client.ts";
 import { linkTableSide } from "#shared/db/link-table.ts";
+import type { ListingOption } from "#shared/db/listings.ts";
 import { swapSortOrder } from "#shared/db/query.ts";
 import { col, defineTable } from "#shared/db/table.ts";
+/* jscpd:ignore-end */
 
 export type Attribute = {
   id: number;
@@ -252,27 +256,56 @@ export const getAttributeIdsOrdered = async (): Promise<number[]> =>
 export const getAllAttributeOptionIds = async (): Promise<Set<number>> =>
   new Set(await queryIds("SELECT id FROM attribute_options"));
 
-type OptionListingRow = { listing_id: number; option_id: number };
+type OptionListingRow = {
+  listing_active: number;
+  listing_id: number;
+  listing_name: EnvKeyEncrypted;
+  option_id: number;
+};
 
-/** The ids of the listings that selected each of an attribute's options,
- * keyed by option id. Options no listing uses are absent from the map. */
-export const getAttributeOptionListingIds = async (
+export type AttributeListingUse = {
+  /** The ids of the listings that selected each option, keyed by option id.
+   * Options no listing uses are absent from the map. */
+  listingIdsByOption: Map<number, number[]>;
+  /** The distinct listings behind those ids in id order, names decrypted. */
+  listings: ListingOption[];
+};
+
+/** Which listings selected each of an attribute's options, in one read: the
+ * per-option listing ids plus each used listing's id, name, and active flag.
+ * Only the names of listings that actually use the attribute are decrypted. */
+export const getAttributeListingUse = async (
   attributeId: number,
-): Promise<Map<number, number[]>> =>
-  groupRows(
-    (row: OptionListingRow) => row.option_id,
-    (row) => row.listing_id,
-  )(
-    await queryAll<OptionListingRow>(
-      `SELECT listingAttribute.option_id, listingAttribute.listing_id
-         FROM listing_attribute_options AS listingAttribute
-         JOIN attribute_options AS attributeOption
-           ON attributeOption.id = listingAttribute.option_id
-        WHERE attributeOption.attribute_id = ?
-        ORDER BY listingAttribute.option_id, listingAttribute.listing_id`,
-      [attributeId],
-    ),
+): Promise<AttributeListingUse> => {
+  const rows = await queryAll<OptionListingRow>(
+    `SELECT listingAttribute.option_id,
+            listing.id AS listing_id,
+            listing.name AS listing_name,
+            listing.active AS listing_active
+       FROM listing_attribute_options AS listingAttribute
+       JOIN attribute_options AS attributeOption
+         ON attributeOption.id = listingAttribute.option_id
+       JOIN listings AS listing
+         ON listing.id = listingAttribute.listing_id
+      WHERE attributeOption.attribute_id = ?
+      ORDER BY listingAttribute.option_id, listingAttribute.listing_id`,
+    [attributeId],
   );
+  const usedListings = sort(
+    (a: OptionListingRow, b: OptionListingRow) => a.listing_id - b.listing_id,
+  )(uniqueBy((row: OptionListingRow) => row.listing_id)(rows));
+  return {
+    listingIdsByOption: groupRows(
+      (row: OptionListingRow) => row.option_id,
+      (row) => row.listing_id,
+    )(rows),
+    listings: await mapParallel(async (row: OptionListingRow) => ({
+      active: row.listing_active === 1,
+      id: row.listing_id,
+      name: await decrypt(row.listing_name),
+    }))(usedListings),
+  };
+};
 
 export const assignNextAttributeSortOrder = async (
   attributeId: number,

--- a/test/lib/server-attribute-detail.test.ts
+++ b/test/lib/server-attribute-detail.test.ts
@@ -78,9 +78,11 @@ describeWithEnv("server (admin attribute detail pages)", { db: true }, () => {
       );
       expect(html).toContain("<td>Easy, Hard</td>");
       // Rows are ordered by listing id (creation order).
-      expect(html.indexOf(">Climbing</a>")).toBeLessThan(
-        html.indexOf(">Both options</a>"),
-      );
+      const climbingIndex = html.indexOf(">Climbing</a>");
+      const bothOptionsIndex = html.indexOf(">Both options</a>");
+      expect(climbingIndex).toBeGreaterThanOrEqual(0);
+      expect(bothOptionsIndex).toBeGreaterThanOrEqual(0);
+      expect(climbingIndex).toBeLessThan(bothOptionsIndex);
     });
 
     test("mutes deactivated listings in the listings table", async () => {

--- a/test/lib/server-attribute-detail.test.ts
+++ b/test/lib/server-attribute-detail.test.ts
@@ -77,6 +77,10 @@ describeWithEnv("server (admin attribute detail pages)", { db: true }, () => {
         `<a href="/admin/listing/${bothListing.id}">Both options</a>`,
       );
       expect(html).toContain("<td>Easy, Hard</td>");
+      // Rows are ordered by listing id (creation order).
+      expect(html.indexOf(">Climbing</a>")).toBeLessThan(
+        html.indexOf(">Both options</a>"),
+      );
     });
 
     test("mutes deactivated listings in the listings table", async () => {

--- a/test/lib/server-attributes.test.ts
+++ b/test/lib/server-attributes.test.ts
@@ -179,6 +179,16 @@ describeWithEnv("server (admin attributes)", { db: true }, () => {
         "In-person",
         "Online",
       ]);
+
+      // Moving it back down restores the original order.
+      await adminFormPost(
+        `/admin/attributes/${id}/options/${second.id}/move-down`,
+      );
+      const restored = (await getAttributeWithOptions(id))!;
+      expect(restored.options.map((option) => option.text)).toEqual([
+        "Online",
+        "In-person",
+      ]);
     });
 
     test("returns 404 or redirects when changing a missing or invalid option", async () => {


### PR DESCRIPTION
## What changed

Follow-up to #1710, addressing the Codex review suggestion there.

The attribute page and the option edit page showed tables of the listings using an attribute, but built them by fetching **every** listing's name (decrypting all of them) and then filtering down to the few that appear in the tables. On a site with many listings that meant the pages scaled with the whole catalogue instead of with the attribute's actual usage.

Now one joined query returns the per-option listing ids together with each used listing's id, name, and active flag. The pages read a single database round trip, and only the names of listings that actually use the attribute are decrypted.

## Tests

- The existing page tests already assert the tables' names, counts, empty states, and greyed-out deactivated listings, so they cover the new read end to end.
- Added an assertion that the listings table keeps its creation order, and a move-down step to the option reordering test.
- Full precommit and the branch mutation gate (100% kill rate) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017a8hmUPw31VFt3MpuRL11x

---
_Generated by [Claude Code](https://claude.ai/code/session_017a8hmUPw31VFt3MpuRL11x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced admin attribute listing data, including correct listing names and active status.
* **Bug Fixes**
  * Fixed and stabilized ordering of listing rows and attribute options on admin pages.
* **Tests**
  * Added assertions to ensure listing rows render in document order by listing id.
  * Extended option reordering coverage to verify moving options both up and back down restores the original order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->