### PR TITLE
Unify the helpers left behind by the big file splits

### DIFF
--- a/src/features/api/booking.ts
+++ b/src/features/api/booking.ts
@@ -1,10 +1,14 @@
-import { apiError, apiResponse } from "#routes/api/cors.ts";
+import { apiError } from "#routes/api/cors.ts";
 import { processParentApiBooking } from "#routes/api/folded-booking.ts";
 import {
+  bookingSuccessResponse,
   checkBookingRateLimit,
+  checkoutFailedResponse,
+  checkoutResponse,
   parseApiJsonBody,
   resolveCustomPrice,
   resolvePositiveQuantity,
+  soldOutResponse,
   toFormParams,
   withActiveListing,
 } from "#routes/api/helpers.ts";
@@ -28,27 +32,16 @@ const bookingResultToResponse = (
 ): Response => {
   switch (result.type) {
     case "success":
-      return apiResponse({
-        booking: {
-          // Outstanding balance in minor units; 0 when fully paid, positive when
-          // the booking was taken without collecting payment (no provider), so
-          // the integration knows the amount left to collect from the buyer.
-          amountOwed: result.attendee.remaining_balance,
-          ticketToken: result.attendee.ticket_token,
-          ticketUrl: `/t/${result.attendee.ticket_token}`,
-        },
-      });
+      return bookingSuccessResponse(result.attendee);
     case "checkout":
-      return apiResponse({ booking: { checkoutUrl: result.checkoutUrl } });
+      return checkoutResponse(result.checkoutUrl);
     case "sold_out":
-      return apiError("Sorry, not enough spots available", 409);
+      return soldOutResponse();
     case "checkout_failed":
-      return result.error
-        ? apiError(result.error)
-        : apiError("Failed to create payment session", 500);
+      return checkoutFailedResponse(result.error);
     case "creation_failed":
       return result.reason === "capacity_exceeded"
-        ? apiError("Sorry, not enough spots available", 409)
+        ? soldOutResponse()
         : apiError("Registration failed. Please try again.", 500);
   }
 };

--- a/src/features/api/booking.ts
+++ b/src/features/api/booking.ts
@@ -15,6 +15,7 @@ import {
 import { isRegistrationClosed } from "#routes/format.ts";
 import { parentRequiresChild } from "#routes/public/ticket-payment.ts";
 import { getBaseUrl } from "#routes/url.ts";
+import { bookingError } from "#shared/booking/form.ts";
 import { processBooking } from "#shared/booking.ts";
 import { countsPerDate } from "#shared/capacity-rules.ts";
 import { getAvailableDates } from "#shared/dates.ts";
@@ -42,7 +43,7 @@ const bookingResultToResponse = (
     case "creation_failed":
       return result.reason === "capacity_exceeded"
         ? soldOutResponse()
-        : apiError("Registration failed. Please try again.", 500);
+        : apiError(bookingError.fallback, 500);
   }
 };
 
@@ -60,7 +61,7 @@ const resolveBookingDate = async (
   const submittedDate = String(body.date ?? "");
   const availableDates = getAvailableDates(listing, await getActiveHolidays());
   if (!submittedDate || !availableDates.includes(submittedDate)) {
-    return apiError("Please select a valid date");
+    return apiError(bookingError.invalidDate);
   }
   return submittedDate;
 };

--- a/src/features/api/booking.ts
+++ b/src/features/api/booking.ts
@@ -1,4 +1,4 @@
-import { apiResponse } from "#routes/api/cors.ts";
+import { apiError, apiResponse } from "#routes/api/cors.ts";
 import { processParentApiBooking } from "#routes/api/folded-booking.ts";
 import {
   checkBookingRateLimit,
@@ -41,15 +41,15 @@ const bookingResultToResponse = (
     case "checkout":
       return apiResponse({ booking: { checkoutUrl: result.checkoutUrl } });
     case "sold_out":
-      return apiResponse({ error: "Sorry, not enough spots available" }, 409);
+      return apiError("Sorry, not enough spots available", 409);
     case "checkout_failed":
       return result.error
-        ? apiResponse({ error: result.error }, 400)
-        : apiResponse({ error: "Failed to create payment session" }, 500);
+        ? apiError(result.error)
+        : apiError("Failed to create payment session", 500);
     case "creation_failed":
       return result.reason === "capacity_exceeded"
-        ? apiResponse({ error: "Sorry, not enough spots available" }, 409)
-        : apiResponse({ error: "Registration failed. Please try again." }, 500);
+        ? apiError("Sorry, not enough spots available", 409)
+        : apiError("Registration failed. Please try again.", 500);
   }
 };
 
@@ -67,7 +67,7 @@ const resolveBookingDate = async (
   const submittedDate = String(body.date ?? "");
   const availableDates = getAvailableDates(listing, await getActiveHolidays());
   if (!submittedDate || !availableDates.includes(submittedDate)) {
-    return apiResponse({ error: "Please select a valid date" }, 400);
+    return apiError("Please select a valid date");
   }
   return submittedDate;
 };
@@ -94,9 +94,8 @@ export const handleBook = withActiveListing(
     // API entry. A `bookable_alone` child has its own page/API eligibility, so it
     // books directly here.
     if (await anyNonStandaloneChild([listing.id])) {
-      return apiResponse(
-        { error: "This listing must be booked through its parent listing." },
-        400,
+      return apiError(
+        "This listing must be booked through its parent listing.",
       );
     }
 
@@ -104,7 +103,7 @@ export const handleBook = withActiveListing(
     if (limited) return limited;
 
     if (isRegistrationClosed(listing)) {
-      return apiResponse({ error: "Registration is closed" }, 400);
+      return apiError("Registration is closed");
     }
 
     const body = await parseApiJsonBody(request);
@@ -127,10 +126,7 @@ export const handleBook = withActiveListing(
     // endpoint doesn't accept — booking them here would charge the wrong amount,
     // so they must be booked through the website form.
     if (listing.customisable_days) {
-      return apiResponse(
-        { error: "This listing must be booked through the website." },
-        400,
-      );
+      return apiError("This listing must be booked through the website.");
     }
 
     const form = toFormParams(body);
@@ -140,7 +136,7 @@ export const handleBook = withActiveListing(
     const valResult = tryValidateTicketFields(
       form,
       listing.fields,
-      (msg) => apiResponse({ error: msg }, 400),
+      (msg) => apiError(msg),
       paid,
     );
     if (valResult instanceof Response) return valResult;

--- a/src/features/api/cors.ts
+++ b/src/features/api/cors.ts
@@ -16,6 +16,17 @@ export const apiResponse = (data: unknown, status = 200): Response => {
   return response;
 };
 
+/** Turn a JSON responder into an error responder: the returned function wraps
+ * a message in the shared `{ error: message }` envelope (400 unless told
+ * otherwise), so every API error body is spelled in one place. */
+export const jsonError =
+  (respond: (data: unknown, status?: number) => Response) =>
+  (message: string, status = 400): Response =>
+    respond({ error: message }, status);
+
+/** JSON `{ error: message }` response with CORS headers */
+export const apiError = jsonError(apiResponse);
+
 /** CORS preflight response */
 export const handleOptions = (): Response =>
   new Response(null, { headers: CORS_HEADERS, status: 204 });

--- a/src/features/api/folded-booking.ts
+++ b/src/features/api/folded-booking.ts
@@ -1,7 +1,14 @@
 import * as v from "valibot";
 import { sumOf } from "#fp";
-import { apiError, apiResponse } from "#routes/api/cors.ts";
-import { resolveCustomPrice, toFormParams } from "#routes/api/helpers.ts";
+import { apiError } from "#routes/api/cors.ts";
+import {
+  bookingSuccessResponse,
+  checkoutFailedResponse,
+  checkoutResponse,
+  resolveCustomPrice,
+  soldOutResponse,
+  toFormParams,
+} from "#routes/api/helpers.ts";
 import {
   type ApiChildSelection,
   ChildrenSchema,
@@ -237,18 +244,14 @@ export const completeFoldedBooking = async (
       date,
       fold.dayCount,
     );
-    if (!available) {
-      return apiError("Sorry, not enough spots available", 409);
-    }
+    if (!available) return soldOutResponse();
     const provider = (await getActivePaymentProvider())!;
     const baseUrl = getBaseUrl(request);
     const result = await provider.createCheckoutSession(intent, baseUrl);
-    if (!result) {
-      return apiError("Failed to create payment session", 500);
-    }
+    if (!result) return checkoutFailedResponse();
     return "error" in result
-      ? apiError(result.error)
-      : apiResponse({ booking: { checkoutUrl: result.checkoutUrl } });
+      ? checkoutFailedResponse(result.error)
+      : checkoutResponse(result.checkoutUrl);
   }
   // Free, or provider-less paid (owes the full value). An owed order must record
   // its gross sale legs in the ledger at creation — the outstanding balance
@@ -270,23 +273,14 @@ export const completeFoldedBooking = async (
     modifierUsages: [],
     remainingBalance,
   });
-  if (!reservation.success) {
-    return apiError("Sorry, not enough spots available", 409);
-  }
+  if (!reservation.success) return soldOutResponse();
   // Notify only after stock is committed, exactly like the standalone API booking
   // (`processBooking`) and the web free path (`handleFreePath`) do after
   // `createFreeReservation`: without this the folded free/provider-less
   // parent booking silently skips the confirmation email, registration webhook,
   // and activity log every other booking path fires.
   await logAndNotifyRegistration(reservation.entries);
-  const attendee = reservation.entries[0]!.attendee;
-  return apiResponse({
-    booking: {
-      amountOwed: attendee.remaining_balance,
-      ticketToken: attendee.ticket_token,
-      ticketUrl: `/t/${attendee.ticket_token}`,
-    },
-  });
+  return bookingSuccessResponse(reservation.entries[0]!.attendee);
 };
 
 /**

--- a/src/features/api/folded-booking.ts
+++ b/src/features/api/folded-booking.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 import { sumOf } from "#fp";
-import { apiResponse } from "#routes/api/cors.ts";
+import { apiError, apiResponse } from "#routes/api/cors.ts";
 import { resolveCustomPrice, toFormParams } from "#routes/api/helpers.ts";
 import {
   type ApiChildSelection,
@@ -92,21 +92,15 @@ export const applyChildSelectionsToForm = (
   for (const selection of selections) {
     const child = childBySlug.get(selection.slug);
     if (!child) {
-      return apiResponse(
-        { error: `'${selection.slug}' is not a child of this listing.` },
-        400,
-      );
+      return apiError(`'${selection.slug}' is not a child of this listing.`);
     }
     const childId = child.listing.id;
     if (
       priceByChild.has(childId) &&
       priceByChild.get(childId) !== selection.customPrice
     ) {
-      return apiResponse(
-        {
-          error: `Conflicting prices for '${selection.slug}'. Send one entry per child with a single price.`,
-        },
-        400,
+      return apiError(
+        `Conflicting prices for '${selection.slug}'. Send one entry per child with a single price.`,
       );
     }
     priceByChild.set(childId, selection.customPrice);
@@ -188,7 +182,7 @@ export const foldChildrenOrError = async (
   tree: BookingTree,
 ): Promise<Extract<FoldChildrenResult, { ok: true }> | Response> => {
   const fold = await foldSelectedChildren(ctx, form, base, tree);
-  return fold.ok ? fold : apiResponse({ error: fold.error }, 400);
+  return fold.ok ? fold : apiError(fold.error);
 };
 
 /** Validate a folded order's contact fields against the merged parent+child
@@ -204,7 +198,7 @@ export const validateFoldedFields = (
   tryValidateTicketFields(
     form,
     mergeListingFields(fold.listings.map((e) => e.listing.fields)),
-    (msg) => apiResponse({ error: msg }, 400),
+    (msg) => apiError(msg),
     paid,
   );
 
@@ -244,16 +238,16 @@ export const completeFoldedBooking = async (
       fold.dayCount,
     );
     if (!available) {
-      return apiResponse({ error: "Sorry, not enough spots available" }, 409);
+      return apiError("Sorry, not enough spots available", 409);
     }
     const provider = (await getActivePaymentProvider())!;
     const baseUrl = getBaseUrl(request);
     const result = await provider.createCheckoutSession(intent, baseUrl);
     if (!result) {
-      return apiResponse({ error: "Failed to create payment session" }, 500);
+      return apiError("Failed to create payment session", 500);
     }
     return "error" in result
-      ? apiResponse({ error: result.error }, 400)
+      ? apiError(result.error)
       : apiResponse({ booking: { checkoutUrl: result.checkoutUrl } });
   }
   // Free, or provider-less paid (owes the full value). An owed order must record
@@ -277,7 +271,7 @@ export const completeFoldedBooking = async (
     remainingBalance,
   });
   if (!reservation.success) {
-    return apiResponse({ error: "Sorry, not enough spots available" }, 409);
+    return apiError("Sorry, not enough spots available", 409);
   }
   // Notify only after stock is committed, exactly like the standalone API booking
   // (`processBooking`) and the web free path (`handleFreePath`) do after
@@ -314,19 +308,12 @@ export const processParentApiBooking = async (
   // span its children inherit) can't be booked here — like a customisable
   // standalone listing.
   if (listing.customisable_days) {
-    return apiResponse(
-      { error: "This listing must be booked through the website." },
-      400,
-    );
+    return apiError("This listing must be booked through the website.");
   }
   const selections = parseApiChildSelections(body);
   if (selections === null) {
-    return apiResponse(
-      {
-        error:
-          "Provide a `children` array of { slug, quantity } totalling the booked quantity.",
-      },
-      400,
+    return apiError(
+      "Provide a `children` array of { slug, quantity } totalling the booked quantity.",
     );
   }
 

--- a/src/features/api/guards.ts
+++ b/src/features/api/guards.ts
@@ -1,4 +1,4 @@
-import { apiResponse } from "#routes/api/cors.ts";
+import { apiError } from "#routes/api/cors.ts";
 import { LISTING_NOT_FOUND, withActiveListing } from "#routes/api/helpers.ts";
 import { classifyForDiscovery } from "#routes/public/discovery.ts";
 import type { ServerContext } from "#routes/types.ts";
@@ -33,7 +33,7 @@ const guardChildListing = async (
   listing: ListingWithCount,
 ): Promise<{ isSoldOutParent: boolean } | Response> => {
   const { isChild, isSoldOutParent } = await listingDiscoveryState(listing);
-  if (isChild) return apiResponse(LISTING_NOT_FOUND, 404);
+  if (isChild) return apiError(LISTING_NOT_FOUND, 404);
   return { isSoldOutParent };
 };
 

--- a/src/features/api/helpers.ts
+++ b/src/features/api/helpers.ts
@@ -1,4 +1,4 @@
-import { apiError } from "#routes/api/cors.ts";
+import { apiError, apiResponse } from "#routes/api/cors.ts";
 import type { ServerContext } from "#routes/types.ts";
 import { getClientIp } from "#routes/url.ts";
 import { parseCustomPrice } from "#shared/booking/form.ts";
@@ -10,6 +10,39 @@ import type { ListingWithCount } from "#shared/types.ts";
 import { parseNonNegativeInt } from "#shared/validation/number.ts";
 
 const LISTING_NOT_FOUND = "Listing not found";
+
+/** The public booking JSON body for a booking that was created: the ticket
+ * link plus any balance left to collect. Shared by the standalone and folded
+ * booking paths so the two spell the contract one way. */
+export const bookingSuccessResponse = (attendee: {
+  remaining_balance: number;
+  ticket_token: string;
+}): Response =>
+  apiResponse({
+    booking: {
+      // Outstanding balance in minor units; 0 when fully paid, positive when
+      // the booking was taken without collecting payment (no provider), so
+      // the integration knows the amount left to collect from the buyer.
+      amountOwed: attendee.remaining_balance,
+      ticketToken: attendee.ticket_token,
+      ticketUrl: `/t/${attendee.ticket_token}`,
+    },
+  });
+
+/** The public booking JSON body sending the buyer to the payment provider's
+ * hosted checkout page to finish paying. */
+export const checkoutResponse = (checkoutUrl: string): Response =>
+  apiResponse({ booking: { checkoutUrl } });
+
+/** 409 for a booking that no longer fits the remaining spots. */
+export const soldOutResponse = (): Response =>
+  apiError("Sorry, not enough spots available", 409);
+
+/** Map a failed checkout-session creation to a response: the provider's own
+ * message when it gave one (a 400 the buyer can act on), otherwise the
+ * generic 500. */
+export const checkoutFailedResponse = (error?: string): Response =>
+  error ? apiError(error) : apiError("Failed to create payment session", 500);
 
 /** Resolve a booking's `quantity` field from a JSON body — defaults to 1 for
  * absent/malformed values, rejects an explicit 0 (the admin-only no-quantity

--- a/src/features/api/helpers.ts
+++ b/src/features/api/helpers.ts
@@ -1,4 +1,4 @@
-import { apiResponse } from "#routes/api/cors.ts";
+import { apiError } from "#routes/api/cors.ts";
 import type { ServerContext } from "#routes/types.ts";
 import { getClientIp } from "#routes/url.ts";
 import { parseCustomPrice } from "#shared/booking/form.ts";
@@ -9,7 +9,7 @@ import { FormParams } from "#shared/form-data.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { parseNonNegativeInt } from "#shared/validation/number.ts";
 
-const LISTING_NOT_FOUND = { error: "Listing not found" } as const;
+const LISTING_NOT_FOUND = "Listing not found";
 
 /** Resolve a booking's `quantity` field from a JSON body — defaults to 1 for
  * absent/malformed values, rejects an explicit 0 (the admin-only no-quantity
@@ -20,7 +20,7 @@ export const resolvePositiveQuantity = (
 ): number | Response => {
   const parsedQuantity = parseNonNegativeInt(String(body.quantity ?? "1"));
   if (parsedQuantity === 0) {
-    return apiResponse({ error: "Quantity must be at least 1" }, 400);
+    return apiError("Quantity must be at least 1");
   }
   return parsedQuantity ?? 1;
 };
@@ -42,9 +42,7 @@ export const resolveCustomPrice = (
     listing.unit_price,
     listing.max_price,
   );
-  return priceResult.ok
-    ? priceResult.price
-    : apiResponse({ error: priceResult.error }, 400);
+  return priceResult.ok ? priceResult.price : apiError(priceResult.error);
 };
 
 /** Look up an active listing by slug, returning a 404 response if
@@ -56,9 +54,9 @@ export const findActiveListing = async (
   slug: string,
 ): Promise<ListingWithCount | Response> => {
   const listing = await getListingWithCountBySlug(slug);
-  if (!listing?.active) return apiResponse(LISTING_NOT_FOUND, 404);
+  if (!listing?.active) return apiError(LISTING_NOT_FOUND, 404);
   return (await isHiddenPackageMember(listing.id))
-    ? apiResponse(LISTING_NOT_FOUND, 404)
+    ? apiError(LISTING_NOT_FOUND, 404)
     : listing;
 };
 
@@ -69,7 +67,7 @@ export const parseApiJsonBody = async (
   try {
     return await request.json();
   } catch {
-    return apiResponse({ error: "Invalid JSON body" }, 400);
+    return apiError("Invalid JSON body");
   }
 };
 
@@ -133,10 +131,7 @@ export const checkBookingRateLimit = async (
 ): Promise<Response | null> => {
   const ip = getClientIp(request, server);
   if (await bookingLimiter.isLimited(ip)) {
-    return apiResponse(
-      { error: "Too many booking attempts. Please try again later." },
-      429,
-    );
+    return apiError("Too many booking attempts. Please try again later.", 429);
   }
   await bookingLimiter.record(ip);
   return null;

--- a/src/features/api/helpers.ts
+++ b/src/features/api/helpers.ts
@@ -1,7 +1,7 @@
 import { apiError, apiResponse } from "#routes/api/cors.ts";
 import type { ServerContext } from "#routes/types.ts";
 import { getClientIp } from "#routes/url.ts";
-import { parseCustomPrice } from "#shared/booking/form.ts";
+import { bookingError, parseCustomPrice } from "#shared/booking/form.ts";
 import { bookingLimiter } from "#shared/db/booking-attempts.ts";
 import { isHiddenPackageMember } from "#shared/db/groups.ts";
 import { getListingWithCountBySlug } from "#shared/db/listings.ts";
@@ -36,13 +36,13 @@ export const checkoutResponse = (checkoutUrl: string): Response =>
 
 /** 409 for a booking that no longer fits the remaining spots. */
 export const soldOutResponse = (): Response =>
-  apiError("Sorry, not enough spots available", 409);
+  apiError(bookingError.generic, 409);
 
 /** Map a failed checkout-session creation to a response: the provider's own
  * message when it gave one (a 400 the buyer can act on), otherwise the
  * generic 500. */
 export const checkoutFailedResponse = (error?: string): Response =>
-  error ? apiError(error) : apiError("Failed to create payment session", 500);
+  error ? apiError(error) : apiError(bookingError.paymentSessionFailed, 500);
 
 /** Resolve a booking's `quantity` field from a JSON body — defaults to 1 for
  * absent/malformed values, rejects an explicit 0 (the admin-only no-quantity

--- a/src/features/api/packages.ts
+++ b/src/features/api/packages.ts
@@ -1,4 +1,4 @@
-import { apiResponse } from "#routes/api/cors.ts";
+import { apiError, apiResponse } from "#routes/api/cors.ts";
 import {
   applyChildSelectionsToForm,
   completeFoldedBooking,
@@ -59,7 +59,7 @@ import {
 import type { Group } from "#shared/types.ts";
 import { extractContact } from "#templates/fields/ticket.ts";
 
-const PACKAGE_NOT_FOUND = { error: "Package not found" } as const;
+const PACKAGE_NOT_FOUND = "Package not found";
 
 /** The ctx, group, limit, and tree a package endpoint needs once its slug
  * resolves to a bookable bundle — the loaded shape {@link withPackageContext}
@@ -107,7 +107,7 @@ const loadPackageContext = async (
 const loadPackageContextOr404 = async (
   slug: string,
 ): Promise<PackageContext | Response> =>
-  (await loadPackageContext(slug)) ?? apiResponse(PACKAGE_NOT_FOUND, 404);
+  (await loadPackageContext(slug)) ?? apiError(PACKAGE_NOT_FOUND, 404);
 
 /** Load a bookable package by slug, or respond with the package-not-found 404 —
  * shared by the GET and POST package endpoints via {@link withSlugLoaded} so the
@@ -206,10 +206,7 @@ const applyPackageChildSelections = (
   for (const [parentSlug, perParent] of byParent) {
     const member = ctx.listings.find((e) => e.listing.slug === parentSlug);
     if (!member) {
-      return apiResponse(
-        { error: `'${parentSlug}' is not a member of this package.` },
-        400,
-      );
+      return apiError(`'${parentSlug}' is not a member of this package.`);
     }
     const error = applyChildSelectionsToForm(
       form,
@@ -253,7 +250,7 @@ const resolvePackageOrder = async (
   if (ctx.dates.length > 0) {
     const submitted = String(body.date ?? "");
     if (!ctx.dates.includes(submitted)) {
-      return apiResponse({ error: "Please select a valid date" }, 400);
+      return apiError("Please select a valid date");
     }
     date = submitted;
   }
@@ -269,7 +266,7 @@ const resolvePackageOrder = async (
     standIns,
   );
   if ("error" in dayResult) {
-    return apiResponse({ error: dayResult.error }, 400);
+    return apiError(dayResult.error);
   }
   return { date, dayCount: dayResult.dayCount, form, packageQty, quantities };
 };
@@ -312,12 +309,8 @@ export const handleBookPackage = async (
 
   const selections = parseApiChildSelections(body, PackageChildrenSchema);
   if (selections === null) {
-    return apiResponse(
-      {
-        error:
-          "Provide a `children` array of { parent, slug, quantity } choosing each member's add-ons.",
-      },
-      400,
+    return apiError(
+      "Provide a `children` array of { parent, slug, quantity } choosing each member's add-ons.",
     );
   }
   const selectionError = applyPackageChildSelections(form, ctx, selections);

--- a/src/features/api/packages.ts
+++ b/src/features/api/packages.ts
@@ -30,6 +30,7 @@ import {
 import type { TicketCtx } from "#routes/public/types.ts";
 import type { ServerContext } from "#routes/types.ts";
 import { buildBookingTree } from "#shared/booking/build-tree.ts";
+import { bookingError } from "#shared/booking/form.ts";
 import {
   bookableChildIds,
   packageDayCountsChildrenSupport,
@@ -250,7 +251,7 @@ const resolvePackageOrder = async (
   if (ctx.dates.length > 0) {
     const submitted = String(body.date ?? "");
     if (!ctx.dates.includes(submitted)) {
-      return apiError("Please select a valid date");
+      return apiError(bookingError.invalidDate);
     }
     date = submitted;
   }

--- a/src/features/api/payment-processing/index.ts
+++ b/src/features/api/payment-processing/index.ts
@@ -48,8 +48,8 @@ import {
 import {
   chargeMismatchSpec,
   deletedListingSpec,
+  refundSpec,
   refuseMismatch,
-  unexpectedErrorSpec,
 } from "#routes/api/payment-processing/refunds.ts";
 import {
   datelessGhostBookings,
@@ -312,7 +312,7 @@ const processReservedSession: SessionProcessor = async (
       session,
       intent,
       placeholders,
-      unexpectedErrorSpec(
+      refundSpec("unexpected_error")(
         `Unexpected error completing session ${session.id}: ${String(error)}`,
       ),
     );

--- a/src/features/api/payment-processing/metadata.ts
+++ b/src/features/api/payment-processing/metadata.ts
@@ -29,18 +29,24 @@ import {
 export const businessTime = (session: ValidatedPaymentSession): string =>
   session.createdAt ?? nowIso();
 
-/** Parse per-listing answer IDs from metadata JSON string.
- * Returns undefined for empty input. The JSON was serialized by our own
- * buildMetadata, so we trust the structure. */
-const parseListingAnswerIds = (
-  json: string,
-): Record<string, number[]> | undefined =>
-  json ? (JSON.parse(json) as Record<string, number[]>) : undefined;
+/** Read one optional JSON metadata field: parse it when present, or hand back
+ * the field's own fallback when empty. The JSON was serialized by our own
+ * buildMetadata, so we trust the structure (parseBookingItems is the deliberate
+ * schema-validated exception). */
+const jsonMetaField =
+  <T>(fallback: T) =>
+  (json: string): T =>
+    json ? (JSON.parse(json) as T) : fallback;
 
-const parseListingTextAnswerIds = (
-  json: string,
-): Record<string, TextAnswerRef[]> | undefined =>
-  json ? (JSON.parse(json) as Record<string, TextAnswerRef[]>) : undefined;
+/** Per-listing answer IDs; undefined when the checkout sent none. */
+const parseListingAnswerIds = jsonMetaField<
+  Record<string, number[]> | undefined
+>(undefined);
+
+/** Per-listing free-text answer references; undefined when none. */
+const parseListingTextAnswerIds = jsonMetaField<
+  Record<string, TextAnswerRef[]> | undefined
+>(undefined);
 
 /**
  * Parse booking items from metadata JSON. Returns null when the JSON is
@@ -66,13 +72,13 @@ const parseBookingItems = (itemsJson: string): BookingItem[] | null => {
   return result.success ? result.output : null;
 };
 
-/** Parse the compact modifier references from session metadata. Our own JSON,
- * round-tripped through the provider; absent (empty) means no modifiers. */
-const parseModifierRefs = (json: string): ModifierRef[] =>
-  json ? (JSON.parse(json) as ModifierRef[]) : [];
+/** The compact modifier references; absent (empty) means no modifiers. */
+const parseModifierRefs = jsonMetaField<ModifierRef[]>([]);
 
-const parseAllocations = (json: string): ChildAllocation[] | undefined =>
-  json ? (JSON.parse(json) as ChildAllocation[]) : undefined;
+/** Child ticket allocations; undefined when the checkout sent none. */
+const parseAllocations = jsonMetaField<ChildAllocation[] | undefined>(
+  undefined,
+);
 
 /**
  * Extract booking intent from session metadata.

--- a/src/features/api/payment-processing/pricing.ts
+++ b/src/features/api/payment-processing/pricing.ts
@@ -9,8 +9,8 @@
 import { sumOf } from "#fp";
 import type { ValidatedItem } from "#routes/api/payment-processing/package-pricing.ts";
 import {
-  priceChangedSpec,
   type RefundSpec,
+  refundSpec,
 } from "#routes/api/payment-processing/refunds.ts";
 import type { BookingIntent } from "#routes/api/webhook-types.ts";
 import { calculateBookingFee } from "#shared/booking-fee.ts";
@@ -114,7 +114,7 @@ export const paidPricingRefund = (
   // refunds rather than completing.
   for (const { listing, expectedPrice } of validatedItems) {
     if (expectedPrice === null) {
-      return priceChangedSpec(
+      return refundSpec("price_changed")(
         `Package member listing ${listing.id} is no longer part of its package`,
       );
     }
@@ -129,13 +129,13 @@ export const paidPricingRefund = (
   // mismatches. expectedPrice is non-null by the fail-closed loop above.
   for (const { item, listing, expectedPrice } of validatedItems) {
     if (hasPriceMismatch(item.p, expectedPrice!, listing, 0, item.q)) {
-      return priceChangedSpec(
+      return refundSpec("price_changed")(
         `Per-item price mismatch for listing ${listing.id}: metadata p=${item.p} but expected ${expectedPrice} (can_pay_more=${listing.can_pay_more})`,
       );
     }
   }
   if (pricedOrder.total !== agreed) {
-    return priceChangedSpec(
+    return refundSpec("price_changed")(
       `Re-derived total ${pricedOrder.total} differs from signed total ${agreed}`,
     );
   }

--- a/src/features/api/payment-processing/refunds.ts
+++ b/src/features/api/payment-processing/refunds.ts
@@ -139,6 +139,13 @@ const priceMismatchRefund = (
 ): Promise<PaymentResult> =>
   refundAndFail(session, PRICE_CHANGED_MESSAGE, listingId, 409, detail);
 
+/** The internal log line for a charge that didn't match our signed total. */
+const chargedVsSigned = (
+  session: ValidatedPaymentSession,
+  agreed: number,
+): string =>
+  `Provider charged ${session.amountTotal} but signed total was ${agreed}`;
+
 /**
  * Refund a session the provider charged for an amount other than our signed
  * total. Defers the alert so a slow ntfy never delays the money.
@@ -151,7 +158,7 @@ export const refuseMismatch = (
   addPendingWork(sendNtfyError(ErrorCode.WEBHOOK_PRICE_SIGNATURE));
   return priceMismatchRefund(
     session,
-    `Provider charged ${session.amountTotal} but signed total was ${agreed}`,
+    chargedVsSigned(session, agreed),
     listingId,
   );
 };
@@ -169,54 +176,64 @@ export type RefundSpec = {
   notify?: ErrorCodeType;
 };
 
-export const priceChangedSpec = (detail: string): RefundSpec => ({
-  code: "price_changed",
-  detail,
-  reason: "the listing price changed while they were paying",
-});
+/**
+ * Every reason we keep-and-refund a signed booking, as one table: the
+ * operator-facing phrase for the system note, plus (where the failure means a
+ * broken promise rather than plain bad luck) the alert to page. Unexpected
+ * errors and removed listings page because someone should look; a full event
+ * or a sold-out extra is normal operation.
+ */
+const REFUND_REASONS = {
+  capacity_full: { reason: "the event filled up while they were paying" },
+  charge_mismatch: {
+    notify: ErrorCode.WEBHOOK_PRICE_SIGNATURE,
+    reason: "the amount charged did not match the agreed total",
+  },
+  listing_removed: {
+    notify: ErrorCode.PAYMENT_SESSION,
+    reason: "the listing was removed while they were paying",
+  },
+  price_changed: {
+    reason: "the listing price changed while they were paying",
+  },
+  sold_out: {
+    reason: "an add-on or extra they chose sold out while they were paying",
+  },
+  unexpected_error: {
+    notify: ErrorCode.PAYMENT_SESSION,
+    reason: "an unexpected error stopped the booking being completed",
+  },
+} as const satisfies Record<string, { reason: string; notify?: ErrorCodeType }>;
 
+export type RefundCode = keyof typeof REFUND_REASONS;
+
+/** Build the RefundSpec for a reason code: the table supplies the note phrase
+ *  and any alert, the caller supplies the internal log line (ids/prices, never
+ *  PII). */
+export const refundSpec =
+  (code: RefundCode) =>
+  (detail: string): RefundSpec => ({
+    code,
+    detail,
+    ...REFUND_REASONS[code],
+  });
+
+/** A payment the provider charged for a different amount than our signed total. */
 export const chargeMismatchSpec = (
   session: ValidatedPaymentSession,
   agreed: number,
-): RefundSpec => ({
-  code: "charge_mismatch",
-  detail: `Provider charged ${session.amountTotal} but signed total was ${agreed}`,
-  notify: ErrorCode.WEBHOOK_PRICE_SIGNATURE,
-  reason: "the amount charged did not match the agreed total",
-});
-
-export const soldOutSpec = (detail: string): RefundSpec => ({
-  code: "sold_out",
-  detail,
-  reason: "an add-on or extra they chose sold out while they were paying",
-});
-
-export const capacitySpec = (detail: string): RefundSpec => ({
-  code: "capacity_full",
-  detail,
-  reason: "the event filled up while they were paying",
-});
-
-/** A signed booking that threw an unexpected error after the charge — kept and
- *  refunded rather than crash-looping the webhook over a paid customer. */
-export const unexpectedErrorSpec = (detail: string): RefundSpec => ({
-  code: "unexpected_error",
-  detail,
-  notify: ErrorCode.PAYMENT_SESSION,
-  reason: "an unexpected error stopped the booking being completed",
-});
+): RefundSpec =>
+  refundSpec("charge_mismatch")(chargedVsSigned(session, agreed));
 
 /** A signed booking whose listing was deleted between checkout and payment:
  *  nothing left to honour, but we keep a quantity-0 ghost so the customer (and
  *  their refund) is never lost. */
 export const deletedListingSpec = (
   session: ValidatedPaymentSession,
-): RefundSpec => ({
-  code: "listing_removed",
-  detail: `Listing not found for a signed session (session=${session.id})`,
-  notify: ErrorCode.PAYMENT_SESSION,
-  reason: "the listing was removed while they were paying",
-});
+): RefundSpec =>
+  refundSpec("listing_removed")(
+    `Listing not found for a signed session (session=${session.id})`,
+  );
 
 /**
  * The PII-free system note for a stored-but-refunded booking. Explains in plain

--- a/src/features/api/payment-processing/store-refund.ts
+++ b/src/features/api/payment-processing/store-refund.ts
@@ -16,11 +16,11 @@ import {
 import { businessTime } from "#routes/api/payment-processing/metadata.ts";
 import type { ValidatedItem } from "#routes/api/payment-processing/package-pricing.ts";
 import {
-  capacitySpec,
+  type RefundCode,
   type RefundSpec,
   refundAndFail,
   refundedNoteText,
-  soldOutSpec,
+  refundSpec,
   tryRefund,
 } from "#routes/api/payment-processing/refunds.ts";
 import type {
@@ -215,13 +215,20 @@ export const storeRefundedBooking = async (
   };
 };
 
-/** The placeholder refund reason for a booking we tried but couldn't honour: a
- *  sold-out extra reads differently from a full event, and anything else
- *  (capacity, or the broken-system encryption_error we don't special-case) is
- *  treated as "the event filled up". */
+/** The refund reason code for each way a booking we tried can fail: a sold-out
+ *  extra reads differently from a full event, and the broken-system
+ *  encryption_error we don't special-case is treated as "the event filled up". */
+const FAILURE_REFUND_CODES: Record<
+  Extract<HonourResult, { ok: false }>["reason"],
+  RefundCode
+> = {
+  capacity_exceeded: "capacity_full",
+  encryption_error: "capacity_full",
+  sold_out: "sold_out",
+};
+
+/** The placeholder refund reason for a booking we tried but couldn't honour. */
 export const specForFailure = (
   failure: Extract<HonourResult, { ok: false }>,
 ): RefundSpec =>
-  failure.reason === "sold_out"
-    ? soldOutSpec(failure.detail)
-    : capacitySpec(failure.detail);
+  refundSpec(FAILURE_REFUND_CODES[failure.reason])(failure.detail);

--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -104,27 +104,24 @@ const withReferencedRow = async (
   if (row) await fn(row);
 };
 
-/** Handle a delivery (`sms:delivered`) or failure (`sms:failed`) status event. */
-const handleStatus = (
-  event: string,
-  payload: Record<string, unknown>,
-): Promise<void> =>
-  withReferencedRow(payload, async (row) => {
-    const note =
-      event === "sms:delivered"
-        ? "SMS delivered"
-        : `SMS failed: ${str(payload.reason) || "unknown"}`;
-    await logActivity(note, row.listing_id, row.attendee_id);
-    await deleteSmsMessage(row.id);
-  });
+/** Build a status-event handler: logs `note(payload)` against the referenced
+ * message's attendee, then drops the row (its status is settled). The delivered
+ * and failed events share this shape and differ only in the note they log. */
+const handleStatus =
+  (note: (payload: Record<string, unknown>) => string) =>
+  (payload: Record<string, unknown>): Promise<void> =>
+    withReferencedRow(payload, async (row) => {
+      await logActivity(note(payload), row.listing_id, row.attendee_id);
+      await deleteSmsMessage(row.id);
+    });
 
 const inboundWebhookId = (payload: Record<string, unknown>): string =>
   str(payload.messageId) || str(payload.id);
 
 const handleReceived = async (
   payload: Record<string, unknown>,
-  passphrase: string,
 ): Promise<void> => {
+  const passphrase = settings.smsGatewayPassphrase;
   if (!(await claimProcessedSmsInbound(inboundWebhookId(payload)))) return;
   const message = await tryDecrypt(str(payload.message), passphrase);
   const sender = await tryDecrypt(str(payload.sender), passphrase);
@@ -132,6 +129,21 @@ const handleReceived = async (
     await computePhoneIndex(sender),
   );
   await logActivity(`SMS received: ${message}`, null, attendeeId);
+};
+
+/** What to do for each gateway event we track, keyed by the envelope's event
+ * name. An event not in this table is acknowledged without action — the
+ * gateway may send kinds we don't record, so the envelope schema deliberately
+ * keeps `event` an open string rather than a picklist. */
+const smsEventHandlers: Record<
+  string,
+  (payload: Record<string, unknown>) => Promise<void>
+> = {
+  "sms:delivered": handleStatus(() => "SMS delivered"),
+  "sms:failed": handleStatus(
+    (payload) => `SMS failed: ${str(payload.reason) || "unknown"}`,
+  ),
+  "sms:received": handleReceived,
 };
 
 /** Handle POST /sms/webhook */
@@ -154,11 +166,7 @@ export const handleSmsWebhook = async (request: Request): Promise<Response> => {
   if (!parsed.success) return apiErrorResponse("Invalid payload");
 
   const { event, payload } = parsed.output;
-  if (event === "sms:delivered" || event === "sms:failed") {
-    await handleStatus(event, payload);
-  } else if (event === "sms:received") {
-    await handleReceived(payload, settings.smsGatewayPassphrase);
-  }
+  await smsEventHandlers[event]?.(payload);
 
   // Backstop cleanup for rows whose delivery webhook never arrived.
   const retentionCutoff = new Date(nowMs() - RETENTION_MS).toISOString();

--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -27,6 +27,7 @@ import {
   type SmsMessageRow,
 } from "#shared/db/sms-messages.ts";
 import { nowMs } from "#shared/now.ts";
+import { apiErrorResponse } from "#shared/rest/crud-api.ts";
 import { decryptField } from "#shared/sms/e2e.ts";
 import { computePhoneIndex } from "#shared/sms/phone-index.ts";
 
@@ -136,21 +137,21 @@ const handleReceived = async (
 /** Handle POST /sms/webhook */
 export const handleSmsWebhook = async (request: Request): Promise<Response> => {
   const secret = settings.smsGatewayWebhookSecret;
-  if (!secret) return jsonResponse({ error: "Not configured" }, 404);
+  if (!secret) return apiErrorResponse("Not configured", 404);
 
   const rawBody = await request.text();
   if (!(await isValidSignature(request, rawBody, secret))) {
-    return jsonResponse({ error: "Invalid signature" }, 401);
+    return apiErrorResponse("Invalid signature", 401);
   }
 
   let body: unknown;
   try {
     body = JSON.parse(rawBody);
   } catch {
-    return jsonResponse({ error: "Invalid JSON" }, 400);
+    return apiErrorResponse("Invalid JSON");
   }
   const parsed = v.safeParse(EnvelopeSchema, body);
-  if (!parsed.success) return jsonResponse({ error: "Invalid payload" }, 400);
+  if (!parsed.success) return apiErrorResponse("Invalid payload");
 
   const { event, payload } = parsed.output;
   if (event === "sms:delivered" || event === "sms:failed") {

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -191,6 +191,21 @@ export const groupBy = <T, K>(
 };
 
 /**
+ * Group rows by a key, keeping only the chosen value from each row.
+ * Same ordering guarantee as {@link groupBy}: keys appear in first-occurrence
+ * order and each value list preserves input order.
+ */
+export const groupToMap =
+  <T, K, V>(keyOf: (row: T) => K, valueFrom: (row: T) => V) =>
+  (rows: readonly T[]): Map<K, V[]> =>
+    new Map(
+      [...groupBy(rows, keyOf)].map(([key, group]) => [
+        key,
+        group.map(valueFrom),
+      ]),
+    );
+
+/**
  * Remove null and undefined values from array
  */
 export const compact = <T>(array: (T | null | undefined)[]): T[] =>

--- a/src/locales/en/capacity.json
+++ b/src/locales/en/capacity.json
@@ -1,0 +1,4 @@
+{
+  "capacity.mdash": "—",
+  "capacity.remain": "remain"
+}

--- a/src/locales/en/detail-rows.json
+++ b/src/locales/en/detail-rows.json
@@ -1,6 +1,4 @@
 {
-  "detail_rows.mdash": "—",
-  "detail_rows.remain": "remain",
   "detail_rows.tickets_checked_in": "Tickets Checked In",
   "detail_rows.attendees_checked_in": "Attendees Checked In",
   "detail_rows.total_revenue": "Total Revenue"

--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -12,6 +12,7 @@ import builder from "./builder.json" with { type: "json" };
 import builtSites from "./built-sites.json" with { type: "json" };
 import bulkActions from "./bulk-actions.json" with { type: "json" };
 import bulkEmail from "./bulk-email.json" with { type: "json" };
+import capacity from "./capacity.json" with { type: "json" };
 import catalogTransfer from "./catalog-transfer.json" with { type: "json" };
 import common from "./common.json" with { type: "json" };
 import csv from "./csv.json" with { type: "json" };
@@ -62,6 +63,7 @@ const en: Record<string, string> = {
   ...builtSites,
   ...bulkActions,
   ...bulkEmail,
+  ...capacity,
   ...catalogTransfer,
   ...common,
   ...csv,

--- a/src/locales/en/listings-table.json
+++ b/src/locales/en/listings-table.json
@@ -28,7 +28,6 @@
   "listings_table.days_from_today": "days from today",
   "listings_table.booking_duration": "Booking Duration",
   "listings_table.day_count_with_parens": "day(s)",
-  "listings_table.remain": "remain",
   "listings_table.listing_attendees": "Listing Attendees",
   "listings_table.capacity_per_date": "Capacity of {capacity} applies per date",
   "listings_table.group_attendees": "Group Attendees",

--- a/src/shared/booking/form.ts
+++ b/src/shared/booking/form.ts
@@ -11,9 +11,21 @@ export const parseCustomPrice = (
   maxPrice: number,
 ) => validatePrice(form.getString(fieldName), minPrice, maxPrice);
 
-/** Format error message for failed attendee creation. */
-export const formatAtomicError = capacityErrorFormatter({
+/** The messages a failed public booking answers with — written once here so
+ * the web form and the JSON API never retype (and drift on) the same copy. */
+export const bookingError = {
+  /** A creation failure that isn't about capacity (e.g. encryption_error). */
   fallback: "Registration failed. Please try again.",
+  /** Out of capacity, with no listing name to point at. */
   generic: "Sorry, not enough spots available",
-  withName: (name) => `Sorry, ${name} no longer has enough spots available`,
-});
+  /** A booking for a date the listing doesn't offer. */
+  invalidDate: "Please select a valid date",
+  /** The payment provider wouldn't open a checkout session. */
+  paymentSessionFailed: "Failed to create payment session",
+  /** Out of capacity on a named listing. */
+  withName: (name: string): string =>
+    `Sorry, ${name} no longer has enough spots available`,
+};
+
+/** Format error message for failed attendee creation. */
+export const formatAtomicError = capacityErrorFormatter(bookingError);

--- a/src/shared/db/attendees/delete.ts
+++ b/src/shared/db/attendees/delete.ts
@@ -3,7 +3,11 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { executeBatch, queryAll } from "#shared/db/client.ts";
+import {
+  deleteByFieldStatement,
+  executeBatch,
+  queryAll,
+} from "#shared/db/client.ts";
 import { ticketCountSumExpr } from "#shared/db/migrations/schema.ts";
 
 type DeleteAttendeeOptions = { releaseBookings?: boolean };
@@ -45,34 +49,31 @@ const restoreListingContributions = (
            WHERE id = ?`,
   }));
 
+/** The tables holding an attendee's dependent rows, each with the column that
+ * links it to the attendee. Deleted (in this order) before the attendee row. */
+const DEPENDENT_ROW_TARGETS = [
+  { field: "attendee_id", table: "processed_payments" },
+  { field: "attendee_id", table: "attendee_answers" },
+  { field: "attendee_id", table: "listing_attendees" },
+  { field: "attendee_id", table: "system_notes" },
+  { field: "servicing_attendee_id", table: "service_costs" },
+] as const;
+
 /** Delete an attendee and all dependent data tied to the attendee record. */
 const purgeAttendee = (
   attendeeId: number,
   contributions: ListingContribution[],
 ): Promise<void> =>
   executeBatch([
-    {
-      args: [attendeeId],
-      sql: "DELETE FROM processed_payments WHERE attendee_id = ?",
-    },
-    {
-      args: [attendeeId],
-      sql: "DELETE FROM attendee_answers WHERE attendee_id = ?",
-    },
-    {
-      args: [attendeeId],
-      sql: "DELETE FROM listing_attendees WHERE attendee_id = ?",
-    },
-    {
-      args: [attendeeId],
-      sql: "DELETE FROM system_notes WHERE attendee_id = ?",
-    },
-    {
-      args: [attendeeId],
-      sql: "DELETE FROM service_costs WHERE servicing_attendee_id = ?",
-    },
+    ...DEPENDENT_ROW_TARGETS.map((target) =>
+      deleteByFieldStatement({ ...target, value: attendeeId }),
+    ),
     ...restoreListingContributions(contributions),
-    { args: [attendeeId], sql: "DELETE FROM attendees WHERE id = ?" },
+    deleteByFieldStatement({
+      field: "id",
+      table: "attendees",
+      value: attendeeId,
+    }),
   ]);
 
 /**

--- a/src/shared/db/attendees/queries.ts
+++ b/src/shared/db/attendees/queries.ts
@@ -23,7 +23,7 @@ import {
   queryOne,
   rowExists,
 } from "#shared/db/client.ts";
-import { nameMapByIds } from "#shared/db/query.ts";
+import { nameMapByIds, rowsByIds } from "#shared/db/query.ts";
 import type { Attendee } from "#shared/types.ts";
 import { guardFor } from "#shared/validation/guard.ts";
 
@@ -480,18 +480,15 @@ export const getAttendeeRaw = (id: number): Promise<Attendee | null> => {
  * and only reads each attendee's contact fields. Returns an empty array for no
  * ids. Decrypt with decryptAttendees before display.
  */
-export const getAttendeesByIds = (ids: number[]): Promise<Attendee[]> => {
-  if (ids.length === 0) return Promise.resolve([]);
-  return queryAll<Attendee>(
-    `SELECT ${ATTENDEE_LEFT_JOIN_SELECT}
+export const getAttendeesByIds = (ids: number[]): Promise<Attendee[]> =>
+  rowsByIds<Attendee>(
+    ids,
+    (placeholders) =>
+      `SELECT ${ATTENDEE_LEFT_JOIN_SELECT}
      FROM attendees AS attendee
      LEFT JOIN listing_attendees AS listingAttendee ON listingAttendee.attendee_id = attendee.id
-     WHERE attendee.kind = '${ATTENDEE_KIND}' AND attendee.id IN (${inPlaceholders(
-       ids,
-     )})`,
-    ids,
+     WHERE attendee.kind = '${ATTENDEE_KIND}' AND attendee.id IN (${placeholders})`,
   );
-};
 
 /**
  * Bounded id → name lookup for the given attendees, decrypting only the name
@@ -517,11 +514,10 @@ export const getAttendeeNamesByIds = (
 export const getAttendeeKindsByIds = async (
   ids: number[],
 ): Promise<Map<number, string>> => {
-  if (ids.length === 0) return new Map();
-  const rows = await queryAll<{ id: number; kind: string }>(
-    `SELECT id, kind FROM attendees
-     WHERE id IN (${inPlaceholders(ids)})`,
+  const rows = await rowsByIds<{ id: number; kind: string }>(
     ids,
+    (placeholders) =>
+      `SELECT id, kind FROM attendees WHERE id IN (${placeholders})`,
   );
   return new Map(rows.map((row) => [row.id, row.kind]));
 };

--- a/src/shared/db/attendees/queries.ts
+++ b/src/shared/db/attendees/queries.ts
@@ -23,7 +23,7 @@ import {
   queryOne,
   rowExists,
 } from "#shared/db/client.ts";
-import { nameMapByIds, rowsByIds } from "#shared/db/query.ts";
+import { columnMapByIds, nameMapByIds, rowsByIds } from "#shared/db/query.ts";
 import type { Attendee } from "#shared/types.ts";
 import { guardFor } from "#shared/validation/guard.ts";
 
@@ -511,16 +511,10 @@ export const getAttendeeNamesByIds = (
 
 /** Bounded id → kind lookup for attendee-linked admin surfaces. Empty ids ⇒
  * empty map. Unknown/deleted ids are omitted. */
-export const getAttendeeKindsByIds = async (
+export const getAttendeeKindsByIds = (
   ids: number[],
-): Promise<Map<number, string>> => {
-  const rows = await rowsByIds<{ id: number; kind: string }>(
-    ids,
-    (placeholders) =>
-      `SELECT id, kind FROM attendees WHERE id IN (${placeholders})`,
-  );
-  return new Map(rows.map((row) => [row.id, row.kind]));
-};
+): Promise<Map<number, string>> =>
+  columnMapByIds<string>("attendees", "attendee", "kind", ids);
 
 /**
  * Get an attendee by ID (decrypted)

--- a/src/shared/db/attendees/tokens.ts
+++ b/src/shared/db/attendees/tokens.ts
@@ -2,7 +2,7 @@
  * Ticket-token lookups for attendees.
  */
 
-import { groupBy, map, unique } from "#fp";
+import { groupToMap, map, unique } from "#fp";
 import { computeTicketTokenIndex } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, OwnerKeyEncrypted } from "#shared/crypto/sealed.ts";
 import type {
@@ -60,17 +60,6 @@ const bookingRowWithoutAttendee = (
   start_at: row.start_at,
 });
 
-const rowsByAttendeeId = <Row extends { attendee_id: number }, Booking>(
-  rows: Row[],
-  withoutAttendee: (row: Row) => Booking,
-): Map<number, Booking[]> =>
-  new Map(
-    [...groupBy(rows, (row) => row.attendee_id)].map(([attendeeId, group]) => [
-      attendeeId,
-      group.map(withoutAttendee),
-    ]),
-  );
-
 const bookingRowsByAttendeeIds = async (
   attendeeIds: number[],
 ): Promise<Map<number, ListingAttendeeRow[]>> => {
@@ -85,7 +74,10 @@ const bookingRowsByAttendeeIds = async (
     attendeeIds,
   );
 
-  return rowsByAttendeeId(rows, bookingRowWithoutAttendee);
+  return groupToMap(
+    (row: BookingRowWithAttendee) => row.attendee_id,
+    bookingRowWithoutAttendee,
+  )(rows);
 };
 
 const PREVIOUS_BOOKING_LINE_COLS = `${listingAttendeeColumn("listing_id")}, ${listingAttendeeColumn("quantity")}, ${pricePaidFromLedger(
@@ -116,7 +108,10 @@ const previousBookingLinesByAttendeeIds = async (
     attendeeIds,
   );
 
-  return rowsByAttendeeId(rows, previousBookingLineWithoutAttendee);
+  return groupToMap(
+    (row: RowWithAttendee<PreviousBookingLine>) => row.attendee_id,
+    previousBookingLineWithoutAttendee,
+  )(rows);
 };
 
 type TokenIndexedRow = { ticket_token_index: BlindIndex };

--- a/src/shared/db/built-sites.ts
+++ b/src/shared/db/built-sites.ts
@@ -490,6 +490,12 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
   },
   name: "built_sites",
   primaryKey: "id",
+  // The façade's rows are already decrypted (its fromDb is identity), so a
+  // single column's stored value is already its readable value.
+  readColumn: <K extends keyof BuiltSite & string>(
+    _col: K,
+    value: BuiltSite[K],
+  ): Promise<BuiltSite[K]> => Promise.resolve(value),
   // The CRUD adapter is a façade over the raw table — the built-site blob
   // is always reconstructed from BuiltSiteFormInput, so rowToInput just picks
   // the exposed camelCase fields off an already-decrypted BuiltSite.

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -281,25 +281,39 @@ export const countRows = async (table: string): Promise<number> => {
   return row!.n;
 };
 
+/** One delete-rows-matching-a-field target: which table, matched on which
+ * field, for which value. */
+export type DeleteByFieldTarget = {
+  table: string;
+  field: string;
+  value: InValue;
+};
+
+/** Build the DELETE statement for one {@link DeleteByFieldTarget} — for batches
+ * that mix these deletes with other statements. */
+export const deleteByFieldStatement = ({
+  table,
+  field,
+  value,
+}: DeleteByFieldTarget): { sql: string; args: InValue[] } => ({
+  args: [value],
+  sql: `DELETE FROM ${table} WHERE ${field} = ?`,
+});
+
 /** Delete rows matching a field value */
 export const deleteByField = async (
   table: string,
   field: string,
   value: InValue,
 ): Promise<void> => {
-  await execute(`DELETE FROM ${table} WHERE ${field} = ?`, [value]);
+  const { args, sql } = deleteByFieldStatement({ field, table, value });
+  await execute(sql, args);
 };
 
 /** Delete rows from multiple tables in a single batch transaction */
 export const deleteByFieldBatch = (
-  deletes: Array<{ table: string; field: string; value: InValue }>,
-): Promise<void> =>
-  executeBatch(
-    deletes.map(({ table, field, value }) => ({
-      args: [value],
-      sql: `DELETE FROM ${table} WHERE ${field} = ?`,
-    })),
-  );
+  deletes: DeleteByFieldTarget[],
+): Promise<void> => executeBatch(deletes.map(deleteByFieldStatement));
 
 /**
  * Reset selected aggregate columns from trusted SQL expressions. Each

--- a/src/shared/db/modifier-usage.ts
+++ b/src/shared/db/modifier-usage.ts
@@ -9,12 +9,8 @@
  */
 
 import type { InValue } from "@libsql/client";
-import {
-  inPlaceholders,
-  queryAll,
-  type SqlStatement,
-} from "#shared/db/client.ts";
-import { mapByIds } from "#shared/db/query.ts";
+import type { SqlStatement } from "#shared/db/client.ts";
+import { mapByIds, rowsByIds } from "#shared/db/query.ts";
 import { nowIso } from "#shared/now.ts";
 
 /** One modifier consumed by an order: the modifier, how many, and the amount
@@ -113,9 +109,10 @@ export const anyModifierSoldOut = async (
   const ids = usages.map((u) => u.modifierId);
   if (ids.length === 0) return false;
   const used = await modifierUsedQuantities(ids);
-  const rows = await queryAll<{ id: number; stock: number | null }>(
-    `SELECT id, stock FROM modifiers WHERE id IN (${inPlaceholders(ids)})`,
+  const rows = await rowsByIds<{ id: number; stock: number | null }>(
     ids,
+    (placeholders) =>
+      `SELECT id, stock FROM modifiers WHERE id IN (${placeholders})`,
   );
   const stockById = new Map(rows.map((r) => [r.id, r.stock]));
   return usages.some((u) => {

--- a/src/shared/db/modifier-usage.ts
+++ b/src/shared/db/modifier-usage.ts
@@ -10,7 +10,7 @@
 
 import type { InValue } from "@libsql/client";
 import type { SqlStatement } from "#shared/db/client.ts";
-import { mapByIds, rowsByIds } from "#shared/db/query.ts";
+import { columnMapByIds, mapByIds } from "#shared/db/query.ts";
 import { nowIso } from "#shared/now.ts";
 
 /** One modifier consumed by an order: the modifier, how many, and the amount
@@ -109,12 +109,12 @@ export const anyModifierSoldOut = async (
   const ids = usages.map((u) => u.modifierId);
   if (ids.length === 0) return false;
   const used = await modifierUsedQuantities(ids);
-  const rows = await rowsByIds<{ id: number; stock: number | null }>(
+  const stockById = await columnMapByIds<number | null>(
+    "modifiers",
+    "modifier",
+    "stock",
     ids,
-    (placeholders) =>
-      `SELECT id, stock FROM modifiers WHERE id IN (${placeholders})`,
   );
-  const stockById = new Map(rows.map((r) => [r.id, r.stock]));
   return usages.some((u) => {
     const stock = stockById.get(u.modifierId);
     if (stock === null || stock === undefined) return false;

--- a/src/shared/db/query.ts
+++ b/src/shared/db/query.ts
@@ -52,9 +52,10 @@ export const swapSortOrder = (
 /**
  * Run an id-keyed SELECT, short-circuiting to `[]` (no query) when `ids` is
  * empty. `buildSql` receives the bound `?`-placeholder list for `ids`, so `ids`
- * are the only query args. The base skeleton for the id-map helpers below.
+ * are the only query args. The base skeleton for the id-map helpers below and
+ * for any read that loads rows for a caller-supplied id list.
  */
-const rowsByIds = async <Row>(
+export const rowsByIds = async <Row>(
   ids: number[],
   buildSql: (placeholders: string) => string,
 ): Promise<Row[]> =>

--- a/src/shared/db/query.ts
+++ b/src/shared/db/query.ts
@@ -1,3 +1,4 @@
+import type { InValue } from "@libsql/client";
 import { mapParallel } from "#fp";
 import {
   execute,
@@ -65,11 +66,11 @@ export const rowsByIds = async <Row>(
  * Run an integer-keyed lookup query and turn each row into a `[key, value]`
  * pair via `toEntry`, returning the id-keyed map (empty when `ids` is empty).
  */
-export const mapByIds = async <Row>(
+export const mapByIds = async <Row, Value = number>(
   ids: number[],
   buildSql: (placeholders: string) => string,
-  toEntry: (row: Row) => [number, number],
-): Promise<Map<number, number>> =>
+  toEntry: (row: Row) => [number, Value],
+): Promise<Map<number, Value>> =>
   new Map((await rowsByIds<Row>(ids, buildSql)).map(toEntry));
 
 type NameRow<Raw> = { id: number; name: Raw };
@@ -138,20 +139,22 @@ export const allNamesById = <Raw>(
   );
 
 /**
- * Map each row's `id` to one of its integer columns (`id → column`) for the
- * rows of `table` whose id is in `ids`, optionally narrowed by an extra `where`
- * fragment appended verbatim (e.g. ` AND modifier_id IS NOT NULL`). `alias` is
- * the table's singular-word alias and qualifies the selected columns. `table`,
- * `alias`, `column` and `where` are always internal constants, never user input.
+ * Map each row's `id` to one of its columns (`id → column`) for the rows of
+ * `table` whose id is in `ids`, optionally narrowed by an extra `where`
+ * fragment appended verbatim (e.g. ` AND modifier_id IS NOT NULL`). `Value` is
+ * the column's stored type (a number unless the caller says otherwise —
+ * strings and nullable columns work too). `alias` is the table's singular-word
+ * alias and qualifies the selected columns. `table`, `alias`, `column` and
+ * `where` are always internal constants, never user input.
  */
-export const columnMapByIds = (
+export const columnMapByIds = <Value extends InValue = number>(
   table: string,
   alias: string,
   column: string,
   ids: number[],
   where = "",
-): Promise<Map<number, number>> =>
-  mapByIds<{ id: number; value: number }>(
+): Promise<Map<number, Value>> =>
+  mapByIds<{ id: number; value: Value }, Value>(
     ids,
     (placeholders) =>
       `SELECT ${alias}.id, ${alias}.${column} AS value FROM ${table} AS ${alias} WHERE ${alias}.id IN (${placeholders})${where}`,

--- a/src/shared/db/questions/attendee-answers/reads.ts
+++ b/src/shared/db/questions/attendee-answers/reads.ts
@@ -9,7 +9,8 @@ import { groupToMap, mapParallel } from "#fp";
 import { decryptWithOwnerKey } from "#shared/crypto/keys.ts";
 import type { OwnerKeyEncrypted } from "#shared/crypto/sealed.ts";
 import { ATTENDEE_KIND } from "#shared/db/attendees/kind.ts";
-import { inPlaceholders, queryAll } from "#shared/db/client.ts";
+import { queryAll } from "#shared/db/client.ts";
+import { rowsByIds } from "#shared/db/query.ts";
 import type { QuestionWithAnswers } from "#shared/db/question-types.ts";
 import { getQuestionsWithListingIds } from "#shared/db/questions/queries.ts";
 import { answersTable } from "#shared/db/questions/tables.ts";
@@ -30,16 +31,15 @@ const selectAttendeeAnswerRows = <R>(
   selectColumns: string,
   join = "",
 ): Promise<R[]> =>
-  attendeeIds.length === 0
-    ? Promise.resolve([])
-    : queryAll<R>(
-        `SELECT ${selectColumns}
-         FROM attendee_answers AS attendee_answer
-         ${join}
-        WHERE attendee_answer.${column} IS NOT NULL
-          AND attendee_answer.attendee_id IN (${inPlaceholders(attendeeIds)})`,
-        attendeeIds,
-      );
+  rowsByIds<R>(
+    attendeeIds,
+    (placeholders) =>
+      `SELECT ${selectColumns}
+       FROM attendee_answers AS attendee_answer
+       ${join}
+      WHERE attendee_answer.${column} IS NOT NULL
+        AND attendee_answer.attendee_id IN (${placeholders})`,
+  );
 
 const choiceAnswerIdsBatch = async (
   attendeeIds: number[],

--- a/src/shared/db/questions/attendee-answers/reads.ts
+++ b/src/shared/db/questions/attendee-answers/reads.ts
@@ -5,7 +5,7 @@
  * the owner-key-decrypted free-text table cells.
  */
 
-import { groupBy, mapParallel } from "#fp";
+import { groupToMap, mapParallel } from "#fp";
 import { decryptWithOwnerKey } from "#shared/crypto/keys.ts";
 import type { OwnerKeyEncrypted } from "#shared/crypto/sealed.ts";
 import { ATTENDEE_KIND } from "#shared/db/attendees/kind.ts";
@@ -15,14 +15,10 @@ import { getQuestionsWithListingIds } from "#shared/db/questions/queries.ts";
 import { answersTable } from "#shared/db/questions/tables.ts";
 
 /** Group `(attendee_id, answer_id)` rows into an attendee → answer-ids map. */
-const choiceAnswerMapFromRows = (
-  rows: { attendee_id: number; answer_id: number }[],
-): Map<number, number[]> =>
-  new Map(
-    [...groupBy(rows, (r) => r.attendee_id)].map(
-      ([id, rs]) => [id, rs.map((r) => r.answer_id)] as const,
-    ),
-  );
+const choiceAnswerMapFromRows = groupToMap(
+  (r: { attendee_id: number; answer_id: number }) => r.attendee_id,
+  (r) => r.answer_id,
+);
 
 /** Load `attendee_answers` rows for a set of attendees, restricted to rows where
  * `column` is set (non-null). Returns an empty array for an empty attendee
@@ -105,14 +101,15 @@ export const getAttendeeTextAnswersBatch = async (
     questionId: row.question_id,
     text: await decryptWithOwnerKey(row.encrypted_text, privateKey),
   }))(rows);
+  const textPairsByAttendee = groupToMap(
+    (d: (typeof decrypted)[number]) => d.attendeeId,
+    (d) => [d.questionId, d.text] as const,
+  )(decrypted);
   return new Map(
-    [...groupBy(decrypted, (d) => d.attendeeId)].map(
-      ([attendeeId, group]) =>
-        [
-          attendeeId,
-          new Map(group.map((d) => [d.questionId, d.text] as const)),
-        ] as const,
-    ),
+    [...textPairsByAttendee].map(([attendeeId, pairs]) => [
+      attendeeId,
+      new Map(pairs),
+    ]),
   );
 };
 

--- a/src/shared/db/questions/attendee-answers/reads.ts
+++ b/src/shared/db/questions/attendee-answers/reads.ts
@@ -217,21 +217,12 @@ export const getAttendeeAnswersByQuestion = async (
      WHERE attendeeAnswer.answer_id IS NOT NULL AND attendeeAnswer.attendee_id = ?`,
     [attendeeId],
   );
-  // Decrypt each chosen answer in parallel, then key by question id.
-  const decrypted = await mapParallel(async (row: ChoiceAnswerRow) => {
-    const answer = await answersTable.fromDb({
-      active: true,
-      id: row.answer_id,
-      question_id: row.question_id,
-      sort_order: 0,
-      text: row.answer_text,
-    });
-    return {
-      answerId: row.answer_id,
-      answerText: answer.text,
-      questionId: row.question_id,
-    };
-  })(rows);
+  // Decrypt each chosen answer's text in parallel, then key by question id.
+  const decrypted = await mapParallel(async (row: ChoiceAnswerRow) => ({
+    answerId: row.answer_id,
+    answerText: await answersTable.readColumn("text", row.answer_text),
+    questionId: row.question_id,
+  }))(rows);
   return new Map(
     decrypted.map((d) => [
       d.questionId,

--- a/src/shared/db/questions/delete.ts
+++ b/src/shared/db/questions/delete.ts
@@ -2,35 +2,25 @@
  * Deletion for questions and answers (and their dependent rows).
  */
 
-import { executeBatch } from "#shared/db/client.ts";
+import { deleteByFieldBatch } from "#shared/db/client.ts";
 
-/** Delete a question and all related data in a single batch. Every
- * attendee_answers row carries question_id (choice and free-text alike, the
- * validate trigger enforces it), so the answers delete by it directly. The
- * answer→modifier link is a column on answers, so it's removed with the rows. */
-export const deleteQuestion = async (questionId: number): Promise<void> => {
-  await executeBatch([
-    {
-      args: [questionId],
-      sql: "DELETE FROM attendee_answers WHERE question_id = ?",
-    },
-    { args: [questionId], sql: "DELETE FROM answers WHERE question_id = ?" },
-    {
-      args: [questionId],
-      sql: "DELETE FROM listing_questions WHERE question_id = ?",
-    },
-    { args: [questionId], sql: "DELETE FROM questions WHERE id = ?" },
+/** Delete a question and all related data in a single batch, child rows before
+ * the question itself. Every attendee_answers row carries question_id (choice
+ * and free-text alike, the validate trigger enforces it), so the answers delete
+ * by it directly. The answer→modifier link is a column on answers, so it's
+ * removed with the rows. */
+export const deleteQuestion = (questionId: number): Promise<void> =>
+  deleteByFieldBatch([
+    { field: "question_id", table: "attendee_answers", value: questionId },
+    { field: "question_id", table: "answers", value: questionId },
+    { field: "question_id", table: "listing_questions", value: questionId },
+    { field: "id", table: "questions", value: questionId },
   ]);
-};
 
 /** Delete an answer and all related attendee answers in a single batch (its
  * modifier_id link is a column on the row, so it's removed with the answer). */
-export const deleteAnswer = async (answerId: number): Promise<void> => {
-  await executeBatch([
-    {
-      args: [answerId],
-      sql: "DELETE FROM attendee_answers WHERE answer_id = ?",
-    },
-    { args: [answerId], sql: "DELETE FROM answers WHERE id = ?" },
+export const deleteAnswer = (answerId: number): Promise<void> =>
+  deleteByFieldBatch([
+    { field: "answer_id", table: "attendee_answers", value: answerId },
+    { field: "id", table: "answers", value: answerId },
   ]);
-};

--- a/src/shared/db/questions/queries.ts
+++ b/src/shared/db/questions/queries.ts
@@ -17,7 +17,9 @@ import {
 import type { Answer, QuestionWithAnswers } from "#shared/db/question-types.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 
-/** Flat row from a question ← LEFT JOIN answers query */
+/** Flat row from a question ← LEFT JOIN answers query. `q_assign_all` is the
+ * stored form (INTEGER 0/1) — {@link decryptQuestion} turns it into a boolean
+ * via the column's read transform. */
 type JoinedRow = {
   q_id: number;
   q_assign_all: boolean;
@@ -45,13 +47,14 @@ const decryptQuestion = async (
   rawText: string,
   rawAnswers: Answer[],
 ): Promise<QuestionWithAnswers> => {
-  const [text, answers] = await Promise.all([
+  const [text, assign_all, answers] = await Promise.all([
     questionsTable.readColumn("text", rawText),
+    questionsTable.readColumn("assign_all", assignAll),
     mapParallel((a: Answer) => answersTable.fromDb(a))(rawAnswers),
   ]);
   return {
     answers,
-    assign_all: assignAll,
+    assign_all,
     display_type: displayType,
     id,
     text,

--- a/src/shared/db/questions/queries.ts
+++ b/src/shared/db/questions/queries.ts
@@ -45,16 +45,17 @@ const decryptQuestion = async (
   rawText: string,
   rawAnswers: Answer[],
 ): Promise<QuestionWithAnswers> => {
-  const [question, ...answers] = await Promise.all([
-    questionsTable.fromDb({
-      assign_all: assignAll,
-      display_type: displayType,
-      id,
-      text: rawText,
-    }),
-    ...map((a: Answer) => answersTable.fromDb(a))(rawAnswers),
+  const [text, answers] = await Promise.all([
+    questionsTable.readColumn("text", rawText),
+    mapParallel((a: Answer) => answersTable.fromDb(a))(rawAnswers),
   ]);
-  return { ...question, answers };
+  return {
+    answers,
+    assign_all: assignAll,
+    display_type: displayType,
+    id,
+    text,
+  };
 };
 
 /** Group flat joined rows into QuestionWithAnswers[], preserving row order.

--- a/src/shared/db/questions/queries.ts
+++ b/src/shared/db/questions/queries.ts
@@ -7,7 +7,7 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { filter, groupBy, map, mapParallel, reduce } from "#fp";
+import { filter, groupBy, groupToMap, map, mapParallel, reduce } from "#fp";
 import {
   executeBatch,
   inPlaceholders,
@@ -150,11 +150,10 @@ export const getAllQuestionListingIds = async (): Promise<
     `SELECT question_id, listing_id FROM listing_questions
      ORDER BY question_id, listing_id`,
   );
-  return new Map(
-    [...groupBy(rows, (r) => r.question_id)].map(
-      ([qid, rs]) => [qid, rs.map((r) => r.listing_id)] as const,
-    ),
-  );
+  return groupToMap(
+    (r: (typeof rows)[number]) => r.question_id,
+    (r) => r.listing_id,
+  )(rows);
 };
 
 /** Get the IDs of the listings a question is assigned to */

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -112,14 +112,6 @@ export interface Table<Row, Input> {
   fromDb: (row: Row) => Promise<Row>;
   inputKeyMap: Record<string, string>;
 
-  /** Run one column's declared read transform (e.g. decrypt) on a stored
-   * value — identity when the column declares none or the value is null. For
-   * reading a single column back without building a whole row. */
-  readColumn: <K extends keyof Row & string>(
-    col: K,
-    value: Row[K],
-  ) => Promise<Row[K]>;
-
   /** Insert a new row, returns the created row */
   insert: (input: Input) => Promise<Row>;
   /** Build the INSERT statement without executing it (for transactional callers).
@@ -127,6 +119,14 @@ export interface Table<Row, Input> {
   insertStatement?: (input: Input) => Promise<{ sql: string; args: InValue[] }>;
   name: string;
   primaryKey: keyof Row & string;
+
+  /** Run one column's declared read transform (e.g. decrypt) on a stored
+   * value — identity when the column declares none or the value is null. For
+   * reading a single column back without building a whole row. */
+  readColumn: <K extends keyof Row & string>(
+    col: K,
+    value: Row[K],
+  ) => Promise<Row[K]>;
 
   /**
    * Build an Input object from an existing Row by copying the input-eligible

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -112,6 +112,14 @@ export interface Table<Row, Input> {
   fromDb: (row: Row) => Promise<Row>;
   inputKeyMap: Record<string, string>;
 
+  /** Run one column's declared read transform (e.g. decrypt) on a stored
+   * value — identity when the column declares none or the value is null. For
+   * reading a single column back without building a whole row. */
+  readColumn: <K extends keyof Row & string>(
+    col: K,
+    value: Row[K],
+  ) => Promise<Row[K]>;
+
   /** Insert a new row, returns the created row */
   insert: (input: Input) => Promise<Row>;
   /** Build the INSERT statement without executing it (for transactional callers).
@@ -209,16 +217,26 @@ export const defineTable = <Row, Input = Row>(
   ): unknown =>
     (input as Record<string, unknown>)[inputKeyMap[dbCol] as string];
 
+  // Run one column's read transform on a stored value (identity when the
+  // column declares none or the value is null) — the per-column read logic
+  // shared by fromDb and the single-column readColumn.
+  const readColumn = async <K extends keyof Row & string>(
+    col: K,
+    value: Row[K],
+  ): Promise<Row[K]> => {
+    const def = schema[col];
+    if (def.read && value !== null) {
+      return (await def.read(value as never)) as Row[K];
+    }
+    return value;
+  };
+
   // Transform a row from DB (apply read transforms)
   const fromDb = async (row: Row): Promise<Row> => {
-    const entries = await mapParallel(async (col: keyof Row & string) => {
-      const def = schema[col];
-      const value = row[col];
-      if (def.read && value !== null) {
-        return [col, await def.read(value as never)] as const;
-      }
-      return [col, value] as const;
-    })(allColumns);
+    const entries = await mapParallel(
+      async (col: keyof Row & string) =>
+        [col, await readColumn(col, row[col])] as const,
+    )(allColumns);
     return Object.fromEntries(entries) as Row;
   };
 
@@ -406,6 +424,7 @@ export const defineTable = <Row, Input = Row>(
     insertStatement,
     name,
     primaryKey,
+    readColumn,
     rowToInput,
     schema,
     toDbValues,

--- a/src/shared/forms.tsx
+++ b/src/shared/forms.tsx
@@ -118,16 +118,23 @@ type FieldValidationResult =
   | { valid: true; value: string | number | null }
   | { valid: false; error: string };
 
-/** Render select options HTML */
-const renderSelectOptions = (
-  options: readonly { value: string; label: string }[],
-  selectedValue: string,
-): string =>
+/** One entry in a select's option list. */
+export type SelectOption = {
+  value: string;
+  label: string;
+  /** Marks this entry as the chosen one. */
+  selected?: boolean;
+};
+
+/** Render a select's option list, escaping every value and label. The one
+ * builder behind every dropdown — booking-page selectors, admin filters, and
+ * the form framework's own select fields all share it. */
+export const renderSelectOptions = (options: readonly SelectOption[]): string =>
   options
     .map(
       (opt) =>
         `<option value="${escapeHtml(opt.value)}"${
-          opt.value === selectedValue ? " selected" : ""
+          opt.selected ? " selected" : ""
         }>${escapeHtml(opt.label)}</option>`,
     )
     .join("");
@@ -220,7 +227,9 @@ const renderFieldInput = (field: Field, value: string): JSX.Element => {
     return rawField(
       `<select name="${escapeHtml(field.name)}" id="${escapeHtml(
         field.id ?? field.name,
-      )}">${renderSelectOptions(field.options, value)}</select>`,
+      )}">${renderSelectOptions(
+        field.options.map((opt) => ({ ...opt, selected: opt.value === value })),
+      )}</select>`,
     );
   }
   if (field.type === "checkbox-group" && field.options) {

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -608,6 +608,29 @@ export const extractSessionMetadata = (
   };
 };
 
+/**
+ * Assemble the one ValidatedPaymentSession shape every provider adapter
+ * returns. Owns the createdAt rule — the key is left out entirely when the
+ * provider gave no usable timestamp — and normalizes the guarded wire metadata
+ * into the canonical shape. `metadata` must already have passed
+ * hasRequiredSessionMetadata (or come from our own staged checkout row).
+ */
+export const validatedPaymentSession = (fields: {
+  amountTotal: number;
+  createdAt: string | undefined;
+  id: string;
+  metadata: SessionMetadata;
+  paymentReference: string;
+  paymentStatus: ValidatedPaymentSession["paymentStatus"];
+}): ValidatedPaymentSession => ({
+  amountTotal: fields.amountTotal,
+  ...(fields.createdAt !== undefined ? { createdAt: fields.createdAt } : {}),
+  id: fields.id,
+  metadata: extractSessionMetadata(fields.metadata),
+  paymentReference: fields.paymentReference,
+  paymentStatus: fields.paymentStatus,
+});
+
 export const parseWebhookPayload = (
   payload: string,
   errorCode: ErrorCodeType,

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -14,6 +14,10 @@ import { getEffectiveDomain } from "#shared/config.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { ErrorCodeType, LogCategory } from "#shared/logger.ts";
 import { logDebug, logError } from "#shared/logger.ts";
+import {
+  PAYMENT_PROVIDERS,
+  type PaymentProviderMeta,
+} from "#shared/payment-providers.ts";
 import { signPriceSync } from "#shared/payment-signature.ts";
 import type {
   BookingIntent,
@@ -26,7 +30,7 @@ import type {
   WebhookEvent,
   WebhookVerifyResult,
 } from "#shared/payments.ts";
-import type { ContactInfo } from "#shared/types.ts";
+import type { ContactInfo, PaymentProviderType } from "#shared/types.ts";
 
 /** Extract a human-readable message from an unknown caught value */
 export const errorMessage = (err: unknown): string =>
@@ -306,6 +310,34 @@ export const buildItemsMetadata = async (
 };
 
 /**
+ * Build a checkout's signed metadata the way the given provider needs it, with
+ * the caps read from the provider registry: build the logical shape within the
+ * per-value and entry caps, pack the small fields into one entry when the
+ * provider needs that to fit, and enforce the caps on the shape that reaches
+ * the wire. SumUp's caps are unbounded (its metadata is stored locally, never
+ * sent to the provider), which makes the enforcement a no-op for it.
+ */
+export const assembleCheckoutMetadata = async (
+  providerType: PaymentProviderType,
+  intent: CheckoutIntent,
+  total: number,
+): Promise<Record<string, string>> => {
+  const caps: PaymentProviderMeta["metadata"] =
+    PAYMENT_PROVIDERS[providerType].metadata;
+  const built = await buildItemsMetadata(
+    intent,
+    total,
+    caps.maxValueLength,
+    caps.maxEntries,
+  );
+  return enforceMetadataLimits(
+    caps.packs ? packMetadata(built) : built,
+    caps.maxValueLength,
+    caps.maxEntries,
+  );
+};
+
+/**
  * Compact the resolved modifier specs to id/quantity references for metadata.
  *
  * Every trigger (automatic, code, opt-in add-on, and answer) is carried the
@@ -402,19 +434,6 @@ export const withCheckoutError = async (
     return null;
   }
 };
-
-/** Stripe metadata constraint: each value max 500 characters */
-export const STRIPE_METADATA_MAX_VALUE_LENGTH = 500;
-
-/** Stripe metadata constraint: max 50 entries. */
-export const STRIPE_METADATA_MAX_ENTRIES = 50;
-
-/** Square metadata constraint: each value max 255 characters */
-export const SQUARE_METADATA_MAX_VALUE_LENGTH = 255;
-
-/** Square metadata constraint: max 10 entries — the tightest provider cap, and
- * the reason small fields are packed into one `b` entry (see packMetadata). */
-export const SQUARE_METADATA_MAX_ENTRIES = 10;
 
 /**
  * Small, bounded booking fields collapsed into a single packed `b` entry.

--- a/src/shared/payment-providers.ts
+++ b/src/shared/payment-providers.ts
@@ -20,21 +20,41 @@ export type PaymentProviderMeta = {
    * webhooks are unsigned (authenticity is re-established via the provider API
    * instead — see `PaymentProvider.requiresWebhookSignature`). */
   readonly webhookSignatureHeader: string | null;
+  /** The provider's checkout-metadata caps: the longest value it accepts, an
+   * optional limit on how many entries a session may carry, and whether the
+   * small fields are packed into one entry to fit that limit. An unbounded
+   * (Infinity, no maxEntries) provider makes cap enforcement a no-op. */
+  readonly metadata: {
+    readonly maxValueLength: number;
+    readonly maxEntries?: number;
+    readonly packs: boolean;
+  };
 };
 
 /** Provider metadata keyed by identifier. Declaration order drives the settings
  * radio list, so keep it in the order operators should see. */
-export const PAYMENT_PROVIDERS: Record<
-  PaymentProviderType,
-  PaymentProviderMeta
-> = {
+export const PAYMENT_PROVIDERS = {
   square: {
     label: "Square",
+    // Square allows only 10 metadata entries of 255 characters each — the
+    // tightest caps of any provider, and the reason small fields are packed
+    // into one `b` entry (see packMetadata in payment-helpers.ts).
+    metadata: { maxEntries: 10, maxValueLength: 255, packs: true },
     webhookSignatureHeader: "x-square-hmacsha256-signature",
   },
-  stripe: { label: "Stripe", webhookSignatureHeader: "stripe-signature" },
-  sumup: { label: "SumUp", webhookSignatureHeader: null },
-};
+  stripe: {
+    label: "Stripe",
+    metadata: { maxEntries: 50, maxValueLength: 500, packs: false },
+    webhookSignatureHeader: "stripe-signature",
+  },
+  sumup: {
+    label: "SumUp",
+    // SumUp carries no provider metadata: the booking fields are stored
+    // locally (db/sumup-checkouts.ts), so nothing is capped or packed.
+    metadata: { maxValueLength: Number.POSITIVE_INFINITY, packs: false },
+    webhookSignatureHeader: null,
+  },
+} as const satisfies Record<PaymentProviderType, PaymentProviderMeta>;
 
 /** Provider ids in declared order. */
 export const PAYMENT_PROVIDER_IDS = Object.keys(
@@ -42,6 +62,6 @@ export const PAYMENT_PROVIDER_IDS = Object.keys(
 ) as PaymentProviderType[];
 
 /** Webhook signature headers of every provider that signs its webhooks. */
-export const WEBHOOK_SIGNATURE_HEADERS = PAYMENT_PROVIDER_IDS.map(
+export const WEBHOOK_SIGNATURE_HEADERS: string[] = PAYMENT_PROVIDER_IDS.map(
   (id) => PAYMENT_PROVIDERS[id].webhookSignatureHeader,
-).filter((header): header is string => header !== null);
+).filter((header) => header !== null);

--- a/src/shared/rest/crud-api.ts
+++ b/src/shared/rest/crud-api.ts
@@ -19,6 +19,7 @@
 
 import type { InValue } from "@libsql/client";
 import { verifyIdentifierOrJsonError } from "#routes/admin/confirmation.ts";
+import { jsonError } from "#routes/api/cors.ts";
 import { ADMIN_API, type AuthPolicy, withAuth } from "#routes/auth.ts";
 import { jsonResponse } from "#routes/response.ts";
 import type { RouteHandlerFn } from "#routes/router.ts";
@@ -122,9 +123,8 @@ export const parseOptionalArray = <T>(
   return { input: items, ok: true };
 };
 
-/** JSON error response for API endpoints */
-export const apiErrorResponse = (message: string, status = 400): Response =>
-  jsonResponse({ error: message }, status);
+/** JSON `{ error: message }` response for API endpoints (no CORS headers) */
+export const apiErrorResponse = jsonError(jsonResponse);
 
 /** Result of parsing + validating: either the input or a pre-built error response */
 export type ValidatedInput<Input> =

--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -14,10 +14,10 @@
 
 import { logDebug } from "#shared/logger.ts";
 import {
-  extractSessionMetadata,
   hasRequiredSessionMetadata,
   toCanonicalIso,
   toCheckoutResult,
+  validatedPaymentSession,
   withCheckoutError,
 } from "#shared/payment-helpers.ts";
 import type {
@@ -127,15 +127,14 @@ export const squarePaymentProvider: PaymentProvider = {
       }
     }
 
-    const createdAt = toCanonicalIso(order.createdAt);
-    return {
+    return validatedPaymentSession({
       amountTotal: Number(order.totalMoney.amount),
-      ...(createdAt !== undefined ? { createdAt } : {}),
+      createdAt: toCanonicalIso(order.createdAt),
       id: order.id,
-      metadata: extractSessionMetadata(metadata),
+      metadata,
       paymentReference,
       paymentStatus,
-    };
+    });
   },
 
   setupWebhookEndpoint(

--- a/src/shared/square.ts
+++ b/src/shared/square.ts
@@ -20,17 +20,13 @@ import {
   secureCompare,
 } from "#shared/payment-crypto.ts";
 import {
-  buildItemsMetadata,
+  assembleCheckoutMetadata,
   buildProviderLineItems,
   cachedClientFactory,
   createWithClient,
-  enforceMetadataLimits,
   errorMessage,
   PaymentUserError,
-  packMetadata,
   parseWebhookPayload,
-  SQUARE_METADATA_MAX_ENTRIES,
-  SQUARE_METADATA_MAX_VALUE_LENGTH,
 } from "#shared/payment-helpers.ts";
 import type {
   CheckoutIntent,
@@ -143,17 +139,6 @@ const rethrowAsUserError = (err: unknown): never => {
   }
   throw err;
 };
-
-/** Enforce Square's metadata value-length and 10-entry limits via the shared
- * helper, so an over-cap checkout fails with a batching message up front. */
-const enforceSquareMetadataLimits = (
-  metadata: Record<string, string>,
-): Record<string, string> =>
-  enforceMetadataLimits(
-    metadata,
-    SQUARE_METADATA_MAX_VALUE_LENGTH,
-    SQUARE_METADATA_MAX_ENTRIES,
-  );
 
 /** Square API version for all requests */
 export const SQUARE_API_VERSION = "2025-01-23";
@@ -549,17 +534,16 @@ const buildCheckoutOptions = (
   phone: normalizeCheckoutPhone(intent.phone),
 });
 
-/** Shared setup for payment link creation: validates config and metadata */
+/** Shared setup for payment link creation: resolves config for the assembled
+ * (already cap-enforced) metadata. */
 const preparePaymentLink = (
-  rawMetadata: Record<string, string>,
+  metadata: Record<string, string>,
   label: string,
 ): PreparedLink | null => {
   const config = getPaymentLinkConfig();
   if (!config) return null;
 
   logDebug("Square", `Creating ${label}`);
-
-  const metadata = enforceSquareMetadataLimits(rawMetadata);
 
   return { config, metadata };
 };
@@ -591,15 +575,8 @@ export const squareApi: {
     // and the signed proof, so the two can never disagree (see #1300).
     const order = priceCheckout(intent);
 
-    const prep = await preparePaymentLink(
-      packMetadata(
-        await buildItemsMetadata(
-          intent,
-          order.total,
-          SQUARE_METADATA_MAX_VALUE_LENGTH,
-          SQUARE_METADATA_MAX_ENTRIES,
-        ),
-      ),
+    const prep = preparePaymentLink(
+      await assembleCheckoutMetadata("square", intent, order.total),
       `payment link for ${intent.items.length} listing(s)`,
     );
     if (!prep) return null;

--- a/src/shared/square.ts
+++ b/src/shared/square.ts
@@ -534,20 +534,6 @@ const buildCheckoutOptions = (
   phone: normalizeCheckoutPhone(intent.phone),
 });
 
-/** Shared setup for payment link creation: resolves config for the assembled
- * (already cap-enforced) metadata. */
-const preparePaymentLink = (
-  metadata: Record<string, string>,
-  label: string,
-): PreparedLink | null => {
-  const config = getPaymentLinkConfig();
-  if (!config) return null;
-
-  logDebug("Square", `Creating ${label}`);
-
-  return { config, metadata };
-};
-
 /** Type for the Square API client returned by createSquareClient */
 export type SquareClient = ReturnType<typeof createSquareClient>;
 
@@ -575,11 +561,21 @@ export const squareApi: {
     // and the signed proof, so the two can never disagree (see #1300).
     const order = priceCheckout(intent);
 
-    const prep = preparePaymentLink(
-      await assembleCheckoutMetadata("square", intent, order.total),
-      `payment link for ${intent.items.length} listing(s)`,
+    // Resolve config before assembling metadata: a missing payment-link
+    // config must return null before an over-cap cart can throw its
+    // "too many listings" user error.
+    const config = getPaymentLinkConfig();
+    if (!config) return null;
+
+    logDebug(
+      "Square",
+      `Creating payment link for ${intent.items.length} listing(s)`,
     );
-    if (!prep) return null;
+
+    const prep: PreparedLink = {
+      config,
+      metadata: await assembleCheckoutMetadata("square", intent, order.total),
+    };
 
     const lineItems = buildProviderLineItems<SquareLineItem>(
       order,

--- a/src/shared/stripe-provider.ts
+++ b/src/shared/stripe-provider.ts
@@ -7,15 +7,16 @@
 
 import { asString } from "#fp";
 import {
-  extractSessionMetadata,
   hasRequiredSessionMetadata,
   toCheckoutResult,
+  validatedPaymentSession,
   withCheckoutError,
 } from "#shared/payment-helpers.ts";
 import {
   type CheckoutIntent,
   isPaymentStatus,
   type PaymentProvider,
+  type PaymentStatus,
   type ValidatedPaymentSession,
   type WebhookEvent,
   type WebhookVerifyResult,
@@ -29,6 +30,10 @@ import {
   refundPayment as stripeRefund,
   verifyWebhookSignature,
 } from "#shared/stripe.ts";
+
+/** Stripe's payment_status string, or "unpaid" when it isn't one we know. */
+const toPaymentStatus = (status: string): PaymentStatus =>
+  isPaymentStatus(status) ? status : "unpaid";
 
 /** Stripe payment provider implementation */
 export const stripePaymentProvider: PaymentProvider = {
@@ -69,17 +74,16 @@ export const stripePaymentProvider: PaymentProvider = {
       typeof amountTotal === "number" &&
       hasRequiredSessionMetadata(metadata)
     ) {
-      const createdAt = isoFromUnixSeconds(obj.created);
-      return Promise.resolve({
-        amountTotal,
-        createdAt,
-        id,
-        metadata: extractSessionMetadata(metadata),
-        paymentReference: asString(obj.payment_intent),
-        paymentStatus: isPaymentStatus(paymentStatus)
-          ? paymentStatus
-          : "unpaid",
-      });
+      return Promise.resolve(
+        validatedPaymentSession({
+          amountTotal,
+          createdAt: isoFromUnixSeconds(obj.created),
+          id,
+          metadata,
+          paymentReference: asString(obj.payment_intent),
+          paymentStatus: toPaymentStatus(paymentStatus),
+        }),
+      );
     }
 
     // Fallback: retrieve session by ID from listing data
@@ -105,17 +109,14 @@ export const stripePaymentProvider: PaymentProvider = {
 
     if (amount_total === null) return null;
 
-    const createdAt = isoFromUnixSeconds(session.created);
-    return {
+    return validatedPaymentSession({
       amountTotal: amount_total,
-      createdAt,
+      createdAt: isoFromUnixSeconds(session.created),
       id,
-      metadata: extractSessionMetadata(metadata),
+      metadata,
       paymentReference: payment_intent ?? "",
-      paymentStatus: isPaymentStatus(payment_status)
-        ? payment_status
-        : "unpaid",
-    };
+      paymentStatus: toPaymentStatus(payment_status),
+    });
   },
 
   setupWebhookEndpoint(...args: Parameters<typeof setupWebhookEndpoint>) {

--- a/src/shared/stripe.ts
+++ b/src/shared/stripe.ts
@@ -16,16 +16,13 @@ import {
   secureCompare,
 } from "#shared/payment-crypto.ts";
 import {
-  buildItemsMetadata,
+  assembleCheckoutMetadata,
   buildProviderLineItems,
   type CredentialCheck,
   cachedClientFactory,
   createWithClient,
-  enforceMetadataLimits,
   errorMessage,
   parseWebhookPayload,
-  STRIPE_METADATA_MAX_ENTRIES,
-  STRIPE_METADATA_MAX_VALUE_LENGTH,
 } from "#shared/payment-helpers.ts";
 import type {
   CheckoutIntent,
@@ -309,16 +306,7 @@ export const stripeApi: {
       payment_method_types: ["card"],
       success_url: `${baseUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       ...(intent.email ? { customer_email: intent.email } : {}),
-      metadata: enforceMetadataLimits(
-        await buildItemsMetadata(
-          intent,
-          order.total,
-          STRIPE_METADATA_MAX_VALUE_LENGTH,
-          STRIPE_METADATA_MAX_ENTRIES,
-        ),
-        STRIPE_METADATA_MAX_VALUE_LENGTH,
-        STRIPE_METADATA_MAX_ENTRIES,
-      ),
+      metadata: await assembleCheckoutMetadata("stripe", intent, order.total),
     };
 
     logDebug("Stripe", "Calling Stripe API checkout.sessions.create");

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -17,9 +17,9 @@ import {
   hasSumupCheckoutId,
 } from "#shared/db/sumup-checkouts.ts";
 import {
-  extractSessionMetadata,
   toCanonicalIso,
   toCheckoutResult,
+  validatedPaymentSession,
   withCheckoutError,
 } from "#shared/payment-helpers.ts";
 import type {
@@ -52,17 +52,15 @@ const toPaymentStatus = (status: SumupCheckout["status"]): PaymentStatus =>
 const buildValidatedSession = (
   checkout: SumupCheckout,
   metadata: Record<string, string>,
-): ValidatedPaymentSession => {
-  const createdAt = toCanonicalIso(checkout.createdAt);
-  return {
+): ValidatedPaymentSession =>
+  validatedPaymentSession({
     amountTotal: checkout.amountMinor,
-    ...(createdAt !== undefined ? { createdAt } : {}),
+    createdAt: toCanonicalIso(checkout.createdAt),
     id: checkout.reference,
-    metadata: extractSessionMetadata(metadata as SessionMetadata),
+    metadata: metadata as SessionMetadata,
     paymentReference: checkout.transactionId,
     paymentStatus: toPaymentStatus(checkout.status),
-  };
-};
+  });
 
 /** SumUp payment provider implementation. */
 export const sumupPaymentProvider: PaymentProvider = {

--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -27,7 +27,7 @@ import {
 } from "#shared/db/sumup-checkouts.ts";
 import { ErrorCode, logDebug, logError } from "#shared/logger.ts";
 import {
-  buildItemsMetadata,
+  assembleCheckoutMetadata,
   type CredentialCheck,
   createWithClient,
   errorMessage,
@@ -178,11 +178,11 @@ export const sumupApi: {
     // webhook or redirect arrives. An orphaned row (if create fails) is pruned.
     const reference = crypto.randomUUID();
     // SumUp carries no provider metadata: the booking fields are stored locally
-    // (db/sumup-checkouts.ts), so there is no per-value cap to bound and the
-    // operator's thank_you_url is always retained (pass an unbounded cap).
+    // (db/sumup-checkouts.ts), so its registry caps are unbounded and the
+    // operator's thank_you_url is always retained.
     await storeSumupCheckout(
       reference,
-      await buildItemsMetadata(intent, totalMinor, Number.POSITIVE_INFINITY),
+      await assembleCheckoutMetadata("sumup", intent, totalMinor),
     );
 
     return withClient(async (client) => {

--- a/src/ui/templates/admin/detail-rows.tsx
+++ b/src/ui/templates/admin/detail-rows.tsx
@@ -8,6 +8,11 @@ import { formatCurrency } from "#shared/currency.ts";
 import { type Attendee, hasTicketQuantity } from "#shared/types.ts";
 import { questionTextFlat } from "#templates/admin/questions.tsx";
 import type { TableQuestionData } from "#templates/attendee-table.tsx";
+import {
+  capacityLevel,
+  capacityMeterHtml,
+  capacityMeterText,
+} from "#templates/components/capacity.tsx";
 
 /** A key/value row for the listing-details-table */
 export type DetailRow = {
@@ -75,10 +80,6 @@ export const getCheckedInStats = (allAttendees: Attendee[]): CheckedInStats => {
   };
 };
 
-/** Format "done / total — remaining remain" */
-const formatProgress = (done: number, total: number): string =>
-  `${done} / ${total} ${t("detail_rows.mdash")} ${total - done} ${t("detail_rows.remain")}`;
-
 /** A progress DetailRow: `${t(labelKey)}${suffix}` keyed to "done / total …". */
 const progressRow = (
   labelKey: string,
@@ -87,7 +88,7 @@ const progressRow = (
   total: number,
 ): DetailRow => ({
   key: `${t(labelKey)}${suffix}`,
-  value: formatProgress(done, total),
+  value: capacityMeterText(done, total),
 });
 
 /** Build the checked-in detail row(s) — splits into two when multi-quantity */
@@ -177,29 +178,22 @@ export type SharedDetailInput = {
   revenue?: number;
 };
 
-/** Whether a count is at or above 90% of capacity */
-const isNearCapacity = (count: number, capacity: number): boolean =>
-  capacity > 0 && count >= capacity * 0.9;
-
-/** Wrap text in a danger-text span when near capacity */
-const wrapDanger = (text: string, danger: boolean): string =>
-  danger ? `<span class="danger-text">${text}</span>` : text;
-
 /** Build a single attendee-count detail row, with danger styling near capacity */
 const buildAttendeeRow = (
   count: number,
   maxCapacity: number,
   suffix: string,
-): DetailRow => {
-  const display =
+): DetailRow => ({
+  key: `${t("terms.attendees")}${suffix}`,
+  value:
     maxCapacity > 0
-      ? `${count} / ${maxCapacity} ${t("detail_rows.mdash")} ${maxCapacity - count} ${t("detail_rows.remain")}`
-      : String(count);
-  return {
-    key: `${t("terms.attendees")}${suffix}`,
-    value: wrapDanger(display, isNearCapacity(count, maxCapacity)),
-  };
-};
+      ? capacityMeterHtml({
+          count,
+          danger: capacityLevel(count, maxCapacity).nearLimit,
+          max: maxCapacity,
+        })
+      : String(count),
+});
 
 /** Build a revenue detail row from a minor-units total */
 const buildRevenueRow = (revenue: number): DetailRow => ({

--- a/src/ui/templates/admin/groups.tsx
+++ b/src/ui/templates/admin/groups.tsx
@@ -67,6 +67,7 @@ import {
   SaveChangesButton,
   SubmitButton,
 } from "#templates/components/actions.tsx";
+import { GroupCapacityMeter } from "#templates/components/capacity.tsx";
 import { DataTable, textColumns } from "#templates/components/data-table.tsx";
 import { DetailTable } from "#templates/components/detail-table.tsx";
 import {
@@ -399,16 +400,11 @@ const GroupAttendeesRow = ({
       </tr>
     );
   }
-  const remaining = Math.max(0, group.max_attendees - attendeeCount);
-  const overCap = attendeeCount >= group.max_attendees;
-  const nearCap = attendeeCount >= group.max_attendees * 0.9;
   return (
     <tr>
       <th>{t("groups.group_attendees")}</th>
       <td>
-        <span class={overCap || nearCap ? "danger-text" : ""}>
-          {attendeeCount} / {group.max_attendees} &mdash; {remaining} remain
-        </span>{" "}
+        <GroupCapacityMeter count={attendeeCount} max={group.max_attendees} />{" "}
         <small>across all listings in the group</small>
       </td>
     </tr>

--- a/src/ui/templates/admin/listings/aggregates.tsx
+++ b/src/ui/templates/admin/listings/aggregates.tsx
@@ -17,6 +17,7 @@ import {
 import type { RecalculateRow } from "#templates/admin/recalculate.tsx";
 import type { TableQuestionData } from "#templates/attendee-table.tsx";
 import { recalculatePageRenderer } from "#templates/components/aggregate-sections.tsx";
+import { capacityLevel } from "#templates/components/capacity.tsx";
 import { listingAggregateFields } from "#templates/fields/aggregate.ts";
 
 export {
@@ -32,7 +33,7 @@ export const buildAnswerSummaryRows = (
 ): string => renderDetailRows(buildAnswerSummaryDetailRows(questionData));
 
 export const nearCapacity = (listing: ListingWithCount): boolean =>
-  listing.attendee_count >= listing.max_attendees * 0.9;
+  capacityLevel(listing.attendee_count, listing.max_attendees).nearLimit;
 
 const listingAggregateFormatters: Record<
   ListingAggregateField,

--- a/src/ui/templates/admin/listings/attendees.tsx
+++ b/src/ui/templates/admin/listings/attendees.tsx
@@ -2,7 +2,7 @@
 import { filter, joinStrings, map, pipe } from "#fp";
 import { t } from "#i18n";
 import { formatDatetimeShort } from "#shared/dates.ts";
-import { CsrfForm, renderFields } from "#shared/forms.tsx";
+import { CsrfForm, renderFields, renderSelectOptions } from "#shared/forms.tsx";
 import { isIncompletePayment } from "#shared/incomplete-payment.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import {
@@ -149,17 +149,18 @@ const DateSelector = ({
   dateFilter: string | null;
   dates: DateOption[];
 }): string => {
-  const options = [
-    `<option value="${rosterHref(listingId, activeFilter, null)}"${
-      !dateFilter ? " selected" : ""
-    }>${t("listings_table.all_dates")}</option>`,
-    ...dates.map(
-      (d) =>
-        `<option value="${rosterHref(listingId, activeFilter, d.value)}"${
-          dateFilter === d.value ? " selected" : ""
-        }>${d.label}</option>`,
-    ),
-  ].join("");
+  const options = renderSelectOptions([
+    {
+      label: t("listings_table.all_dates"),
+      selected: !dateFilter,
+      value: rosterHref(listingId, activeFilter, null),
+    },
+    ...dates.map((d) => ({
+      label: d.label,
+      selected: dateFilter === d.value,
+      value: rosterHref(listingId, activeFilter, d.value),
+    })),
+  ]);
   return `<select data-nav-select aria-label="${t(
     "listings_table.filter_by_date",
   )}">${options}</select>`;

--- a/src/ui/templates/admin/listings/capacity-rows.tsx
+++ b/src/ui/templates/admin/listings/capacity-rows.tsx
@@ -1,6 +1,11 @@
 import { t } from "#i18n";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { ListingWithCount } from "#shared/types.ts";
+import {
+  CapacityMeter,
+  capacityLevel,
+  GroupCapacityMeter,
+} from "#templates/components/capacity.tsx";
 import { DetailTable } from "#templates/components/detail-table.tsx";
 import type { GroupContext } from "./types.ts";
 
@@ -43,27 +48,28 @@ const AttendeeCountDisplay = (
   const { listing, isDaily, dateFilter, adjustedCount, completeQuantitySum } =
     props;
   if (isDaily && dateFilter) {
-    const overLimit = completeQuantitySum >= listing.max_attendees;
     return (
-      <span class={overLimit ? "danger-text" : ""}>
-        {completeQuantitySum} / {listing.max_attendees} {"\u2014"}{" "}
-        {listing.max_attendees - completeQuantitySum}{" "}
-        {t("listings_table.remain")}
-      </span>
+      <CapacityMeter
+        count={completeQuantitySum}
+        danger={
+          capacityLevel(completeQuantitySum, listing.max_attendees).overLimit
+        }
+        max={listing.max_attendees}
+      />
     );
   }
-  const nearLimit = adjustedCount >= listing.max_attendees * 0.9;
+  const level = capacityLevel(adjustedCount, listing.max_attendees);
+  if (isDaily) {
+    return (
+      <span class={level.nearLimit ? "danger-text" : ""}>{adjustedCount}</span>
+    );
+  }
   return (
-    <span class={nearLimit ? "danger-text" : ""}>
-      {adjustedCount}
-      {!isDaily && (
-        <>
-          {" "}
-          / {listing.max_attendees} {"\u2014"}{" "}
-          {listing.max_attendees - adjustedCount} {t("listings_table.remain")}
-        </>
-      )}
-    </span>
+    <CapacityMeter
+      count={adjustedCount}
+      danger={level.nearLimit}
+      max={listing.max_attendees}
+    />
   );
 };
 
@@ -102,9 +108,6 @@ export const GroupAttendeesRow = ({
   groupAttendeeCount: number;
   dailySuffix: string;
 }): JSX.Element => {
-  const remaining = Math.max(0, group.max_attendees - groupAttendeeCount);
-  const overLimit = groupAttendeeCount >= group.max_attendees;
-  const nearLimit = groupAttendeeCount >= group.max_attendees * 0.9;
   return (
     <tr>
       <th>
@@ -112,10 +115,10 @@ export const GroupAttendeesRow = ({
         {dailySuffix}
       </th>
       <td>
-        <span class={overLimit || nearLimit ? "danger-text" : ""}>
-          {groupAttendeeCount} / {group.max_attendees} {"\u2014"} {remaining}{" "}
-          {t("listings_table.remain")}
-        </span>{" "}
+        <GroupCapacityMeter
+          count={groupAttendeeCount}
+          max={group.max_attendees}
+        />{" "}
         <small>
           {t("listings_table.across_all_listings_in")}{" "}
           <a href={`/admin/groups/${group.id}`}>{group.name}</a>

--- a/src/ui/templates/components/capacity.tsx
+++ b/src/ui/templates/components/capacity.tsx
@@ -1,0 +1,83 @@
+/**
+ * The one shared capacity meter: "count / max — n remain", plus the single
+ * place the 90% warning threshold and the seats-left maths live.
+ */
+
+import { t } from "#i18n";
+
+/** How full a count is against its cap: seats left, whether the count is
+ * close to the cap (90% or more), and whether it has reached the cap. A cap
+ * of zero means "no cap", so nothing is ever near or over it. */
+export const capacityLevel = (
+  count: number,
+  max: number,
+): { remaining: number; nearLimit: boolean; overLimit: boolean } => ({
+  nearLimit: max > 0 && count >= max * 0.9,
+  overLimit: max > 0 && count >= max,
+  remaining: max - count,
+});
+
+/** The meter's text: "12 / 20 — 8 remain". Pass `remaining` when the shown
+ * seats-left figure differs from the raw maths (group rows floor it at 0). */
+export const capacityMeterText = (
+  count: number,
+  max: number,
+  remaining: number = capacityLevel(count, max).remaining,
+): string =>
+  `${count} / ${max} ${t("capacity.mdash")} ${remaining} ${t("capacity.remain")}`;
+
+/** What every meter render needs: the figures plus the caller's warning flag. */
+export type CapacityMeterProps = {
+  count: number;
+  max: number;
+  /** Turns the meter red — callers pass the level flag their table warns on. */
+  danger: boolean;
+  /** Overrides the shown seats-left figure (group rows floor it at 0). */
+  remaining?: number | undefined;
+};
+
+/** Meter for string-built tables: plain text normally, wrapped in a danger
+ * span when the caller's warning flag is on (these tables add no span at all
+ * when the level is safe). */
+export const capacityMeterHtml = ({
+  count,
+  max,
+  danger,
+  remaining,
+}: CapacityMeterProps): string => {
+  const text = capacityMeterText(count, max, remaining);
+  return danger ? `<span class="danger-text">${text}</span>` : text;
+};
+
+/** Meter for JSX tables: a span that turns red when the warning flag is on. */
+export const CapacityMeter = ({
+  count,
+  max,
+  danger,
+  remaining,
+}: CapacityMeterProps): JSX.Element => (
+  <span class={danger ? "danger-text" : ""}>
+    {capacityMeterText(count, max, remaining)}
+  </span>
+);
+
+/** The group-attendees meter: warns from 90% full, and never shows fewer
+ * than zero seats left. Shared by the group page and the listing page's
+ * group row so the two can't drift. */
+export const GroupCapacityMeter = ({
+  count,
+  max,
+}: {
+  count: number;
+  max: number;
+}): JSX.Element => {
+  const level = capacityLevel(count, max);
+  return (
+    <CapacityMeter
+      count={count}
+      danger={level.nearLimit}
+      max={max}
+      remaining={Math.max(0, level.remaining)}
+    />
+  );
+};

--- a/src/ui/templates/public/reservations/inputs.ts
+++ b/src/ui/templates/public/reservations/inputs.ts
@@ -5,11 +5,44 @@ import {
 } from "#shared/booking/tree.ts";
 import { formatCurrency, toMajorUnits } from "#shared/currency.ts";
 import { formatDateLabel } from "#shared/dates.ts";
-import { renderSelectOptions, savedFormValue } from "#shared/forms.tsx";
+import {
+  renderSelectOptions,
+  type SelectOption,
+  savedFormValue,
+} from "#shared/forms.tsx";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { moneyPattern } from "#templates/components/price-input.tsx";
 import { escapeHtml } from "#templates/layout.tsx";
+
+/** Everything one of the booking form's labeled dropdowns needs: an error box
+ * when there is nothing to choose from, else a label plus a required select
+ * with a placeholder option in front of the choices. */
+type LabeledSelect = {
+  name: string;
+  /** Trusted label HTML (the date selector appends a duration hint). */
+  label: string;
+  placeholder: string;
+  /** Shown instead of the select when there are no options. */
+  emptyError: string;
+  options: SelectOption[];
+};
+
+/** The one shell behind the booking form's date and day-count pickers. */
+const renderLabeledSelect = ({
+  name,
+  label,
+  placeholder,
+  emptyError,
+  options,
+}: LabeledSelect): string =>
+  options.length === 0
+    ? `<div class="error">${emptyError}</div>`
+    : `<label for="${name}">${label}</label>
+       <select name="${name}" id="${name}" required>
+         <option value="">${placeholder}</option>
+         ${renderSelectOptions(options)}
+       </select>`;
 
 /** A date-selector dropdown for daily listings. */
 export const renderDateSelector = (
@@ -17,25 +50,23 @@ export const renderDateSelector = (
   selected = "",
   durationDays = 1,
 ): string =>
-  dates.length === 0
-    ? `<div class="error">${t("public.ticket.no_dates_available")}</div>`
-    : `<label for="date">${t("public.ticket.select_date")}${
-        durationDays > 1
-          ? ` <small>(${t("public.ticket.date_duration_hint", {
-              durationDays,
-            })})</small>`
-          : ""
-      }</label>
-       <select name="date" id="date" required>
-         <option value="">${t("public.ticket.select_date_placeholder")}</option>
-         ${renderSelectOptions(
-           dates.map((d) => ({
-             label: formatDateLabel(d),
-             selected: d === selected,
-             value: d,
-           })),
-         )}
-       </select>`;
+  renderLabeledSelect({
+    emptyError: t("public.ticket.no_dates_available"),
+    label: `${t("public.ticket.select_date")}${
+      durationDays > 1
+        ? ` <small>(${t("public.ticket.date_duration_hint", {
+            durationDays,
+          })})</small>`
+        : ""
+    }`,
+    name: "date",
+    options: dates.map((d) => ({
+      label: formatDateLabel(d),
+      selected: d === selected,
+      value: d,
+    })),
+    placeholder: t("public.ticket.select_date_placeholder"),
+  });
 
 /** Render the "number of days" selector for customisable-days listings. When a
  * single listing drives the page, each option shows its price for that span.
@@ -44,28 +75,25 @@ export const renderDayCountSelector = (
   counts: number[],
   priceFor?: (days: number) => number | null,
 ): string => {
-  if (counts.length === 0) {
-    return `<div class="error">${t("public.ticket.no_booking_lengths")}</div>`;
-  }
   const selected = savedFormValue("day_count");
-  return `<label for="day_count">${t("public.ticket.number_of_days")}</label>
-       <select name="day_count" id="day_count" required>
-         <option value="">${t("public.ticket.select_placeholder")}</option>
-         ${renderSelectOptions(
-           counts.map((n) => {
-             const price = priceFor?.(n);
-             const suffix =
-               price !== undefined && price !== null
-                 ? ` — ${formatCurrency(price)}`
-                 : "";
-             return {
-               label: `${t("public.ticket.day_option", { count: n })}${suffix}`,
-               selected: selected === String(n),
-               value: String(n),
-             };
-           }),
-         )}
-       </select>`;
+  return renderLabeledSelect({
+    emptyError: t("public.ticket.no_booking_lengths"),
+    label: t("public.ticket.number_of_days"),
+    name: "day_count",
+    options: counts.map((n) => {
+      const price = priceFor?.(n);
+      const suffix =
+        price !== undefined && price !== null
+          ? ` — ${formatCurrency(price)}`
+          : "";
+      return {
+        label: `${t("public.ticket.day_option", { count: n })}${suffix}`,
+        selected: selected === String(n),
+        value: String(n),
+      };
+    }),
+    placeholder: t("public.ticket.select_placeholder"),
+  });
 };
 
 /** A price input for pay-more listings. `required` is the HTML constraint: page

--- a/src/ui/templates/public/reservations/inputs.ts
+++ b/src/ui/templates/public/reservations/inputs.ts
@@ -5,7 +5,7 @@ import {
 } from "#shared/booking/tree.ts";
 import { formatCurrency, toMajorUnits } from "#shared/currency.ts";
 import { formatDateLabel } from "#shared/dates.ts";
-import { savedFormValue } from "#shared/forms.tsx";
+import { renderSelectOptions, savedFormValue } from "#shared/forms.tsx";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { moneyPattern } from "#templates/components/price-input.tsx";
@@ -28,14 +28,13 @@ export const renderDateSelector = (
       }</label>
        <select name="date" id="date" required>
          <option value="">${t("public.ticket.select_date_placeholder")}</option>
-         ${dates
-           .map(
-             (d) =>
-               `<option value="${d}"${d === selected ? " selected" : ""}>${formatDateLabel(
-                 d,
-               )}</option>`,
-           )
-           .join("")}
+         ${renderSelectOptions(
+           dates.map((d) => ({
+             label: formatDateLabel(d),
+             selected: d === selected,
+             value: d,
+           })),
+         )}
        </select>`;
 
 /** Render the "number of days" selector for customisable-days listings. When a
@@ -52,18 +51,20 @@ export const renderDayCountSelector = (
   return `<label for="day_count">${t("public.ticket.number_of_days")}</label>
        <select name="day_count" id="day_count" required>
          <option value="">${t("public.ticket.select_placeholder")}</option>
-         ${counts
-           .map((n) => {
+         ${renderSelectOptions(
+           counts.map((n) => {
              const price = priceFor?.(n);
              const suffix =
                price !== undefined && price !== null
                  ? ` — ${formatCurrency(price)}`
                  : "";
-             return `<option value="${n}"${
-               selected === String(n) ? " selected" : ""
-             }>${t("public.ticket.day_option", { count: n })}${suffix}</option>`;
-           })
-           .join("")}
+             return {
+               label: `${t("public.ticket.day_option", { count: n })}${suffix}`,
+               selected: selected === String(n),
+               value: String(n),
+             };
+           }),
+         )}
        </select>`;
 };
 
@@ -121,14 +122,13 @@ export const renderTermsAndCheckbox = (terms: string): string => {
 
 /** An `<option>` list `0..max` for a quantity selector, with `selected` chosen. */
 export const quantityOptions = (max: number, selected: number): string =>
-  Array.from({ length: max + 1 }, (_, i) => i)
-    .map(
-      (n) =>
-        `<option value="${n}"${
-          n === selected ? " selected" : ""
-        }>${n}</option>`,
-    )
-    .join("");
+  renderSelectOptions(
+    Array.from({ length: max + 1 }, (_, i) => ({
+      label: String(i),
+      selected: i === selected,
+      value: String(i),
+    })),
+  );
 
 /** Per-listing pre-fill applied when scanning a signed QR link */
 export type TicketPrefill = {

--- a/src/ui/templates/public/reservations/packages.ts
+++ b/src/ui/templates/public/reservations/packages.ts
@@ -19,7 +19,11 @@ import {
   quantityOptions,
   restoredPackageQuantity,
 } from "./inputs.ts";
-import { buildListingRows, renderListingDescription } from "./rows.ts";
+import {
+  buildListingRows,
+  renderListingDescription,
+  soldOutLabel,
+} from "./rows.ts";
 
 /** A package member row: name + fixed per-package quantity, read-only — the
  * buyer chooses the package count, not per-member quantities. A member that is
@@ -107,7 +111,7 @@ const renderPackageSection = (render: PackageRender): string => {
   const heading = `<legend>${escapeHtml(pkg.name)}</legend>`;
   const body =
     limit < 1
-      ? `<span class="sold-out-label">${t("public.sold_out")}</span>`
+      ? soldOutLabel()
       : renderListingDescription(pkg.description) +
         renderPackageControls(render);
   return `<fieldset class="ticket-package${

--- a/src/ui/templates/public/reservations/rows.ts
+++ b/src/ui/templates/public/reservations/rows.ts
@@ -31,6 +31,11 @@ export const renderListingDescription = (description: string): string =>
     ? `<div class="description-compact">${renderMarkdown(description)}</div>`
     : "";
 
+/** The dimmed badge shown in place of booking controls — "Sold out" unless a
+ * caller passes other copy (the closed row shows "Registration closed"). */
+export const soldOutLabel = (text: string = t("public.sold_out")): string =>
+  `<span class="sold-out-label">${text}</span>`;
+
 /** Render quantity selector for an listing row.
  *
  * An optional per-listing `prefill` pre-selects the quantity (clamped to the
@@ -77,7 +82,7 @@ export const renderListingRow = (
         ${imageHtml}
         <label>${escapeHtml(listing.name)}</label>
         ${attributesHtml}
-        <span class="sold-out-label">${t("public.registration_closed")}</span>
+        ${soldOutLabel(t("public.registration_closed"))}
       </div>
     `;
   }
@@ -89,7 +94,7 @@ export const renderListingRow = (
         <label>${escapeHtml(listing.name)}</label>
         ${renderListingDescription(listing.description)}
         ${attributesHtml}
-        <span class="sold-out-label">${t("public.sold_out")}</span>
+        ${soldOutLabel()}
       </div>
     `;
   }

--- a/test/lib/built-sites.test.ts
+++ b/test/lib/built-sites.test.ts
@@ -283,6 +283,11 @@ describeWithEnv("built-sites", { db: true }, () => {
       expect(result).toEqual(site);
     });
 
+    test("readColumn returns the stored value unchanged", async () => {
+      const value = await builtSitesCrudTable.readColumn("name", "Test");
+      expect(value).toBe("Test");
+    });
+
     test("inputKeyMap exposes form-facing fields", () => {
       expect(builtSitesCrudTable.inputKeyMap).toEqual({
         assignable: "assignable",

--- a/test/lib/checkout-pricing-consistency.test.ts
+++ b/test/lib/checkout-pricing-consistency.test.ts
@@ -22,9 +22,9 @@ import type {
   ModifierSpec,
 } from "#shared/payments.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
+import { checkoutItem } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import {
-  checkoutItem,
   insertModifier,
   linkModifierAnswer,
   linkModifierListing,

--- a/test/lib/forms/rendering.test.ts
+++ b/test/lib/forms/rendering.test.ts
@@ -6,6 +6,7 @@ import {
   type Field,
   renderField,
   renderFields,
+  renderSelectOptions,
   setSavedFormData,
 } from "#shared/forms.tsx";
 
@@ -386,5 +387,30 @@ describe("renderFields with saved form data", () => {
     ]);
     expect(html).toContain('value="GB"');
     expect(html).not.toContain('value="US"');
+  });
+});
+
+describe("renderSelectOptions", () => {
+  test("renders each entry, marking only the chosen one", () => {
+    const html = renderSelectOptions([
+      { label: "One", value: "1" },
+      { label: "Two", selected: true, value: "2" },
+    ]);
+    expect(html).toBe(
+      '<option value="1">One</option><option value="2" selected>Two</option>',
+    );
+  });
+
+  test("escapes both value and label", () => {
+    const html = renderSelectOptions([
+      { label: "Fish & Chips <hot>", value: 'a"&b' },
+    ]);
+    expect(html).toBe(
+      '<option value="a&quot;&amp;b">Fish &amp; Chips &lt;hot&gt;</option>',
+    );
+  });
+
+  test("renders nothing for an empty list", () => {
+    expect(renderSelectOptions([])).toBe("");
   });
 });

--- a/test/lib/fp.test.ts
+++ b/test/lib/fp.test.ts
@@ -7,6 +7,7 @@ import {
   filter,
   firstMatch,
   flatMap,
+  groupToMap,
   lazyRef,
   map,
   once,
@@ -431,6 +432,40 @@ describe("fp", () => {
       expect(freshResult).toEqual([1, 2, 3]);
       // Now the cache IS populated with fresh data
       expect(cache.size()).toBe(3);
+    });
+  });
+
+  describe("groupToMap", () => {
+    test("groups rows by key, keeping only the chosen value from each row", () => {
+      const rows = [
+        { listing: 20, question: 1 },
+        { listing: 30, question: 2 },
+        { listing: 10, question: 1 },
+      ];
+      const listingsByQuestion = groupToMap(
+        (r: { question: number; listing: number }) => r.question,
+        (r) => r.listing,
+      )(rows);
+      expect(listingsByQuestion).toEqual(
+        new Map([
+          [1, [20, 10]],
+          [2, [30]],
+        ]),
+      );
+    });
+
+    test("keeps keys in first-occurrence order and returns an empty map for no rows", () => {
+      const rows = [
+        { k: "b", v: 1 },
+        { k: "a", v: 2 },
+        { k: "b", v: 3 },
+      ];
+      const grouped = groupToMap(
+        (r: { k: string; v: number }) => r.k,
+        (r) => r.v,
+      );
+      expect([...grouped(rows).keys()]).toEqual(["b", "a"]);
+      expect(grouped([])).toEqual(new Map());
     });
   });
 

--- a/test/lib/payment-helpers/build-items.test.ts
+++ b/test/lib/payment-helpers/build-items.test.ts
@@ -6,10 +6,8 @@ import {
   buildItemsMetadata,
   extractSessionMetadata,
   packMetadata,
-  SQUARE_METADATA_MAX_ENTRIES,
-  SQUARE_METADATA_MAX_VALUE_LENGTH,
-  STRIPE_METADATA_MAX_VALUE_LENGTH,
 } from "#shared/payment-helpers.ts";
+import { PAYMENT_PROVIDERS } from "#shared/payment-providers.ts";
 import { verifyPrice } from "#shared/payment-signature.ts";
 import type {
   BookingItem,
@@ -17,6 +15,10 @@ import type {
   SessionMetadata,
 } from "#shared/payments.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+
+// The provider registry is the single source of the caps these tests exercise.
+const SQUARE_CAPS = PAYMENT_PROVIDERS.square.metadata;
+const STRIPE_CAPS = PAYMENT_PROVIDERS.stripe.metadata;
 
 // hmacHash needs the encryption key configured, which describeWithEnv handles.
 describeWithEnv(
@@ -46,7 +48,7 @@ describeWithEnv(
       const metadata = await buildItemsMetadata(
         baseIntent("plain-token-xyz"),
         0,
-        STRIPE_METADATA_MAX_VALUE_LENGTH,
+        STRIPE_CAPS.maxValueLength,
       );
       const expected = await hmacHash("plain-token-xyz");
       // site_token_index is packed into `b` on the wire; the webhook recovers it
@@ -61,7 +63,7 @@ describeWithEnv(
       const metadata = await buildItemsMetadata(
         baseIntent("plain-token-xyz"),
         0,
-        STRIPE_METADATA_MAX_VALUE_LENGTH,
+        STRIPE_CAPS.maxValueLength,
       );
       for (const value of Object.values(metadata)) {
         expect(value.includes("plain-token-xyz")).toBe(false);
@@ -72,7 +74,7 @@ describeWithEnv(
       const metadata = await buildItemsMetadata(
         baseIntent(),
         0,
-        STRIPE_METADATA_MAX_VALUE_LENGTH,
+        STRIPE_CAPS.maxValueLength,
       );
       expect("site_token_index" in metadata).toBe(false);
     });
@@ -102,11 +104,7 @@ describeWithEnv(
       const total = priceCheckout(intent).total;
       // Apply the Square packing step over the signed metadata.
       const wire = packMetadata(
-        await buildItemsMetadata(
-          intent,
-          total,
-          SQUARE_METADATA_MAX_VALUE_LENGTH,
-        ),
+        await buildItemsMetadata(intent, total, SQUARE_CAPS.maxValueLength),
       );
       // Small fields (phone, date, …) are packed on the wire.
       expect("phone" in wire).toBe(false);
@@ -165,14 +163,14 @@ describeWithEnv(
 
     test("omits an over-cap URL and the proof still verifies (not tampered)", async () => {
       const longUrl = `https://example.com/${"x".repeat(
-        SQUARE_METADATA_MAX_VALUE_LENGTH,
+        SQUARE_CAPS.maxValueLength,
       )}`;
       const intent = intentWithUrl(longUrl);
       const total = priceCheckout(intent).total;
       const metadata = await buildItemsMetadata(
         intent,
         total,
-        SQUARE_METADATA_MAX_VALUE_LENGTH,
+        SQUARE_CAPS.maxValueLength,
       );
       // The over-cap URL is dropped from the emitted metadata...
       expect("thank_you_url" in metadata).toBe(false);
@@ -228,15 +226,15 @@ describeWithEnv(
       const metadata = await buildItemsMetadata(
         intent,
         total,
-        SQUARE_METADATA_MAX_VALUE_LENGTH,
-        SQUARE_METADATA_MAX_ENTRIES,
+        SQUARE_CAPS.maxValueLength,
+        SQUARE_CAPS.maxEntries,
       );
       // The short URL is dropped because keeping it would overflow the cap...
       expect("thank_you_url" in metadata).toBe(false);
       // ...and the wire (after Square packs the small fields) is within the cap.
       const wire = packMetadata(metadata);
       expect(Object.keys(wire).length).toBeLessThanOrEqual(
-        SQUARE_METADATA_MAX_ENTRIES,
+        SQUARE_CAPS.maxEntries,
       );
       // The proof signed over the URL-less payload still verifies.
       const { sig, total: signedTotal } = proofParts(metadata);
@@ -257,8 +255,8 @@ describeWithEnv(
       const metadata = await buildItemsMetadata(
         intent,
         total,
-        SQUARE_METADATA_MAX_VALUE_LENGTH,
-        SQUARE_METADATA_MAX_ENTRIES,
+        SQUARE_CAPS.maxValueLength,
+        SQUARE_CAPS.maxEntries,
       );
       expect(metadata.thank_you_url).toBe("https://example.com/thanks");
     });
@@ -270,7 +268,7 @@ describeWithEnv(
       const metadata = await buildItemsMetadata(
         intent,
         total,
-        SQUARE_METADATA_MAX_VALUE_LENGTH,
+        SQUARE_CAPS.maxValueLength,
       );
       expect(metadata.thank_you_url).toBe(url);
       const { sig, total: signedTotal } = proofParts(metadata);
@@ -281,13 +279,8 @@ describeWithEnv(
       expect(await verifyPrice(extracted, signedTotal, sig)).toBe(true);
       // Stripe's larger cap also retains it.
       expect(
-        (
-          await buildItemsMetadata(
-            intent,
-            total,
-            STRIPE_METADATA_MAX_VALUE_LENGTH,
-          )
-        ).thank_you_url,
+        (await buildItemsMetadata(intent, total, STRIPE_CAPS.maxValueLength))
+          .thank_you_url,
       ).toBe(url);
     });
   },
@@ -323,19 +316,17 @@ describe("signed metadata budget", () => {
     const metadata = await buildItemsMetadata(
       intent,
       priceCheckout(intent).total,
-      SQUARE_METADATA_MAX_VALUE_LENGTH,
-      SQUARE_METADATA_MAX_ENTRIES,
+      SQUARE_CAPS.maxValueLength,
+      SQUARE_CAPS.maxEntries,
     );
     // The wire shape (Square packs the small fields into `b`) must fit both caps
     // even with the per-line edge tags and the allocations map present.
     const wire = packMetadata(metadata);
     expect(Object.keys(wire).length).toBeLessThanOrEqual(
-      SQUARE_METADATA_MAX_ENTRIES,
+      SQUARE_CAPS.maxEntries,
     );
     for (const value of Object.values(wire)) {
-      expect(value.length).toBeLessThanOrEqual(
-        SQUARE_METADATA_MAX_VALUE_LENGTH,
-      );
+      expect(value.length).toBeLessThanOrEqual(SQUARE_CAPS.maxValueLength);
     }
     // Package members carry the compact edge tag; the folded child stays untagged.
     const lines = JSON.parse(wire.items ?? "[]") as BookingItem[];

--- a/test/lib/server-parents-booking/api-book-payments.test.ts
+++ b/test/lib/server-parents-booking/api-book-payments.test.ts
@@ -1,5 +1,9 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import {
+  expectCapturedItemPriced,
+  stubCheckout,
+} from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import { bookableStartDates } from "#test-utils/db-helpers/listings.ts";
@@ -10,10 +14,6 @@ import {
   makeParent,
 } from "#test-utils/parents.ts";
 import { enablePublicApi, setupStripe } from "#test-utils/settings.ts";
-import {
-  expectCapturedItemPriced,
-  stubCheckout,
-} from "../server-reservation/helpers.ts";
 
 /** A pay-more parent (£10 unit price, £50 max) with a free add-on child — the
  *  scenario behind both parent-`customPrice` tests (the accepted £30 and the

--- a/test/lib/server-parents-gate/customisable-fold.test.ts
+++ b/test/lib/server-parents-gate/customisable-fold.test.ts
@@ -2,6 +2,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
+import { expectCapturedItemPriced } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import {
@@ -14,7 +15,6 @@ import {
   parentField,
   postCalculate,
 } from "#test-utils/parents.ts";
-import { expectCapturedItemPriced } from "../server-reservation/helpers.ts";
 import { firstBookableDate, stubCheckoutIntent } from "./helpers.ts";
 
 // jscpd:ignore-end

--- a/test/lib/server-parents-gate/helpers.ts
+++ b/test/lib/server-parents-gate/helpers.ts
@@ -104,7 +104,7 @@ export const makeDailyGroupWithFiller = async (): Promise<{
  */
 export const stubCheckoutIntent = async (sessionId: string) => {
   const { setupStripe } = await import("#test-utils/settings.ts");
-  const { stubCheckout } = await import("../server-reservation/helpers.ts");
+  const { stubCheckout } = await import("#test-utils/checkout.ts");
   await setupStripe();
   return stubCheckout(sessionId);
 };

--- a/test/lib/server-payments/cancel.test.ts
+++ b/test/lib/server-payments/cancel.test.ts
@@ -8,6 +8,7 @@ import {
   assertPublicHtml,
   expectHtmlResponse,
 } from "#test-utils/assertions.ts";
+import { johnCheckoutSession } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -23,13 +24,7 @@ import { stubRetrieveCheckoutSession } from "#test-utils/webhooks.ts";
  *  the shape every /payment/cancel test stubs, differing only in the id and
  *  which listing/package ids the items carry. */
 const cancelSession = (sessionId: string, items: string) =>
-  stubRetrieveCheckoutSession({
-    amountTotal: 0,
-    metadata: { email: "john@example.com", items, name: "John" },
-    paymentIntent: null,
-    paymentStatus: "unpaid",
-    sessionId,
-  });
+  johnCheckoutSession(sessionId, { items, paid: false });
 
 describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
   describe("GET /payment/cancel", () => {

--- a/test/lib/server-payments/confirm.test.ts
+++ b/test/lib/server-payments/confirm.test.ts
@@ -8,6 +8,7 @@ import {
   expectRedirect,
   followRedirect,
 } from "#test-utils/assertions.ts";
+import { johnCheckoutSession } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -19,17 +20,14 @@ import { stubRetrieveCheckoutSession } from "#test-utils/webhooks.ts";
 
 // jscpd:ignore-end
 
-/** A signed, paid "John" checkout for a single listing — the trusted-session
- *  shape the confirmation tests share, differing only in the id, the items,
- *  and the agreed total. */
+/** A signed, paid "John" checkout for a single listing — the shared
+ *  {@link johnCheckoutSession} pinned to this suite's fixed `pi_test_123`
+ *  payment intent (the replay test books an attendee under that same id). */
 const johnSession = (sessionId: string, items: string, amountTotal: number) =>
-  stubRetrieveCheckoutSession({
+  johnCheckoutSession(sessionId, {
     amountTotal,
-    email: "john@example.com",
     items,
-    name: "John",
     paymentIntent: "pi_test_123",
-    sessionId,
   });
 
 describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {

--- a/test/lib/server-payments/purchase.test.ts
+++ b/test/lib/server-payments/purchase.test.ts
@@ -5,11 +5,11 @@ import { stub } from "@std/testing/mock";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import { getDb } from "#shared/db/client.ts";
 import { modifiersTable } from "#shared/db/modifiers.ts";
-import type { CheckoutIntent } from "#shared/payments.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { expectFlash, expectRedirect } from "#test-utils/assertions.ts";
+import { stubCheckout } from "#test-utils/checkout.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
@@ -18,26 +18,6 @@ import { awaitTestRequest } from "#test-utils/mocks.ts";
 import { setupStripe } from "#test-utils/settings.ts";
 
 // jscpd:ignore-end
-
-/** Stub `createCheckoutSession` to a fixed successful result while capturing
- *  the intent it was handed — the shape every "carries X into the checkout
- *  intent" test needs, differing only in the returned session id and what it
- *  asserts about the captured intent. */
-const captureCheckoutIntent = (sessionId: string) => {
-  const captured: { intent?: CheckoutIntent } = {};
-  const mock = stub(
-    stripePaymentProvider,
-    "createCheckoutSession",
-    (intent: CheckoutIntent) => {
-      captured.intent = intent;
-      return Promise.resolve({
-        checkoutUrl: "https://stripe.test/checkout",
-        sessionId,
-      });
-    },
-  );
-  return { captured, mock };
-};
 
 describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
   describe("payment routes", () => {
@@ -196,7 +176,7 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
         thankYouUrl: "https://example.com/thanks",
       });
 
-      const { captured, mock } = captureCheckoutIntent("cs_customisable_web");
+      const { checkout, getCaptured } = stubCheckout("cs_customisable_web");
 
       try {
         const response = await submitTicketForm(listing.slug, {
@@ -207,10 +187,10 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
 
         expect(response.status).toBe(302);
         // The chosen span and its price are carried into the checkout intent.
-        expect(captured.intent?.dayCount).toBe(2);
-        expect(captured.intent?.items[0]?.unitPrice).toBe(1800);
+        expect(getCaptured()?.dayCount).toBe(2);
+        expect(getCaptured()?.items[0]?.unitPrice).toBe(1800);
       } finally {
-        mock.restore();
+        checkout.restore();
       }
     });
 
@@ -256,7 +236,7 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
         sql: "UPDATE modifiers SET trigger = ?, code_index = ? WHERE id = ?",
       });
 
-      const { captured, mock } = captureCheckoutIntent("cs_modifiers_web");
+      const { checkout, getCaptured } = stubCheckout("cs_modifiers_web");
 
       try {
         const response = await submitTicketForm(listing.slug, {
@@ -269,7 +249,7 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
 
         expect(response.status).toBe(302);
         const byId = new Map(
-          (captured.intent?.modifiers ?? []).map((m) => [m.id, m]),
+          (getCaptured()?.modifiers ?? []).map((m) => [m.id, m]),
         );
         // The add-on is applied at the chosen quantity, the promo at quantity 1,
         // and the unselected add-on is absent.
@@ -277,7 +257,7 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
         expect(byId.get(promo.id)?.quantity).toBe(1);
         expect(byId.has(skippedAddOn.id)).toBe(false);
       } finally {
-        mock.restore();
+        checkout.restore();
       }
     });
 

--- a/test/lib/server-qr-book.test.ts
+++ b/test/lib/server-qr-book.test.ts
@@ -25,6 +25,7 @@ import {
 } from "#shared/qr-token.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { todayInTz } from "#shared/timezone.ts";
+import { stubCheckout } from "#test-utils/checkout.ts";
 import { hasInputWithValue, submitTicketForm } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { getAttendeesRaw } from "#test-utils/db-helpers/attendees.ts";
@@ -42,25 +43,19 @@ import { setupStripe } from "#test-utils/settings.ts";
 const qrBookPath = (slug: string, token: string): string =>
   `/ticket/${slug}/qr-book?t=${encodeURIComponent(token)}`;
 
-/** Stub Stripe as the active provider with a canned checkout URL */
-const stubStripe = (checkoutUrl = "https://stripe.example/checkout") => {
+/** Stub Stripe as the active provider, capturing the checkout intent through
+ *  the shared {@link stubCheckout}. */
+const stubStripe = () => {
   const providerStub = stub(paymentsApi, "getConfiguredProvider", () =>
     mockProviderType("stripe"),
   );
-  const checkoutStub = stub(
-    stripePaymentProvider,
-    "createCheckoutSession",
-    () =>
-      Promise.resolve({
-        checkoutUrl,
-        sessionId: "cs_test_123",
-      }),
-  );
+  const { calls, checkout, getCaptured } = stubCheckout("cs_test_123");
   return {
-    checkoutStub,
+    calls,
+    getCaptured,
     restore: () => {
       providerStub.restore();
-      checkoutStub.restore();
+      checkout.restore();
     },
   };
 };
@@ -92,7 +87,7 @@ const expectStripeRedirect = (
 ): void => {
   expect(response.status).toBe(302);
   expect(response.headers.get("location")).toContain("stripe.example");
-  expect(stripe.checkoutStub.calls.length).toBe(1);
+  expect(stripe.calls()).toBe(1);
 };
 
 /** Assert the most recent Stripe checkout session was created with a single
@@ -104,8 +99,7 @@ const expectStripeCheckoutAtPrice = (
   expectedUnitPrice: number,
 ): void => {
   expect(response.status).toBe(302);
-  const intent = stripe.checkoutStub.calls[0]!.args[0];
-  expect(intent.items[0]!.unitPrice).toBe(expectedUnitPrice);
+  expect(stripe.getCaptured()!.items[0]!.unitPrice).toBe(expectedUnitPrice);
 };
 
 /** Scan a listing's QR-book link (token built from `payload`) and return the response. */
@@ -288,8 +282,8 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
       await scanWithStripe(listing, async ({ response, stripe }) => {
         expect(response.status).toBe(302);
         expect(response.headers.get("location")).toContain("stripe.example");
-        expect(stripe.checkoutStub.calls.length).toBe(1);
-        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(stripe.calls()).toBe(1);
+        const intent = stripe.getCaptured()!;
         expect(intent.name).toBe("Ada");
         expect(intent.items[0]!.unitPrice).toBe(1000);
         expect(intent.items[0]!.quantity).toBe(1);
@@ -307,7 +301,7 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
       await scanWithStripe(listing, async ({ response, stripe }) => {
         // The visitor must choose a day count, so the form renders instead.
         expect(response.status).toBe(200);
-        expect(stripe.checkoutStub.calls.length).toBe(0);
+        expect(stripe.calls()).toBe(0);
         expect(await response.text()).toContain('name="day_count"');
       });
     });
@@ -376,7 +370,7 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
       });
       await scanWithStripe(listing, async ({ response, stripe }) => {
         expect(response.status).toBe(200);
-        expect(stripe.checkoutStub.calls.length).toBe(0);
+        expect(stripe.calls()).toBe(0);
       });
     });
 
@@ -395,7 +389,7 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
           qrBookPath(listing.slug, token),
         );
         expect(response.status).toBe(200);
-        expect(stripe.checkoutStub.calls.length).toBe(0);
+        expect(stripe.calls()).toBe(0);
       });
     });
 
@@ -415,7 +409,7 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
           qrBookPath(listing.slug, token),
         );
         expect(response.status).toBe(302);
-        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        const intent = stripe.getCaptured()!;
         expect(intent.date).toBe(tomorrow);
       });
     });
@@ -463,8 +457,8 @@ describeWithEnv("qr-book scan handler", { db: true }, () => {
         });
         // Response is a 302 redirect to Stripe
         expect(response.status).toBe(302);
-        expect(stripe.checkoutStub.calls.length).toBe(1);
-        const intent = stripe.checkoutStub.calls[0]!.args[0];
+        expect(stripe.calls()).toBe(1);
+        const intent = stripe.getCaptured()!;
         expect(intent.items[0]!.unitPrice).toBe(overridePrice);
       });
     });
@@ -559,7 +553,7 @@ describeWithEnv("qr-book scan handler > parent gate", { db: true }, () => {
       const response = await awaitTestRequest(qrBookPath(tokenSlug, token));
       // The child gate forces the form path so prepareOrder can fold the child.
       expect(response.status).toBe(200);
-      expect(stripe.checkoutStub.calls.length).toBe(0);
+      expect(stripe.calls()).toBe(0);
     } finally {
       stripe.restore();
     }

--- a/test/lib/server-reservation/edge-cases.test.ts
+++ b/test/lib/server-reservation/edge-cases.test.ts
@@ -8,10 +8,10 @@ import { getAttendeeOrderSummary } from "#shared/db/attendees/balance.ts";
 import { getDb } from "#shared/db/client.ts";
 import { modifiersTable } from "#shared/db/modifiers.ts";
 import { resetStripeClient, stripeApi } from "#shared/stripe.ts";
+import { captureCheckoutIntent } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { mockRequest } from "#test-utils/mocks.ts";
 import {
-  captureCheckoutIntent,
   createProgrammeCharge,
   createSave10Promo,
   expectRefundedPlaceholder,

--- a/test/lib/server-reservation/edge-cases.test.ts
+++ b/test/lib/server-reservation/edge-cases.test.ts
@@ -12,13 +12,15 @@ import { captureCheckoutIntent } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { mockRequest } from "#test-utils/mocks.ts";
 import {
+  modifierUsageAmount,
+  modifierUsageCount,
+} from "#test-utils/modifiers.ts";
+import {
   createProgrammeCharge,
   createSave10Promo,
   expectRefundedPlaceholder,
   latestAttendee,
   modifierRefs,
-  modifierUsageAmount,
-  modifierUsageCount,
   setPublicReservation,
   setupReservationListing,
   stubPaidSession,

--- a/test/lib/server-reservation/helpers.ts
+++ b/test/lib/server-reservation/helpers.ts
@@ -1,5 +1,4 @@
 import { expect } from "@std/expect";
-import { stub } from "@std/testing/mock";
 import {
   attendeeStatuses,
   getPublicDefaultStatus,
@@ -9,11 +8,11 @@ import { pricePaidFromLedger } from "#shared/db/attendees/queries.ts";
 import { getDb } from "#shared/db/client.ts";
 import { modifiersTable } from "#shared/db/modifiers.ts";
 import { settings } from "#shared/db/settings.ts";
-import { stripeApi } from "#shared/stripe.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { signMeta } from "#test-utils/factories.ts";
 import { setupStripe } from "#test-utils/settings.ts";
+import { stubRetrieveCheckoutSession } from "#test-utils/webhooks.ts";
 
 /** Turn the seeded public-default status into a reservation charging `amount`. */
 export const setPublicReservation = async (amount: string): Promise<number> => {
@@ -34,17 +33,12 @@ export const stubPaidSession = (
   metadata: Record<string, string>,
   amountTotal: number,
 ) =>
-  stub(stripeApi, "retrieveCheckoutSession", () =>
-    Promise.resolve({
-      amount_total: amountTotal,
-      id,
-      metadata: signMeta(metadata, amountTotal),
-      payment_intent: `pi_${id}`,
-      payment_status: "paid",
-    } as unknown as Awaited<
-      ReturnType<typeof stripeApi.retrieveCheckoutSession>
-    >),
-  );
+  stubRetrieveCheckoutSession({
+    amountTotal,
+    metadata: signMeta(metadata, amountTotal),
+    paymentIntent: `pi_${id}`,
+    sessionId: id,
+  });
 
 /** The most recently created attendee's plaintext reservation columns. */
 export const latestAttendee = async (): Promise<{

--- a/test/lib/server-reservation/helpers.ts
+++ b/test/lib/server-reservation/helpers.ts
@@ -9,9 +9,7 @@ import { pricePaidFromLedger } from "#shared/db/attendees/queries.ts";
 import { getDb } from "#shared/db/client.ts";
 import { modifiersTable } from "#shared/db/modifiers.ts";
 import { settings } from "#shared/db/settings.ts";
-import type { CheckoutIntent } from "#shared/payments.ts";
 import { stripeApi } from "#shared/stripe.ts";
-import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { signMeta } from "#test-utils/factories.ts";
@@ -164,33 +162,6 @@ export const modifierUsageAmount = async (
 export const modifierRefs = (id: number, quantity = 1): string =>
   JSON.stringify([{ i: id, q: quantity }]);
 
-/** Stub the checkout-session provider and capture the intent it was called
- * with — the shared "inspect what checkout would have charged" fixture
- * behind every test that never actually completes a paid session. The optional
- * `sessionId` labels the captured intent (defaults to `"cs_test"`). Returns
- * `checkout` (the mock, for `restore()`), `getCaptured()` (the intent handed
- * over), and `calls()` (how many times the provider was reached) so the
- * sold-out preflight case can assert it was never called. */
-export const stubCheckout = (sessionId = "cs_test") => {
-  let captured: CheckoutIntent | undefined;
-  const checkout = stub(
-    stripePaymentProvider,
-    "createCheckoutSession",
-    (intent: CheckoutIntent) => {
-      captured = intent;
-      return Promise.resolve({
-        checkoutUrl: "https://stripe.example/checkout",
-        sessionId,
-      });
-    },
-  );
-  return {
-    calls: () => checkout.calls.length,
-    checkout,
-    getCaptured: () => captured,
-  };
-};
-
 /** Submit a plain buyer order for one unit of `listing` — the default
  * quantity/email/name shape shared by every test that completes a real
  * booking (rather than inspecting a checkout intent). `fields` overrides or
@@ -215,43 +186,6 @@ export const addServiceCharge = () =>
     direction: "charge",
     name: "Service charge",
   });
-
-/** Submit a buyer's ticket form through a stubbed checkout provider, assert
- * the redirect succeeded, and return the checkout intent it captured — the
- * shared "what would checkout have charged" flow behind every test that
- * inspects the outgoing intent rather than completing a paid session. */
-export const captureCheckoutIntent = async (
-  listing: { id: number; slug: string },
-  fields: Record<string, string> = {},
-): Promise<CheckoutIntent | undefined> => {
-  const { checkout, getCaptured } = stubCheckout();
-  try {
-    const response = await submitTicketForm(listing.slug, {
-      [`quantity_${listing.id}`]: "1",
-      email: "buyer@example.com",
-      name: "Buyer",
-      ...fields,
-    });
-    expect([302, 303]).toContain(response.status);
-    return getCaptured();
-  } finally {
-    checkout.restore();
-  }
-};
-
-/** Find the captured intent's line item for `listing` and assert its
- *  `unitPrice` — the shared "this folded line was charged X" check behind
- *  every test that inspects the outgoing intent's per-line prices. Pass the
- *  captured intent (`getCaptured()`), the listing whose price to check, and the
- *  expected unit price in the smallest currency unit (e.g. pence). */
-export const expectCapturedItemPriced = (
-  intent: CheckoutIntent | undefined,
-  listing: { id: number },
-  unitPrice: number,
-): void => {
-  const item = intent?.items.find((i) => i.listingId === listing.id);
-  expect(item?.unitPrice).toBe(unitPrice);
-};
 
 /** Create a modifier that only applies when the buyer opts in (an add-on),
  * rather than one folded automatically into every booking. */

--- a/test/lib/server-reservation/helpers.ts
+++ b/test/lib/server-reservation/helpers.ts
@@ -11,6 +11,7 @@ import { settings } from "#shared/db/settings.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { signMeta } from "#test-utils/factories.ts";
+import { modifierUsageCount } from "#test-utils/modifiers.ts";
 import { setupStripe } from "#test-utils/settings.ts";
 import { stubRetrieveCheckoutSession } from "#test-utils/webhooks.ts";
 
@@ -77,16 +78,6 @@ export const attendeeCount = async (): Promise<number> => {
   return Number(rows[0]!.c);
 };
 
-export const modifierUsageCount = async (
-  modifierId: number,
-): Promise<number> => {
-  const { rows } = await getDb().execute({
-    args: [modifierId],
-    sql: "SELECT COALESCE(SUM(quantity), 0) AS c FROM modifier_usages WHERE modifier_id = ?",
-  });
-  return Number(rows[0]!.c);
-};
-
 /** Create a listing plus a one-unit, stock-limited discount modifier whose unit
  * is consumed by a concurrent order — simulated with an AFTER INSERT trigger on
  * attendees — so the checkout's own consumeModifierStock loses the race and
@@ -141,16 +132,6 @@ export const totalContactActivity = async (): Promise<{
     bookings: Number(rows[0]!.bookings),
     visits: Number(rows[0]!.visits),
   };
-};
-
-export const modifierUsageAmount = async (
-  modifierId: number,
-): Promise<number> => {
-  const { rows } = await getDb().execute({
-    args: [modifierId],
-    sql: "SELECT COALESCE(SUM(amount_applied), 0) AS c FROM modifier_usages WHERE modifier_id = ?",
-  });
-  return Number(rows[0]!.c);
 };
 
 export const modifierRefs = (id: number, quantity = 1): string =>

--- a/test/lib/server-reservation/no-provider.test.ts
+++ b/test/lib/server-reservation/no-provider.test.ts
@@ -6,10 +6,12 @@ import { resetStripeClient } from "#shared/stripe.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import {
-  createOptionalAddOn,
-  latestAttendee,
   modifierUsageAmount,
   modifierUsageCount,
+} from "#test-utils/modifiers.ts";
+import {
+  createOptionalAddOn,
+  latestAttendee,
   submitBuyerOrder,
 } from "./helpers.ts";
 

--- a/test/lib/server-reservation/promo-addons.test.ts
+++ b/test/lib/server-reservation/promo-addons.test.ts
@@ -3,10 +3,10 @@ import { afterEach, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { resetStripeClient, stripeApi } from "#shared/stripe.ts";
+import { captureCheckoutIntent } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { mockRequest } from "#test-utils/mocks.ts";
 import {
-  captureCheckoutIntent,
   createOptionalAddOn,
   createProgrammeCharge,
   createSave10Promo,

--- a/test/lib/server-reservation/promo-addons.test.ts
+++ b/test/lib/server-reservation/promo-addons.test.ts
@@ -7,14 +7,16 @@ import { captureCheckoutIntent } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { mockRequest } from "#test-utils/mocks.ts";
 import {
+  modifierUsageAmount,
+  modifierUsageCount,
+} from "#test-utils/modifiers.ts";
+import {
   createOptionalAddOn,
   createProgrammeCharge,
   createSave10Promo,
   expectRefundedPlaceholder,
   latestAttendee,
   modifierRefs,
-  modifierUsageAmount,
-  modifierUsageCount,
   setupReservationListing,
   stubPaidSession,
 } from "./helpers.ts";

--- a/test/lib/server-reservation/public-default-modifiers.test.ts
+++ b/test/lib/server-reservation/public-default-modifiers.test.ts
@@ -6,6 +6,7 @@ import { modifierUsedQuantities } from "#shared/db/modifier-usage.ts";
 import { modifiersTable } from "#shared/db/modifiers.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
 import { expectFlash } from "#test-utils/assertions.ts";
+import { captureCheckoutIntent } from "#test-utils/checkout.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -13,7 +14,6 @@ import { setupStripe } from "#test-utils/settings.ts";
 import {
   addServiceCharge,
   attendeeCount,
-  captureCheckoutIntent,
   modifierUsageAmount,
   setPublicReservation,
   setupSoldOutModifierRace,

--- a/test/lib/server-reservation/public-default-modifiers.test.ts
+++ b/test/lib/server-reservation/public-default-modifiers.test.ts
@@ -10,11 +10,11 @@ import { captureCheckoutIntent } from "#test-utils/checkout.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { modifierUsageAmount } from "#test-utils/modifiers.ts";
 import { setupStripe } from "#test-utils/settings.ts";
 import {
   addServiceCharge,
   attendeeCount,
-  modifierUsageAmount,
   setPublicReservation,
   setupSoldOutModifierRace,
   submitBuyerOrder,

--- a/test/lib/server-webhooks/custom-questions-multi.test.ts
+++ b/test/lib/server-webhooks/custom-questions-multi.test.ts
@@ -1,7 +1,6 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { afterEach, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import {
   getAttendeeAnswersBatch,
@@ -34,20 +33,15 @@ const submitMultiTicketFormWithStubbedCheckout = async (
   formData: Record<string, string>,
   stubSessionId: string,
 ): Promise<void> => {
-  const { stripePaymentProvider } = await import("#shared/stripe-provider.ts");
-  const mockCreate = stub(stripePaymentProvider, "createCheckoutSession", () =>
-    Promise.resolve({
-      checkoutUrl: `https://checkout.stripe.com/pay/${stubSessionId}`,
-      sessionId: stubSessionId,
-    }),
-  );
+  const { stubCheckout } = await import("#test-utils/checkout.ts");
+  const { checkout } = stubCheckout(stubSessionId);
   const { expectCheckoutRedirect } = await import("#test-utils/assertions.ts");
   const { submitMultiTicketForm } = await import("#test-utils/csrf.ts");
   try {
     const checkoutResponse = await submitMultiTicketForm(slug, formData);
     expectCheckoutRedirect(checkoutResponse);
   } finally {
-    mockCreate.restore();
+    checkout.restore();
   }
 };
 

--- a/test/lib/server-webhooks/custom-questions-multi.test.ts
+++ b/test/lib/server-webhooks/custom-questions-multi.test.ts
@@ -34,15 +34,10 @@ const submitMultiTicketFormWithStubbedCheckout = async (
   stubSessionId: string,
 ): Promise<void> => {
   const { stubCheckout } = await import("#test-utils/checkout.ts");
-  const { checkout } = stubCheckout(stubSessionId);
+  using _checkout = stubCheckout(stubSessionId).checkout;
   const { expectCheckoutRedirect } = await import("#test-utils/assertions.ts");
   const { submitMultiTicketForm } = await import("#test-utils/csrf.ts");
-  try {
-    const checkoutResponse = await submitMultiTicketForm(slug, formData);
-    expectCheckoutRedirect(checkoutResponse);
-  } finally {
-    checkout.restore();
-  }
+  expectCheckoutRedirect(await submitMultiTicketForm(slug, formData));
 };
 
 /** Fetch both listings' attendees, assert each has exactly one and that

--- a/test/lib/server-webhooks/custom-questions-single.test.ts
+++ b/test/lib/server-webhooks/custom-questions-single.test.ts
@@ -1,7 +1,6 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { afterEach, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
 import {
   getAttendeeAnswersBatch,
   getAttendeeTextAnswers,
@@ -9,7 +8,6 @@ import {
 import { setListingQuestions } from "#shared/db/questions/queries.ts";
 import { getOrCreateStringIds } from "#shared/db/questions/strings.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
-import type { CheckoutIntent } from "#shared/payments.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
 import { getTestPrivateKey } from "#test-utils/crypto.ts";
@@ -104,21 +102,8 @@ describeWithEnv(
       // listingTextAnswerIds is exactly what gets serialized into the provider
       // metadata, so a dropped `s` here is the production bug. The earlier
       // free-text test hand-built this metadata and so could never catch it.
-      const { stripePaymentProvider } = await import(
-        "#shared/stripe-provider.ts"
-      );
-      const captured: CheckoutIntent[] = [];
-      const mockCreate = stub(
-        stripePaymentProvider,
-        "createCheckoutSession",
-        (intent: CheckoutIntent) => {
-          captured.push(intent);
-          return Promise.resolve({
-            checkoutUrl: "https://checkout.stripe.com/pay/cs_round_trip",
-            sessionId: "cs_round_trip",
-          });
-        },
-      );
+      const { stubCheckout } = await import("#test-utils/checkout.ts");
+      const { checkout, getCaptured } = stubCheckout("cs_round_trip");
       const { expectCheckoutRedirect } = await import(
         "#test-utils/assertions.ts"
       );
@@ -132,12 +117,12 @@ describeWithEnv(
           }),
         );
       } finally {
-        mockCreate.restore();
+        checkout.restore();
       }
 
       // The resolved ref must carry a real numeric string id, never the
       // undefined that JSON.stringify would silently drop from signed metadata.
-      const refs = captured[0]!.listingTextAnswerIds![String(listing.id)]!;
+      const refs = getCaptured()!.listingTextAnswerIds![String(listing.id)]!;
       expect(refs.length).toBe(1);
       expect(refs[0]!.q).toBe(question.id);
       expect(Number.isInteger(refs[0]!.s)).toBe(true);
@@ -154,7 +139,7 @@ describeWithEnv(
               items: singleItem(listing.id, 1, 1000),
               name: "Round Tripper",
               text_answer_ids: JSON.stringify(
-                captured[0]!.listingTextAnswerIds,
+                getCaptured()!.listingTextAnswerIds,
               ),
             },
             1000,

--- a/test/lib/server-webhooks/sumup.test.ts
+++ b/test/lib/server-webhooks/sumup.test.ts
@@ -10,7 +10,7 @@ import {
   setSumupCheckoutId,
   storeSumupCheckout,
 } from "#shared/db/sumup-checkouts.ts";
-import { buildItemsMetadata } from "#shared/payment-helpers.ts";
+import { assembleCheckoutMetadata } from "#shared/payment-helpers.ts";
 import type { CheckoutIntent } from "#shared/payments.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
 import { sumupApi } from "#shared/sumup.ts";
@@ -27,7 +27,7 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
   });
 
   /** Configure SumUp and stage a real checkout for the given listing:
-   * production buildItemsMetadata output, encrypted store, id mapping. */
+   * production assembleCheckoutMetadata output, encrypted store, id mapping. */
   const stageSumupCheckout = async (listing: {
     id: number;
     name: string;
@@ -56,10 +56,10 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
       special_instructions: "",
     };
     // Price once and sign that total, exactly as production checkout does.
-    const metadata = await buildItemsMetadata(
+    const metadata = await assembleCheckoutMetadata(
+      "sumup",
       intent,
       priceCheckout(intent).total,
-      Number.POSITIVE_INFINITY,
     );
     await storeSumupCheckout(reference, metadata);
     await setSumupCheckoutId(reference, "co_e2e");

--- a/test/lib/square/fixtures.ts
+++ b/test/lib/square/fixtures.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { stub } from "@std/testing/mock";
 import { settings } from "#shared/db/settings.ts";
-import type { CheckoutIntent, CheckoutItem } from "#shared/payments.ts";
+import type { CheckoutIntent } from "#shared/payments.ts";
 import { squareApi } from "#shared/square.ts";
 import { withMocks } from "#test-utils/mocks.ts";
 import { createMockClient } from "./harness.ts";
@@ -26,18 +26,6 @@ export const withSquareClient = (
     () => body(mock),
   );
 };
-
-/** One ticket line for a checkout, with easy-to-override defaults. */
-export const ticketLine = (
-  overrides: Partial<CheckoutItem> = {},
-): CheckoutItem => ({
-  listingId: 1,
-  name: "Test",
-  quantity: 1,
-  slug: "test-listing",
-  unitPrice: 1000,
-  ...overrides,
-});
 
 /** Asserts that creating a payment link for this intent yields no link. */
 export const expectNoLink = async (
@@ -87,17 +75,3 @@ export const configureSquare = async (
     await settings.update.square.webhookSignatureKey(opts.webhookSignatureKey);
   }
 };
-
-/** A ticket purchase intent with sensible defaults; override any field. */
-export const buyTickets = (
-  overrides: Partial<CheckoutIntent> = {},
-): CheckoutIntent => ({
-  address: "",
-  date: null,
-  email: "john@example.com",
-  items: [ticketLine()],
-  name: "John",
-  phone: "",
-  special_instructions: "",
-  ...overrides,
-});

--- a/test/lib/square/payment-link-validation.test.ts
+++ b/test/lib/square/payment-link-validation.test.ts
@@ -7,23 +7,18 @@ import {
 import type { SessionMetadata } from "#shared/payments.ts";
 import type { CreatePaymentLinkInput } from "#shared/square.ts";
 import { squareApi } from "#shared/square.ts";
-import {
-  buyTickets,
-  configureSquare,
-  expectNoLink,
-  ticketLine,
-  withSquareClient,
-} from "./fixtures.ts";
+import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
+import { configureSquare, expectNoLink, withSquareClient } from "./fixtures.ts";
 import { describeSquare } from "./harness.ts";
 
 describeSquare(() => {
   describe("createPaymentLink request handling", () => {
     test("returns null when access token not set", async () => {
       await expectNoLink(
-        buyTickets({
+        checkoutIntent({
           items: [
-            ticketLine({ name: "Listing 1" }),
-            ticketLine({
+            checkoutItem({ name: "Listing 1" }),
+            checkoutItem({
               listingId: 2,
               name: "Listing 2",
               quantity: 2,
@@ -39,8 +34,8 @@ describeSquare(() => {
     test("returns null when location ID not configured", async () => {
       await configureSquare();
       await expectNoLink(
-        buyTickets({
-          items: [ticketLine({ name: "Listing 1" })],
+        checkoutIntent({
+          items: [checkoutItem({ name: "Listing 1" })],
           name: "John Doe",
         }),
       );
@@ -57,9 +52,9 @@ describeSquare(() => {
         },
         async () => {
           const result = await squareApi.createPaymentLink(
-            buyTickets({
+            checkoutIntent({
               email: "bob@example.com",
-              items: [ticketLine({ name: "Listing 1" })],
+              items: [checkoutItem({ name: "Listing 1" })],
               name: "Bob Missing",
             }),
             "http://localhost",
@@ -83,17 +78,17 @@ describeSquare(() => {
         },
         async ({ checkoutCreate }) => {
           const result = await squareApi.createPaymentLink(
-            buyTickets({
+            checkoutIntent({
               email: "alice@example.com",
               items: [
-                ticketLine({
+                checkoutItem({
                   listingId: 10,
                   name: "Workshop A",
                   quantity: 2,
                   slug: "workshop-a",
                   unitPrice: 1500,
                 }),
-                ticketLine({
+                checkoutItem({
                   listingId: 20,
                   name: "Gala Dinner",
                   quantity: 1,
@@ -158,7 +153,7 @@ describeSquare(() => {
       await withSquareClient({}, async ({ checkoutCreate }) => {
         // Generate enough items to exceed 255-char serialized metadata
         const items = Array.from({ length: 30 }, (_, i) =>
-          ticketLine({
+          checkoutItem({
             listingId: i + 1,
             name: `Listing ${i + 1}`,
             slug: `listing-${i + 1}`,
@@ -167,7 +162,11 @@ describeSquare(() => {
 
         await expect(
           squareApi.createPaymentLink(
-            buyTickets({ email: "alice@example.com", items, name: "Alice" }),
+            checkoutIntent({
+              email: "alice@example.com",
+              items,
+              name: "Alice",
+            }),
             "https://tickets.example.com",
           ),
         ).rejects.toThrow(PaymentUserError);
@@ -179,8 +178,8 @@ describeSquare(() => {
   });
 
   describe("createPaymentLink with validation errors", () => {
-    const validationIntent = buyTickets({
-      items: [ticketLine({ name: "Test Listing" })],
+    const validationIntent = checkoutIntent({
+      items: [checkoutItem({ name: "Test Listing" })],
       phone: "bad-phone",
     });
 

--- a/test/lib/square/payment-link.test.ts
+++ b/test/lib/square/payment-link.test.ts
@@ -4,13 +4,12 @@ import { extractSessionMetadata } from "#shared/payment-helpers.ts";
 import type { SessionMetadata } from "#shared/payments.ts";
 import type { CreatePaymentLinkInput } from "#shared/square.ts";
 import { squareApi } from "#shared/square.ts";
+import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { testListing } from "#test-utils/factories.ts";
 import {
-  buyTickets,
   configureSquare,
   expectNoLink,
   linkResult,
-  ticketLine,
   withSquareClient,
 } from "./fixtures.ts";
 import { describeSquare } from "./harness.ts";
@@ -19,8 +18,8 @@ describeSquare(() => {
   describe("createPaymentLink", () => {
     test("returns null when access token not set", async () => {
       await expectNoLink(
-        buyTickets({
-          items: [ticketLine({ name: "Test Listing" })],
+        checkoutIntent({
+          items: [checkoutItem({ name: "Test Listing" })],
           name: "John Doe",
         }),
       );
@@ -29,7 +28,7 @@ describeSquare(() => {
     test("returns null when location ID not configured", async () => {
       await configureSquare();
       // No location ID set
-      await expectNoLink(buyTickets());
+      await expectNoLink(checkoutIntent());
     });
 
     test("constructs correct SDK call for single-listing checkout", async () => {
@@ -38,10 +37,10 @@ describeSquare(() => {
         linkResult("order_abc", "https://square.link/abc"),
         async ({ checkoutCreate }) => {
           const result = await squareApi.createPaymentLink(
-            buyTickets({
+            checkoutIntent({
               email: "jane@example.com",
               items: [
-                ticketLine({
+                checkoutItem({
                   listingId: 7,
                   name: "Concert",
                   quantity: 3,
@@ -107,10 +106,10 @@ describeSquare(() => {
         async ({ checkoutCreate }) => {
           const listing = testListing({ unit_price: 1000 });
           await squareApi.createPaymentLink(
-            buyTickets({
+            checkoutIntent({
               email: "jane@example.com",
               items: [
-                ticketLine({
+                checkoutItem({
                   listingId: listing.id,
                   name: listing.name,
                   quantity: 2,
@@ -139,7 +138,10 @@ describeSquare(() => {
       await withSquareClient(
         linkResult("order_xyz", "https://square.link/xyz"),
         async ({ checkoutCreate }) => {
-          await squareApi.createPaymentLink(buyTickets(), "http://localhost");
+          await squareApi.createPaymentLink(
+            checkoutIntent(),
+            "http://localhost",
+          );
 
           const args = checkoutCreate.calls[0]
             ?.args[0] as CreatePaymentLinkInput;
@@ -161,7 +163,7 @@ describeSquare(() => {
         },
         async () => {
           const result = await squareApi.createPaymentLink(
-            buyTickets(),
+            checkoutIntent(),
             "http://localhost",
           );
           expect(result).toBeNull();

--- a/test/lib/square/provider.test.ts
+++ b/test/lib/square/provider.test.ts
@@ -1,13 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { squarePaymentProvider } from "#shared/square-provider.ts";
-import {
-  buyTickets,
-  configureSquare,
-  linkResult,
-  ticketLine,
-  withSquareClient,
-} from "./fixtures.ts";
+import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
+import { configureSquare, linkResult, withSquareClient } from "./fixtures.ts";
 import { describeSquare } from "./harness.ts";
 
 describeSquare(() => {
@@ -215,7 +210,7 @@ describeSquare(() => {
         async () => {
           await configureSquare({ locationId: "L_loc_prov" });
           const result = await squarePaymentProvider.createCheckoutSession(
-            buyTickets(),
+            checkoutIntent(),
             "http://localhost",
           );
           expectCheckout(result, "order_prov", "https://square.link/prov");
@@ -229,8 +224,8 @@ describeSquare(() => {
         async () => {
           await configureSquare({ locationId: "L_loc_prov" });
           const result = await squarePaymentProvider.createCheckoutSession(
-            buyTickets({
-              items: [ticketLine({ name: "Listing 1", slug: "listing-1" })],
+            checkoutIntent({
+              items: [checkoutItem({ name: "Listing 1", slug: "listing-1" })],
             }),
             "http://localhost",
           );

--- a/test/lib/stripe/connection.test.ts
+++ b/test/lib/stripe/connection.test.ts
@@ -13,11 +13,10 @@ import {
   testStripeConnection,
   verifyWebhookSignature,
 } from "#shared/stripe.ts";
+import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { withMocks } from "#test-utils/mocks.ts";
 import {
-  checkout,
-  line,
   lineFor,
   noWebhooks,
   okBalance,
@@ -299,7 +298,7 @@ describeStripe("stripe", () => {
     test("includes phone in metadata when provided", async () => {
       const listing = testListing({ unit_price: 1000 });
       await expectSessionCreated(
-        checkout({
+        checkoutIntent({
           email: "john@example.com",
           items: [lineFor(listing)],
           name: "John Doe",
@@ -313,7 +312,7 @@ describeStripe("stripe", () => {
     test("creates checkout session without customer_email when email is empty", async () => {
       const listing = testListing({ unit_price: 1000 });
       await expectSessionCreated(
-        checkout({
+        checkoutIntent({
           email: "",
           items: [lineFor(listing)],
           name: "No Email User",
@@ -326,11 +325,11 @@ describeStripe("stripe", () => {
   describe("createCheckoutSession", () => {
     test("creates multi-checkout session with phone metadata", async () => {
       await expectSessionCreated(
-        checkout({
+        checkoutIntent({
           email: "jane@example.com",
           items: [
-            line({ name: "Listing A", quantity: 2, slug: "listing-a" }),
-            line({
+            checkoutItem({ name: "Listing A", quantity: 2, slug: "listing-a" }),
+            checkoutItem({
               listingId: 2,
               name: "Listing B",
               slug: "listing-b",
@@ -345,9 +344,9 @@ describeStripe("stripe", () => {
 
     test("returns null when stripe key not set", async () => {
       const result = await createCheckoutSession(
-        checkout({
+        checkoutIntent({
           email: "jane@example.com",
-          items: [line({ name: "Listing A", slug: "listing-a" })],
+          items: [checkoutItem({ name: "Listing A", slug: "listing-a" })],
           name: "Jane Doe",
         }),
         "http://localhost:3000",
@@ -357,11 +356,11 @@ describeStripe("stripe", () => {
 
     test("creates multi-checkout session without customer_email when email is empty", async () => {
       await expectSessionCreated(
-        checkout({
+        checkoutIntent({
           email: "",
           items: [
-            line({ name: "Listing A", slug: "listing-a" }),
-            line({
+            checkoutItem({ name: "Listing A", slug: "listing-a" }),
+            checkoutItem({
               listingId: 2,
               name: "Listing B",
               quantity: 2,

--- a/test/lib/stripe/core.test.ts
+++ b/test/lib/stripe/core.test.ts
@@ -14,13 +14,12 @@ import {
   retrieveCheckoutSession,
   verifyWebhookSignature,
 } from "#shared/stripe.ts";
+import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { createTestDb, resetDb } from "#test-utils/db.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { withMocks } from "#test-utils/mocks.ts";
 import {
   type CreatedSessionParams,
-  checkout,
-  line,
   lineFor,
   signedHeader,
   stripeClient,
@@ -118,7 +117,7 @@ describeStripe("stripe", () => {
       // First create a session using intent-based flow
       const listing = testListing({ unit_price: 1000 });
       const createdSession = await createCheckoutSession(
-        checkout({
+        checkoutIntent({
           email: "john@example.com",
           items: [lineFor(listing)],
           name: "John Doe",
@@ -140,7 +139,7 @@ describeStripe("stripe", () => {
 
       const listing = testListing({ max_quantity: 5, unit_price: 1000 });
       const session = await createCheckoutSession(
-        checkout({
+        checkoutIntent({
           email: "john@example.com",
           items: [lineFor(listing, 2)],
           name: "John Doe",
@@ -182,9 +181,9 @@ describeStripe("stripe", () => {
 
     test("returns null when stripe key not set", async () => {
       const result = await createCheckoutSession(
-        checkout({
+        checkoutIntent({
           email: "john@example.com",
-          items: [line({ name: "Test", slug: "test-listing" })],
+          items: [checkoutItem({ name: "Test", slug: "test-listing" })],
           name: "John",
         }),
         "http://localhost",
@@ -207,7 +206,7 @@ describeStripe("stripe", () => {
         async (createSpy) => {
           const listing = testListing({ unit_price: 1000 });
           await createCheckoutSession(
-            checkout({
+            checkoutIntent({
               email: "jane@example.com",
               items: [lineFor(listing)],
               name: "Jane",
@@ -243,7 +242,7 @@ describeStripe("stripe", () => {
         async (createSpy) => {
           const listing = testListing({ unit_price: 1000 });
           await createCheckoutSession(
-            checkout({
+            checkoutIntent({
               email: "jane@example.com",
               items: [lineFor(listing, 2)],
               name: "Jane",

--- a/test/lib/stripe/fixtures.ts
+++ b/test/lib/stripe/fixtures.ts
@@ -1,8 +1,9 @@
 import { stub } from "@std/testing/mock";
 import { settings } from "#shared/db/settings.ts";
-import type { CheckoutIntent, CheckoutItem } from "#shared/payments.ts";
+import type { CheckoutItem } from "#shared/payments.ts";
 import { getStripeClient } from "#shared/stripe.ts";
 import type { Listing } from "#shared/types.ts";
+import { checkoutItem } from "#test-utils/checkout.ts";
 import { withMocks } from "#test-utils/mocks.ts";
 
 type StripeClient = NonNullable<Awaited<ReturnType<typeof getStripeClient>>>;
@@ -20,38 +21,15 @@ export const stripeClient = async (
   return (await getStripeClient())!;
 };
 
-/** One checkout line with easy-to-override defaults. */
-export const line = (overrides: Partial<CheckoutItem> = {}): CheckoutItem => ({
-  listingId: 1,
-  name: "Evt",
-  quantity: 1,
-  slug: "evt",
-  unitPrice: 1000,
-  ...overrides,
-});
-
 /** A checkout line that mirrors a listing's id, name, slug, and price. */
-export const lineFor = (listing: Listing, quantity = 1): CheckoutItem => ({
-  listingId: listing.id,
-  name: listing.name,
-  quantity,
-  slug: listing.slug,
-  unitPrice: listing.unit_price,
-});
-
-/** A checkout intent with sensible defaults; override any field. */
-export const checkout = (
-  overrides: Partial<CheckoutIntent> = {},
-): CheckoutIntent => ({
-  address: "",
-  date: null,
-  email: "buyer@example.com",
-  items: [line()],
-  name: "Buyer",
-  phone: "",
-  special_instructions: "",
-  ...overrides,
-});
+export const lineFor = (listing: Listing, quantity = 1): CheckoutItem =>
+  checkoutItem({
+    listingId: listing.id,
+    name: listing.name,
+    quantity,
+    slug: listing.slug,
+    unitPrice: listing.unit_price,
+  });
 
 /**
  * The shape of the checkout params Stripe's `sessions.create` receives — just

--- a/test/lib/stripe/provider.test.ts
+++ b/test/lib/stripe/provider.test.ts
@@ -11,10 +11,11 @@ import {
   stripeApi,
 } from "#shared/stripe.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
+import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { setTestEnv } from "#test-utils/env.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { withMocks } from "#test-utils/mocks.ts";
-import { checkout, line, lineFor, stripeClient } from "./fixtures.ts";
+import { lineFor, stripeClient } from "./fixtures.ts";
 import { describeStripe } from "./harness.ts";
 
 describeStripe("stripe-provider", () => {
@@ -40,7 +41,7 @@ describeStripe("stripe-provider", () => {
         async () => {
           const listing = testListing({ unit_price: 1000 });
           const result = await stripePaymentProvider.createCheckoutSession(
-            checkout({
+            checkoutIntent({
               email: "john@example.com",
               items: [lineFor(listing)],
               name: "John",
@@ -517,7 +518,7 @@ describeStripe("stripe-provider", () => {
           ),
         async () => {
           const result = await stripePaymentProvider.createCheckoutSession(
-            checkout({ email: "jane@example.com", name: "Jane" }),
+            checkoutIntent({ email: "jane@example.com", name: "Jane" }),
             "http://localhost:3000",
           );
           expect(result).toBeNull();
@@ -531,14 +532,14 @@ describeStripe("stripe-provider", () => {
       await settings.update.stripe.secretKey("sk_test_mock");
       // Generate enough items to exceed 500-char serialized metadata
       const items = Array.from({ length: 40 }, (_, i) =>
-        line({
+        checkoutItem({
           listingId: i + 1,
           name: `Listing ${i + 1}`,
           slug: `listing-${i + 1}`,
         }),
       );
       const result = await stripePaymentProvider.createCheckoutSession(
-        checkout({ email: "alice@example.com", items, name: "Alice" }),
+        checkoutIntent({ email: "alice@example.com", items, name: "Alice" }),
         "http://localhost:3000",
       );
       expect(result).not.toBeNull();
@@ -555,7 +556,7 @@ describeStripe("stripe-provider", () => {
         Promise.reject(new TypeError("unexpected"));
       try {
         const result = await stripePaymentProvider.createCheckoutSession(
-          checkout({ email: "john@example.com", name: "John" }),
+          checkoutIntent({ email: "john@example.com", name: "John" }),
           "http://localhost:3000",
         );
         expect(result).toBeNull();

--- a/test/lib/webhook-price-signature/helpers.ts
+++ b/test/lib/webhook-price-signature/helpers.ts
@@ -74,22 +74,6 @@ export const stubCompletedSession = async (object: {
   );
 };
 
-/** Stub the redirect path's session retrieval for a paid session. */
-export const stubRetrievedSession = (object: {
-  amount_total: number;
-  id: string;
-  metadata: Record<string, string>;
-}) =>
-  stub(stripeApi, "retrieveCheckoutSession", () =>
-    Promise.resolve({
-      ...object,
-      payment_intent: `pi_${object.id}`,
-      payment_status: "paid",
-    } as unknown as Awaited<
-      ReturnType<typeof stripeApi.retrieveCheckoutSession>
-    >),
-  );
-
 export const webhookRequest = () =>
   handleRequest(mockWebhookRequest({}, { "stripe-signature": "sig_valid" }));
 

--- a/test/lib/webhook-price-signature/stored-refund-and-ignore.test.ts
+++ b/test/lib/webhook-price-signature/stored-refund-and-ignore.test.ts
@@ -13,6 +13,7 @@ import { getTestPrivateKey } from "#test-utils/crypto.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { singleItem, webhookMeta } from "#test-utils/factories.ts";
 import { setupStripe } from "#test-utils/settings.ts";
+import { stubRetrieveCheckoutSession } from "#test-utils/webhooks.ts";
 import {
   expectAcknowledgedIgnore,
   expectNoAttendees,
@@ -24,7 +25,6 @@ import {
   setupWithListing,
   signedMeta,
   stubRefundOk,
-  stubRetrievedSession,
   webhookRequest,
 } from "./helpers.ts";
 
@@ -306,10 +306,11 @@ describeWithEnv(
         price_proof: `1000.${"A".repeat(44)}`,
       };
       const refund = stubRefundOk();
-      const retrieve = stubRetrievedSession({
-        amount_total: 1000,
-        id: "cs_foreign_redirect",
+      const retrieve = stubRetrieveCheckoutSession({
+        amountTotal: 1000,
         metadata,
+        paymentIntent: "pi_cs_foreign_redirect",
+        sessionId: "cs_foreign_redirect",
       });
       try {
         const response = await redirectRequest("cs_foreign_redirect");

--- a/test/routes/api/book-parents.test.ts
+++ b/test/routes/api/book-parents.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
+import type { CheckoutIntent } from "#shared/payments.ts";
+import { stubCheckout } from "#test-utils/checkout.ts";
 import { makeParent } from "#test-utils/parents.ts";
 import { setupStripe } from "#test-utils/settings.ts";
 
@@ -22,34 +23,20 @@ describePublicApi(() => {
       return { slug: parent.slug };
     };
 
-    /** Stub the checkout session to a fixed success, book `slug` (asserting the
-     *  order is taken), and return the intent the route handed the provider so a
-     *  folded field can be asserted. */
-    const captureCheckoutIntent = async (
+    /** Book `slug` through the shared checkout stub (asserting the order is
+     *  taken) and return the intent the route handed the provider so a folded
+     *  field can be asserted. */
+    const captureBookingIntent = async (
       slug: string,
-    ): Promise<Record<string, unknown>> => {
-      const { stripePaymentProvider } = await import(
-        "#shared/stripe-provider.ts"
-      );
-      let captured: Record<string, unknown> = {};
-      const mockCreate = stub(
-        stripePaymentProvider,
-        "createCheckoutSession",
-        (intent) => {
-          captured = intent as unknown as Record<string, unknown>;
-          return Promise.resolve({
-            checkoutUrl: "https://checkout.test/session",
-            sessionId: "sess_test",
-          });
-        },
-      );
+    ): Promise<CheckoutIntent | undefined> => {
+      const { checkout, getCaptured } = stubCheckout("sess_test");
       try {
         const { response } = await bookListing(slug);
         expect(response.status).toBe(200);
       } finally {
-        mockCreate.restore();
+        checkout.restore();
       }
-      return captured;
+      return getCaptured();
     };
 
     test("returns a checkout URL for a parent whose child is paid", async () => {
@@ -127,8 +114,8 @@ describePublicApi(() => {
         children: [{ maxAttendees: 10, unitPrice: 500 }],
         parent: { maxAttendees: 10, unitPrice: 1000 },
       });
-      const intent = await captureCheckoutIntent(parent.slug);
-      expect(intent.allocations).toEqual([
+      const intent = await captureBookingIntent(parent.slug);
+      expect(intent?.allocations).toEqual([
         { childId: child.id, parentId: parent.id, qty: 1 },
       ]);
     });
@@ -264,8 +251,8 @@ describePublicApi(() => {
           unitPrice: 0,
         },
       });
-      const intent = await captureCheckoutIntent(parent.slug);
-      expect(intent.thankYouUrl).toBe("https://example.com/thanks");
+      const intent = await captureBookingIntent(parent.slug);
+      expect(intent?.thankYouUrl).toBe("https://example.com/thanks");
     });
 
     test("omits the thank-you URL when the parent has none", async () => {
@@ -273,8 +260,8 @@ describePublicApi(() => {
       // success handler's default single-listing rule still applies otherwise.
       await setupStripe();
       const parent = await parentWithPaidChild();
-      const intent = await captureCheckoutIntent(parent.slug);
-      expect(intent.thankYouUrl).toBeUndefined();
+      const intent = await captureBookingIntent(parent.slug);
+      expect(intent?.thankYouUrl).toBeUndefined();
     });
   });
 });

--- a/test/routes/api/booking-responses.test.ts
+++ b/test/routes/api/booking-responses.test.ts
@@ -1,0 +1,65 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  bookingSuccessResponse,
+  checkoutFailedResponse,
+  checkoutResponse,
+  soldOutResponse,
+} from "#routes/api/helpers.ts";
+import { expectCorsHeaders } from "./helpers.ts";
+
+describe("bookingSuccessResponse", () => {
+  test("answers with the ticket link and the balance left to collect", async () => {
+    const response = bookingSuccessResponse({
+      remaining_balance: 1500,
+      ticket_token: "tok123",
+    });
+    expect(response.status).toBe(200);
+    expectCorsHeaders(response);
+    expect(await response.json()).toEqual({
+      booking: {
+        amountOwed: 1500,
+        ticketToken: "tok123",
+        ticketUrl: "/t/tok123",
+      },
+    });
+  });
+});
+
+describe("checkoutResponse", () => {
+  test("answers with the hosted checkout URL", async () => {
+    const response = checkoutResponse("https://pay.example/session");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      booking: { checkoutUrl: "https://pay.example/session" },
+    });
+  });
+});
+
+describe("soldOutResponse", () => {
+  test("answers 409 with the shared sold-out message", async () => {
+    const response = soldOutResponse();
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "Sorry, not enough spots available",
+    });
+  });
+});
+
+describe("checkoutFailedResponse", () => {
+  test("answers 400 with the provider's own message when it gave one", async () => {
+    const response = checkoutFailedResponse("Card country not supported");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Card country not supported",
+    });
+  });
+
+  test("answers 500 with the generic message when the provider gave none", async () => {
+    const response = checkoutFailedResponse();
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "Failed to create payment session",
+    });
+  });
+});

--- a/test/routes/api/error-envelope.test.ts
+++ b/test/routes/api/error-envelope.test.ts
@@ -7,7 +7,7 @@ import { expectCorsHeaders } from "./helpers.ts";
 describe("jsonError", () => {
   test("wraps the message in the { error } envelope via the given responder", async () => {
     const seen: { data: unknown; status?: number }[] = [];
-    const respond = jsonError((data, status) => {
+    const respond = jsonError((data, status = 200) => {
       seen.push({ data, status });
       return new Response(null, { status });
     });
@@ -18,7 +18,7 @@ describe("jsonError", () => {
 
   test("defaults the status to 400", () => {
     const respond = jsonError(
-      (_data, status) => new Response(null, { status }),
+      (_data, status = 200) => new Response(null, { status }),
     );
     expect(respond("bad input").status).toBe(400);
   });

--- a/test/routes/api/error-envelope.test.ts
+++ b/test/routes/api/error-envelope.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { apiError, jsonError } from "#routes/api/cors.ts";
+import { apiErrorResponse } from "#shared/rest/crud-api.ts";
+import { expectCorsHeaders } from "./helpers.ts";
+
+describe("jsonError", () => {
+  test("wraps the message in the { error } envelope via the given responder", async () => {
+    const seen: { data: unknown; status?: number }[] = [];
+    const respond = jsonError((data, status) => {
+      seen.push({ data, status });
+      return new Response(null, { status });
+    });
+    const response = respond("boom", 418);
+    expect(response.status).toBe(418);
+    expect(seen).toEqual([{ data: { error: "boom" }, status: 418 }]);
+  });
+
+  test("defaults the status to 400", () => {
+    const respond = jsonError(
+      (_data, status) => new Response(null, { status }),
+    );
+    expect(respond("bad input").status).toBe(400);
+  });
+});
+
+describe("apiError", () => {
+  test("responds with the envelope, the status, and CORS headers", async () => {
+    const response = apiError("Listing not found", 404);
+    expect(response.status).toBe(404);
+    expectCorsHeaders(response);
+    expect(await response.json()).toEqual({ error: "Listing not found" });
+  });
+});
+
+describe("apiErrorResponse", () => {
+  test("responds with the envelope and no CORS headers", async () => {
+    const response = apiErrorResponse("Invalid signature", 401);
+    expect(response.status).toBe(401);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(await response.json()).toEqual({ error: "Invalid signature" });
+  });
+
+  test("defaults the status to 400", async () => {
+    const response = apiErrorResponse("Invalid JSON");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON" });
+  });
+});

--- a/test/routes/renewal.test.ts
+++ b/test/routes/renewal.test.ts
@@ -6,8 +6,8 @@ import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
 import { addMonthsIso } from "#shared/dates.ts";
 import { builtSites, insertBuiltSite } from "#shared/db/built-sites.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
-import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { expectHtmlResponse } from "#test-utils/assertions.ts";
+import { stubCheckout } from "#test-utils/checkout.ts";
 import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { provisionTestBuiltSite } from "#test-utils/db-helpers/built-sites.ts";
@@ -238,15 +238,7 @@ describeWithEnv("routes > renewal", { db: true }, () => {
       );
       const csrf = extractCsrfToken(await getResponse.text())!;
 
-      const mockCreate = stub(
-        stripePaymentProvider,
-        "createCheckoutSession",
-        () =>
-          Promise.resolve({
-            checkoutUrl: "https://checkout.stripe.com/renew",
-            sessionId: "cs_renew_test",
-          }),
-      );
+      const { checkout, getCaptured } = stubCheckout("cs_renew_test");
 
       try {
         const response = await handleRequest(
@@ -259,15 +251,14 @@ describeWithEnv("routes > renewal", { db: true }, () => {
         );
         expect(response.status).toBe(302);
 
-        const intent = mockCreate.calls[0]!
-          .args[0] as import("#shared/payments.ts").CheckoutIntent;
+        const intent = getCaptured()!;
         expect(intent.siteToken).toBe(token);
         expect(intent.items).toHaveLength(1);
         expect(intent.items[0]!.listingId).toBe(tier.id);
         expect(intent.items[0]!.quantity).toBe(3);
         expect(intent.items[0]!.unitPrice).toBe(500);
       } finally {
-        mockCreate.restore();
+        checkout.restore();
       }
     });
 
@@ -299,15 +290,7 @@ describeWithEnv("routes > renewal", { db: true }, () => {
         ).text(),
       )!;
 
-      const mockCreate = stub(
-        stripePaymentProvider,
-        "createCheckoutSession",
-        () =>
-          Promise.resolve({
-            checkoutUrl: "https://checkout.stripe.com/multi",
-            sessionId: "cs_multi",
-          }),
-      );
+      const { checkout, getCaptured } = stubCheckout("cs_multi");
 
       try {
         await handleRequest(
@@ -319,13 +302,12 @@ describeWithEnv("routes > renewal", { db: true }, () => {
             [`quantity_${annual.id}`]: "1",
           }),
         );
-        const intent = mockCreate.calls[0]!
-          .args[0] as import("#shared/payments.ts").CheckoutIntent;
+        const intent = getCaptured()!;
         expect(intent.siteToken).toBe(token);
         const ids = intent.items.map((i) => i.listingId).sort();
         expect(ids).toEqual([monthly.id, annual.id].sort());
       } finally {
-        mockCreate.restore();
+        checkout.restore();
       }
     });
 
@@ -387,15 +369,7 @@ describeWithEnv("routes > renewal", { db: true }, () => {
       });
       const { token } = await setupRenewalSite();
 
-      const mockCreate = stub(
-        stripePaymentProvider,
-        "createCheckoutSession",
-        () =>
-          Promise.resolve({
-            checkoutUrl: "https://checkout.stripe.com/should-not-run",
-            sessionId: "cs_should_not_run",
-          }),
-      );
+      const { checkout, calls } = stubCheckout("cs_should_not_run");
 
       try {
         const response = await handleRequest(
@@ -408,9 +382,9 @@ describeWithEnv("routes > renewal", { db: true }, () => {
         // Standard ticket-form behavior: missing CSRF → redirect back to the
         // form (no payment session created).
         expect(response.status).toBe(302);
-        expect(mockCreate.calls.length).toBe(0);
+        expect(calls()).toBe(0);
       } finally {
-        mockCreate.restore();
+        checkout.restore();
       }
     });
   });

--- a/test/routes/site-assignment-checkout.test.ts
+++ b/test/routes/site-assignment-checkout.test.ts
@@ -1,9 +1,8 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
 import { handleRequest } from "#routes";
 import { resetStripeClient } from "#shared/stripe.ts";
-import { stripePaymentProvider } from "#shared/stripe-provider.ts";
+import { stubCheckout } from "#test-utils/checkout.ts";
 import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -38,15 +37,7 @@ describeWithEnv(
           ).text(),
         )!;
 
-        const mockCreate = stub(
-          stripePaymentProvider,
-          "createCheckoutSession",
-          () =>
-            Promise.resolve({
-              checkoutUrl: "https://checkout.stripe.com/should-not-run",
-              sessionId: "cs_should_not_run",
-            }),
-        );
+        const { checkout, calls } = stubCheckout("cs_should_not_run");
 
         try {
           const response = await handleRequest(
@@ -59,9 +50,9 @@ describeWithEnv(
           );
 
           expect(response.status).toBe(302);
-          expect(mockCreate.calls.length).toBe(0);
+          expect(calls()).toBe(0);
         } finally {
-          mockCreate.restore();
+          checkout.restore();
         }
       });
     });

--- a/test/shared/db/client.test.ts
+++ b/test/shared/db/client.test.ts
@@ -7,6 +7,7 @@ import {
   resetCacheRegistry,
 } from "#shared/cache-registry.ts";
 import {
+  deleteByFieldStatement,
   execute,
   executeUpdate,
   extractUpdateColumns,
@@ -164,6 +165,16 @@ describeWithEnv("db > client", { db: true }, () => {
     const client1 = getDb();
     const client2 = getDb();
     expect(client1).toBe(client2);
+  });
+
+  test("deleteByFieldStatement builds the DELETE for one table, field and value", () => {
+    const stmt = deleteByFieldStatement({
+      field: "user_id",
+      table: "sessions",
+      value: 7,
+    });
+    expect(stmt.sql).toBe("DELETE FROM sessions WHERE user_id = ?");
+    expect(stmt.args).toEqual([7]);
   });
 
   test("insert builds sql and args from record", () => {

--- a/test/shared/db/modifier-resolve.test.ts
+++ b/test/shared/db/modifier-resolve.test.ts
@@ -25,10 +25,10 @@ import {
 } from "#shared/db/modifiers.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
+import { checkoutItem } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import {
-  checkoutItem,
   consumeModifierStock,
   insertModifier,
   linkModifierGroup,

--- a/test/shared/db/query.test.ts
+++ b/test/shared/db/query.test.ts
@@ -149,6 +149,25 @@ describeWithEnv("db > query > id-keyed lookups", { db: true }, () => {
     expect(map.has(beta)).toBe(false);
   });
 
+  test("columnMapByIds carries string columns, not just numbers", async () => {
+    const alpha = await insertStatus("Alpha", 1);
+    const beta = await insertStatus("Beta", 2);
+
+    const map = await columnMapByIds<string>(
+      "attendee_statuses",
+      "status",
+      "name",
+      [alpha, beta],
+    );
+
+    expect(map).toEqual(
+      new Map([
+        [alpha, "Alpha"],
+        [beta, "Beta"],
+      ]),
+    );
+  });
+
   test("columnMapByIds returns an empty map for empty ids", async () => {
     expect(
       await columnMapByIds("attendee_statuses", "status", "sort_order", []),

--- a/test/shared/db/query.test.ts
+++ b/test/shared/db/query.test.ts
@@ -6,6 +6,7 @@ import {
   columnMapByIds,
   mapByIds,
   nameMapByIds,
+  rowsByIds,
   swapSortOrder,
 } from "#shared/db/query.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -68,6 +69,32 @@ describeWithEnv("db > query > swapSortOrder", { db: true }, () => {
 });
 
 describeWithEnv("db > query > id-keyed lookups", { db: true }, () => {
+  test("rowsByIds returns an empty array for empty ids without building a query", async () => {
+    // The builder must not run at all on the empty short-circuit — a thrown
+    // builder proves no SQL was even constructed.
+    const rows = await rowsByIds([], () => {
+      throw new Error("buildSql must not be called for empty ids");
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("rowsByIds fetches exactly the requested rows", async () => {
+    const alpha = await insertStatus("Alpha", 1);
+    const beta = await insertStatus("Beta", 2);
+    await insertStatus("Gamma", 3); // not requested
+
+    const rows = await rowsByIds<{ id: number; name: string }>(
+      [alpha, beta],
+      (placeholders) =>
+        `SELECT status.id, status.name FROM attendee_statuses AS status WHERE status.id IN (${placeholders}) ORDER BY status.id`,
+    );
+
+    expect(rows).toEqual([
+      { id: alpha, name: "Alpha" },
+      { id: beta, name: "Beta" },
+    ]);
+  });
+
   test("mapByIds returns an empty map for empty ids without building a query", async () => {
     // The builder must not run at all on the empty short-circuit — a thrown
     // builder proves no SQL was even constructed.

--- a/test/shared/db/table.test.ts
+++ b/test/shared/db/table.test.ts
@@ -115,6 +115,35 @@ describeWithEnv("db > table utilities", { db: true }, () => {
     await assertEncRoundTrip(def);
   });
 
+  test("readColumn runs the column's read transform on one stored value", async () => {
+    const { col, defineTable } = await import("#shared/db/table.ts");
+    type Row = { id: number; text: string };
+    const table = defineTable<Row, { text: string }>({
+      name: "listings",
+      primaryKey: "id",
+      schema: {
+        id: col.generated<number>(),
+        text: col.encrypted(enc, dec),
+      },
+    });
+    expect(await table.readColumn("text", "enc:hello")).toBe("hello");
+  });
+
+  test("readColumn returns the value as-is for null values and columns with no read transform", async () => {
+    const { col, defineTable } = await import("#shared/db/table.ts");
+    type Row = { id: number; note: string | null };
+    const table = defineTable<Row, { note: string | null }>({
+      name: "listings",
+      primaryKey: "id",
+      schema: {
+        id: col.generated<number>(),
+        note: col.encryptedNullable(col.encrypted(enc, dec)),
+      },
+    });
+    expect(await table.readColumn("note", null)).toBe(null);
+    expect(await table.readColumn("id", 7)).toBe(7);
+  });
+
   test("defineTable.findAll returns all rows", async () => {
     const { col, defineTable } = await import("#shared/db/table.ts");
     const testTable = buildListingsTestTable<{ name: string }>(

--- a/test/templates/admin/listings/detail-roster.test.ts
+++ b/test/templates/admin/listings/detail-roster.test.ts
@@ -249,6 +249,20 @@ describe("adminListingPage roster and attendees", () => {
     expect(html).toContain('class="danger-text"');
     expect(html).toContain("0 remain");
   });
+
+  test("shows danger-text on the total count for a near-capacity daily listing without a date filter", () => {
+    const dailyListing = testListingWithCount({
+      attendee_count: 91,
+      listing_type: "daily",
+      max_attendees: 100,
+    });
+    const html = renderListingDetail({
+      allowedDomain: "localhost",
+      attendees: [],
+      listing: dailyListing,
+    });
+    expect(html).toContain('class="danger-text">91<');
+  });
 });
 
 describe("adminListingPage optional fields", () => {

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -1,8 +1,34 @@
 import { expect } from "@std/expect";
 import { stub } from "@std/testing/mock";
-import type { CheckoutIntent } from "#shared/payments.ts";
+import type { CheckoutIntent, CheckoutItem } from "#shared/payments.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { submitTicketForm } from "./csrf.ts";
+
+/** A checkout line item with sensible defaults; override any field. */
+export const checkoutItem = (
+  overrides: Partial<CheckoutItem> = {},
+): CheckoutItem => ({
+  listingId: 1,
+  name: "General",
+  quantity: 1,
+  slug: "general",
+  unitPrice: 1000,
+  ...overrides,
+});
+
+/** A checkout intent with sensible defaults; override any field. */
+export const checkoutIntent = (
+  overrides: Partial<CheckoutIntent> = {},
+): CheckoutIntent => ({
+  address: "",
+  date: null,
+  email: "buyer@example.com",
+  items: [checkoutItem()],
+  name: "Buyer",
+  phone: "",
+  special_instructions: "",
+  ...overrides,
+});
 
 /** Stub the checkout-session provider and capture the intent it was called
  * with — the shared "inspect what checkout would have charged" fixture

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -3,6 +3,7 @@ import { stub } from "@std/testing/mock";
 import type { CheckoutIntent, CheckoutItem } from "#shared/payments.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { submitTicketForm } from "./csrf.ts";
+import { stubRetrieveCheckoutSession } from "./webhooks.ts";
 
 /** A checkout line item with sensible defaults; override any field. */
 export const checkoutItem = (
@@ -79,6 +80,44 @@ export const captureCheckoutIntent = async (
     checkout.restore();
   }
 };
+
+/** Stub the retrieved checkout session as the standard "John" buyer — the
+ *  session shape the payment-flow suites share, varying only in the id, the
+ *  items, and the agreed total. A paid session (the default) carries signed
+ *  metadata and a payment intent (defaulting to `pi_<sessionId>`); pass
+ *  `paid: false` for the cancelled variant — unsigned metadata, no payment
+ *  intent, and a zero total, as an abandoned checkout retrieves. */
+export const johnCheckoutSession = (
+  sessionId: string,
+  opts:
+    | { paid: false; items: string }
+    | {
+        paid?: true;
+        items: string;
+        amountTotal: number;
+        paymentIntent?: string;
+      },
+) =>
+  opts.paid === false
+    ? stubRetrieveCheckoutSession({
+        amountTotal: 0,
+        metadata: {
+          email: "john@example.com",
+          items: opts.items,
+          name: "John",
+        },
+        paymentIntent: null,
+        paymentStatus: "unpaid",
+        sessionId,
+      })
+    : stubRetrieveCheckoutSession({
+        amountTotal: opts.amountTotal,
+        email: "john@example.com",
+        items: opts.items,
+        name: "John",
+        paymentIntent: opts.paymentIntent ?? `pi_${sessionId}`,
+        sessionId,
+      });
 
 /** Find the captured intent's line item for `listing` and assert its
  *  `unitPrice` — the shared "this folded line was charged X" check behind

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -84,9 +84,9 @@ export const captureCheckoutIntent = async (
 /** Stub the retrieved checkout session as the standard "John" buyer — the
  *  session shape the payment-flow suites share, varying only in the id, the
  *  items, and the agreed total. A paid session (the default) carries signed
- *  metadata and a payment intent (defaulting to `pi_<sessionId>`); pass
- *  `paid: false` for the cancelled variant — unsigned metadata, no payment
- *  intent, and a zero total, as an abandoned checkout retrieves. */
+ *  metadata and a payment intent; pass `paid: false` for the cancelled
+ *  variant — unsigned metadata, no payment intent, and a zero total, as an
+ *  abandoned checkout retrieves. */
 export const johnCheckoutSession = (
   sessionId: string,
   opts:
@@ -95,7 +95,7 @@ export const johnCheckoutSession = (
         paid?: true;
         items: string;
         amountTotal: number;
-        paymentIntent?: string;
+        paymentIntent: string;
       },
 ) =>
   opts.paid === false
@@ -115,7 +115,7 @@ export const johnCheckoutSession = (
         email: "john@example.com",
         items: opts.items,
         name: "John",
-        paymentIntent: opts.paymentIntent ?? `pi_${sessionId}`,
+        paymentIntent: opts.paymentIntent,
         sessionId,
       });
 

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -1,0 +1,69 @@
+import { expect } from "@std/expect";
+import { stub } from "@std/testing/mock";
+import type { CheckoutIntent } from "#shared/payments.ts";
+import { stripePaymentProvider } from "#shared/stripe-provider.ts";
+import { submitTicketForm } from "./csrf.ts";
+
+/** Stub the checkout-session provider and capture the intent it was called
+ * with — the shared "inspect what checkout would have charged" fixture
+ * behind every test that never actually completes a paid session. The optional
+ * `sessionId` labels the captured intent (defaults to `"cs_test"`). Returns
+ * `checkout` (the mock, for `restore()`), `getCaptured()` (the intent handed
+ * over), and `calls()` (how many times the provider was reached) so the
+ * sold-out preflight case can assert it was never called. */
+export const stubCheckout = (sessionId = "cs_test") => {
+  let captured: CheckoutIntent | undefined;
+  const checkout = stub(
+    stripePaymentProvider,
+    "createCheckoutSession",
+    (intent: CheckoutIntent) => {
+      captured = intent;
+      return Promise.resolve({
+        checkoutUrl: "https://stripe.example/checkout",
+        sessionId,
+      });
+    },
+  );
+  return {
+    calls: () => checkout.calls.length,
+    checkout,
+    getCaptured: () => captured,
+  };
+};
+
+/** Submit a buyer's ticket form through a stubbed checkout provider, assert
+ * the redirect succeeded, and return the checkout intent it captured — the
+ * shared "what would checkout have charged" flow behind every test that
+ * inspects the outgoing intent rather than completing a paid session. */
+export const captureCheckoutIntent = async (
+  listing: { id: number; slug: string },
+  fields: Record<string, string> = {},
+): Promise<CheckoutIntent | undefined> => {
+  const { checkout, getCaptured } = stubCheckout();
+  try {
+    const response = await submitTicketForm(listing.slug, {
+      [`quantity_${listing.id}`]: "1",
+      email: "buyer@example.com",
+      name: "Buyer",
+      ...fields,
+    });
+    expect([302, 303]).toContain(response.status);
+    return getCaptured();
+  } finally {
+    checkout.restore();
+  }
+};
+
+/** Find the captured intent's line item for `listing` and assert its
+ *  `unitPrice` — the shared "this folded line was charged X" check behind
+ *  every test that inspects the outgoing intent's per-line prices. Pass the
+ *  captured intent (`getCaptured()`), the listing whose price to check, and the
+ *  expected unit price in the smallest currency unit (e.g. pence). */
+export const expectCapturedItemPriced = (
+  intent: CheckoutIntent | undefined,
+  listing: { id: number },
+  unitPrice: number,
+): void => {
+  const item = intent?.items.find((i) => i.listingId === listing.id);
+  expect(item?.unitPrice).toBe(unitPrice);
+};

--- a/test/test-utils/modifiers.ts
+++ b/test/test-utils/modifiers.ts
@@ -10,19 +10,6 @@ import {
   type ModifierInput,
   modifiersTable,
 } from "#shared/db/modifiers.ts";
-import type { CheckoutItem } from "#shared/payments.ts";
-
-/** A checkout line item with sensible defaults for pricing/modifier tests. */
-export const checkoutItem = (
-  overrides: Partial<CheckoutItem> = {},
-): CheckoutItem => ({
-  listingId: 1,
-  name: "General",
-  quantity: 1,
-  slug: "general",
-  unitPrice: 1000,
-  ...overrides,
-});
 
 /** Insert a modifier through the production table, defaulting to a £5 charge. */
 export const insertModifier = (overrides: Partial<ModifierInput> = {}) =>

--- a/test/test-utils/modifiers.ts
+++ b/test/test-utils/modifiers.ts
@@ -109,16 +109,23 @@ export const insertModifierUsage = (
     sql: "INSERT INTO modifier_usages (modifier_id, attendee_id, quantity, amount_applied, created) VALUES (?, ?, ?, ?, ?)",
   });
 
-/** Sum of `amount_applied` recorded against a modifier by a webhook/checkout. */
-export const modifierUsageAmount = async (
-  modifierId: number,
-): Promise<number> => {
-  const result = await getDb().execute({
-    args: [modifierId],
-    sql: "SELECT amount_applied FROM modifier_usages WHERE modifier_id = ?",
-  });
-  return Number(result.rows[0]!.amount_applied);
-};
+/** Sum a `modifier_usages` column across a modifier's recorded rows — safe
+ *  for one, many, or no rows (no usage sums to 0). */
+const modifierUsageSum =
+  (column: "quantity" | "amount_applied") =>
+  async (modifierId: number): Promise<number> => {
+    const { rows } = await getDb().execute({
+      args: [modifierId],
+      sql: `SELECT COALESCE(SUM(${column}), 0) AS total FROM modifier_usages WHERE modifier_id = ?`,
+    });
+    return Number(rows[0]!.total);
+  };
+
+/** Total quantity recorded against a modifier by a webhook/checkout. */
+export const modifierUsageCount = modifierUsageSum("quantity");
+
+/** Total `amount_applied` recorded against a modifier by a webhook/checkout. */
+export const modifierUsageAmount = modifierUsageSum("amount_applied");
 
 /**
  * total_revenue is projected from the transfers ledger as balanceOf(modifier)

--- a/test/test-utils/modifiers.ts
+++ b/test/test-utils/modifiers.ts
@@ -116,7 +116,7 @@ const modifierUsageSum =
   async (modifierId: number): Promise<number> => {
     const { rows } = await getDb().execute({
       args: [modifierId],
-      sql: `SELECT COALESCE(SUM(${column}), 0) AS total FROM modifier_usages WHERE modifier_id = ?`,
+      sql: `SELECT COALESCE(SUM(modifierUsage.${column}), 0) AS total FROM modifier_usages AS modifierUsage WHERE modifierUsage.modifier_id = ?`,
     });
     return Number(rows[0]!.total);
   };

--- a/test/test-utils/order-journey.ts
+++ b/test/test-utils/order-journey.ts
@@ -28,12 +28,7 @@ import {
   SELECT_PREFIX,
   START_DATE_FIELD,
 } from "#shared/order-select.ts";
-import {
-  buildItemsMetadata,
-  enforceMetadataLimits,
-  STRIPE_METADATA_MAX_ENTRIES,
-  STRIPE_METADATA_MAX_VALUE_LENGTH,
-} from "#shared/payment-helpers.ts";
+import { assembleCheckoutMetadata } from "#shared/payment-helpers.ts";
 import type { CheckoutIntent } from "#shared/payments.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
@@ -251,16 +246,7 @@ const completePaidCheckout = async (
   sessionId: string,
 ): Promise<void> => {
   const total = priceCheckout(intent).total;
-  const metadata = enforceMetadataLimits(
-    await buildItemsMetadata(
-      intent,
-      total,
-      STRIPE_METADATA_MAX_VALUE_LENGTH,
-      STRIPE_METADATA_MAX_ENTRIES,
-    ),
-    STRIPE_METADATA_MAX_VALUE_LENGTH,
-    STRIPE_METADATA_MAX_ENTRIES,
-  );
+  const metadata = await assembleCheckoutMetadata("stripe", intent, total);
   const verifyStub = await stubWebhookVerify({
     data: {
       object: {

--- a/test/ui/templates/components/capacity.test.tsx
+++ b/test/ui/templates/components/capacity.test.tsx
@@ -1,0 +1,119 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  CapacityMeter,
+  capacityLevel,
+  capacityMeterHtml,
+  capacityMeterText,
+  GroupCapacityMeter,
+} from "#templates/components/capacity.tsx";
+
+describe("capacityLevel", () => {
+  test("is calm below 90% of the cap", () => {
+    expect(capacityLevel(8, 10)).toEqual({
+      nearLimit: false,
+      overLimit: false,
+      remaining: 2,
+    });
+  });
+
+  test("warns exactly at 90% of the cap", () => {
+    expect(capacityLevel(9, 10)).toEqual({
+      nearLimit: true,
+      overLimit: false,
+      remaining: 1,
+    });
+  });
+
+  test("warns between 90% and the cap", () => {
+    expect(capacityLevel(19, 20)).toEqual({
+      nearLimit: true,
+      overLimit: false,
+      remaining: 1,
+    });
+  });
+
+  test("is over exactly at the cap", () => {
+    expect(capacityLevel(10, 10)).toEqual({
+      nearLimit: true,
+      overLimit: true,
+      remaining: 0,
+    });
+  });
+
+  test("reports negative seats left past the cap", () => {
+    expect(capacityLevel(12, 10)).toEqual({
+      nearLimit: true,
+      overLimit: true,
+      remaining: -2,
+    });
+  });
+
+  test("treats a zero cap as no cap at all", () => {
+    expect(capacityLevel(100, 0)).toEqual({
+      nearLimit: false,
+      overLimit: false,
+      remaining: -100,
+    });
+  });
+});
+
+describe("capacityMeterText", () => {
+  test("formats count, cap, and seats left", () => {
+    expect(capacityMeterText(12, 20)).toBe("12 / 20 — 8 remain");
+  });
+
+  test("shows an overridden seats-left figure", () => {
+    expect(capacityMeterText(12, 10, 0)).toBe("12 / 10 — 0 remain");
+  });
+});
+
+describe("capacityMeterHtml", () => {
+  test("is plain text when the warning flag is off", () => {
+    expect(capacityMeterHtml({ count: 5, danger: false, max: 20 })).toBe(
+      "5 / 20 — 15 remain",
+    );
+  });
+
+  test("wraps the text in a danger span when the warning flag is on", () => {
+    expect(capacityMeterHtml({ count: 19, danger: true, max: 20 })).toBe(
+      '<span class="danger-text">19 / 20 — 1 remain</span>',
+    );
+  });
+});
+
+describe("CapacityMeter", () => {
+  test("renders a span with an empty class when calm", () => {
+    const html = String(<CapacityMeter count={5} danger={false} max={20} />);
+    expect(html).toBe('<span class="">5 / 20 — 15 remain</span>');
+  });
+
+  test("renders a danger span when the warning flag is on", () => {
+    const html = String(<CapacityMeter count={19} danger={true} max={20} />);
+    expect(html).toBe('<span class="danger-text">19 / 20 — 1 remain</span>');
+  });
+
+  test("shows an overridden seats-left figure", () => {
+    const html = String(
+      <CapacityMeter count={12} danger={true} max={10} remaining={0} />,
+    );
+    expect(html).toBe('<span class="danger-text">12 / 10 — 0 remain</span>');
+  });
+});
+
+describe("GroupCapacityMeter", () => {
+  test("is calm below 90% of the group cap", () => {
+    const html = String(<GroupCapacityMeter count={20} max={50} />);
+    expect(html).toBe('<span class="">20 / 50 — 30 remain</span>');
+  });
+
+  test("warns from 90% of the group cap", () => {
+    const html = String(<GroupCapacityMeter count={9} max={10} />);
+    expect(html).toBe('<span class="danger-text">9 / 10 — 1 remain</span>');
+  });
+
+  test("never shows fewer than zero seats left", () => {
+    const html = String(<GroupCapacityMeter count={12} max={10} />);
+    expect(html).toBe('<span class="danger-text">12 / 10 — 0 remain</span>');
+  });
+});

--- a/test/ui/templates/public/reservation-rows.test.ts
+++ b/test/ui/templates/public/reservation-rows.test.ts
@@ -1,0 +1,15 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { soldOutLabel } from "#templates/public/reservations/rows.ts";
+
+describe("soldOutLabel", () => {
+  test("shows the Sold Out badge by default", () => {
+    expect(soldOutLabel()).toBe('<span class="sold-out-label">Sold Out</span>');
+  });
+
+  test("shows the caller's copy when given", () => {
+    expect(soldOutLabel("Registration Closed")).toBe(
+      '<span class="sold-out-label">Registration Closed</span>',
+    );
+  });
+});


### PR DESCRIPTION
## What this does

When we split up our big files recently, lots of small helper functions were extracted along the way. Many of those helpers turned out to be near-copies of each other, each drifting slightly from its siblings. This change hunts those down and folds each family of look-alike helpers into one shared, declarative mechanism, so the same job is done in exactly one place.

## Payments

- The six refund-reason factory functions became one table (`REFUND_REASONS`) plus a curried `refundSpec(code)(detail)` builder. Picking a refund reason for a failed booking now goes through a complete lookup map, so a new failure kind can't silently fall through to the wrong reason the way `encryption_error` used to.
- Each payment provider's metadata size limits (how long a value can be, how many entries fit, whether small fields get packed together) now live on the provider registry itself, read by one shared `assembleCheckoutMetadata` helper — instead of each provider re-spelling its own limits and assembly steps.
- All three providers (Stripe, Square, SumUp) build their "validated payment session" object through one shared builder, fixing a quiet inconsistency where Stripe included an empty `createdAt` field the others left out.
- Four copy-pasted "parse this optional JSON field" one-liners became one curried `jsonMetaField` helper.

## Public API

- The `{ error: message }` JSON reply was hand-typed in about two dozen places; it now comes from one curried `jsonError` helper (with and without CORS headers).
- The booking success/checkout/sold-out replies were built independently by the two booking paths; both now share one set of response shapers, so the public booking contract lives in one place.
- Booking error copy ("Sorry, not enough spots available" and friends) is imported from the shared `bookingError` table instead of being retyped.
- The SMS webhook now picks its event handler from a lookup table instead of an if/else chain.

## Database layer

- A new `groupToMap` helper in `#fp` replaces four hand-rolled "group rows and keep one value from each" reducers.
- The "safe even when the id list is empty" query skeleton is now exported from `query.ts` and reused at the four places that had re-implemented it (forgetting that guard is a runtime SQL error).
- Deleting a question and its related rows now uses the ready-made `deleteByFieldBatch`, and the attendee purge builds its deletes from a small declarative list.
- `columnMapByIds` can now carry any column type, so string and nullable columns stopped hand-rolling their own maps.
- Tables gained `readColumn` for decrypting a single stored value, removing two places that built fake rows full of dummy fields just to decrypt one column.

## Admin and booking pages

- Every "12 / 50 — 38 remain" capacity count now renders through one shared meter, which also owns the single 90%-full warning threshold (previously re-derived in five files). This fixes the group page showing untranslated English for that text.
- Every `&lt;select&gt;`'s options render through the one shared, escaping option builder instead of five hand-rolled loops (most of which didn't escape).
- The booking form's date and length-of-stay pickers share one config-driven "labelled select" shell.
- The "Sold out" badge fragment is shared instead of copied three times.

## Test helpers

- The stub that captures an outgoing checkout, and the checkout item/intent fixtures, moved into a shared `test/test-utils/checkout.ts` — they were re-implemented in four folders and inlined in about ten more files.
- Fixed a name collision: two different `modifierUsageAmount` helpers with different SQL existed under the same name; the safe-for-any-row-count version is now the only one.

## Notes

- No user-visible behaviour changes, apart from the group page capacity text now being translated like everywhere else.
- Every phase kept jscpd at 0%, lint clean, and the covering test suites green; new helpers got direct unit tests.
- Follow-up candidates spotted but deliberately left out (bigger judgement calls): unifying the four entity-load wrappers in `entity-handlers.ts` (currently under a `jscpd:ignore`), and merging the two "is this a child listing that can't be booked alone" checks on the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGqiEWD7ejcB19kSKStvN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGqiEWD7ejcB19kSKStvN1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent capacity meters across admin listing and group views, including improved near-cap warnings and accurate “seats left” formatting.
  * Standardized “Sold out” / “registration closed” badge rendering across reservation pages.

* **Bug Fixes**
  * More consistent booking and folded-booking API responses and error messaging (including clearer invalid-date validation and sold-out/payment-session failures).
  * Improved checkout/payment metadata handling consistency across payment providers.

* **Tests**
  * Added coverage for the new capacity display and select rendering helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->