### PR TITLE
Keep the SMS webhook off the CRUD API import path

### DIFF
--- a/src/features/admin/api.ts
+++ b/src/features/admin/api.ts
@@ -11,6 +11,7 @@ import { t } from "#i18n";
 import { groupApiRoutes } from "#routes/admin/api-groups.ts";
 import { holidayApiRoutes } from "#routes/admin/api-holidays.ts";
 import { verifyIdentifierOrJsonError } from "#routes/admin/confirmation.ts";
+import { apiErrorResponse } from "#routes/api/cors.ts";
 import { jsonResponse } from "#routes/response.ts";
 import type { RouteHandlerFn } from "#routes/router.ts";
 import type { TxScope } from "#shared/db/client.ts";
@@ -43,7 +44,6 @@ import {
   validateListingInput,
 } from "#shared/listings-actions.ts";
 import {
-  apiErrorResponse,
   bodyNumber,
   type DeleteBody,
   defineCrudApi,

--- a/src/features/api/cors.ts
+++ b/src/features/api/cors.ts
@@ -19,7 +19,7 @@ export const apiResponse = (data: unknown, status = 200): Response => {
 /** Turn a JSON responder into an error responder: the returned function wraps
  * a message in the shared `{ error: message }` envelope (400 unless told
  * otherwise), so every API error body is spelled in one place. */
-export const jsonError =
+const jsonError =
   (respond: (data: unknown, status?: number) => Response) =>
   (message: string, status = 400): Response =>
     respond({ error: message }, status);

--- a/src/features/api/cors.ts
+++ b/src/features/api/cors.ts
@@ -27,6 +27,12 @@ export const jsonError =
 /** JSON `{ error: message }` response with CORS headers */
 export const apiError = jsonError(apiResponse);
 
+/** JSON `{ error: message }` response for API endpoints (no CORS headers).
+ * Lives here rather than in the CRUD API module so lightweight edge routes
+ * (e.g. the SMS webhook) can build error envelopes without evaluating the
+ * admin CRUD/auth import graph. */
+export const apiErrorResponse = jsonError(jsonResponse);
+
 /** CORS preflight response */
 export const handleOptions = (): Response =>
   new Response(null, { headers: CORS_HEADERS, status: 204 });

--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -10,6 +10,7 @@
  */
 
 import * as v from "valibot";
+import { apiErrorResponse } from "#routes/api/cors.ts";
 import { jsonResponse } from "#routes/response.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import { constantTimeEqual } from "#shared/crypto/utils.ts";
@@ -27,7 +28,6 @@ import {
   type SmsMessageRow,
 } from "#shared/db/sms-messages.ts";
 import { nowMs } from "#shared/now.ts";
-import { apiErrorResponse } from "#shared/rest/crud-api.ts";
 import { decryptField } from "#shared/sms/e2e.ts";
 import { computePhoneIndex } from "#shared/sms/phone-index.ts";
 

--- a/src/shared/rest/crud-api.ts
+++ b/src/shared/rest/crud-api.ts
@@ -19,7 +19,7 @@
 
 import type { InValue } from "@libsql/client";
 import { verifyIdentifierOrJsonError } from "#routes/admin/confirmation.ts";
-import { jsonError } from "#routes/api/cors.ts";
+import { apiErrorResponse } from "#routes/api/cors.ts";
 import { ADMIN_API, type AuthPolicy, withAuth } from "#routes/auth.ts";
 import { jsonResponse } from "#routes/response.ts";
 import type { RouteHandlerFn } from "#routes/router.ts";
@@ -122,9 +122,6 @@ export const parseOptionalArray = <T>(
   }
   return { input: items, ok: true };
 };
-
-/** JSON `{ error: message }` response for API endpoints (no CORS headers) */
-export const apiErrorResponse = jsonError(jsonResponse);
 
 /** Result of parsing + validating: either the input or a pre-built error response */
 export type ValidatedInput<Input> =

--- a/test/routes/api/error-envelope.test.ts
+++ b/test/routes/api/error-envelope.test.ts
@@ -1,27 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { apiError, apiErrorResponse, jsonError } from "#routes/api/cors.ts";
+import { apiError, apiErrorResponse } from "#routes/api/cors.ts";
 import { expectCorsHeaders } from "./helpers.ts";
-
-describe("jsonError", () => {
-  test("wraps the message in the { error } envelope via the given responder", async () => {
-    const seen: { data: unknown; status?: number }[] = [];
-    const respond = jsonError((data, status = 200) => {
-      seen.push({ data, status });
-      return new Response(null, { status });
-    });
-    const response = respond("boom", 418);
-    expect(response.status).toBe(418);
-    expect(seen).toEqual([{ data: { error: "boom" }, status: 418 }]);
-  });
-
-  test("defaults the status to 400", () => {
-    const respond = jsonError(
-      (_data, status = 200) => new Response(null, { status }),
-    );
-    expect(respond("bad input").status).toBe(400);
-  });
-});
 
 describe("apiError", () => {
   test("responds with the envelope, the status, and CORS headers", async () => {
@@ -29,6 +9,12 @@ describe("apiError", () => {
     expect(response.status).toBe(404);
     expectCorsHeaders(response);
     expect(await response.json()).toEqual({ error: "Listing not found" });
+  });
+
+  test("defaults the status to 400", async () => {
+    const response = apiError("bad input");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "bad input" });
   });
 });
 

--- a/test/routes/api/error-envelope.test.ts
+++ b/test/routes/api/error-envelope.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { apiError, jsonError } from "#routes/api/cors.ts";
-import { apiErrorResponse } from "#shared/rest/crud-api.ts";
+import { apiError, apiErrorResponse, jsonError } from "#routes/api/cors.ts";
 import { expectCorsHeaders } from "./helpers.ts";
 
 describe("jsonError", () => {


### PR DESCRIPTION
Follow-up to #1735, addressing the Codex P2 comment left after it was queued: `apiErrorResponse` lived in `src/shared/rest/crud-api.ts`, so a cold POST to `/sms/webhook` evaluated the admin CRUD/auth import graph (`#routes/auth.ts`, admin confirmation helpers, …) just to build `{ error }` JSON bodies.

## Changes

- Move `apiErrorResponse = jsonError(jsonResponse)` into `src/features/api/cors.ts`, next to its sibling `apiError = jsonError(apiResponse)`. That module only imports `#routes/response.ts`, so it's safe for lightweight edge routes.
- Point the three importers (`crud-api.ts`, `features/admin/api.ts`, `features/api/sms-webhook.ts`) and the error-envelope test at the new location. No behavior change.

## Verification

- `deno info src/features/api/sms-webhook.ts` no longer lists `crud-api.ts` or `routes/auth.ts` in the webhook's module graph.
- Lint, typecheck, cpd, the API-route suites (116 tests) and all SMS suites (86 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGqiEWD7ejcB19kSKStvN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGqiEWD7ejcB19kSKStvN1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized API error responses across administrative, webhook, and data routes.
  * Preserved consistent `{ error: message }` responses while maintaining appropriate CORS behavior.
  * API errors now default to HTTP status `400` when no status is specified.

* **Tests**
  * Updated error-handling coverage to verify default statuses and response contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->