### PR TITLE
Harden listing aggregates template tests to 100% mutation kill rate

### DIFF
--- a/test/ui/templates/admin/listings/aggregates.test.ts
+++ b/test/ui/templates/admin/listings/aggregates.test.ts
@@ -1,6 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { adminListingRecalculatePage } from "#templates/admin/listings/aggregates.tsx";
+import {
+  adminListingRecalculatePage,
+  ListingAggregateMismatchNotice,
+  ListingAggregateMismatchRow,
+} from "#templates/admin/listings/aggregates.tsx";
 import {
   registerListingTemplateHooks,
   TEST_SESSION,
@@ -8,6 +12,12 @@ import {
 import { testListingWithCount } from "#test-utils/factories.ts";
 
 registerListingTemplateHooks();
+
+/** booked_quantity mismatches (9 vs 4), tickets_count matches (5 vs 5). */
+const oneMismatch = {
+  booked_quantity: { current: 9, recalculated: 4 },
+  tickets_count: { current: 5, recalculated: 5 },
+};
 
 describe("adminListingRecalculatePage", () => {
   test("shows current and attendee-derived totals with checkboxes", () => {
@@ -29,5 +39,82 @@ describe("adminListingRecalculatePage", () => {
     expect(html).toContain('value="booked_quantity"');
     expect(html).toContain(">9<");
     expect(html).toContain(">4<");
+    // The recalculate page marks the Home nav entry (/admin/) active.
+    expect(html).toContain('<a class="active" href="/admin/">');
+  });
+});
+
+describe("ListingAggregateMismatchNotice", () => {
+  test("renders only the mismatched field with the error copy", () => {
+    const html = ListingAggregateMismatchNotice({
+      actionHref: "/admin/listings/recalculate/1",
+      aggregateRecalculation: oneMismatch,
+    })!.toString();
+
+    expect(html).toContain(
+      "Listing running totals do not match attendee rows.",
+    );
+    expect(html).toContain("Expected values come from attendee rows.");
+    expect(html).toContain(
+      '<a href="/admin/listings/recalculate/1">Review and recalculate totals</a>',
+    );
+    // booked_quantity drifted (expected 4, got 9); tickets_count matched.
+    expect(html).toContain(
+      "<strong>Total Attendees Ever</strong>: expected <strong>4</strong>, got <strong>9</strong>",
+    );
+    expect(html).not.toContain("Total Ticket Records");
+  });
+
+  test("renders no notice when there is no recalculation", () => {
+    const html = String(
+      ListingAggregateMismatchNotice({
+        actionHref: "/x",
+        aggregateRecalculation: undefined,
+      }),
+    );
+    expect(html).not.toContain("Listing running totals do not match");
+  });
+
+  test("renders no notice when every stored total already matches", () => {
+    const html = String(
+      ListingAggregateMismatchNotice({
+        actionHref: "/x",
+        aggregateRecalculation: {
+          booked_quantity: { current: 3, recalculated: 3 },
+          tickets_count: { current: 2, recalculated: 2 },
+        },
+      }),
+    );
+    expect(html).not.toContain("Listing running totals do not match");
+  });
+});
+
+describe("ListingAggregateMismatchRow", () => {
+  const listing = testListingWithCount({ name: "Workshop" });
+
+  test("wraps the mismatch notice in a labelled table row", () => {
+    const html = ListingAggregateMismatchRow({
+      aggregateRecalculation: oneMismatch,
+      listing,
+    })!.toString();
+
+    expect(html).toContain("<th>Running total check</th>");
+    expect(html).toContain(
+      "Listing running totals do not match attendee rows.",
+    );
+    expect(html).toContain(`/admin/listings/recalculate/${listing.id}`);
+    expect(html).toContain("Review and recalculate totals");
+    expect(html).toContain(
+      "<strong>Total Attendees Ever</strong>: expected <strong>4</strong>, got <strong>9</strong>",
+    );
+  });
+
+  test("is null when there is no mismatch", () => {
+    expect(
+      ListingAggregateMismatchRow({
+        aggregateRecalculation: undefined,
+        listing,
+      }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## What

`src/ui/templates/admin/listings/aggregates.tsx` was among the thinnest-tested source files per `deno task unit-tests-report` (a 4.61 src:test line ratio). Running the mutation suite over it confirmed the gap:

```
deno task mutation 'src/ui/templates/admin/listings/aggregates.tsx' \
                   'test/ui/templates/admin/listings/aggregates.test.ts'
```

**Before:** score 50% — 11 of 22 mutants survived. The existing test only rendered the recalculate page; the two mismatch-notice components and the empty/matching branches of `listingAggregateMismatchItems` were unverified.

## Changes

Test-only changes in `test/ui/templates/admin/listings/aggregates.test.ts`:

- **`ListingAggregateMismatchNotice`**: renders only the drifted field (expected vs got) with the error title, explanation, and action link; renders nothing when there is no recalculation or when every stored total already matches.
- **`ListingAggregateMismatchRow`**: wraps the notice in a labelled `<th>Running total check</th>` row pointing at the listing's recalculate path; null when there is no mismatch.
- Assert the recalculate page marks the `/admin/` (Home) nav entry active.

**After:** score 100% — all 22 mutants killed.

Note: no source changes; `deno task cpd` reports 0 clones and the file typechecks/lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for listing aggregate mismatch notices and table rows.
  * Verified expected-versus-actual values, recalculation links, and field labels.
  * Confirmed notices are hidden when no recalculation data exists or totals already match.
  * Verified the Admin navigation entry is marked active on the recalculation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->