### PR TITLE
Enable useConsistentArrayType biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -66,6 +66,12 @@
       "style": {
         "noNonNullAssertion": "off",
         "noUnusedTemplateLiteral": "error",
+        "useConsistentArrayType": {
+          "level": "error",
+          "options": {
+            "syntax": "shorthand"
+          }
+        },
         "useConst": "error",
         "useTemplate": "error"
       },
@@ -151,9 +157,7 @@
       }
     },
     {
-      "includes": [
-        "src/shared/db/migrations/schema.ts"
-      ],
+      "includes": ["src/shared/db/migrations/schema.ts"],
       "linter": {
         "rules": {
           "nursery": {

--- a/src/features/admin/attendees-merge.ts
+++ b/src/features/admin/attendees-merge.ts
@@ -225,7 +225,7 @@ const updateTargetPiiFromDecision = async (
 };
 
 /** Build labeled count strings from summary fields, omitting zero-count entries */
-const mergeCountParts = (fields: Array<[number, string]>): string[] =>
+const mergeCountParts = (fields: [number, string][]): string[] =>
   pipe(
     filter(([count]: [number, string]) => count > 0),
     map(([count, label]) => `${count} ${label}`),
@@ -233,7 +233,7 @@ const mergeCountParts = (fields: Array<[number, string]>): string[] =>
 
 /** The booking-movement counts every merge message leads with, before each
  *  surface adds its own (the log is fuller; the flash is a short confirmation). */
-const bookingMoveParts = (summary: MergeSummary): Array<[number, string]> => [
+const bookingMoveParts = (summary: MergeSummary): [number, string][] => [
   [summary.bookingsMoved, "booking(s) moved"],
   [summary.bookingsSkipped, "booking(s) skipped"],
 ];

--- a/src/shared/accounting/mappers.ts
+++ b/src/shared/accounting/mappers.ts
@@ -219,7 +219,7 @@ export const mapBooking = async (
  * `postedBy` is the actor (an admin id or "system").
  */
 export type RefundFacts = {
-  readonly orderLegs: ReadonlyArray<Transfer>;
+  readonly orderLegs: readonly Transfer[];
   readonly occurredAt: string;
   readonly postedBy?: string;
   /** Optional PII-free reason code stamped on every refund leg (e.g. why an

--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -127,7 +127,7 @@ export type DependsOnEntry =
  */
 export const registerDependencies = (
   ownTable: string,
-  deps: ReadonlyArray<DependsOnEntry>,
+  deps: readonly DependsOnEntry[],
   invalidate: () => void,
 ): void => {
   registerTableInvalidation([ownTable], invalidate);

--- a/src/shared/db/common-schema.ts
+++ b/src/shared/db/common-schema.ts
@@ -35,7 +35,7 @@ export const cachedEntityTable = <Row, Input, Cached = Row>(
   name: string,
   table: Table<Row, Input>,
   config: KeyedCacheConfig<Cached>,
-  dependsOn: ReadonlyArray<DependsOnEntry> = [],
+  dependsOn: readonly DependsOnEntry[] = [],
 ): { cache: KeyedCache<Cached>; table: Table<Row, Input> } => {
   const cache = createKeyedCache(config);
   registerCache(() => ({ entries: cache.size(), name }));

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -433,7 +433,7 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
   table: Table<Row, Input>;
   /** Extra tables (beyond the table itself) whose writes should clear it.
    * Entries may carry `whenColumns` to gate on specific UPDATE columns. */
-  dependsOn?: ReadonlyArray<DependsOnEntry>;
+  dependsOn?: readonly DependsOnEntry[];
 }): {
   getAll: () => Promise<Cached[]>;
   invalidate: () => void;
@@ -464,7 +464,7 @@ export const defineCachedListTable = <Row, Input>(
   config: TableDefinition<Row> & {
     /** ORDER BY clause without the keyword, e.g. `"start_date ASC"`. */
     orderBy: string;
-    dependsOn?: ReadonlyArray<DependsOnEntry>;
+    dependsOn?: readonly DependsOnEntry[];
   },
 ) => {
   const table = defineTable<Row, Input>(config);

--- a/src/shared/google-wallet.ts
+++ b/src/shared/google-wallet.ts
@@ -111,7 +111,7 @@ export const buildListingTicketObject = (
   data: WalletPassData,
   creds: GoogleWalletCredentials,
 ): Record<string, unknown> => {
-  const textModules: Array<Record<string, unknown>> = [];
+  const textModules: Record<string, unknown>[] = [];
 
   if (data.attendeeDate) {
     textModules.push({

--- a/src/shared/images/transcode.ts
+++ b/src/shared/images/transcode.ts
@@ -19,7 +19,7 @@ import type { DecodableMime, ImageTarget } from "./types.ts";
 export const transcodeToWebp = async (
   data: Uint8Array,
   mime: DecodableMime,
-  targets: ReadonlyArray<ImageTarget>,
+  targets: readonly ImageTarget[],
 ): Promise<Uint8Array[]> => {
   const decoded = await decodeImage(data, mime);
   const variants: Uint8Array[] = [];

--- a/src/shared/largest-remainder.ts
+++ b/src/shared/largest-remainder.ts
@@ -8,11 +8,11 @@ type LargestRemainderAllocationOptions = {
   tieBreaker?: (index: number) => number;
 };
 
-const sumNumbers = (values: ReadonlyArray<number>): number =>
+const sumNumbers = (values: readonly number[]): number =>
   values.reduce((total, value) => total + value, 0);
 
 const largestRemainderIndexes = (
-  shares: ReadonlyArray<number>,
+  shares: readonly number[],
   count: number,
   options: LargestRemainderOptions = {},
 ): Set<number> => {
@@ -33,7 +33,7 @@ const largestRemainderIndexes = (
 };
 
 export const largestRemainderAllocation = (
-  weights: ReadonlyArray<number>,
+  weights: readonly number[],
   amount: number,
   options: LargestRemainderAllocationOptions = {},
 ): number[] => {

--- a/src/shared/reservation-amount.ts
+++ b/src/shared/reservation-amount.ts
@@ -143,7 +143,7 @@ type AllocationUnit = {
  */
 export const allocateReservationDeposit = (
   raw: string,
-  items: ReadonlyArray<ReservationAllocationItem>,
+  items: readonly ReservationAllocationItem[],
 ): ReservationDepositAllocation => {
   const perItemTotals = Array.from({ length: items.length }, () => 0);
   const units: AllocationUnit[] = items.flatMap((item, itemIndex) =>

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -241,7 +241,7 @@ export const deleteListingAttachmentFile = async (
 
 /** Delete all attachment files for a list of listings */
 export const deleteAllListingAttachmentFiles = async (
-  listings: ReadonlyArray<ListingWithAttachmentStorage>,
+  listings: readonly ListingWithAttachmentStorage[],
 ): Promise<void> => {
   for (const listing of listings) {
     await deleteListingAttachmentFile(listing, "database reset");
@@ -286,7 +286,7 @@ export const deleteImageStorageFilesStrict = async (
 
 /** Delete all first-class image files. */
 export const deleteAllImageStorageFiles = async (
-  images: ReadonlyArray<ImageWithStorage>,
+  images: readonly ImageWithStorage[],
 ): Promise<void> => {
   for (const image of images) {
     await deleteImageStorageFiles(image, "database reset");
@@ -392,7 +392,7 @@ const encryptAndUpload = async (
 export const uploadImageTargets = async (
   data: Uint8Array,
   mime: DecodableMime,
-  targets: ReadonlyArray<ImageTarget>,
+  targets: readonly ImageTarget[],
 ): Promise<string[]> => {
   const { transcodeToWebp } = await import("#shared/images/transcode.ts");
   const variants = await transcodeToWebp(data, mime, targets);
@@ -602,7 +602,7 @@ export const listFilesWithMeta = async (
   // readDirSafe handles a missing directory. Other failures (401/403 bad
   // credentials, 5xx outages) must surface, not masquerade as an empty zone.
   if (response.status === 404) return [];
-  const items = (await response.json()) as Array<Record<string, unknown>>;
+  const items = (await response.json()) as Record<string, unknown>[];
   return byName(
     items
       // Bunny lists directories alongside files; keep only files so per-site

--- a/test/admin-api-groups.test.ts
+++ b/test/admin-api-groups.test.ts
@@ -564,7 +564,7 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
 
     test("PUT rejects malformed package members (bad id, price, or quantity)", async () => {
       const { group, listing } = await groupWithMember("BadMembers");
-      const cases: Array<[Record<string, unknown>, string]> = [
+      const cases: [Record<string, unknown>, string][] = [
         [{ listing_id: -1, price: 100 }, "listing_id"],
         [{ listing_id: listing.id, price: -5 }, "price"],
         [{ listing_id: listing.id, price: 100, quantity: 0 }, "quantity"],
@@ -714,7 +714,7 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
 
     test("PUT rejects malformed day_prices (shape, keys, and values)", async () => {
       const { group, listing } = await groupWithMember("BadDayPrices");
-      const cases: Array<Record<string, unknown>> = [
+      const cases: Record<string, unknown>[] = [
         { day_prices: [1500], listing_id: listing.id, price: null },
         { day_prices: { "0": 1500 }, listing_id: listing.id, price: null },
         { day_prices: { "2": -1 }, listing_id: listing.id, price: null },

--- a/test/admin-api-listings/input-parsers.test.ts
+++ b/test/admin-api-listings/input-parsers.test.ts
@@ -66,7 +66,7 @@ describeWithEnv("Admin API - Listings", { db: true }, () => {
     test("maps the use_defaults flag both ways and omits it when absent", async () => {
       // true/false both round-trip (so the API can opt in *and* out), and an
       // absent flag stays absent rather than defaulting to either value.
-      const cases: Array<[boolean | undefined, boolean | undefined]> = [
+      const cases: [boolean | undefined, boolean | undefined][] = [
         [true, true],
         [false, false],
         [undefined, undefined],

--- a/test/lib/db/attendees/apply-attendee-atomic-edit.test.ts
+++ b/test/lib/db/attendees/apply-attendee-atomic-edit.test.ts
@@ -93,7 +93,7 @@ const expectRejected = (
 
 /** Assert each listing currently has the expected number of attendee rows. */
 const expectRawCounts = async (
-  pairs: Array<[{ id: number }, number]>,
+  pairs: [{ id: number }, number][],
 ): Promise<void> => {
   for (const [listing, count] of pairs) {
     expect((await getAttendeesRaw(listing.id)).length).toBe(count);

--- a/test/lib/db/listing-aggregates.test.ts
+++ b/test/lib/db/listing-aggregates.test.ts
@@ -55,7 +55,7 @@ describe("tickets_count shared predicate guard", () => {
   // reference it, or the recalculate/repair flow would fight the triggers. This
   // asserts the shared predicate appears at every site (incl. both listings.ts
   // queries), so a future edit can't silently drop it from one of them.
-  const ticketCountSites: Array<[name: string, sql: string]> = [
+  const ticketCountSites: [name: string, sql: string][] = [
     ...TRIGGERS.filter((t) =>
       t.name.startsWith("trg_listing_attendees_aggregates_"),
     ).map((t): [string, string] => [t.name, t.sql]),

--- a/test/lib/server-editor.test.ts
+++ b/test/lib/server-editor.test.ts
@@ -65,7 +65,7 @@ describeWithEnv("server (editor role)", { db: true }, () => {
       const listing = await createTestListing();
       const group = await createTestGroup();
 
-      const allowed: Array<[string, string]> = [
+      const allowed: [string, string][] = [
         ["listings index", "/admin/listings"],
         ["new listing", "/admin/listing/new"],
         ["edit listing", `/admin/listing/${listing.id}/edit`],
@@ -113,7 +113,7 @@ describeWithEnv("server (editor role)", { db: true }, () => {
     test("editor renders every Site → Pages screen and can create; manager is 403", async () => {
       const { cookie } = await createTestEditorSession();
       const page = await createTestSitePage("role-matrix");
-      const screens: Array<[string, string]> = [
+      const screens: [string, string][] = [
         ["pages list", "/admin/site/pages"],
         ["new page", "/admin/site/pages/new"],
         ["edit page", `/admin/site/pages/${page.id}/edit`],
@@ -158,7 +158,7 @@ describeWithEnv("server (editor role)", { db: true }, () => {
       const listing = await createTestListing();
       const group = await createTestGroup();
 
-      const forbidden: Array<[string, string]> = [
+      const forbidden: [string, string][] = [
         ["attendee CSV", `/admin/listing/${listing.id}/attendees.csv`],
         ["listings CSV", "/admin/listings/csv"],
         ["attendees", "/admin/attendees"],

--- a/test/lib/server-instance.test.ts
+++ b/test/lib/server-instance.test.ts
@@ -38,7 +38,7 @@ const siteNames = async (response: Response): Promise<string[]> => {
 };
 
 /** One eligible site (script id + read-only creds) per update channel. */
-const TIERED_SITES: ReadonlyArray<[name: string, tier: UpdateTier]> = [
+const TIERED_SITES: readonly [name: string, tier: UpdateTier][] = [
   ["AlphaSite", "alpha"],
   ["BetaSite", "beta"],
   ["ReleaseSite", "release"],

--- a/test/lib/server-misc-routing.test.ts
+++ b/test/lib/server-misc-routing.test.ts
@@ -136,7 +136,7 @@ describeWithEnv("server (misc: security and routing)", { db: true }, () => {
         expect(match?.[1]).toBe(expected);
       };
 
-      const coreDirectives: Array<[string, string]> = [
+      const coreDirectives: [string, string][] = [
         ["default-src", "'self'"],
         // The Logistics map loads its tiles straight from OpenStreetMap.
         ["img-src", "'self' https://tile.openstreetmap.org"],

--- a/test/lib/servicing/capacity.test.ts
+++ b/test/lib/servicing/capacity.test.ts
@@ -46,9 +46,12 @@ describe("servicing §0 — capacity overlap predicate is half-open", () => {
   const day = "2026-06-24";
   const { startAt, endAt } = dateToRange(day);
 
-  const cases: Array<
-    [label: string, start: string, end: string, expected: boolean]
-  > = [
+  const cases: [
+    label: string,
+    start: string,
+    end: string,
+    expected: boolean,
+  ][] = [
     ["entire span is the day itself", startAt, endAt, true],
     [
       "a one-hour slice within the day",

--- a/test/lib/servicing/kind.test.ts
+++ b/test/lib/servicing/kind.test.ts
@@ -29,9 +29,11 @@ import {
 } from "#shared/db/attendees/kind.ts";
 
 describe("servicing §0 — kind guard helper classifies rows", () => {
-  const cases: Array<
-    [label: string, kind: string | null | undefined, expected: boolean]
-  > = [
+  const cases: [
+    label: string,
+    kind: string | null | undefined,
+    expected: boolean,
+  ][] = [
     ["attendee kind", ATTENDEE_KIND, false],
     ["servicing kind", SERVICING_KIND, true],
     ["null kind", null, false],
@@ -64,7 +66,7 @@ describe("servicing §0 — kind guard helper classifies rows", () => {
 });
 
 describe("servicing §0 — kind-aware ref link routing", () => {
-  const cases: Array<[label: string, kind: string, expectedPath: string]> = [
+  const cases: [label: string, kind: string, expectedPath: string][] = [
     ["servicing row", SERVICING_KIND, "/admin/servicing/42"],
     ["attendee row", ATTENDEE_KIND, "/admin/attendees/42"],
     ["unknown kind defaults to attendee route", "bogus", "/admin/attendees/42"],

--- a/test/shared/apple-wallet.test.ts
+++ b/test/shared/apple-wallet.test.ts
@@ -20,10 +20,10 @@ import { generateTestCerts } from "#test-utils/crypto.ts";
 
 /** Type for listingTicket field groups in pass.json */
 type TicketFields = {
-  primaryFields: Array<Record<string, unknown>>;
-  secondaryFields: Array<Record<string, unknown>>;
-  auxiliaryFields: Array<Record<string, unknown>>;
-  backFields: Array<Record<string, unknown>>;
+  primaryFields: Record<string, unknown>[];
+  secondaryFields: Record<string, unknown>[];
+  auxiliaryFields: Record<string, unknown>[];
+  backFields: Record<string, unknown>[];
 };
 
 const makePassData = (overrides: Partial<PassData> = {}): PassData => ({
@@ -61,7 +61,7 @@ describe("apple-wallet", () => {
       expect(pass.organizationName).toBe("Test Platform");
       expect(pass.description).toBe("Ticket for Summer Concert");
 
-      const barcodes = pass.barcodes as Array<Record<string, string>>;
+      const barcodes = pass.barcodes as Record<string, string>[];
       expect(barcodes).toHaveLength(1);
       expect(barcodes[0]!.format).toBe("PKBarcodeFormatQR");
       expect(barcodes[0]!.message).toBe("https://example.com/checkin/ABC123");

--- a/test/shared/db/migrations.test.ts
+++ b/test/shared/db/migrations.test.ts
@@ -35,7 +35,7 @@ import { stubNtfyFetch } from "#test-utils/mocks.ts";
 describeWithEnv("db > migrations", { db: true }, () => {
   describe("initDb version check", () => {
     const resultSet = (
-      rows: Array<Record<string, unknown>>,
+      rows: Record<string, unknown>[],
       rowsAffected = 0,
     ): ResultSet => ({
       columns: [],

--- a/test/shared/google-wallet.test.ts
+++ b/test/shared/google-wallet.test.ts
@@ -26,7 +26,7 @@ const makePassData = (
 });
 
 const findTextModule = (
-  obj: { textModulesData: Array<Record<string, string>> },
+  obj: { textModulesData: Record<string, string>[] },
   id: string,
 ): Record<string, string> =>
   obj.textModulesData.find((m) => m.id === id) as Record<string, string>;

--- a/test/shared/payment-signature.test.ts
+++ b/test/shared/payment-signature.test.ts
@@ -31,7 +31,7 @@ const baseMeta = (
  * can be checked against an untouched signature. Includes the contact and
  * fulfilment fields (email/phone/site_token_index) that feed pricing or renewal
  * indirectly and so must be bound, not just the obvious price fields. */
-const fieldMutations: Array<[string, Record<string, string>]> = [
+const fieldMutations: [string, Record<string, string>][] = [
   ["email", { email: "attacker@example.com" }],
   ["phone", { phone: "07700900000" }],
   ["site_token_index", { site_token_index: "deadbeefcafe" }],
@@ -49,7 +49,7 @@ const fieldMutations: Array<[string, Record<string, string>]> = [
 
 /** Keys deliberately left out of the signed payload — changing them must not
  * invalidate a signature (see the module doc for why each is excluded). */
-const excludedKeys: Array<[string, Record<string, string>]> = [
+const excludedKeys: [string, Record<string, string>][] = [
   ["_origin", { _origin: "other-instance.example.test" }],
   ["price_proof", { price_proof: "9999.somedigest" }],
   ["b", { b: '{"phone":"07700900000"}' }],

--- a/test/shared/sms/gateway.test.ts
+++ b/test/shared/sms/gateway.test.ts
@@ -32,12 +32,12 @@ const fakeFetch =
   };
 
 const recordingFetch = (
-  responseFor: (calls: Array<[string, RequestInit | undefined]>) => FetchResult,
+  responseFor: (calls: [string, RequestInit | undefined][]) => FetchResult,
 ): {
-  calls: Array<[string, RequestInit | undefined]>;
+  calls: [string, RequestInit | undefined][];
   fetchImpl: (url: string, init?: RequestInit) => Promise<FetchResult>;
 } => {
-  const calls: Array<[string, RequestInit | undefined]> = [];
+  const calls: [string, RequestInit | undefined][] = [];
   return {
     calls,
     fetchImpl: (url, init) => {

--- a/test/shared/validation/money.test.ts
+++ b/test/shared/validation/money.test.ts
@@ -14,10 +14,7 @@ import { testWithSetting } from "#test-utils/settings.ts";
 /** Build a table-driven describe for one currency-aware parser. */
 const parserTable =
   (parse: (raw: string) => number | null) =>
-  (
-    currency: SettingsData["currency"],
-    rows: Array<[string, number | null]>,
-  ) => {
+  (currency: SettingsData["currency"], rows: [string, number | null][]) => {
     for (const [input, expected] of rows) {
       testWithSetting(
         `${currency}: ${JSON.stringify(input)} → ${expected}`,
@@ -38,7 +35,7 @@ const parserTable =
 describe("parsePositiveMinorUnits", () => {
   const table = (
     currency: SettingsData["currency"],
-    rows: Array<[string, number | null]>,
+    rows: [string, number | null][],
   ): void => {
     for (const [input, expected] of rows) {
       testWithSetting(
@@ -252,7 +249,7 @@ describe("validatePrice (bounded public/QR price)", () => {
 describe("exceedsCurrencyPrecision (already-parsed major-unit amount)", () => {
   const table = (
     currency: SettingsData["currency"],
-    rows: Array<[number, boolean]>,
+    rows: [number, boolean][],
   ) => {
     for (const [value, expected] of rows) {
       testWithSetting(

--- a/test/ui/templates/fields/contracts.test.ts
+++ b/test/ui/templates/fields/contracts.test.ts
@@ -118,7 +118,7 @@ describe("fields contracts", () => {
   describe("required flags across the settings/auth factories", () => {
     // Each factory's fields are all required; a `required: true -> false` mutant
     // on any of them flips one of these to false.
-    const cases: Array<[string, Field[]]> = [
+    const cases: [string, Field[]][] = [
       ["login", getLoginFields()],
       ["setup", getSetupFields()],
       ["stripe key", getStripeKeyFields()],


### PR DESCRIPTION
## Summary

Enables the previously-off `style/useConsistentArrayType` Biome rule as an `error`, configured with `syntax: "shorthand"`. This enforces a single, consistent array-type notation (`T[]`) throughout the codebase instead of mixing `T[]` and `Array<T>`.

It's a low-risk, high-consistency quality win: the rule is auto-fixable, purely about type-annotation style (no runtime behaviour changes), and the existing violations were few and localized.

## Changes

- `biome.json`: switch `style/useConsistentArrayType` from off → `"error"` with `{ "syntax": "shorthand" }`.
- Converted all existing `Array<T>` annotations to the `T[]` shorthand across `src/`, `test/`, `cli/` (24 source/test files).

## Verification

- `deno run -A scripts/biome.ts check --error-on-warnings src test scripts cli biome.json` — clean.
- `deno task typecheck` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwi1imwpbhabiUdwvDemiF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized TypeScript array and tuple type syntax across application code and tests.
  * Improved consistency for read-only collections and array declarations without changing runtime behavior.

* **Tests**
  * Updated test fixture and helper typings to use the standardized syntax.
  * Existing test cases, assertions, and expected outcomes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->