### PR TITLE
Harden admin logistics template tests to 100% mutation kill rate

### DIFF
--- a/test/ui/templates/admin/logistics.test.ts
+++ b/test/ui/templates/admin/logistics.test.ts
@@ -1,11 +1,15 @@
 import { expect } from "@std/expect";
-import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { beforeAll, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
+import { settings } from "#shared/db/settings.ts";
 import type { AdminSession, LogisticsAgent } from "#shared/types.ts";
 import {
   type AgentUserOption,
   adminLogisticsAgentEditPage,
+  adminLogisticsPage,
+  logisticsAgentPages,
 } from "#templates/admin/logistics.tsx";
+import { describeWithEnv } from "#test-utils/db.ts";
 import { setupTestEncryptionKey } from "#test-utils/env.ts";
 
 const session: AdminSession = { adminLevel: "owner" };
@@ -27,6 +31,10 @@ describe("adminLogisticsAgentEditPage", () => {
     expect(html).toContain("<legend>Agent details</legend>");
     expect(html).toContain("<legend>Assigned users</legend>");
     expect(html).toContain("Van 1");
+    // The agent-details fieldset and the assigned-users fieldset carry their
+    // exact classes.
+    expect(html).toContain('<fieldset class="listing-section">');
+    expect(html).toContain('class="checkboxes listing-section"');
   });
 
   test("explains that agent-class users only see the deliveries page", () => {
@@ -58,5 +66,82 @@ describe("adminLogisticsAgentEditPage", () => {
   test("shows a placeholder when there are no users to assign", () => {
     const html = adminLogisticsAgentEditPage(agent, [], new Set(), session);
     expect(html).toContain("No users to assign yet.");
+  });
+});
+
+describe("logisticsAgentPages delete page", () => {
+  test("confirms the agent by name and posts to its delete path", () => {
+    const html = logisticsAgentPages.deletePage(agent, session);
+    expect(html).toContain('action="/admin/logistics/7/delete"');
+    expect(html).toContain(
+      "delete the logistics agent <strong>Van 1</strong>?",
+    );
+    expect(html).toContain("Type the agent name &quot;Van 1&quot; to confirm:");
+  });
+
+  test("renders the delete as a non-danger confirmation", () => {
+    const html = logisticsAgentPages.deletePage(agent, session);
+    // delete.danger is false, so the submit is the plain (check) button, not
+    // the red danger one.
+    expect(html).not.toContain('<button class="danger"');
+  });
+});
+
+describe("logisticsAgentPages new page", () => {
+  test("renders the add-agent form posting to the logistics base path", () => {
+    const html = logisticsAgentPages.newPage(session);
+    expect(html).toContain("Add Logistics Agent");
+    expect(html).toContain("Create Agent");
+    expect(html).toContain('action="/admin/logistics"');
+    // The resource pages mark the logistics nav entry active.
+    expect(html).toContain('<a class="active" href="/admin/logistics">');
+  });
+});
+
+describeWithEnv("adminLogisticsPage", { db: true, encryptionKey: true }, () => {
+  beforeEach(async () => {
+    await signCsrfToken();
+  });
+
+  test("always renders the has-logistics toggle and guide footer", async () => {
+    await settings.update.hasLogistics(false);
+    const html = adminLogisticsPage([agent], session);
+
+    expect(html).toContain('action="/admin/logistics/has-logistics"');
+    expect(html).toContain('name="has_logistics"');
+    expect(html).toContain('href="/admin/guide#logistics"');
+    expect(html).toContain("Logistics guide");
+    // With logistics disabled the agents section is hidden entirely.
+    expect(html).not.toContain("Logistics Agents");
+    expect(html).not.toContain('href="/admin/logistics/7/edit"');
+  });
+
+  test("reveals the agents section with a row per agent when enabled", async () => {
+    await settings.update.hasLogistics(true);
+    const html = adminLogisticsPage([agent], session);
+
+    expect(html).toContain("Logistics Agents");
+    expect(html).toContain("Agents (e.g. vans, drivers, or crew)");
+    expect(html).toContain('href="/admin/logistics/7/edit"');
+    expect(html).toContain("Van 1");
+    // The inline add form, its section fieldset and the add (plus) button.
+    expect(html).toContain('action="/admin/logistics"');
+    expect(html).toContain('class="listing-section"');
+    expect(html).toContain('href="/icons.svg#plus"');
+    expect(html).toContain("Add Agent");
+    // The page marks the logistics nav entry active.
+    expect(html).toContain('<a class="active" href="/admin/logistics">');
+    // A populated list shows the table, not the empty-state placeholder.
+    expect(html).not.toContain("No logistics agents yet.");
+  });
+
+  test("shows the empty-state placeholder when enabled with no agents", async () => {
+    await settings.update.hasLogistics(true);
+    const html = adminLogisticsPage([], session);
+
+    expect(html).toContain("Logistics Agents");
+    expect(html).toContain("No logistics agents yet.");
+    // No agent rows are rendered.
+    expect(html).not.toContain('href="/admin/logistics/7/edit"');
   });
 });


### PR DESCRIPTION
## What

`src/ui/templates/admin/logistics.tsx` was the thinnest-tested source file per `deno task unit-tests-report` (a 3.83 src:test line ratio). Running the mutation suite over it confirmed the gap:

```
deno task mutation 'src/ui/templates/admin/logistics.tsx' \
                   'test/ui/templates/admin/logistics.test.ts'
```

**Before:** score 52% — 24 of 50 mutants survived. The existing test only rendered `adminLogisticsAgentEditPage`; the main settings page, the agents section, and the resource add/delete pages were unverified.

## Changes

Test-only changes in `test/ui/templates/admin/logistics.test.ts`:

- **`adminLogisticsPage`** (DB-backed via `describeWithEnv({ db: true, encryptionKey: true })`): the has-logistics toggle and guide footer that always render; the agents section revealed when logistics is enabled (agent rows, inline add form, `listing-section` class, the add `#plus` icon, active nav entry); and the empty-state placeholder when enabled with no agents. Also asserts the section stays hidden and no rows render when logistics is disabled.
- **`logisticsAgentPages.deletePage`**: name-based confirmation copy, the type-to-confirm prompt, the delete path, and that it renders as a non-danger (plain check) confirmation rather than the red danger button.
- **`logisticsAgentPages.newPage`**: the add form, base path, and active nav entry.
- **Edit page**: pins the exact `listing-section` / `checkboxes listing-section` fieldset classes.

**After:** score 100% — all 50 mutants killed.

Note: no source changes; `deno task cpd` reports 0 clones and the file typechecks/lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_