### PR TITLE
Make the fold test prove a rejected booking leaves the count untouched

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -506,18 +506,7 @@ helper) before the brace-depth checks, and add a direct regression test for the
 comment-with-`}`-then-nested-template case asserting `parseArgList` doesn't
 misinterpret the comma.
 
-### 3. `foldOutcomeValid` should assert rejected folds preserve the prior quantity
-
-`test/lib/fold-tree.test.ts` — for the above-cap (rejected) case the validator
-checks `recordedQty !== running`, which only proves the quantity wasn't clamped
-to the attempted total; it doesn't prove the rejected fold left the *prior*
-recorded quantity unchanged.
-
-Fix direction: capture the recorded quantity before calling `foldChild`, thread
-it into `foldOutcomeValid`, and assert exact equality against that pre-fold
-value for rejected outcomes (retaining the accepted-case checks).
-
-### 4. `mutation.ts` CLI value flags should fail fast on a missing value
+### 3. `mutation.ts` CLI value flags should fail fast on a missing value
 
 `scripts/mutation.ts` — in `applyArg`, a recognized value flag (`--source`,
 `--test`, `--timeout`, `--jobs`) with no following token falls through and is

--- a/test/shared/booking/fold-tree.test.ts
+++ b/test/shared/booking/fold-tree.test.ts
@@ -14,6 +14,7 @@ import {
   resolveChildSelections,
   resolvedByNodeKey,
 } from "#shared/booking/fold-tree.ts";
+import { formatAtomicError } from "#shared/booking/form.ts";
 import {
   buildTicketListing,
   type TicketListing,
@@ -64,18 +65,19 @@ const freshState = () => ({
 
 /** Validate a single foldChild outcome against the running total and cap:
  * within the cap the fold must be accepted and the running quantity recorded;
- * above the cap it must be rejected (never clamped) and the recorded quantity
- * left exactly as it was before this fold. */
+ * above the cap it must be rejected with the capacity error (never clamped) and
+ * the recorded quantity left exactly as it was before this fold. */
 const foldOutcomeValid = (
   error: ReturnType<typeof foldChild>,
   recordedQty: number | undefined,
   prevRecordedQty: number | undefined,
   running: number,
   max: number,
+  capacityError: string,
 ): boolean =>
   running <= max
     ? error === null && recordedQty === running
-    : error !== null && recordedQty === prevRecordedQty;
+    : error === capacityError && recordedQty === prevRecordedQty;
 
 /** Mirror the production adapter's steps, purely (no DB; holidays default none):
  * build the tree, resolve each node's availability, run the walk. */
@@ -525,6 +527,10 @@ describe("fold selection algebra (property-based)", () => {
         }),
         (max, qtys) => {
           const child = line(1, { max_attendees: max, max_quantity: max });
+          const capacityError = formatAtomicError(
+            "capacity_exceeded",
+            child.listing.name,
+          );
           const state = freshState();
           let running = 0;
           for (const q of qtys) {
@@ -538,6 +544,7 @@ describe("fold selection algebra (property-based)", () => {
                 prevQty,
                 running,
                 max,
+                capacityError,
               )
             ) {
               return false;

--- a/test/shared/booking/fold-tree.test.ts
+++ b/test/shared/booking/fold-tree.test.ts
@@ -63,17 +63,19 @@ const freshState = () => ({
 });
 
 /** Validate a single foldChild outcome against the running total and cap:
- * within the cap the fold must be accepted and the quantity recorded; above
- * the cap it must be rejected (never clamped) and the quantity left unchanged. */
+ * within the cap the fold must be accepted and the running quantity recorded;
+ * above the cap it must be rejected (never clamped) and the recorded quantity
+ * left exactly as it was before this fold. */
 const foldOutcomeValid = (
   error: ReturnType<typeof foldChild>,
   recordedQty: number | undefined,
+  prevRecordedQty: number | undefined,
   running: number,
   max: number,
 ): boolean =>
   running <= max
     ? error === null && recordedQty === running
-    : error !== null && recordedQty !== running;
+    : error !== null && recordedQty === prevRecordedQty;
 
 /** Mirror the production adapter's steps, purely (no DB; holidays default none):
  * build the tree, resolve each node's availability, run the walk. */
@@ -526,10 +528,17 @@ describe("fold selection algebra (property-based)", () => {
           const state = freshState();
           let running = 0;
           for (const q of qtys) {
+            const prevQty = state.quantities.get(1);
             const error = foldChild(state, child, q, 1, PARENT_ID, undefined);
             running += q;
             if (
-              !foldOutcomeValid(error, state.quantities.get(1), running, max)
+              !foldOutcomeValid(
+                error,
+                state.quantities.get(1),
+                prevQty,
+                running,
+                max,
+              )
             ) {
               return false;
             }


### PR DESCRIPTION
## What this changes

A property-based test in `test/shared/booking/fold-tree.test.ts` checks how the booking "fold" behaves when someone tries to add more of a child item than is allowed. When the total goes over the cap, the fold should be rejected and the already-counted quantity should stay exactly as it was.

The old check was too loose in two ways:
- It only checked the recorded quantity "wasn't the attempted total" — which doesn't actually prove the previous count was left alone.
- It only checked that *some* error came back, not that it was the right one — so an unrelated failure could have slipped through and still looked correct.

## What it now does

- Remembers the counted quantity from just before each fold and asserts a rejected fold leaves it exactly unchanged.
- Asserts the rejection returns the specific "capacity exceeded" message, not just any error.

No product code changed — this only tightens the test so it can't pass for the wrong reason. The matching follow-up note is removed from `TODO.md`.

## Checks

- Lint and type-check pass.
- The fold-tree test suite passes (5 tests, 26 steps), including the property test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)