### PR TITLE
Harden payments.ts tests to 100% mutation kill rate

### DIFF
--- a/test/shared/payments.test.ts
+++ b/test/shared/payments.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { type Spy, spy } from "@std/testing/mock";
 import * as v from "valibot";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
+import { setSuppressDebugLogs } from "#shared/logger.ts";
 import {
   type BookingItem,
   BookingItemsSchema,
@@ -47,6 +49,14 @@ describe("booking line validation", () => {
     accepts(validItem); // neither
     rejects({ ...validItem, k: "p" }); // k without r
     rejects({ ...validItem, r: 1 }); // r without k
+  });
+
+  test("the paired-edge-tag rejection carries its explanatory message", () => {
+    const result = v.safeParse(BookingItemsSchema, [{ ...validItem, k: "p" }]);
+    expect(result.success).toBe(false);
+    expect(result.issues?.map((issue) => issue.message)).toContain(
+      "edge tag k and r must both be present or both absent",
+    );
   });
 
   test("the listing id (e) must be a positive integer", () => {
@@ -104,8 +114,32 @@ describe("BookingItemsSchema", () => {
 });
 
 describeWithEnv("getActivePaymentProvider", { db: true }, () => {
+  let debugSpy: Spy;
+  const debugLogged = (needle: string): boolean =>
+    debugSpy.calls.some((call) => String(call.args[0]).includes(needle));
+
+  beforeEach(() => {
+    setSuppressDebugLogs(false);
+    debugSpy = spy(console, "debug");
+  });
+  afterEach(() => {
+    debugSpy.restore();
+    setSuppressDebugLogs(null);
+  });
+
   test("returns null when no provider is configured", async () => {
     expect(await getActivePaymentProvider()).toBeNull();
+    expect(
+      debugLogged("[Payment] No payment provider configured in settings"),
+    ).toBe(true);
+  });
+
+  test("logs the provider it resolves under the Payment category", async () => {
+    await settings.update.paymentProvider("stripe");
+    await getActivePaymentProvider();
+    expect(debugLogged("[Payment] Resolving payment provider: stripe")).toBe(
+      true,
+    );
   });
 
   test("returns null for a provider type the module doesn't recognise", async () => {


### PR DESCRIPTION
## What

`src/shared/payments.ts` was among the thinnest-tested source files per `deno task unit-tests-report` (a 3.18 src:test line ratio). Running the mutation suite over it confirmed the gap:

```
deno task mutation 'src/shared/payments.ts' 'test/shared/payments.test.ts'
```

**Before:** score 71.4% — 6 of 21 mutants survived. The gaps were the `BookingItem` paired-edge-tag refinement message and the `logDebug` calls in `getActivePaymentProvider`, neither of which any test asserted.

## Changes

Test-only changes in `test/shared/payments.test.ts`:

- Assert the paired-edge-tag (`k`/`r`) rejection surfaces its explanatory valibot message, not merely that validation fails.
- Un-suppress debug logs (`setSuppressDebugLogs(false)`) and spy `console.debug` to assert `getActivePaymentProvider` logs `No payment provider configured in settings` when unset, and `Resolving payment provider: <type>` under the `Payment` category when set.

**After:** score 100% — all 21 mutants killed.

Note: no source changes; `deno task cpd` reports 0 clones and the file typechecks/lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_