### PR TITLE
Pin demo sample pools and the error-code table against blanked-string mutants

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -838,3 +838,8 @@ src/shared/dates.ts:432:30  1 → 0    # bookedRangeLabel's `fallbackDurationDay
 # from the routeAdmin/adminPathSegment run over the manifest + footer suites.
 src/features/admin/index.ts:257:21  ?? → ||   # `path.split("/")[2] ?? ""`: the RHS is "" and the only falsy string is "", so `x ?? ""` and `x || ""` agree on every string|undefined input
 src/features/admin/index.ts:299:55  return null → return undefined   # routeAdmin's only consumer folds the result with `?? notFoundResponse()` (features/index.ts routeMainApp), and ?? treats null and undefined identically
+
+# Logger (logger.ts) — two provably-equivalent survivors from the run over the
+# logger suites.
+src/shared/logger.ts:314:27  = → +=   # errorPersistGuard.active is always false at this line (the guard early-returns otherwise), and false + true === 1 — read only for truthiness, exactly like true; the finally still resets it to false
+src/shared/logger.ts:321:69  ?? → ||   # context.listingId is number|undefined and listing ids are positive autoincrement integers, so the LHS is never a falsy non-null value — ?? and || agree on every input

--- a/test/lib/logger/log-error.test.ts
+++ b/test/lib/logger/log-error.test.ts
@@ -4,6 +4,7 @@ import { stub } from "@std/testing/mock";
 import {
   bestEffort,
   ErrorCode,
+  errorCodeLabel,
   logError,
   logErrorLocal,
 } from "#shared/logger.ts";
@@ -20,6 +21,20 @@ import { setupErrorSpy } from "#test-utils/error-spy.ts";
 // Outer describe ensures sequential execution — createTestListing() calls
 // handleRequest which sets a request-scoped ID via AsyncLocalStorage.
 // Without sequential ordering, that context can leak into later blocks.
+describe("error code table", () => {
+  // Codes are persisted into the activity log and matched by admin tooling, so
+  // a blanked or duplicated code would corrupt every logged error's identity.
+  test("every code is E_-prefixed, unique, and labelled", () => {
+    const codes = Object.values(ErrorCode);
+    expect(codes.length).toBeGreaterThan(20);
+    expect(new Set(codes).size).toBe(codes.length);
+    for (const code of codes) {
+      expect(code).toMatch(/^E_[A-Z_]+$/);
+      expect(errorCodeLabel[code].length, code).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe("log-error", () => {
   describe("logError", () => {
     const spyRef = setupErrorSpy();

--- a/test/shared/demo.test.ts
+++ b/test/shared/demo.test.ts
@@ -20,6 +20,7 @@ import {
   LISTING_DEMO_FIELDS,
   wrapResourceForDemo,
 } from "#shared/demo/overrides.ts";
+import * as demoSamples from "#shared/demo/samples.ts";
 import {
   DEMO_EMAILS,
   DEMO_GROUP_NAMES,
@@ -37,6 +38,25 @@ import {
   resetDb,
   setupTestEncryptionKey,
 } from "#test-utils";
+
+describe("demo sample pools", () => {
+  // applyDemoOverrides only replaces fields that arrive non-empty, so a blank
+  // sample would silently erase real submitted data. Walking every exported
+  // pool keeps that invariant pinned for pools added later too.
+  test("every exported pool has entries and no entry is empty", () => {
+    const pools = Object.entries(demoSamples).filter(
+      (entry): entry is [string, readonly string[]] => Array.isArray(entry[1]),
+    );
+    expect(pools.length).toBeGreaterThan(10);
+    for (const [name, pool] of pools) {
+      expect(pool.length, name).toBeGreaterThan(0);
+      for (const value of pool) {
+        expect(typeof value, name).toBe("string");
+        expect(value.length, `${name} has an empty entry`).toBeGreaterThan(0);
+      }
+    }
+  });
+});
 
 describeWithEnv("isDemoMode", { env: { DEMO_MODE: undefined } }, () => {
   beforeEach(() => setDemoModeForTest(false));


### PR DESCRIPTION
Follow-up to #1717: the targeted mutation runs over the files that PR touched surfaced survivors in `demo/samples.ts` and `logger.ts` after the PR had already entered the merge queue (the branch was locked, so these land as a fresh PR per the merged-branch rule).

## What this closes

**Demo sample pools** — every `→ ""` string mutant in `src/shared/demo/samples.ts` survived because nothing asserted pool shape (membership checks can't deterministically catch one blanked entry behind `randomChoice`). A blank sample matters: `applyDemoOverrides` only replaces fields that arrive non-empty, so an empty sample would silently erase real submitted data. The new test in `test/shared/demo.test.ts` walks **every exported pool** (current and future) and asserts each is non-empty with no empty entries.

**Logger error-code table** — the `E_* → ""` mutants in `src/shared/logger.ts` survived for the same reason. Codes are persisted into the activity log, so a blanked or duplicated code corrupts every logged error's identity. The new test in `test/lib/logger/log-error.test.ts` asserts every `ErrorCode` value is `E_`-prefixed, unique, and has a non-empty `errorCodeLabel`.

**Recorded equivalents** (with proofs in `scripts/mutation/equivalent-mutants.txt`):
- `logger.ts:314:27 = → +=` — the persist-guard flag is always `false` at that line (the guard early-returns otherwise), `false + true === 1`, and the flag is only ever read for truthiness.
- `logger.ts:321:69 ?? → ||` — `context.listingId` is `number | undefined` and listing ids are positive autoincrement integers, so the LHS is never a falsy non-null value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AknEXnHn3eAcsfYmk6w3p

---
_Generated by [Claude Code](https://claude.ai/code/session_015AknEXnHn3eAcsfYmk6w3p)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure error codes are uniquely named and consistently labeled.
  * Added checks confirming demo sample collections are populated and contain no blank entries.
  * Improved automated coverage for logging and demonstration data integrity.

* **Documentation**
  * Recorded additional proven-equivalent mutation cases to improve mutation testing accuracy and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->