### PR TITLE
Share Claude Code settings for this repo: fewer prompts, auto-setup, auto-format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,59 @@
 {
   "permissions": {
     "allow": [
-      "mcp__Claude_Code_Remote__send_later"
+      "mcp__Claude_Code_Remote__send_later",
+      "Bash(./setup.sh)",
+      "Bash(mise install)",
+      "Bash(deno task test)",
+      "Bash(deno task test:*)",
+      "Bash(deno task typecheck)",
+      "Bash(deno task lint)",
+      "Bash(deno task lint:ci)",
+      "Bash(deno task cpd)",
+      "Bash(deno task precommit)",
+      "Bash(deno task precommit:*)",
+      "Bash(deno task mutation:*)",
+      "Bash(deno task line-counts)",
+      "Bash(deno task find-unused-src)",
+      "Bash(mise exec -- deno task test)",
+      "Bash(mise exec -- deno task test:*)",
+      "Bash(mise exec -- deno task typecheck)",
+      "Bash(mise exec -- deno task lint)",
+      "Bash(mise exec -- deno task lint:ci)",
+      "Bash(mise exec -- deno task cpd)",
+      "Bash(mise exec -- deno task precommit)",
+      "Bash(mise exec -- deno task precommit:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./setup.sh",
+            "timeout": 300,
+            "statusMessage": "Installing pinned Deno toolchain and caching deps..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json|*.jsonc|*.css) D=$(command -v deno || echo \"$HOME/.deno/bin/deno\"); \"$D\" run -A scripts/biome.ts check --write \"$f\" ;; esac; } 2>/dev/null || true"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,7 @@
       "Bash(deno task cpd)",
       "Bash(deno task precommit)",
       "Bash(deno task precommit:*)",
+      "Bash(deno task mutation)",
       "Bash(deno task mutation:*)",
       "Bash(deno task line-counts)",
       "Bash(deno task find-unused-src)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,9 +26,8 @@
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)",
-      "Bash(git show:*)",
-      "Bash(git branch:*)",
-      "Bash(git fetch:*)"
+      "Bash(git branch --show-current)",
+      "Bash(git fetch origin:*)"
     ]
   },
   "hooks": {
@@ -37,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./setup.sh",
+            "command": "./setup.sh && { D=\"$HOME/.deno/bin/deno\"; if [ -x \"$D\" ]; then mkdir -p \"$HOME/.local/bin\" && ln -sf \"$D\" \"$HOME/.local/bin/deno\"; [ -n \"${CLAUDE_ENV_FILE:-}\" ] && printf 'export PATH=\"%s/.local/bin:%s/.deno/bin:$PATH\"\\n' \"$HOME\" \"$HOME\" >> \"$CLAUDE_ENV_FILE\"; fi; } || true",
             "timeout": 300,
             "statusMessage": "Installing pinned Deno toolchain and caching deps..."
           }

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ ARCHITECTURE.md
 deploy/certs/*.pem
 .i18n-work/
 .jscpd-*
-.claude/
+.claude/*
+!.claude/settings.json
 
 # Test artifacts from storage tests run without LOCAL_STORAGE_PATH set
 /undefined/


### PR DESCRIPTION
## What this does

Adds a small, checked-in Claude Code settings file (`.claude/settings.json`) that teaches Claude this repo's own habits, so every session — and every teammate — gets the same helpful behaviour instead of answering the same prompts over and over. Four things:

**1. Stops the "Allow Claude to use send later?" prompt**
Claude schedules quiet check-ins for itself (e.g. "re-look at this pull request's tests in an hour") using a tool called `send_later`. Without a saved answer it asked every single time. Now it's always allowed.

**2. Stops prompting for the routine safety checks**
The project's own workflow has Claude constantly running the `deno task` checks (tests, typecheck, lint, duplication, mutation, and the required `precommit` before finishing) plus read-only git commands like `status` and `diff`. These are safe and repeatable, so they're pre-approved — no more clicking "allow" mid-task. Both the plain and `mise exec --` forms are covered.

**3. Gets a fresh session ready to work on its own**
Web sessions start in a brand-new, empty container. A start-up step now runs `./setup.sh`, which installs the pinned Deno version and caches dependencies so tests and the linter work from the very first turn. It's the repo's documented setup script, it's safe to re-run, and it skips the slow full test run by default.

**4. Keeps edited files tidy automatically**
After Claude writes or edits a file, it now runs Biome (the project's formatter) on just that file, so changes stay consistent with the house style and CI. It only touches file types Biome handles and never blocks an edit if something's off.

## The `.gitignore` change

The whole `.claude/` folder was ignored, so none of this could be shared. It now ignores the folder's *contents* but keeps this one shared settings file tracked (`.claude/*` + `!.claude/settings.json`). Anything personal or local under `.claude/` stays ignored exactly as before.

## Why check it in

Web sessions run in a throwaway container, so a setting saved only in the home directory disappears when the session ends. Committing it to the repo makes the preferences stick for every future session and applies for anyone else working here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QycWbEqwfARZicJQ1FbpR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration for automated development-tool permissions and session/workflow hooks.
  * Runs `./setup.sh` on session start (with a timeout), creates a stable Deno executable link, and updates `PATH` when applicable.
  * After supported file types are written or edited, automatically runs a formatting/lint check for the changed file without blocking on failures.
  * Updated repository ignore rules so the primary Claude settings stay version-controlled while other local Claude files remain ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->