### PR TITLE
Harden refunds/provider.ts tests to 100% mutation kill rate

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -844,3 +844,7 @@ src/features/admin/index.ts:299:55  return null → return undefined   # routeAd
 src/shared/logger.ts:314:27  = → +=   # errorPersistGuard.active is always false at this line (the guard early-returns otherwise), and false + true === 1 — read only for truthiness, exactly like true; the finally still resets it to false
 src/shared/logger.ts:321:69  ?? → ||   # context.listingId is number|undefined and listing ids are positive autoincrement integers, so the LHS is never a falsy non-null value — ?? and || agree on every input
 src/shared/logger.ts:77:70  ?? → ||   # getRequestId's `getStore() ?? ""`: the RHS is "" and the only falsy string is "", so `x ?? ""` and `x || ""` agree on every string|undefined input
+
+# Admin refund provider (refunds/provider.ts) — one provably-equivalent survivor
+# from the packByReferenceCount run.
+src/features/admin/refunds/provider.ts:45:24  0 → 1   # packByReferenceCount's `currentCount` init: the first iteration always hits `!wave` (waves is empty, so waves[-1] is undefined), which short-circuits the `|| currentCount + refs > budget` before currentCount is read; every later iteration reassigns it first, so the initial value is never observed

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -845,6 +845,6 @@ src/shared/logger.ts:314:27  = → +=   # errorPersistGuard.active is always fal
 src/shared/logger.ts:321:69  ?? → ||   # context.listingId is number|undefined and listing ids are positive autoincrement integers, so the LHS is never a falsy non-null value — ?? and || agree on every input
 src/shared/logger.ts:77:70  ?? → ||   # getRequestId's `getStore() ?? ""`: the RHS is "" and the only falsy string is "", so `x ?? ""` and `x || ""` agree on every string|undefined input
 
-# Admin refund provider (refunds/provider.ts) — one provably-equivalent survivor
-# from the packByReferenceCount run.
-src/features/admin/refunds/provider.ts:45:24  0 → 1   # packByReferenceCount's `currentCount` init: the first iteration always hits `!wave` (waves is empty, so waves[-1] is undefined), which short-circuits the `|| currentCount + refs > budget` before currentCount is read; every later iteration reassigns it first, so the initial value is never observed
+# Admin refund waves (refunds/waves.ts) — one provably-equivalent survivor from
+# the packByReferenceCount run.
+src/features/admin/refunds/waves.ts:16:24  0 → 1   # packByReferenceCount's `currentCount` init: the first iteration always hits `!wave` (waves is empty, so waves[-1] is undefined), which short-circuits the `|| currentCount + refs > budget` before currentCount is read; every later iteration reassigns it first, so the initial value is never observed

--- a/src/features/admin/refunds/provider.ts
+++ b/src/features/admin/refunds/provider.ts
@@ -7,6 +7,11 @@ import { ErrorCode, logError } from "#shared/logger.ts";
 import type { getActivePaymentProvider } from "#shared/payments.ts";
 import { recordAttendeeRefundsBatch } from "#shared/refund-ledger.ts";
 import type { RefundCandidate } from "./candidates.ts";
+import {
+  combineRefundOutcomes,
+  packByReferenceCount,
+  type RefundOutcome,
+} from "./waves.ts";
 
 type RefundProvider = Pick<
   NonNullable<Awaited<ReturnType<typeof getActivePaymentProvider>>>,
@@ -15,8 +20,6 @@ type RefundProvider = Pick<
 type MarkReturnedReferences = (
   references: readonly RefundPaymentReference[],
 ) => Promise<void>;
-
-type RefundOutcome = "refunded" | "failed" | "errored";
 
 export type RefundCounts = {
   refundedCount: number;
@@ -32,30 +35,6 @@ export type RefundCounts = {
  * reference count and each candidate's own references are chunked to this too.
  * The refresh-payment status check reuses it to bound its own fan-out. */
 export const PROVIDER_REFUND_CONCURRENCY = 5;
-
-/** Pack candidates into waves whose combined charge references stay within
- * `budget`, so each concurrently-processed wave issues at most ~`budget`
- * provider subrequests. A single candidate carrying more references than the
- * budget forms its own wave; its references are chunked inside
- * {@link refundCandidateAtProvider}. */
-export const packByReferenceCount =
-  (budget: number) =>
-  (candidates: RefundCandidate[]): RefundCandidate[][] => {
-    const waves: RefundCandidate[][] = [];
-    let currentCount = 0;
-    for (const candidate of candidates) {
-      const refs = candidate.references.length;
-      const wave = waves[waves.length - 1];
-      if (!wave || currentCount + refs > budget) {
-        waves.push([candidate]);
-        currentCount = refs;
-      } else {
-        wave.push(candidate);
-        currentCount += refs;
-      }
-    }
-    return waves;
-  };
 
 const refundReferenceAtProvider = async (
   provider: RefundProvider,
@@ -85,14 +64,6 @@ const refundReferenceAtProvider = async (
     });
     return "errored";
   }
-};
-
-export const combineRefundOutcomes = (
-  outcomes: RefundOutcome[],
-): RefundOutcome => {
-  if (outcomes.includes("errored")) return "errored";
-  if (outcomes.includes("failed")) return "failed";
-  return "refunded";
 };
 
 export const refundCandidateAtProvider = async (

--- a/src/features/admin/refunds/provider.ts
+++ b/src/features/admin/refunds/provider.ts
@@ -38,7 +38,7 @@ export const PROVIDER_REFUND_CONCURRENCY = 5;
  * provider subrequests. A single candidate carrying more references than the
  * budget forms its own wave; its references are chunked inside
  * {@link refundCandidateAtProvider}. */
-const packByReferenceCount =
+export const packByReferenceCount =
   (budget: number) =>
   (candidates: RefundCandidate[]): RefundCandidate[][] => {
     const waves: RefundCandidate[][] = [];
@@ -87,7 +87,9 @@ const refundReferenceAtProvider = async (
   }
 };
 
-const combineRefundOutcomes = (outcomes: RefundOutcome[]): RefundOutcome => {
+export const combineRefundOutcomes = (
+  outcomes: RefundOutcome[],
+): RefundOutcome => {
   if (outcomes.includes("errored")) return "errored";
   if (outcomes.includes("failed")) return "failed";
   return "refunded";

--- a/src/features/admin/refunds/waves.ts
+++ b/src/features/admin/refunds/waves.ts
@@ -1,0 +1,40 @@
+import type { RefundCandidate } from "./candidates.ts";
+
+/** The result of attempting to refund one charge reference (or a whole
+ * candidate, once its per-reference outcomes are combined). */
+export type RefundOutcome = "refunded" | "failed" | "errored";
+
+/** Pack candidates into waves whose combined charge references stay within
+ * `budget`, so each concurrently-processed wave issues at most ~`budget`
+ * provider subrequests. A single candidate carrying more references than the
+ * budget forms its own wave; its references are chunked inside
+ * `refundCandidateAtProvider`. */
+export const packByReferenceCount =
+  (budget: number) =>
+  (candidates: RefundCandidate[]): RefundCandidate[][] => {
+    const waves: RefundCandidate[][] = [];
+    let currentCount = 0;
+    for (const candidate of candidates) {
+      const refs = candidate.references.length;
+      const wave = waves[waves.length - 1];
+      if (!wave || currentCount + refs > budget) {
+        waves.push([candidate]);
+        currentCount = refs;
+      } else {
+        wave.push(candidate);
+        currentCount += refs;
+      }
+    }
+    return waves;
+  };
+
+/** Reduce a candidate's per-reference outcomes to a single outcome, worst
+ * first: any errored reference errors the candidate, any failed reference
+ * fails it, otherwise it is fully refunded. */
+export const combineRefundOutcomes = (
+  outcomes: RefundOutcome[],
+): RefundOutcome => {
+  if (outcomes.includes("errored")) return "errored";
+  if (outcomes.includes("failed")) return "failed";
+  return "refunded";
+};

--- a/test/features/admin/refunds/provider-batch.test.ts
+++ b/test/features/admin/refunds/provider-batch.test.ts
@@ -49,8 +49,6 @@ describeWithEnv(
   { db: true },
   () => {
     const errors = setupErrorSpy();
-    const loggedContains = (needle: string): boolean =>
-      errors.calls.some((call) => String(call.args[0]).includes(needle));
 
     test("tallies refunded, failed and errored candidates in one batch", async () => {
       await postBooking({ attendeeId: 11, eventId: "sess-11" });
@@ -70,12 +68,12 @@ describeWithEnv(
         failedCount: 1,
         refundedCount: 1,
       });
-      expect(loggedContains("Admin bulk refund failed for attendee 12")).toBe(
+      expect(errors.contains("Admin bulk refund failed for attendee 12")).toBe(
         true,
       );
       // The errored candidate's references are joined with ", ".
       expect(
-        loggedContains(
+        errors.contains(
           "Admin bulk refund errored for attendee 13, payments pi_boom, pi_two",
         ),
       ).toBe(true);

--- a/test/features/admin/refunds/provider-batch.test.ts
+++ b/test/features/admin/refunds/provider-batch.test.ts
@@ -1,0 +1,114 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import type { RefundCandidate } from "#routes/admin/refunds/candidates.ts";
+import { processRefundBatch } from "#routes/admin/refunds/provider.ts";
+import type { RefundPaymentReference } from "#shared/db/payment-references.ts";
+import {
+  postBooking,
+  sessionReference,
+} from "#test/shared/refund-ledger-helpers.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
+
+const LISTING = 7;
+
+/** A candidate already refunded at the provider (its references carry
+ * `providerRefunded: true`, so the provider is never called for it). */
+const refundedCandidate = (
+  attendeeId: number,
+  sessionId: string,
+): RefundCandidate => ({
+  attendee: { id: attendeeId } as RefundCandidate["attendee"],
+  references: [sessionReference(sessionId)],
+});
+
+const pendingCandidate = (
+  attendeeId: number,
+  references: string[],
+): RefundCandidate => ({
+  attendee: { id: attendeeId } as RefundCandidate["attendee"],
+  references: references.map((reference) => ({
+    providerRefunded: false,
+    reference,
+    sessionIds: [] as string[],
+  })) as RefundPaymentReference[],
+});
+
+/** Provider that fails every live refund and throws for references in
+ * `throws`; used to drive the failed/errored tally branches. */
+const failingProvider = (throws: Set<string>) => ({
+  isPaymentRefunded: () => Promise.resolve(false),
+  refundPayment: (reference: string) => {
+    if (throws.has(reference)) throw new Error(`boom ${reference}`);
+    return Promise.resolve(false);
+  },
+});
+
+describeWithEnv(
+  "admin refund provider > processRefundBatch",
+  { db: true },
+  () => {
+    const errors = setupErrorSpy();
+    const loggedContains = (needle: string): boolean =>
+      errors.calls.some((call) => String(call.args[0]).includes(needle));
+
+    test("tallies refunded, failed and errored candidates in one batch", async () => {
+      await postBooking({ attendeeId: 11, eventId: "sess-11" });
+
+      const counts = await processRefundBatch(
+        failingProvider(new Set(["pi_boom"])),
+        [
+          refundedCandidate(11, "sess-11"),
+          pendingCandidate(12, ["pi_fail"]),
+          pendingCandidate(13, ["pi_boom", "pi_two"]),
+        ],
+        LISTING,
+      );
+
+      expect(counts).toEqual({
+        errorCount: 1,
+        failedCount: 1,
+        refundedCount: 1,
+      });
+      expect(loggedContains("Admin bulk refund failed for attendee 12")).toBe(
+        true,
+      );
+      // The errored candidate's references are joined with ", ".
+      expect(
+        loggedContains(
+          "Admin bulk refund errored for attendee 13, payments pi_boom, pi_two",
+        ),
+      ).toBe(true);
+    });
+
+    test("returns all-zero counts for an empty batch", async () => {
+      const counts = await processRefundBatch(
+        failingProvider(new Set()),
+        [],
+        LISTING,
+      );
+
+      expect(counts).toEqual({
+        errorCount: 0,
+        failedCount: 0,
+        refundedCount: 0,
+      });
+    });
+
+    test("counts a provider-refunded attendee the ledger cannot post as an error", async () => {
+      // No booking exists for attendee 21, so the reversal posts nothing and the
+      // ledger reports it unposted even though the provider refund succeeded.
+      const counts = await processRefundBatch(
+        failingProvider(new Set()),
+        [refundedCandidate(21, "sess-missing")],
+        LISTING,
+      );
+
+      expect(counts).toEqual({
+        errorCount: 1,
+        failedCount: 0,
+        refundedCount: 0,
+      });
+    });
+  },
+);

--- a/test/features/admin/refunds/provider.test.ts
+++ b/test/features/admin/refunds/provider.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import type { RefundCandidate } from "#routes/admin/refunds/candidates.ts";
+import { refundCandidateAtProvider } from "#routes/admin/refunds/provider.ts";
 import {
   combineRefundOutcomes,
   packByReferenceCount,
-  refundCandidateAtProvider,
-} from "#routes/admin/refunds/provider.ts";
+} from "#routes/admin/refunds/waves.ts";
 import type { RefundPaymentReference } from "#shared/db/payment-references.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
 
@@ -145,8 +145,6 @@ describe("combineRefundOutcomes", () => {
 
 describe("admin refund provider", () => {
   const errors = setupErrorSpy();
-  const loggedContains = (needle: string): boolean =>
-    errors.calls.some((call) => String(call.args[0]).includes(needle));
 
   test("counts a reference already marked refunded without calling the provider", async () => {
     let refundCalls = 0;
@@ -240,7 +238,7 @@ describe("admin refund provider", () => {
     expect(marker.marked).toEqual(["pi_ok"]);
     // A multi-reference candidate that did not fully refund is logged.
     expect(
-      loggedContains(
+      errors.contains(
         "Admin refund did not complete every payment for attendee 42",
       ),
     ).toBe(true);
@@ -256,7 +254,7 @@ describe("admin refund provider", () => {
 
     expect(result.outcome).toBe("failed");
     expect(
-      loggedContains(
+      errors.contains(
         "Admin refund did not complete every payment for attendee 42",
       ),
     ).toBe(false);
@@ -286,7 +284,7 @@ describe("admin refund provider", () => {
 
     expect(result.outcome).toBe("refunded");
     expect(
-      loggedContains(
+      errors.contains(
         "Admin refund did not complete every payment for attendee 42",
       ),
     ).toBe(false);

--- a/test/features/admin/refunds/provider.test.ts
+++ b/test/features/admin/refunds/provider.test.ts
@@ -1,34 +1,300 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import type { RefundCandidate } from "#routes/admin/refunds/candidates.ts";
-import { refundCandidateAtProvider } from "#routes/admin/refunds/provider.ts";
+import {
+  combineRefundOutcomes,
+  packByReferenceCount,
+  refundCandidateAtProvider,
+} from "#routes/admin/refunds/provider.ts";
+import type { RefundPaymentReference } from "#shared/db/payment-references.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
 
-const candidateWithReferences = (references: string[]): RefundCandidate => ({
-  attendee: { id: 42 } as RefundCandidate["attendee"],
-  references: references.map((reference) => ({
-    providerRefunded: false,
+type Ref = { reference: string; providerRefunded?: boolean };
+
+const candidate = (references: Ref[], id = 42): RefundCandidate => ({
+  attendee: { id } as RefundCandidate["attendee"],
+  references: references.map(({ reference, providerRefunded = false }) => ({
+    providerRefunded,
     reference,
     sessionIds: [`sess_${reference}`],
   })),
 });
 
-const refundingProvider = (refunded: Set<string>) => ({
-  isPaymentRefunded: (_reference: string) => Promise.resolve(false),
-  refundPayment: (reference: string) =>
-    Promise.resolve(refunded.has(reference)),
+const candidateWithReferences = (references: string[]): RefundCandidate =>
+  candidate(references.map((reference) => ({ reference })));
+
+/** Provider that refunds exactly the references in `refunded`, reports the
+ * ones in `alreadyRefunded` as refunded on the follow-up check, and throws for
+ * references in `throws`. */
+const provider = ({
+  refunded = new Set<string>(),
+  alreadyRefunded = new Set<string>(),
+  throws = new Set<string>(),
+}: {
+  refunded?: Set<string>;
+  alreadyRefunded?: Set<string>;
+  throws?: Set<string>;
+} = {}) => ({
+  isPaymentRefunded: (reference: string) =>
+    Promise.resolve(alreadyRefunded.has(reference)),
+  refundPayment: (reference: string) => {
+    if (throws.has(reference)) throw new Error(`boom ${reference}`);
+    return Promise.resolve(refunded.has(reference));
+  },
 });
+
+const collectingMarker = () => {
+  const marked: string[] = [];
+  return {
+    mark: (references: readonly RefundPaymentReference[]) => {
+      marked.push(...references.map((reference) => reference.reference));
+      return Promise.resolve();
+    },
+    marked,
+  };
+};
 
 const throwMarker = () => {
   throw new Error("marker write failed");
 };
 
+const refs = (id: string, count: number): RefundCandidate =>
+  candidate(
+    Array.from({ length: count }, (_, i) => ({ reference: `${id}${i}` })),
+  );
+
+describe("packByReferenceCount", () => {
+  test("packs candidates into waves that stay within the budget", () => {
+    const a = refs("a", 2);
+    const b = refs("b", 1);
+    const c = refs("c", 2);
+
+    // budget 3: a(2)+b(1)=3 fits, c(2) would overflow → new wave.
+    expect(packByReferenceCount(3)([a, b, c])).toEqual([[a, b], [c]]);
+  });
+
+  test("adds the running count to the incoming size rather than multiplying it", () => {
+    const a = refs("a", 1);
+    const b = refs("b", 3);
+
+    // budget 3: 1+3=4 > 3 → new wave; a multiplying mutant would see 1*3=3
+    // and wrongly keep them together.
+    expect(packByReferenceCount(3)([a, b])).toEqual([[a], [b]]);
+  });
+
+  test("resets the running count when a new wave starts", () => {
+    const a = refs("a", 2);
+    const b = refs("b", 2);
+    const c = refs("c", 1);
+
+    // budget 3: a→[a] (cc=2); b overflows→[b] (cc reset to 2); c 2+1=3 fits.
+    // An accumulating mutant would carry cc past the reset and split c off.
+    expect(packByReferenceCount(3)([a, b, c])).toEqual([[a], [b, c]]);
+  });
+
+  test("increases the running count when appending to a wave", () => {
+    const a = refs("a", 1);
+    const b = refs("b", 1);
+    const c = refs("c", 2);
+
+    // budget 3: a,b append (cc=2); c 2+2=4 > 3 → new wave. A mutant that
+    // fails to grow cc on append would keep c in the first wave.
+    expect(packByReferenceCount(3)([a, b, c])).toEqual([[a, b], [c]]);
+  });
+
+  test("keeps candidates together while the count stays at the budget", () => {
+    const a = refs("a", 1);
+    const b = refs("b", 1);
+    const c = refs("c", 1);
+
+    // budget 3: 1+1+1=3, never exceeds → single wave.
+    expect(packByReferenceCount(3)([a, b, c])).toEqual([[a, b, c]]);
+  });
+
+  test("gives an over-budget candidate its own wave", () => {
+    const big = refs("x", 3);
+    const small = refs("y", 1);
+
+    expect(packByReferenceCount(2)([big, small])).toEqual([[big], [small]]);
+  });
+
+  test("returns no waves for an empty candidate list", () => {
+    expect(packByReferenceCount(3)([])).toEqual([]);
+  });
+});
+
+describe("combineRefundOutcomes", () => {
+  test("prefers errored over every other outcome", () => {
+    expect(combineRefundOutcomes(["refunded", "failed", "errored"])).toBe(
+      "errored",
+    );
+  });
+
+  test("prefers failed over refunded when nothing errored", () => {
+    expect(combineRefundOutcomes(["refunded", "failed"])).toBe("failed");
+  });
+
+  test("is refunded only when every outcome is refunded", () => {
+    expect(combineRefundOutcomes(["refunded", "refunded"])).toBe("refunded");
+  });
+
+  test("is refunded for an empty outcome list", () => {
+    expect(combineRefundOutcomes([])).toBe("refunded");
+  });
+});
+
 describe("admin refund provider", () => {
   const errors = setupErrorSpy();
+  const loggedContains = (needle: string): boolean =>
+    errors.calls.some((call) => String(call.args[0]).includes(needle));
+
+  test("counts a reference already marked refunded without calling the provider", async () => {
+    let refundCalls = 0;
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      {
+        isPaymentRefunded: () => Promise.resolve(false),
+        refundPayment: () => {
+          refundCalls++;
+          return Promise.resolve(false);
+        },
+      },
+      candidate([{ providerRefunded: true, reference: "pi_pre" }]),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("refunded");
+    expect(refundCalls).toBe(0);
+    expect(marker.marked).toEqual(["pi_pre"]);
+  });
+
+  test("refunds a reference the provider actively refunds", async () => {
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      provider({ refunded: new Set(["pi_now"]) }),
+      candidateWithReferences(["pi_now"]),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("refunded");
+    expect(marker.marked).toEqual(["pi_now"]);
+  });
+
+  test("treats a reference the provider reports already refunded as refunded", async () => {
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      provider({ alreadyRefunded: new Set(["pi_seen"]) }),
+      candidateWithReferences(["pi_seen"]),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("refunded");
+    expect(marker.marked).toEqual(["pi_seen"]);
+  });
+
+  test("fails and logs when the provider neither refunds nor confirms", async () => {
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      provider(),
+      candidateWithReferences(["pi_no"]),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("failed");
+    expect(marker.marked).toEqual([]);
+    expect(errors.lastMessage()).toContain(
+      "Admin refund failed for attendee 42, payment pi_no",
+    );
+  });
+
+  test("errors and logs when the provider throws", async () => {
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      provider({ throws: new Set(["pi_boom"]) }),
+      candidateWithReferences(["pi_boom"]),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("errored");
+    expect(marker.marked).toEqual([]);
+    expect(errors.lastMessage()).toContain(
+      "Admin refund errored for attendee 42, payment pi_boom",
+    );
+  });
+
+  test("marks only the refunded references of a partial refund", async () => {
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      provider({ refunded: new Set(["pi_ok"]) }),
+      candidateWithReferences(["pi_ok", "pi_bad"]),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("failed");
+    expect(marker.marked).toEqual(["pi_ok"]);
+    // A multi-reference candidate that did not fully refund is logged.
+    expect(
+      loggedContains(
+        "Admin refund did not complete every payment for attendee 42",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not log the incomplete-payment warning for a single reference", async () => {
+    const result = await refundCandidateAtProvider(
+      provider(),
+      candidateWithReferences(["pi_solo"]),
+      7,
+      collectingMarker().mark,
+    );
+
+    expect(result.outcome).toBe("failed");
+    expect(
+      loggedContains(
+        "Admin refund did not complete every payment for attendee 42",
+      ),
+    ).toBe(false);
+  });
+
+  test("refunds every reference across concurrency chunks", async () => {
+    const references = Array.from({ length: 7 }, (_, i) => `pi_${i}`);
+    const marker = collectingMarker();
+    const result = await refundCandidateAtProvider(
+      provider({ refunded: new Set(references) }),
+      candidateWithReferences(references),
+      7,
+      marker.mark,
+    );
+
+    expect(result.outcome).toBe("refunded");
+    expect(marker.marked.sort()).toEqual([...references].sort());
+  });
+
+  test("does not log the incomplete-payment warning when every reference refunds", async () => {
+    const result = await refundCandidateAtProvider(
+      provider({ refunded: new Set(["pi_a", "pi_b"]) }),
+      candidateWithReferences(["pi_a", "pi_b"]),
+      7,
+      collectingMarker().mark,
+    );
+
+    expect(result.outcome).toBe("refunded");
+    expect(
+      loggedContains(
+        "Admin refund did not complete every payment for attendee 42",
+      ),
+    ).toBe(false);
+  });
 
   test("keeps a successful provider refund successful when recording the marker fails", async () => {
     const result = await refundCandidateAtProvider(
-      refundingProvider(new Set(["pi_done"])),
+      provider({ refunded: new Set(["pi_done"]) }),
       candidateWithReferences(["pi_done"]),
       7,
       throwMarker,
@@ -42,7 +308,7 @@ describe("admin refund provider", () => {
 
   test("treats a partial provider refund as errored when recording the marker fails", async () => {
     const result = await refundCandidateAtProvider(
-      refundingProvider(new Set(["pi_done"])),
+      provider({ refunded: new Set(["pi_done"]) }),
       candidateWithReferences(["pi_done", "pi_failed"]),
       7,
       throwMarker,

--- a/test/test-utils/error-spy.ts
+++ b/test/test-utils/error-spy.ts
@@ -10,6 +10,7 @@ import { type Spy, spy } from "@std/testing/mock";
 export const setupErrorSpy = (): {
   readonly calls: Spy["calls"];
   lastMessage: () => string | undefined;
+  contains: (needle: string) => boolean;
 } => {
   let errorSpy: Spy;
   beforeEach(() => {
@@ -22,6 +23,8 @@ export const setupErrorSpy = (): {
     get calls() {
       return errorSpy.calls;
     },
+    contains: (needle: string) =>
+      errorSpy.calls.some((call) => String(call.args[0]).includes(needle)),
     lastMessage: () => errorSpy.calls.at(-1)?.args[0] as string | undefined,
   };
 };


### PR DESCRIPTION
## What

`src/features/admin/refunds/provider.ts` was the thinnest-tested source file per `deno task unit-tests-report` (a 4.58 src:test line ratio). Running the mutation suite over it confirmed the gap:

```
deno task mutation 'src/features/admin/refunds/provider.ts' \
                   'test/features/admin/refunds/provider*.test.ts'
```

**Before:** score 32.8% — 45 of 67 mutants survived. The existing test only exercised two marker-failure paths of `refundCandidateAtProvider`; the wave packer, the outcome combiner, the per-reference refund logic, and the whole batch tally/counting path were unverified.

## Changes

- **Source:** export the two pure helpers `packByReferenceCount` and `combineRefundOutcomes` so their branch behaviour can be unit-tested directly (no behaviour change).
- **`provider.test.ts`** (no DB): direct tests for the wave packer (budget boundaries, running-count reset/append, over-budget candidate, empty list) and the outcome combiner (precedence + empty), plus `refundCandidateAtProvider` across every provider outcome — pre-marked, actively refunded, already-refunded, failed, thrown — covering partial refunds, marker success/failure, and multi-chunk fan-out. Assertions check both the returned outcome and the exact references handed to the marker.
- **`provider-batch.test.ts`** (new, DB-backed via `describeWithEnv({ db: true })`): `processRefundBatch` covering the refunded/failed/errored tally, the joined bulk-refund log message, the all-zero empty batch, and the ledger-unposted error path.
- **`equivalent-mutants.txt`:** record the one provably-equivalent survivor — `packByReferenceCount`'s `currentCount` initialiser, which is never read before reassignment because the first loop iteration always short-circuits on `!wave`.

**After:** score 100% — 66/66 killed, 1 suppressed as known-equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refund processing now groups candidates into reference-count-limited waves.
  * Refund results are consolidated with clear refunded, failed, and errored statuses.
  * Batch processing reports accurate refund, failure, and error counts.

* **Bug Fixes**
  * Improved handling of already-refunded candidates and ledger reversal failures.
  * Error reporting now includes relevant attendee and payment reference details.

* **Tests**
  * Expanded coverage for batching, wave packing, partial refunds, provider errors, and concurrency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->