### PR TITLE
Add merge check workflow

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches-ignore: [main]
 
+concurrency:
+  group: merge-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   merge-check:
     runs-on: ubicloud-standard-2
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -1,0 +1,22 @@
+name: Merge Check
+
+on:
+  push:
+    branches-ignore: [main]
+
+jobs:
+  merge-check:
+    runs-on: ubicloud-standard-2
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check branch merges cleanly into main
+        run: |
+          git config user.email "ci@example.com"
+          git config user.name "CI"
+          git fetch origin main
+          git merge --no-commit --no-ff origin/main


### PR DESCRIPTION
Adds a minimal CI workflow that fails when the branch cannot be cleanly merged into `main`.

## What it does

- Runs on every push to non-`main` branches (mirrors `test.yml`'s trigger).
- Checks out the full history (`fetch-depth: 0`), fetches `main`, and attempts `git merge --no-commit --no-ff origin/main`. If the merge hits conflicts, git exits non-zero and the step (and job) fails.
- Runs on `ubicloud-standard-2` as requested — no Deno or dependencies needed since it's pure git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAp98yQWxL4hQSCKqR5gDA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated merge validation for pushes to non-main branches.
  * Checks whether changes can be merged cleanly with the latest main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->