### PR TITLE
Lay out the listing attributes tab's options as checkbox rows

### DIFF
--- a/src/ui/templates/admin/attributes.tsx
+++ b/src/ui/templates/admin/attributes.tsx
@@ -384,6 +384,10 @@ export const ListingAttributesPanel = (
                   />
                 ))
               ),
+            // The row-based checkbox layout the logistics tab's user selector
+            // uses, so an attribute's options flow as a wrapping row under its
+            // legend instead of stacking one per line.
+            className: "checkboxes listing-section",
             legend: attribute.name,
           }))}
         />

--- a/test/lib/server-attribute-detail.test.ts
+++ b/test/lib/server-attribute-detail.test.ts
@@ -56,6 +56,10 @@ describeWithEnv("server (admin attribute detail pages)", { db: true }, () => {
       // Easy is set on one listing; Hard on none.
       expect(html).toContain('<td class="col-quantity">1</td>');
       expect(html).toContain('<td class="col-quantity">0</td>');
+      // The attribute's own delete action stays on its detail page.
+      expect(html).toContain(
+        `<a class="danger" href="/admin/attributes/${attribute.id}/delete">`,
+      );
     });
 
     test("lists each listing using the attribute with its selected options", async () => {

--- a/test/lib/server-attributes.test.ts
+++ b/test/lib/server-attributes.test.ts
@@ -357,6 +357,8 @@ describeWithEnv("server (admin attributes)", { db: true }, () => {
           attribute.options[1]!.id
         }"`,
       );
+      // Each attribute's options render as a row-based checkbox fieldset.
+      expect(html).toContain('<fieldset class="checkboxes listing-section">');
     });
 
     test("shows attributes that do not have options yet", async () => {


### PR DESCRIPTION
## What changed

On `/admin/listing/:id/attributes`, each attribute's option checkboxes now render in a `"checkboxes listing-section"` fieldset — the shared row-based layout the logistics tab already uses for its user selector — so options flow as a wrapping row under the attribute's legend instead of stacking one per line.

## Tests

- The listing attributes tab test now asserts the fieldset carries the row-based class, and the attribute detail test gained an assertion for the page's delete link.
- Full precommit and the branch mutation gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017a8hmUPw31VFt3MpuRL11x

---
_Generated by [Claude Code](https://claude.ai/code/session_017a8hmUPw31VFt3MpuRL11x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated attribute option checkboxes in the admin interface to display in a row-based layout beneath the attribute legend, improving readability and selection.

* **Tests**
  * Added coverage confirming the attribute delete action remains available on the detail page.
  * Added validation that attribute options render in the updated checkbox fieldset layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->