### PR TITLE
Harden public error-page tests to 100% mutation kill rate

### DIFF
--- a/test/ui/templates/public/errors.test.ts
+++ b/test/ui/templates/public/errors.test.ts
@@ -84,24 +84,36 @@ describe("databaseBusyPage", () => {
 });
 
 describe("readOnlyPage", () => {
-  test("includes the renewal link when RENEWAL_URL is set", () => {
-    Deno.env.set("RENEWAL_URL", "https://example.com/renew");
+  // Capture and restore RENEWAL_URL so these env mutations don't leak into
+  // other tests, whatever the value was (or wasn't) beforehand.
+  const withRenewalUrl = (value: string | undefined, run: () => void): void => {
+    const original = Deno.env.get("RENEWAL_URL");
+    if (value === undefined) Deno.env.delete("RENEWAL_URL");
+    else Deno.env.set("RENEWAL_URL", value);
     try {
+      run();
+    } finally {
+      if (original === undefined) Deno.env.delete("RENEWAL_URL");
+      else Deno.env.set("RENEWAL_URL", original);
+    }
+  };
+
+  test("includes the renewal link when RENEWAL_URL is set", () => {
+    withRenewalUrl("https://example.com/renew", () => {
       const html = readOnlyPage();
       expect(html).toContain("This site is in read-only mode.");
       expect(html).toContain(
         '<a href="https://example.com/renew">Renew now</a>',
       );
-    } finally {
-      Deno.env.delete("RENEWAL_URL");
-    }
+    });
   });
 
   test("omits the renewal link when RENEWAL_URL is unset", () => {
-    Deno.env.delete("RENEWAL_URL");
-    const html = readOnlyPage();
-    expect(html).toContain("This site is in read-only mode.");
-    expect(html).not.toContain("Renew now");
+    withRenewalUrl(undefined, () => {
+      const html = readOnlyPage();
+      expect(html).toContain("This site is in read-only mode.");
+      expect(html).not.toContain("Renew now");
+    });
   });
 });
 

--- a/test/ui/templates/public/errors.test.ts
+++ b/test/ui/templates/public/errors.test.ts
@@ -1,8 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  databaseBusyPage,
   migrationInProgressPage,
   notFoundPage,
+  qrBookErrorPage,
+  rateLimitedPage,
+  readOnlyPage,
   siteNotActivatedPage,
   temporaryErrorPage,
 } from "#templates/public/errors.tsx";
@@ -26,6 +30,78 @@ describe("temporaryErrorPage", () => {
     expect(html).toContain('content="2"');
     expect(html).toContain("<style>");
     expect(html).toContain("font-family:system-ui");
+    // Points at Bunny's status page, with the space before the link kept.
+    expect(html).toContain(
+      'Check <strong><a href="https://status.bunny.net/">status.bunny.net</a>',
+    );
+  });
+});
+
+describe("qrBookErrorPage", () => {
+  test("offers the normal booking page when the listing has a slug", () => {
+    const html = qrBookErrorPage("summer-fete");
+    expect(html).toContain("<h1>QR code expired or invalid</h1>");
+    expect(html).toContain("This QR code has expired");
+    expect(html).toContain(
+      '<a href="/ticket/summer-fete">Go to booking page</a>',
+    );
+  });
+
+  test("omits the booking link when there is no standalone page", () => {
+    const html = qrBookErrorPage(null);
+    expect(html).toContain("This QR code has expired");
+    expect(html).not.toContain("Go to booking page");
+    expect(html).not.toContain('href="/ticket/');
+  });
+});
+
+describe("rateLimitedPage", () => {
+  test("renders the too-many-requests message", () => {
+    const html = rateLimitedPage();
+    expect(html).toContain("<h1>Too Many Requests</h1>");
+    expect(html).toContain("You've hit too many invalid ticket links.");
+  });
+});
+
+describe("databaseBusyPage", () => {
+  test("auto-refreshes and reassures when the method is idempotent", () => {
+    const html = databaseBusyPage(true);
+    expect(html).toContain("<h1>The database is too busy.</h1>");
+    expect(html).toContain('http-equiv="refresh"');
+    expect(html).toContain("Reloading so you can try again.");
+    expect(html).not.toContain("your submission was not saved");
+  });
+
+  test("skips the refresh and asks to resubmit for non-idempotent methods", () => {
+    const html = databaseBusyPage(false);
+    expect(html).toContain("<h1>The database is too busy.</h1>");
+    expect(html).not.toContain('http-equiv="refresh"');
+    expect(html).toContain(
+      "Please go back and try again — your submission was not saved.",
+    );
+    expect(html).not.toContain("Reloading so you can try again.");
+  });
+});
+
+describe("readOnlyPage", () => {
+  test("includes the renewal link when RENEWAL_URL is set", () => {
+    Deno.env.set("RENEWAL_URL", "https://example.com/renew");
+    try {
+      const html = readOnlyPage();
+      expect(html).toContain("This site is in read-only mode.");
+      expect(html).toContain(
+        '<a href="https://example.com/renew">Renew now</a>',
+      );
+    } finally {
+      Deno.env.delete("RENEWAL_URL");
+    }
+  });
+
+  test("omits the renewal link when RENEWAL_URL is unset", () => {
+    Deno.env.delete("RENEWAL_URL");
+    const html = readOnlyPage();
+    expect(html).toContain("This site is in read-only mode.");
+    expect(html).not.toContain("Renew now");
   });
 });
 

--- a/test/ui/templates/public/errors.test.ts
+++ b/test/ui/templates/public/errors.test.ts
@@ -11,6 +11,7 @@ import {
   temporaryErrorPage,
 } from "#templates/public/errors.tsx";
 import { registerPublicTemplateHooks } from "#test/templates/public/helpers.ts";
+import { setTestEnv } from "#test-utils/env.ts";
 
 registerPublicTemplateHooks();
 
@@ -84,17 +85,14 @@ describe("databaseBusyPage", () => {
 });
 
 describe("readOnlyPage", () => {
-  // Capture and restore RENEWAL_URL so these env mutations don't leak into
-  // other tests, whatever the value was (or wasn't) beforehand.
+  // Set RENEWAL_URL through the worker-local overlay (not the shared process
+  // env, which parallel test files read) and restore it afterwards.
   const withRenewalUrl = (value: string | undefined, run: () => void): void => {
-    const original = Deno.env.get("RENEWAL_URL");
-    if (value === undefined) Deno.env.delete("RENEWAL_URL");
-    else Deno.env.set("RENEWAL_URL", value);
+    const restore = setTestEnv({ RENEWAL_URL: value });
     try {
       run();
     } finally {
-      if (original === undefined) Deno.env.delete("RENEWAL_URL");
-      else Deno.env.set("RENEWAL_URL", original);
+      restore();
     }
   };
 


### PR DESCRIPTION
## What

`src/ui/templates/public/errors.tsx` was among the thinnest-tested source files per `deno task unit-tests-report` (a 3.11 src:test line ratio). Running the mutation suite over it confirmed the gap:

```
deno task mutation 'src/ui/templates/public/errors.tsx' \
                   'test/ui/templates/public/errors.test.ts'
```

**Before:** score 38% — 21 of 34 mutants survived. The existing test covered only the not-found, temporary, migration, and not-activated pages; four whole pages plus the temporary page's status link were unverified.

## Changes

Test-only changes in `test/ui/templates/public/errors.test.ts`:

- **`qrBookErrorPage`**: renders the `/ticket/<slug>` booking link when the listing has a slug; omits it (and any `/ticket/` href) when the slug is `null`.
- **`rateLimitedPage`**: renders the too-many-requests message.
- **`databaseBusyPage`**: auto-refreshes with the reload message for idempotent requests; skips the refresh and asks to resubmit for non-idempotent ones.
- **`readOnlyPage`**: includes the renewal link when `RENEWAL_URL` is set, omits it when unset.
- Assert the temporary page's `status.bunny.net` link and the spacing before it.

**After:** score 100% — all 34 mutants killed.

Note: no source changes; `deno task cpd` reports 0 clones and the file typechecks/lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded UI test coverage for public error pages, including temporary errors, QR booking errors (with and without booking context), rate-limited states, database busy states (idempotent vs non-idempotent refresh and messaging), and read-only renewal behavior.
  * Added assertions for rendered status links, booking details, auto-refresh behavior, and renewal messaging driven by an environment-provided renewal URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->