### PR TITLE
Restrict opencode action to new issues only

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,10 +1,6 @@
 name: opencode
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened]
 
@@ -22,51 +18,18 @@ jobs:
         with:
           script: |
             const OPEN_CODE_COMMAND = /(^|\s)\/(?:oc|opencode)(?=\s|$)/;
-            const commentBody =
-              context.payload.comment?.body ??
-              context.payload.issue?.body ??
-              "";
+            const issueBody = context.payload.issue?.body ?? "";
 
-            if (!OPEN_CODE_COMMAND.test(commentBody)) {
+            if (!OPEN_CODE_COMMAND.test(issueBody)) {
               core.info("No OpenCode command mention found.");
               core.setOutput("should_run", "false");
               return;
             }
 
             const trustedAuthors = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
-            const authorAssociation =
-              context.payload.comment?.author_association ??
-              context.payload.issue?.author_association;
+            const authorAssociation = context.payload.issue?.author_association;
             if (!trustedAuthors.has(authorAssociation)) {
               core.info(`Ignoring OpenCode command from ${authorAssociation ?? "unknown"} author.`);
-              core.setOutput("should_run", "false");
-              return;
-            }
-
-            const pullNumber = context.payload.issue?.pull_request
-              ? context.payload.issue.number
-              : context.payload.pull_request?.number;
-
-            if (pullNumber) {
-              const { data: pull } = await github.rest.pulls.get({
-                ...context.repo,
-                pull_number: pullNumber,
-              });
-              const sameRepository =
-                pull.head.repo?.full_name === pull.base.repo?.full_name;
-
-              if (!sameRepository) {
-                core.info("OpenCode commands do not run on fork pull requests.");
-                core.setOutput("should_run", "false");
-                return;
-              }
-
-              core.setOutput("should_run", "true");
-              return;
-            }
-
-            if (!context.payload.issue?.number) {
-              core.info("OpenCode commands only run on issues or pull requests.");
               core.setOutput("should_run", "false");
               return;
             }

--- a/test/lib/opencode-workflow.test.ts
+++ b/test/lib/opencode-workflow.test.ts
@@ -7,16 +7,9 @@ const GATE_SCRIPT_MARKER = "          script: |\n";
 const GATE_SCRIPT_INDENT = "            ";
 
 type GatePayload = {
-  comment?: {
+  issue?: {
     author_association?: string;
     body?: string;
-  };
-  issue?: {
-    number?: number;
-    pull_request?: unknown;
-  };
-  pull_request?: {
-    number?: number;
   };
 };
 
@@ -29,29 +22,6 @@ type GateContext = {
   };
 };
 
-type PullCheck = {
-  owner: string;
-  pull_number: number;
-  repo: string;
-};
-
-type Pull = {
-  base: {
-    repo?: { full_name?: string } | null;
-  };
-  head: {
-    repo?: { full_name?: string } | null;
-  };
-};
-
-type GateGithub = {
-  rest: {
-    pulls: {
-      get: (check: PullCheck) => Promise<{ data: Pull }>;
-    };
-  };
-};
-
 type GateCore = {
   info: (message: string) => void;
   setOutput: (name: string, value: string) => void;
@@ -59,7 +29,7 @@ type GateCore = {
 
 type GateFunction = (
   context: GateContext,
-  github: GateGithub,
+  github: unknown,
   core: GateCore,
 ) => Promise<void>;
 
@@ -93,18 +63,8 @@ const gateScriptFrom = (workflow: string): string => {
     .join("\n");
 };
 
-const sameRepositoryPull: Pull = {
-  base: { repo: { full_name: "chobbledotcom/tickets" } },
-  head: { repo: { full_name: "chobbledotcom/tickets" } },
-};
-
-const runGate = async (
-  payload: GatePayload,
-  eventName = "issue_comment",
-  pull = sameRepositoryPull,
-) => {
+const runGate = async (payload: GatePayload, eventName = "issues") => {
   const outputs = new Map<string, string>();
-  const pullNumbers: number[] = [];
   const script = gateScriptFrom(await readWorkflow());
   const gate = new AsyncFunction("context", "github", "core", script);
   const context: GateContext = {
@@ -112,31 +72,20 @@ const runGate = async (
     payload,
     repo: { owner: "chobbledotcom", repo: "tickets" },
   };
-  const github: GateGithub = {
-    rest: {
-      pulls: {
-        get: (check) => {
-          pullNumbers.push(check.pull_number);
-          return Promise.resolve({ data: pull });
-        },
-      },
-    },
-  };
   const core: GateCore = {
     info: () => undefined,
     setOutput: (name, value) => outputs.set(name, value),
   };
 
-  await gate(context, github, core);
+  await gate(context, {}, core);
 
   return {
-    pullNumbers,
     shouldRun: outputs.get("should_run") === "true",
   };
 };
 
 describe("OpenCode workflow", () => {
-  test("grants the token scopes needed before checkout and PR checks", async () => {
+  test("grants the token scopes needed before checkout", async () => {
     const workflow = await readWorkflow();
 
     expect(workflow).toContain("contents: read");
@@ -144,14 +93,19 @@ describe("OpenCode workflow", () => {
     expect(workflow).toContain("pull-requests: read");
   });
 
-  test("checks the command token and same-repository PR before using secrets", async () => {
+  test("only triggers on newly opened issues", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toContain("issues:\n    types: [opened]");
+    expect(workflow).not.toContain("issue_comment:");
+    expect(workflow).not.toContain("pull_request_review_comment:");
+  });
+
+  test("checks the command token before using secrets", async () => {
     const workflow = await readWorkflow();
 
     expect(workflow).not.toContain("contains(github.event.comment.body");
     expect(workflow).toContain("OPEN_CODE_COMMAND");
-    expect(workflow).toContain("github.rest.pulls.get");
-    expect(workflow).toContain("pull.head.repo?.full_name");
-    expect(workflow).toContain("pull.base.repo?.full_name");
     expect(workflow).toContain("steps.gate.outputs.should_run == 'true'");
 
     const gatePosition = positionOf(workflow, "name: Check OpenCode request");
@@ -164,30 +118,48 @@ describe("OpenCode workflow", () => {
     expect(gatePosition).toBeLessThan(keyPosition);
   });
 
-  test("runs when a trusted PR comment mentions OpenCode inline", async () => {
+  test("runs when a trusted issue mentions OpenCode inline", async () => {
     const result = await runGate({
-      comment: {
+      issue: {
         author_association: "OWNER",
-        body: "Delete the stale branch /oc",
+        body: "Please investigate this bug /oc",
       },
-      issue: { number: 42, pull_request: {} },
     });
 
     expect(result.shouldRun).toBe(true);
-    expect(result.pullNumbers).toEqual([42]);
   });
 
-  test("runs for trusted OpenCode comments on normal issues", async () => {
+  test("runs for trusted issues opening with the OpenCode command", async () => {
     const result = await runGate({
-      comment: {
+      issue: {
         author_association: "MEMBER",
         body: "/opencode summarize the problem",
       },
-      issue: { number: 84 },
     });
 
     expect(result.shouldRun).toBe(true);
-    expect(result.pullNumbers).toEqual([]);
+  });
+
+  test("ignores issues without the OpenCode command", async () => {
+    const result = await runGate({
+      issue: {
+        author_association: "OWNER",
+        body: "Just a regular issue with no command",
+      },
+    });
+
+    expect(result.shouldRun).toBe(false);
+  });
+
+  test("ignores the OpenCode command from untrusted authors", async () => {
+    const result = await runGate({
+      issue: {
+        author_association: "NONE",
+        body: "/oc do something",
+      },
+    });
+
+    expect(result.shouldRun).toBe(false);
   });
 
   test("pins actions and the OpenCode binary to immutable commits and releases", async () => {


### PR DESCRIPTION
## What

Limits the `opencode` GitHub Action so it only runs when a **new issue is opened**, and no longer on issue comments or pull request review comments.

## Changes

- Removed the `issue_comment` and `pull_request_review_comment` triggers from the `on:` block, leaving only `issues: [opened]`.
- Simplified the gate script accordingly: since only the issue-opened event can now fire, the dead comment/pull-request code paths (including the fork check) were removed. The gate still requires the `/oc` (or `/opencode`) command in the issue body and a trusted author association (`OWNER`, `MEMBER`, `COLLABORATOR`).

## Behavior

Opening a new issue that contains `/oc` or `/opencode` from a trusted author still triggers the workflow. Comments on issues or PRs no longer trigger it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1YsvwXuWUWfZ1MbSTWeoG)_