### PR TITLE
Harden expected-actual.tsx tests to 100% mutation kill rate

### DIFF
--- a/test/ui/templates/admin/expected-actual.test.tsx
+++ b/test/ui/templates/admin/expected-actual.test.tsx
@@ -70,8 +70,12 @@ test("ExpectedActualNotice appends the pluralised extra count for many items", (
   expect(html).toContain("(+2 more)");
   expect(html).not.toContain("(+3 more)");
   expect(html).not.toContain("(+1 more)");
-  // Only the first item drives the summary line.
-  expect(html).toContain("<strong>Total</strong>: expected");
+  // Only the first item drives the summary line, so scope the check to the
+  // <summary> to make sure a later item can't satisfy it.
+  const summary = html.match(/<summary>[\s\S]*?<\/summary>/)?.[0];
+  expect(summary).toContain("<strong>Total</strong>: expected");
+  expect(summary).not.toContain("<strong>Subtotal</strong>");
+  expect(summary).not.toContain("<strong>Tax</strong>");
   // The full list renders every item, spacing between the labels and values
   // included.
   expect(html.match(/<li>/g)?.length).toBe(3);

--- a/test/ui/templates/admin/expected-actual.test.tsx
+++ b/test/ui/templates/admin/expected-actual.test.tsx
@@ -1,15 +1,162 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { ExpectedActualNotice } from "#templates/admin/expected-actual.tsx";
+import {
+  type ExpectedActualItem,
+  ExpectedActualNotice,
+  ExpectedActualTableRow,
+  hasExpectedActualMismatches,
+} from "#templates/admin/expected-actual.tsx";
 
-test("ExpectedActualNotice uses the default title when none is provided", () => {
+const item = (over: Partial<ExpectedActualItem> = {}): ExpectedActualItem => ({
+  actual: "4",
+  expected: "3",
+  label: "Total",
+  ...over,
+});
+
+test("hasExpectedActualMismatches is false only for an empty list", () => {
+  expect(hasExpectedActualMismatches([])).toBe(false);
+  expect(hasExpectedActualMismatches([item()])).toBe(true);
+  expect(hasExpectedActualMismatches([item(), item()])).toBe(true);
+});
+
+test("ExpectedActualNotice returns null when there are no items", () => {
+  expect(ExpectedActualNotice({ explanation: "explanation", items: [] })).toBe(
+    null,
+  );
+});
+
+test("ExpectedActualNotice renders the wrapper, badge and first item", () => {
   const html = ExpectedActualNotice({
     explanation: "The stored value does not match the expected value.",
-    items: [{ actual: "4", expected: "3", label: "Total" }],
+    items: [item({ actual: "4", expected: "3", label: "Total" })],
   })!.toString();
 
+  expect(html).toContain('class="expected-actual-notice"');
+  expect(html).toContain('role="alert"');
+  expect(html).toContain('class="badge-alert"');
+  // Default badge label and title come from i18n.
+  expect(html).toContain(">Mismatch</span>");
   expect(html).toContain("Stored total mismatch");
-  expect(html).toContain("expected <strong>3</strong>, got");
-  expect(html).toContain("Mismatch");
-  expect(html).not.toContain("Click for info.");
+  // Summary spells out the first item with the surrounding spacing preserved.
+  expect(html).toContain(
+    "<strong>Total</strong>: expected <strong>3</strong>, got <strong>4</strong>.",
+  );
+  expect(html).toContain("The stored value does not match the expected value.");
+});
+
+test("ExpectedActualNotice omits the extra summary text for a single item", () => {
+  const html = ExpectedActualNotice({
+    explanation: "explanation",
+    items: [item()],
+  })!.toString();
+
+  expect(html).not.toContain("more)");
+  // Single item: exactly one list entry.
+  expect(html.match(/<li>/g)?.length).toBe(1);
+});
+
+test("ExpectedActualNotice appends the pluralised extra count for many items", () => {
+  const html = ExpectedActualNotice({
+    explanation: "explanation",
+    items: [
+      item({ label: "Total" }),
+      item({ label: "Subtotal" }),
+      item({ label: "Tax" }),
+    ],
+  })!.toString();
+
+  // count = items.length - 1 = 2 → "(+2 more)".
+  expect(html).toContain("(+2 more)");
+  expect(html).not.toContain("(+3 more)");
+  expect(html).not.toContain("(+1 more)");
+  // Only the first item drives the summary line.
+  expect(html).toContain("<strong>Total</strong>: expected");
+  // The full list renders every item, spacing between the labels and values
+  // included.
+  expect(html.match(/<li>/g)?.length).toBe(3);
+  expect(html).toContain(
+    "<strong>Subtotal</strong>: expected <strong>3</strong>, got <strong>4</strong>",
+  );
+  expect(html).toContain(
+    "<strong>Tax</strong>: expected <strong>3</strong>, got <strong>4</strong>",
+  );
+});
+
+test("ExpectedActualNotice honours explicit badge and title overrides", () => {
+  const html = ExpectedActualNotice({
+    badgeLabel: "Custom badge",
+    explanation: "explanation",
+    items: [item()],
+    title: "Custom title",
+  })!.toString();
+
+  expect(html).toContain(">Custom badge</span>");
+  expect(html).toContain("Custom title");
+  expect(html).not.toContain("Mismatch");
+  expect(html).not.toContain("Stored total mismatch");
+});
+
+test("ExpectedActualNotice keeps empty-string overrides instead of the defaults", () => {
+  const html = ExpectedActualNotice({
+    badgeLabel: "",
+    explanation: "explanation",
+    items: [item()],
+    title: "",
+  })!.toString();
+
+  // `??` keeps the empty strings; `||` would fall back to the i18n defaults.
+  expect(html).not.toContain("Mismatch");
+  expect(html).not.toContain("Stored total mismatch");
+});
+
+test("ExpectedActualNotice renders the action link only when both parts are set", () => {
+  const withLink = ExpectedActualNotice({
+    actionHref: "/fix",
+    actionLabel: "Fix it",
+    explanation: "explanation",
+    items: [item()],
+  })!.toString();
+  expect(withLink).toContain('<a href="/fix">Fix it</a>');
+
+  const hrefOnly = ExpectedActualNotice({
+    actionHref: "/fix",
+    explanation: "explanation",
+    items: [item()],
+  })!.toString();
+  expect(hrefOnly).not.toContain("<a href=");
+
+  const labelOnly = ExpectedActualNotice({
+    actionLabel: "Fix it",
+    explanation: "explanation",
+    items: [item()],
+  })!.toString();
+  expect(labelOnly).not.toContain("<a href=");
+
+  const neither = ExpectedActualNotice({
+    explanation: "explanation",
+    items: [item()],
+  })!.toString();
+  expect(neither).not.toContain("<a href=");
+});
+
+test("ExpectedActualTableRow returns null when there are no mismatches", () => {
+  expect(
+    ExpectedActualTableRow({
+      header: "Header",
+      notice: { explanation: "explanation", items: [] },
+    }),
+  ).toBe(null);
+});
+
+test("ExpectedActualTableRow wraps the notice in a table row when there are mismatches", () => {
+  const html = ExpectedActualTableRow({
+    header: "Order total",
+    notice: { explanation: "explanation", items: [item()] },
+  })!.toString();
+
+  expect(html).toContain("<tr>");
+  expect(html).toContain("<th>Order total</th>");
+  expect(html).toContain("<td>");
+  expect(html).toContain('class="expected-actual-notice"');
 });

--- a/test/ui/templates/admin/expected-actual.test.tsx
+++ b/test/ui/templates/admin/expected-actual.test.tsx
@@ -110,6 +110,9 @@ test("ExpectedActualNotice keeps empty-string overrides instead of the defaults"
   })!.toString();
 
   // `??` keeps the empty strings; `||` would fall back to the i18n defaults.
+  // Assert the overrides are rendered as empty elements, not merely omitted.
+  expect(html).toContain('<span class="badge-alert"></span>');
+  expect(html).toContain("<div><p></p><p>explanation</p>");
   expect(html).not.toContain("Mismatch");
   expect(html).not.toContain("Stored total mismatch");
 });
@@ -159,8 +162,9 @@ test("ExpectedActualTableRow wraps the notice in a table row when there are mism
     notice: { explanation: "explanation", items: [item()] },
   })!.toString();
 
-  expect(html).toContain("<tr>");
-  expect(html).toContain("<th>Order total</th>");
-  expect(html).toContain("<td>");
-  expect(html).toContain('class="expected-actual-notice"');
+  // Verify the notice is nested inside the same row and cell as the header,
+  // not merely present somewhere in the output.
+  expect(html).toMatch(
+    /^<tr><th>Order total<\/th><td><details class="expected-actual-notice"[\s\S]*<\/details><\/td><\/tr>$/,
+  );
 });


### PR DESCRIPTION
## What

`src/ui/templates/admin/expected-actual.tsx` was the thinnest-tested source file per `deno task unit-tests-report` (a 6.08 src:test line ratio). Running the mutation suite over it confirmed the weakness:

```
deno task mutation 'src/ui/templates/admin/expected-actual.tsx' \
                    'test/ui/templates/admin/expected-actual.test.tsx'
```

**Before:** score 33.3% — 22 of 33 mutants survived. Two of the three exports (`hasExpectedActualMismatches`, `ExpectedActualTableRow`) had no coverage at all, and every conditional branch of `ExpectedActualNotice` was unexercised.

## Changes

Expanded `test/ui/templates/admin/expected-actual.test.tsx` to cover:

- `hasExpectedActualMismatches` — empty vs non-empty.
- Both null-returning guards (`ExpectedActualNotice` with no items, `ExpectedActualTableRow` with no mismatches), asserted as strict `null`.
- Single- vs multi-item summary text and the pluralised `(+N more)` count.
- `badgeLabel` / `title` overrides, including empty-string overrides vs the i18n default fallback (`??` vs `||`).
- The action-link render conditions (both parts set, each part alone, neither).
- `ExpectedActualTableRow` wrapping the notice in a `<tr>`.

Assertions pin the exact rendered spacing so whitespace mutants are caught too.

**After:** score 100% — all 33 mutants killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for expected-versus-actual mismatch logic and UI rendering.
  * Added assertions for empty states, single vs. multiple mismatch summaries, pluralization behavior, and default vs. overridden badge/title handling (including preservation of empty-string overrides).
  * Validates action link rendering only when both action label and href are provided.
  * Added table-row checks for correct structure (including nested notice content) and null output when there are no mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->