### PR TITLE
Clean up stale references to the removed test-utils barrel

### DIFF
--- a/REPO_STRUCTURE.md
+++ b/REPO_STRUCTURE.md
@@ -34,7 +34,6 @@ src/
   index.ts                 # local/server bootstrap
   edge.ts                  # Bunny edge bootstrap
   fp.ts                    # functional primitives
-  test-utils.ts            # test utils barrel
   static.d.ts              # static module declarations
 ```
 

--- a/scripts/unit-tests-report-lib.ts
+++ b/scripts/unit-tests-report-lib.ts
@@ -89,7 +89,6 @@ export const DEFAULT_OPTIONS: ReportOptions = {
     "test/scripts/",
     "test/test-utils/",
     "test/setup.ts",
-    "test/test-utils.ts",
   ],
   srcRoot: "src",
   testRoot: "test",

--- a/test/scripts/mutation-step.test.ts
+++ b/test/scripts/mutation-step.test.ts
@@ -72,7 +72,7 @@ describe("partitionChanged", () => {
       "deno.json",
       "scripts/precommit-mutation.ts",
       "src/styles/app.scss",
-      "test/test-utils.ts",
+      "test/test-utils/db.ts",
     ]);
     expect(result).toEqual({ sources: [], tests: [] });
   });

--- a/test/scripts/unit-tests-report.test.ts
+++ b/test/scripts/unit-tests-report.test.ts
@@ -305,7 +305,6 @@ describe("DEFAULT_OPTIONS and DEFAULT_LIMIT", () => {
       "test/scripts/",
       "test/test-utils/",
       "test/setup.ts",
-      "test/test-utils.ts",
     ]);
   });
 });

--- a/test/test-utils/crypto.ts
+++ b/test/test-utils/crypto.ts
@@ -1,10 +1,10 @@
 /**
  * Test crypto utilities — wallet certificates and related helpers.
  *
- * NOTE: node-forge is imported only in this file. To avoid loading it in
- * workers that don't need wallet certificates, do NOT re-export these
- * functions from the #test-utils barrel. Import directly from
- * "#test-utils/crypto" instead.
+ * NOTE: node-forge is imported only in this file. Keep it that way — import
+ * these helpers directly from "#test-utils/crypto.ts" where they are needed, so
+ * the heavy node-forge dependency is not pulled into workers (or test files)
+ * that never render wallet certificates.
  */
 
 import forge from "node-forge";

--- a/test/test-utils/fast-expect.ts
+++ b/test/test-utils/fast-expect.ts
@@ -11,8 +11,9 @@
  * failure message only when the assertion actually fails — and truncates a
  * huge value there so the error stays readable.
  *
- * Imported for its side effect by `test/test-utils.ts`, so every suite that
- * uses `#test-utils` gets the fast matcher automatically.
+ * Loaded via `deno test --preload` (wired up in `scripts/test-harness.ts` and
+ * `scripts/mutation/runner.ts`), so every test isolate installs the fast
+ * matcher automatically.
  */
 import { expect } from "@std/expect";
 


### PR DESCRIPTION
## Summary

PR #1712 deleted the `test/test-utils.ts` barrel, but a handful of references to it were left behind pointing at a file that no longer exists. This tidies them up. Docs and comments only, plus two small test updates — no behaviour changes.

## What changed

- **`REPO_STRUCTURE.md`** — dropped the `test-utils.ts  # test utils barrel` line from the `src/` layout (the file is gone).
- **`test/test-utils/crypto.ts`** — the node-forge note told callers not to re-export these helpers "from the `#test-utils` barrel", which no longer exists. Reworded to state the real intent: import directly from `#test-utils/crypto.ts` so the heavy node-forge dependency stays isolated to this one file.
- **`test/test-utils/fast-expect.ts`** — its header still said it was loaded "for its side effect by `test/test-utils.ts`". It's now loaded via `deno test --preload` (in `scripts/test-harness.ts` and `scripts/mutation/runner.ts`); the comment now says so.
- **`scripts/unit-tests-report-lib.ts`** — removed the dead `test/test-utils.ts` entry from `exemptTestPrefixes`; the `test/test-utils/` directory prefix already covers the helpers. Updated the matching assertion in `test/scripts/unit-tests-report.test.ts`.
- **`test/scripts/mutation-step.test.ts`** — a `partitionChanged` case used the deleted `test/test-utils.ts` as its "non-src, non-test path" example; swapped for an existing helper (`test/test-utils/db.ts`) that partitions the same way.

## Verification

- `deno task precommit` passes (typecheck, strict lint, cpd, full suite).
- The two directly-affected suites (`test/scripts/unit-tests-report.test.ts`, `test/scripts/mutation-step.test.ts`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcBhoQmNDbwgoidFvbLxpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcBhoQmNDbwgoidFvbLxpZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation to reflect the current test utility structure.
  * Clarified how specialized test helpers and matchers are loaded and used.

* **Tests**
  * Updated unit-test reporting expectations to exclude the test utilities directory.
  * Added coverage for nested test utility paths in change partitioning checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->