### PR TITLE
Turn the child-listing error checks into one ordered rule list

### DIFF
--- a/BUSINESS_LOGIC_TODOS.md
+++ b/BUSINESS_LOGIC_TODOS.md
@@ -331,7 +331,7 @@ pattern to content string fields.
 
 ## Prioritisation
 
-**Shipped (items 1–7):**
+**Shipped (items 1–8):**
 
 - **Item 1 (admin-page schema)** — the schema, nav.tsx migration, and
   nav.test.tsx migration are done. Remaining: `adminLandingPath` derivation

--- a/BUSINESS_LOGIC_TODOS.md
+++ b/BUSINESS_LOGIC_TODOS.md
@@ -173,152 +173,72 @@ consolidate them, but the list is stable and low-risk.
 
 ## 5. Form field options derived from picklist schemas
 
-**Problem.** Several form field definitions hand-maintain option arrays that
-duplicate the declared valibot picklist schemas. The schema exports `.options`
-but the form fields re-type the list. These can drift:
+**Status: Shipped.** The `picklistOptions(schema, labelKeyPrefix)` helper
+(`src/ui/templates/fields/picklist-options.ts`) builds a field's `options`
+list from any picklist schema's `.options`, labelling each value via
+`${labelKeyPrefix}.${value}`. Every field the table above named now derives
+from its schema: `listing_type` and the contact `fields` checkbox group
+(`fields/listing.ts` — `ListingTypeSchema`/`ContactFieldSchema`), all four
+modifier selects (`fields/modifier.ts` — `CalcKindSchema`,
+`ModifierDirectionSchema`, `ModifierTriggerSchema`, `ModifierScopeSchema`),
+and `admin_level` (`fields/admin.ts` — `AdminLevelSchema`). Adding an enum
+member surfaces in the form the moment its translation exists.
 
-| Field | Schema source | Hand-maintained in form |
-|---|---|---|
-| `listing_type` | `ListingTypeSchema.options` (`types.ts:122`) | `getListingFields` options (`listing-fields.ts:43–44`) |
-| `fields` (contact) | `CONTACT_FIELDS` (`types.ts:71`) | `getListingFields` options (`listing-fields.ts:141–147`) |
-| `calc_kind` | `CalcKindSchema.options` (`price-modifier.ts:19`) | `modifierFields` options (`modifier.ts:33–37`) |
-| `direction` | `ModifierDirectionSchema.options` (`price-modifier.ts:25`) | `modifierFields` options (`modifier.ts:44–47`) |
-| `trigger` | `ModifierTriggerSchema.options` (`price-modifier.ts:31`) | `modifierFields` options (`modifier.ts:68–73`) |
-| `scope` | `ModifierScopeSchema.options` (`price-modifier.ts:44`) | `modifierFields` options (`modifier.ts:88–93`) |
-| `admin_level` | `AdminLevelSchema.options` (`types.ts:541`) | `getInviteUserFields` options (`admin.ts:288–293`) |
-
-Tests re-derive the lists too (`listing.test.ts:259–265` re-spells the contact
-fields, `listing.test.ts:278–284` hardcodes `"standard"/"daily"`).
-
-**Plan.** Create a shared helper that builds a field's `<option>` list from
-any picklist schema's `.options`, with an i18n label key template:
-
-```typescript
-export const picklistOptions = <T extends string>(
-  schema: v.PicklistSchema<T>,
-  labelKeyPrefix: string,
-): { value: T; label: string }[] =>
-  schema.options.map((value) => ({ value, label: t(`${labelKeyPrefix}.${value}`) }));
-```
-
-Replace every hand-maintained option array with `picklistOptions(Schema,
-"fields.listing.type")` etc. Tests import `.options` directly from the schema
-instead of re-typing the values. Adding a new enum member propagates to the
-form AND the test automatically.
-
-**Exemplar:** `CONTACT_FIELDS` is already used this way in `types.ts:71`
-(`ContactFieldSchema.options` exported as `CONTACT_FIELDS`). The task is to
-make every other picklist form field follow the same path. The
-`content-form-fields.ts` shared builders (composed by news + site-pages) are
-the structural model for how field-building functions become reusable.
-
-**Also:** the modifier `calc_value` field's inline `validate`
-(`modifier.ts:60–61`) only checks finiteness; the kind-specific bounds
-(`percent ≤ 100`, `multiply > 0`) live in `validateCalcValue`
-(`price-modifier.ts:84–98`) which is not wired to the field. A test exercising
-the field alone misses these bounds. Wire `validateCalcValue(kind, value)`
-through the field's context-built validator (the `defineForm`/`defineResource`
-plumbing supports context-built validators per `app-forms.ts:99–101`).
+The `calc_value` bounds concern is addressed at the save boundary:
+`validateModifier` (`src/features/admin/modifiers.ts`) runs
+`modifierValueError`, which applies the kind-aware `validateCalcValue` rules
+plus a currency-precision guard, so a crafted POST can't bypass them. The
+field's inline `validate` stays a cheap finiteness pre-check for immediate
+feedback.
 
 ---
 
 ## 6. Price-rule precedence as a declarative ordered list
 
-**Problem.** The precedence `OVERRIDE > PAY_MORE > DAY_PRICE > BASE` is
-documented as a comment (`booking/tree.ts:43–60`) and implemented as an
-if/else in `derivePriceRule` (`build-tree.ts:68–88`) plus a switch in
-`effectivePrice` (`price-tree.ts:61–80`). Adding a 5th rule (e.g. an
-"EARLY_BIRD" tier) means editing the switch AND the comment AND the if-chain,
-with a silent-fallthrough risk if one site is missed. This is the
-"hand-rolled dispatcher" the AGENTS.md warns against.
-
-**Plan.** Model price rules as a `Record<PriceRuleKind, evaluator>` with an
-explicit `PRECEDENCE` order (an ordered array of `PriceRuleKind`), so the
-precedence is a compile-enforced data fact and `effectivePrice` becomes a fold:
-
-```typescript
-const PRICE_RULE_EVALUATORS: Record<PriceRuleKind, (ctx) => number> = {
-  OVERRIDE: (ctx) => ctx.rule.amountMinor,
-  DAY_PRICE: (ctx) => ctx.rule.overrides?.get(ctx.dayCount) ?? dayPriceFor(ctx.listing, ctx.dayCount) ?? 0,
-  PAY_MORE: (ctx) => ctx.customPrices.get(ctx.listing.id) ?? ctx.listing.unit_price,
-  BASE: (ctx) => ctx.customPrices.get(ctx.listing.id) ?? ctx.listing.unit_price,
-};
-
-export const effectivePrice = (layer: PriceLayer, ctx: PriceCtx): number =>
-  PRICE_RULE_EVALUATORS[layer.kind](ctx);
-```
-
-A new kind is a compile error in the `Record` until both the evaluator and the
-precedence entry exist.
-
-**Exemplar:** `LISTING_DEFAULT_FIELDS` with its per-field `appliesTo` predicate
-replaced inline if/else chains — same shape, applied to price rules.
+**Status: Shipped.** `src/shared/booking/price-tree.ts` models each tier as a
+`PriceRuleSpec` (`appliesTo` / `build` / `evaluate`) in the exhaustive
+`PRICE_RULES` map keyed by `PriceRuleKind`, and the precedence is the
+`PRICE_RULE_PRECEDENCE` ordered array (`OVERRIDE > PAY_MORE > DAY_PRICE >
+BASE`). The `orderedKinds` helper makes the precedence list exhaustive at
+compile time, so a new tier added to the `PriceRule` union is a type error in
+BOTH tables until it has a spec and a precedence slot — no silent
+fall-through. `selectPriceRule` is the one selector shared by the tree
+builder's `derivePriceRule` (`build-tree.ts`) and `packageMemberPriceRule`
+(webhooks, payment revalidation), and `effectivePrice` dispatches through the
+same table's `evaluate`.
 
 ---
 
 ## 7. Edge compatibility error precedence as a data table
 
-**Problem.** `edgeFieldError` (`listing-parents-rules.ts:77–98`) is a hand-coded
-if-chain encoding a **strict precedence ordering**: parent-renewal >
-child-renewal > daily-type > duration. The precedence lives only as the textual
-order of the `if`s. Tests (`listing-parents-rules.test.ts:223–259`) re-derive
-each pairwise relationship explicitly, and hardcode the full English error
-strings (duplicating the i18n message). Adding a 5th edge rule is a fifth `if`
-arm.
-
-**Plan.** Model the edge rules as an ordered array of `{ check: (parent,
-child) => boolean, messageKey: (name: string) => string }`. The fold returns
-the first match (honouring precedence), or null:
-
-```typescript
-const EDGE_ERROR_RULES = [
-  { applies: (p) => p.months_per_unit > 0, messageKey: (name) => t("listings_table.children_err_parent_renewal", { name }) },
-  { applies: (_p, c) => c.months_per_unit > 0, messageKey: (name) => t("listings_table.children_err_child_renewal", { name }) },
-  { applies: (_p, c) => c.listing_type === "daily" && p.listing_type !== "daily", messageKey: (name) => t("listings_table.children_err_child_daily", { name }) },
-  { applies: (p, c) => !durationsCompatible(p, c), messageKey: (name) => t("listings_table.children_err_child_duration", { name }) },
-] as const;
-
-export const edgeFieldError = (parent, child) =>
-  EDGE_ERROR_RULES.find(r => r.applies(parent, child))?.messageKey(child.name) ?? null;
-```
-
-The precedence tests can then assert against the table's ordering rather than
-each pairwise relationship — and test that the table is exhaustive (every
-check has a covering test).
-
-**Exemplar:** `LISTING_DEFAULT_FIELDS` — an ordered array of entries each
-carrying a predicate and a label key, folded by `resolveListingDefaults`. Same
-shape, different domain.
+**Status: Shipped.** `edgeFieldError` (`listing-parents-rules.ts`) is now a
+fold over `EDGE_ERROR_RULES` — an ordered array of `{ rejects, error }`
+entries whose order IS the precedence (parent-renewal > child-renewal >
+daily-type > duration): the first rule a pairing breaks decides the error, or
+null when the edge is allowed. Each rule carries its own message builder (a
+shared `childError` factory covers the child-blaming rules; the parent-renewal
+rule names the parent), so adding a 5th rule is one new entry in its
+precedence slot, never another `if` arm. The tests
+(`test/shared/listing-parents-rules.test.ts`) build expected messages from the
+same i18n keys via `t()` instead of re-typing the English copy, with guards
+that the resolved messages are real interpolated copy (naming the blamed
+listing) rather than raw-key fallbacks.
 
 ---
 
 ## 8. Capacity rules — consolidate into one declarative reference
 
-**Problem.** Capacity is the most scattered business concern. The rules live
-across six files (booking/model.ts, capacity-tree.ts, package-cap.ts,
-db/attendees/capacity.ts, db/capacity.ts, limits.ts) with no single declarative
-table a reader can consult. The daily-vs-standard branching is enforced by
-filtering listings out of certain queries rather than by a per-listing-type
-rule table. Each rule is individually tested, but the interactions are
-implicit.
-
-**Plan.** This is the most complex item and may be staged:
-
-- **Stage 1 — a `CAPACITY_RULES` data table** that declares, per listing-type
-  facet (`daily` vs `standard`, `customisable_days` true/false), which capacity
-  checks apply: `dateLessCap`, `perDateCap`, `groupPoolCap`,
-  `parentChildUnits`, `adminOverbookBypass`. A pure `applicableCapacityRules
-  (listing)` function returns the active rule set. This makes the daily-vs-
-  standard branching explicit and additive rather than buried in `if`s.
-- **Stage 2 — fold the JS preflight and the SQL guard** over the same rule set,
-  so the invariant ("the JS preflight and the inline SQL must never disagree
-  about capacity", `db/attendees/capacity.ts:1–9`) is enforced by sharing the
-  declaration rather than by a comment.
-
-**Exemplar:** The `BookingNode` union of facets (`booking/tree.ts:81–98`) is
-the codebase's reference for modelling a domain as a typed data structure. A
-capacity-rules table is a simpler version: a flat array of facets + an
-`appliesTo` predicate per rule (mirroring `LISTING_DEFAULT_FIELDS`).
+**Status: Shipped.** `src/shared/capacity-rules.ts` is the pure declarative
+table: each `CapacityRule` (`dateLessCap`, `perDateCap`, `groupPoolCap`,
+`parentChildUnits`, `adminOverbookBypass`) carries an `appliesTo` predicate
+over the listing facets (`listing_type` × `customisable_days`), and
+`allCapacityFacets()` enumerates every combination for exhaustive tests. Both
+enforcement surfaces derive from the same declaration (stage 2): the inline
+SQL guard builds its type predicates from `capacityRuleTypeSql`
+(`src/shared/db/capacity.ts`), and the JS preflight
+(`src/shared/db/attendees/capacity.ts`) imports the same rules — so the
+preflight and the write-time guard can never disagree about which check
+applies.
 
 ---
 
@@ -411,7 +331,7 @@ pattern to content string fields.
 
 ## Prioritisation
 
-**Shipped (items 1–4):**
+**Shipped (items 1–7):**
 
 - **Item 1 (admin-page schema)** — the schema, nav.tsx migration, and
   nav.test.tsx migration are done. Remaining: `adminLandingPath` derivation
@@ -423,12 +343,21 @@ pattern to content string fields.
 - **Item 3 (limits unification)** — done; `MAX_IMAGE_SIZE` bug fixed.
 - **Item 4 (read-only patterns)** — `READ_ONLY_GET_PATTERNS` is schema-derived;
   3 gaps fixed. `READ_ONLY_SAFE_PATHS` remains hand-maintained (stable, low-risk).
+- **Item 5 (picklist form options)** — `picklistOptions` derives every listing,
+  modifier, and invite-user select from its valibot schema; `calc_value`
+  bounds enforced at save via `modifierValueError`.
+- **Item 6 (price-rule precedence)** — `PRICE_RULES` + `PRICE_RULE_PRECEDENCE`
+  in `price-tree.ts`; `selectPriceRule`/`effectivePrice` share the one table,
+  exhaustiveness compile-enforced by `orderedKinds`.
+- **Item 7 (edge error precedence)** — `EDGE_ERROR_RULES` ordered table folded
+  by `edgeFieldError`; tests derive messages from the i18n keys.
+- **Item 8 (capacity rules)** — `capacity-rules.ts` is the declarative table;
+  the JS preflight and the inline SQL guard both derive from it.
 
-**Remaining (items 5–11):**
+**Remaining (items 9–11):**
 
-Items 5, 6, 7, 9, 10, and 11 are independent, medium-size refactors that can be
-done in any order. Item 8 (capacity rules) is the most complex and should be
-staged last.
+Items 9, 10, and 11 are independent, small refactors that can be done in any
+order.
 
 When taking any item, follow the codebase conventions: put the schema in
 `src/shared/` (pure, data-in/data-out), keep the IO shell thin, and migrate

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -43,6 +43,7 @@ src/shared/site-assignment.ts:370:34  ?? → ||    # available[idx]: object|unde
 src/shared/site-assignment.ts:392:34  ?? → ||    # getEmailConfig(): EmailConfig|null
 src/shared/site-assignment.ts:416:53  ?? → ||    # parseEmail(): ValidEmail|null, always truthy or null
 src/shared/ledger/project.ts:19:41  ?? → ||    # allBalances: Map<string,number>.get; the only falsy-non-null number is 0, and 0 ?? 0 === 0 || 0
+src/shared/listing-parents-rules.ts:124:4  ?? → ||    # find()?.error(): an i18n message is never "", so only undefined reaches the fallback either way
 src/shared/ledger/project.ts:37:49  ?? → ||    # balanceOf: same Map<string,number>.get fallback; 0 ?? 0 === 0 || 0
 src/shared/ledger/reconcile.ts:71:29  ?? → ||    # IDENTITY_FIELDS kind: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/ledger/reconcile.ts:113:56  ?? → ||   # multisetDiff: Map<string,number>.get count; 0 ?? 0 === 0 || 0

--- a/src/shared/listing-parents-rules.ts
+++ b/src/shared/listing-parents-rules.ts
@@ -68,31 +68,57 @@ export const durationsCompatible = (
     : childDuration === parentFixedDuration(parent);
 };
 
+/** One edge rule: `rejects` says whether a parent/child pairing breaks it, and
+ * `error` builds its user-facing message. */
+type EdgeRule = {
+  readonly error: (parent: EdgeListing, child: EdgeListing) => string;
+  readonly rejects: (parent: EdgeListing, child: EdgeListing) => boolean;
+};
+
+/** A message builder for the rules whose error names the child. */
+const childError =
+  (messageKey: string) =>
+  (_parent: EdgeListing, child: EdgeListing): string =>
+    t(`listings_table.${messageKey}`, { name: child.name });
+
+/** Every parent→child field rule as data, most fundamental first — the order IS
+ * the precedence: the first rule a pairing breaks decides the error, so a
+ * pairing that breaks several reports the deepest one. A renewal tier can't be
+ * a parent, then can't be a child, then a daily child needs a daily parent,
+ * then the child's span must match the one it inherits. Adding a rule is one
+ * new entry in its precedence slot, never another `if` arm. */
+const EDGE_ERROR_RULES: readonly EdgeRule[] = [
+  {
+    error: (parent) =>
+      t("listings_table.children_err_parent_renewal", { name: parent.name }),
+    rejects: (parent) => parent.months_per_unit > 0,
+  },
+  {
+    error: childError("children_err_child_renewal"),
+    rejects: (_parent, child) => child.months_per_unit > 0,
+  },
+  {
+    error: childError("children_err_child_daily"),
+    rejects: (parent, child) =>
+      child.listing_type === "daily" && parent.listing_type !== "daily",
+  },
+  {
+    error: childError("children_err_child_duration"),
+    rejects: (parent, child) => !durationsCompatible(parent, child),
+  },
+];
+
 /**
  * The user-facing error for a single parent→child edge whose listing *fields*
- * are incompatible (renewal tier on either side, a daily child under a non-daily
- * parent, or a span the child can't match), or null when the edge is allowed.
- * Field-only: structural nesting is checked separately by the editor.
+ * are incompatible — the first {@link EDGE_ERROR_RULES} entry the pairing
+ * breaks — or null when the edge is allowed. Field-only: structural nesting is
+ * checked separately by the editor.
  */
 export const edgeFieldError = (
   parent: EdgeListing,
   child: EdgeListing,
-): string | null => {
-  if (parent.months_per_unit > 0) {
-    return t("listings_table.children_err_parent_renewal", {
-      name: parent.name,
-    });
-  }
-  if (child.months_per_unit > 0) {
-    return t("listings_table.children_err_child_renewal", { name: child.name });
-  }
-  if (child.listing_type === "daily" && parent.listing_type !== "daily") {
-    return t("listings_table.children_err_child_daily", { name: child.name });
-  }
-  if (!durationsCompatible(parent, child)) {
-    return t("listings_table.children_err_child_duration", {
-      name: child.name,
-    });
-  }
-  return null;
-};
+): string | null =>
+  EDGE_ERROR_RULES.find((rule) => rule.rejects(parent, child))?.error(
+    parent,
+    child,
+  ) ?? null;

--- a/test/shared/listing-parents-rules.test.ts
+++ b/test/shared/listing-parents-rules.test.ts
@@ -1,10 +1,17 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { t } from "#i18n";
 import {
   durationsCompatible,
   type EdgeListing,
   edgeFieldError,
 } from "#shared/listing-parents-rules.ts";
+
+/** The i18n message a broken edge rule reports for the named listing — the
+ * same key production formats, so tests assert WHICH rule won (and whose name
+ * it blames) without re-typing the English copy. */
+const ruleError = (messageKey: string, name: string): string =>
+  t(`listings_table.children_err_${messageKey}`, { name });
 
 const listing = (over: Partial<EdgeListing> = {}): EdgeListing => ({
   customisable_days: false,
@@ -166,11 +173,25 @@ describe("edgeFieldError", () => {
     expect(edgeFieldError(parent, child)).toBeNull();
   });
 
+  test("a parent-blaming error resolves to real copy naming the parent, not a raw i18n key", () => {
+    const parent = listing({ months_per_unit: 1, name: "Membership" });
+    const message = edgeFieldError(parent, listing());
+    expect(message).toContain("'Membership'");
+    expect(message).not.toContain("children_err");
+  });
+
+  test("a child-blaming error resolves to real copy naming the child, not a raw i18n key", () => {
+    const child = listing({ months_per_unit: 1, name: "Gold Tier" });
+    const message = edgeFieldError(listing(), child);
+    expect(message).toContain("'Gold Tier'");
+    expect(message).not.toContain("children_err");
+  });
+
   test("the parent-renewal error when the parent is a renewal tier", () => {
     const parent = listing({ months_per_unit: 1, name: "Membership" });
     const child = listing({ name: "Child" });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Membership' is a renewal tier, so it can't require child listings.",
+      ruleError("parent_renewal", "Membership"),
     );
   });
 
@@ -178,7 +199,7 @@ describe("edgeFieldError", () => {
     const parent = listing({ name: "Parent" });
     const child = listing({ months_per_unit: 1, name: "Membership" });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Membership' is a renewal tier, so it can't be a child listing.",
+      ruleError("child_renewal", "Membership"),
     );
   });
 
@@ -186,7 +207,7 @@ describe("edgeFieldError", () => {
     const parent = listing({ listing_type: "standard", name: "Parent" });
     const child = listing({ listing_type: "daily", name: "Cabin" });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Cabin' is a daily listing, so it can only be a child of another daily listing.",
+      ruleError("child_daily", "Cabin"),
     );
   });
 
@@ -216,7 +237,7 @@ describe("edgeFieldError", () => {
       name: "Cabin",
     });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Cabin' can't be booked for the same length as its parent — adjust its duration or day prices to match.",
+      ruleError("child_duration", "Cabin"),
     );
   });
 
@@ -228,7 +249,7 @@ describe("edgeFieldError", () => {
       name: "Child",
     });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Parent' is a renewal tier, so it can't require child listings.",
+      ruleError("parent_renewal", "Parent"),
     );
   });
 
@@ -240,7 +261,7 @@ describe("edgeFieldError", () => {
       name: "Child",
     });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Child' is a renewal tier, so it can't be a child listing.",
+      ruleError("child_renewal", "Child"),
     );
   });
 
@@ -254,7 +275,7 @@ describe("edgeFieldError", () => {
       name: "Cabin",
     });
     expect(edgeFieldError(parent, child)).toBe(
-      "'Cabin' is a daily listing, so it can only be a child of another daily listing.",
+      ruleError("child_daily", "Cabin"),
     );
   });
 });

--- a/test/shared/listing-parents-rules.test.ts
+++ b/test/shared/listing-parents-rules.test.ts
@@ -173,19 +173,45 @@ describe("edgeFieldError", () => {
     expect(edgeFieldError(parent, child)).toBeNull();
   });
 
-  test("a parent-blaming error resolves to real copy naming the parent, not a raw i18n key", () => {
-    const parent = listing({ months_per_unit: 1, name: "Membership" });
-    const message = edgeFieldError(parent, listing());
-    expect(message).toContain("'Membership'");
-    expect(message).not.toContain("children_err");
-  });
+  // One scenario per rule, each breaking only its own rule, paired with the
+  // listing name its message must blame. Guards that every rule's message
+  // resolves to real interpolated copy — a missing translation would make the
+  // ruleError-based expectations below match the raw-key fallback on both
+  // sides, so these assertions are what catch it.
+  const blamedNameCases: [string, EdgeListing, EdgeListing, string][] = [
+    [
+      "parent renewal",
+      listing({ months_per_unit: 1, name: "Membership" }),
+      listing(),
+      "Membership",
+    ],
+    [
+      "child renewal",
+      listing(),
+      listing({ months_per_unit: 1, name: "Gold Tier" }),
+      "Gold Tier",
+    ],
+    [
+      "daily child under a non-daily parent",
+      listing(),
+      listing({ listing_type: "daily", name: "Cabin" }),
+      "Cabin",
+    ],
+    [
+      "duration mismatch",
+      listing({ duration_days: 3, listing_type: "daily" }),
+      listing({ duration_days: 5, listing_type: "daily", name: "Bell Tent" }),
+      "Bell Tent",
+    ],
+  ];
 
-  test("a child-blaming error resolves to real copy naming the child, not a raw i18n key", () => {
-    const child = listing({ months_per_unit: 1, name: "Gold Tier" });
-    const message = edgeFieldError(listing(), child);
-    expect(message).toContain("'Gold Tier'");
-    expect(message).not.toContain("children_err");
-  });
+  for (const [rule, parent, child, blamed] of blamedNameCases) {
+    test(`the ${rule} error resolves to real copy naming '${blamed}', not a raw i18n key`, () => {
+      const message = edgeFieldError(parent, child);
+      expect(message).toContain(`'${blamed}'`);
+      expect(message).not.toContain("children_err");
+    });
+  }
 
   test("the parent-renewal error when the parent is a renewal tier", () => {
     const parent = listing({ months_per_unit: 1, name: "Membership" });


### PR DESCRIPTION
## What changed

When an operator links a child listing to a parent, several rules decide whether the pairing is allowed — and when a pairing breaks more than one rule, the most fundamental one is the error shown. Before, that ordering only existed as the textual order of four `if` statements in `edgeFieldError`. Now the rules live in one ordered list (`EDGE_ERROR_RULES` in `src/shared/listing-parents-rules.ts`), where each entry says when it rejects a pairing and what message it shows. The list's order *is* the precedence, and adding a new rule is one new entry in its slot — never another `if` arm. This is item 7 from `BUSINESS_LOGIC_TODOS.md`, following the same "data table plus one fold" shape as `LISTING_DEFAULT_FIELDS`.

The tests no longer re-type the full English error sentences (which duplicated the translation files). They build the expected message from the same translation key production uses, and a table-driven guard covers all four rules: each rule's message must resolve to real copy naming the blamed listing — not a raw translation key.

## Also in this change

- `BUSINESS_LOGIC_TODOS.md` was stale: items 5 (form options from schemas), 6 (price-rule precedence), and 8 (capacity rules) were already built in the code but still listed as open. Their entries now describe what shipped and where, and the prioritisation section matches.
- One provably-unkillable mutation (`?? → ||` on a message that can never be empty) is recorded in `scripts/mutation/equivalent-mutants.txt`, keeping the module's mutation score at 100%.

## Behaviour

No user-facing behaviour changes — the same pairings are allowed and rejected with the same messages as before. `deno task precommit` passes, and a targeted mutation run on the changed module kills 28/28 mutants (1 suppressed as a documented equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEXUB9mPjBspQGxibHk1Tt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEXUB9mPjBspQGxibHk1Tt)_


## Summary by CodeRabbit

* **Documentation**
  * Updated business-logic documentation to mark schema-ization items 5–8 as shipped, including validation/preference rules and consolidated capacity behavior.
  * Refreshed prioritization to show the new "Shipped (items 1–8)" vs "Remaining (items 9–11)" split.
* **Refactor**
  * Reworked listing compatibility error precedence into an ordered, data-driven rules approach.
* **Tests**
  * Updated tests to derive expected error text from i18n and verify blamed listing name handling and rule-key-specific precedence.
  * Added an additional equivalent-mutant suppression entry to keep mutation checks accurate.