### PR TITLE
Close the demo-override and logger mutation gates, drop magic test floors

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -843,3 +843,4 @@ src/features/admin/index.ts:299:55  return null → return undefined   # routeAd
 # logger suites.
 src/shared/logger.ts:314:27  = → +=   # errorPersistGuard.active is always false at this line (the guard early-returns otherwise), and false + true === 1 — read only for truthiness, exactly like true; the finally still resets it to false
 src/shared/logger.ts:321:69  ?? → ||   # context.listingId is number|undefined and listing ids are positive autoincrement integers, so the LHS is never a falsy non-null value — ?? and || agree on every input
+src/shared/logger.ts:77:70  ?? → ||   # getRequestId's `getStore() ?? ""`: the RHS is "" and the only falsy string is "", so `x ?? ""` and `x || ""` agree on every string|undefined input

--- a/test/lib/logger/log-error.test.ts
+++ b/test/lib/logger/log-error.test.ts
@@ -26,7 +26,7 @@ describe("error code table", () => {
   // a blanked or duplicated code would corrupt every logged error's identity.
   test("every code is E_-prefixed, unique, and labelled", () => {
     const codes = Object.values(ErrorCode);
-    expect(codes.length).toBeGreaterThan(20);
+    expect(codes.length).toBeGreaterThan(0);
     expect(new Set(codes).size).toBe(codes.length);
     for (const code of codes) {
       expect(code).toMatch(/^E_[A-Z_]+$/);

--- a/test/lib/logger/log-output.test.ts
+++ b/test/lib/logger/log-output.test.ts
@@ -100,6 +100,19 @@ describe("logDebug", () => {
     expect(debugSpy.calls.length).toBe(0);
   });
 
+  test("falls back to the TEST_SUPPRESS_DEBUG_LOGS env var when no override is set", () => {
+    const previous = Deno.env.get("TEST_SUPPRESS_DEBUG_LOGS");
+    setSuppressDebugLogs(null);
+    Deno.env.set("TEST_SUPPRESS_DEBUG_LOGS", "1");
+    try {
+      logDebug("Migration", "Step 1");
+      expect(debugSpy.calls.length).toBe(0);
+    } finally {
+      if (previous === undefined) Deno.env.delete("TEST_SUPPRESS_DEBUG_LOGS");
+      else Deno.env.set("TEST_SUPPRESS_DEBUG_LOGS", previous);
+    }
+  });
+
   test("emits output when setSuppressDebugLogs(false)", () => {
     logDebug("Migration", "Step 1");
     expect(debugSpy.calls.length).toBe(1);

--- a/test/lib/logger/request-id.test.ts
+++ b/test/lib/logger/request-id.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, it as test } from "@std/testing/bdd";
-import { spy } from "@std/testing/mock";
+import { spy, stub } from "@std/testing/mock";
 import {
   ErrorCode,
   getRequestId,
@@ -25,6 +25,23 @@ describeWithEnv("runWithRequestId", { env: { NTFY_URL: undefined } }, () => {
     runWithRequestId(() => {
       expect(getRequestId()).toMatch(/^[0-9a-f]{4}$/);
     });
+  });
+
+  test("pads a small random value to exactly four hex chars", () => {
+    // A zeroed buffer forces the shortest possible hex ("0"), so the id is
+    // all padding — the case a lucky random draw would never pin down.
+    const zeroed = stub(
+      crypto,
+      "getRandomValues",
+      <T extends ArrayBufferView | null>(array: T): T => array,
+    );
+    try {
+      runWithRequestId(() => {
+        expect(getRequestId()).toBe("0000");
+      });
+    } finally {
+      zeroed.restore();
+    }
   });
 
   test("getRequestId returns empty string outside request context", () => {

--- a/test/shared/demo.test.ts
+++ b/test/shared/demo.test.ts
@@ -48,7 +48,7 @@ describe("demo sample pools", () => {
     const pools = Object.entries(demoSamples).filter(
       (entry): entry is [string, readonly string[]] => Array.isArray(entry[1]),
     );
-    expect(pools.length).toBeGreaterThan(10);
+    expect(pools.length).toBeGreaterThan(0);
     for (const [name, pool] of pools) {
       expect(pool.length, name).toBeGreaterThan(0);
       for (const value of pool) {

--- a/test/shared/demo.test.ts
+++ b/test/shared/demo.test.ts
@@ -18,6 +18,7 @@ import {
   applyDemoOverrides,
   type DemoFieldMap,
   LISTING_DEMO_FIELDS,
+  LOGISTICS_DEMO_FIELDS,
   wrapResourceForDemo,
 } from "#shared/demo/overrides.ts";
 import * as demoSamples from "#shared/demo/samples.ts";
@@ -122,6 +123,19 @@ describe("applyDemoOverrides", () => {
     expect(DEMO_NAMES as readonly string[]).toContain(form.get("name"));
     expect(form.get("email")).not.toBe("real@example.com");
     expect(DEMO_EMAILS as readonly string[]).toContain(form.get("email"));
+  });
+
+  test("clears pinned coordinates outright instead of substituting text", () => {
+    setDemoModeForTest(true);
+    const form = new FormParams({
+      address: "10 Real Street",
+      lat: "51.5074",
+      lng: "-0.1278",
+    });
+    applyDemoOverrides(form, LOGISTICS_DEMO_FIELDS);
+    expect(form.get("lat")).toBe("");
+    expect(form.get("lng")).toBe("");
+    expect(form.get("address")).not.toBe("10 Real Street");
   });
 
   test("skips fields not present in the form", () => {


### PR DESCRIPTION
Final follow-up in the #1717 → #1722 series. #1722 entered the merge queue while its review round and the next mutation pass were still in flight, so these three commits — written against that branch while it was queue-locked — land here.

## What's included

**Review fixes promised on #1722's threads** — the magic size floors (`> 20` codes, `> 10` pools) are now `> 0`: the floor's only job is to catch the discovery step finding nothing (a vacuous pass if the pools stopped being arrays), not to freeze the table size.

**Demo override gate closed** — the last two demo survivors were the deliberately-empty `lat`/`lng` samples in `LOGISTICS_DEMO_FIELDS` mutating into junk text. A new test pins that demo mode *clears* pinned coordinates rather than substituting text — an exact location is PII even beside a masked address.

**Logger gate closed** — the next survivor layer after #1722's error-code test:
- The `TEST_SUPPRESS_DEBUG_LOGS` env fallback had no test (only the explicit override did); one now asserts the fallback suppresses output.
- The request-id `padStart(4, "0")` was only regex-checked, which kills padding mutants just 1-in-16 random draws; the new test zeroes the random buffer so the id is *all* padding (`"0000"`), a deterministic kill.
- `getRequestId`'s `?? → ||` mutant is recorded as equivalent in `scripts/mutation/equivalent-mutants.txt` — the fallback is the empty string itself, the only falsy string.

With these, the targeted gates over the files the series touched all report 100%: dates (274/274), admin dispatcher (71/71, 2 recorded equivalents), demo modules and logger (verification re-run in CI by the standard mutation step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AknEXnHn3eAcsfYmk6w3p

---
_Generated by [Claude Code](https://claude.ai/code/session_015AknEXnHn3eAcsfYmk6w3p)_