### PR TITLE
Wrap admin footer Chobble link in a span so it doesn't stretch

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -2214,8 +2214,9 @@ button.secondary:hover,
   gap: var(--space-s);
 }
 
-/* The Chobble link grows to fill, the utility links stay their natural width. */
-.admin-footer-top > a {
+/* The Chobble link's span grows to fill, keeping the link itself only as wide
+   as its text; the utility links stay their natural width. */
+.admin-footer-brand {
   flex: 1 1 auto;
   min-width: 0;
 }

--- a/src/ui/templates/admin/footer.tsx
+++ b/src/ui/templates/admin/footer.tsx
@@ -2,7 +2,8 @@
  * Admin footer.
  *
  * Rendered at the bottom of every admin page: a top row with the Chobble
- * Tickets link (growing to fill the space) on the left and inline utility links
+ * Tickets link (wrapped in a span that grows to fill the space, so the link
+ * itself stays only as wide as its text) on the left and inline utility links
  * on the right, all always on one line; and, when query
  * logging is active, a debug menu (render time, SQL queries, cache stats) on a
  * row below them.
@@ -136,9 +137,9 @@ export const adminFooterHtml = (
 ): string =>
   `<footer class="admin-footer">` +
   `<div class="admin-footer-top">` +
-  `<a href="https://github.com/chobbledotcom/tickets">${t(
+  `<span class="admin-footer-brand"><a href="https://github.com/chobbledotcom/tickets">${t(
     "admin.footer.chobble_tickets",
-  )}</a>` +
+  )}</a></span>` +
   `<div class="admin-footer-links">${footerLinks(adminLevel)}</div>` +
   "</div>" +
   (debug

--- a/test/lib/footer.test.ts
+++ b/test/lib/footer.test.ts
@@ -218,6 +218,13 @@ describe("adminFooterHtml", () => {
     expect(html).toContain("Chobble Tickets</a>");
   });
 
+  test("wraps the Chobble link in a span so it doesn't stretch the row", () => {
+    const html = adminFooterHtml(null, "owner");
+    expect(html).toContain(
+      '<span class="admin-footer-brand"><a href="https://github.com/chobbledotcom/tickets">Chobble Tickets</a></span>',
+    );
+  });
+
   test("staff see log, guide, and logout links separated by dots", () => {
     const html = adminFooterHtml(null, "owner");
     expect(html).toContain('<div class="admin-footer-links">');


### PR DESCRIPTION
## Problem

The "Chobble Tickets" link in the admin footer stretched its clickable area across the full width of the footer row. The flex-grow (`flex: 1 1 auto`) sat directly on the anchor, so the link itself — not just its slot — expanded to fill the space and push the utility links to the right.

## Fix

- Wrap the anchor in an `.admin-footer-brand` span in `footer.tsx`.
- Move the flex-grow from `.admin-footer-top > a` onto `.admin-footer-brand` in `style.scss`.

The span now fills the row (still pushing the log/guide/logout links to the right), while the anchor is only as wide as its text.

## Tests

Added a test in `test/lib/footer.test.ts` asserting the link is wrapped in the `.admin-footer-brand` span. Existing footer assertions (`Chobble Tickets</a>`, the GitHub href, the utility links) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDWsMiCAvouQhmGRwpDN7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDWsMiCAvouQhmGRwpDN7s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the admin footer layout so the Chobble Tickets brand link expands into available space while utility links retain their natural width.
  * Preserved the existing link destination and translated label.
* **Tests**
  * Added coverage to verify the updated footer markup and brand-link structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->