### PR TITLE
Harden data-table component tests to 100% mutation kill rate

### DIFF
--- a/test/ui/templates/components/data-table.test.tsx
+++ b/test/ui/templates/components/data-table.test.tsx
@@ -1,7 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  type Column,
   type DataColumn,
+  DataTable,
   dataTable,
 } from "#templates/components/data-table.tsx";
 
@@ -72,5 +74,42 @@ describe("dataTable", () => {
     ])(rows);
     String(indexed);
     expect(seen).toEqual({ count: 2, i: 1 });
+  });
+
+  test("wraps the table in a plain table-scroll div by default", () => {
+    const html = String(dataTable(columns)(rows));
+    expect(html).toContain('<div class="table-scroll">');
+  });
+
+  test("renders a tfoot only when foot content is given", () => {
+    expect(String(dataTable(columns)(rows))).not.toContain("<tfoot>");
+
+    const withFoot = String(
+      dataTable(columns)(rows, { foot: <tr>{<td>Total</td>}</tr> }),
+    );
+    expect(withFoot).toContain("<tfoot><tr><td>Total</td></tr></tfoot>");
+  });
+});
+
+describe("DataTable row shapes", () => {
+  const cols: Column[] = [{ header: "H" }];
+
+  test("wraps positional cell arrays in tr/td", () => {
+    const html = String(DataTable({ columns: cols, rows: [["cell-a"]] }));
+    expect(html).toContain("<tbody><tr><td>cell-a</td></tr></tbody>");
+  });
+
+  test("renders pre-built <tr> elements as-is", () => {
+    const html = String(
+      DataTable({ columns: cols, rows: [<tr>{<td>pre</td>}</tr>] }),
+    );
+    expect(html).toContain("<tbody><tr><td>pre</td></tr></tbody>");
+  });
+
+  test("passes a pre-rendered HTML string straight into the tbody", () => {
+    const html = String(
+      DataTable({ columns: cols, rows: "<tr><td>raw</td></tr>" }),
+    );
+    expect(html).toContain("<tbody><tr><td>raw</td></tr></tbody>");
   });
 });

--- a/test/ui/templates/components/data-table.test.tsx
+++ b/test/ui/templates/components/data-table.test.tsx
@@ -76,26 +76,26 @@ describe("dataTable", () => {
     expect(seen).toEqual({ count: 2, i: 1 });
   });
 
-  test("wraps the table in a plain table-scroll div by default", () => {
-    // No scrollClass and no tableClass — the wrapper opens exactly here.
-    const html = String(dataTable(columns)(rows));
-    expect(html.startsWith('<div class="table-scroll"><table><thead>')).toBe(
-      true,
-    );
+  // The full serialisation for the `columns`/`rows` fixtures, parameterised by
+  // the optional <tfoot> — asserted exactly so a stray node fails.
+  const dtTable = (foot = ""): string =>
+    `<div class="table-scroll"><table>` +
+    `<thead><tr><th>Name</th><th class="col-amount">Amount</th></tr></thead>` +
+    `<tbody><tr><td><a href="/r/1">First</a></td>` +
+    `<td class="col-amount">10</td></tr>` +
+    `<tr><td><a href="/r/2">Second</a></td>` +
+    `<td class="col-amount">20</td></tr></tbody>${foot}</table></div>`;
+
+  test("wraps the table in a plain table-scroll div with no tfoot by default", () => {
+    // No scrollClass/tableClass and no foot — the whole serialisation is fixed.
+    expect(String(dataTable(columns)(rows))).toBe(dtTable());
   });
 
-  test("renders a tfoot, in its exact place, only when foot content is given", () => {
-    // Without foot the table closes straight after the body — no tfoot node.
-    expect(
-      String(dataTable(columns)(rows)).endsWith("</tbody></table></div>"),
-    ).toBe(true);
-
+  test("renders the tfoot in its exact place when foot content is given", () => {
     const withFoot = String(
       dataTable(columns)(rows, { foot: <tr>{<td>Total</td>}</tr> }),
     );
-    expect(withFoot).toContain(
-      "</tbody><tfoot><tr><td>Total</td></tr></tfoot></table></div>",
-    );
+    expect(withFoot).toBe(dtTable("<tfoot><tr><td>Total</td></tr></tfoot>"));
   });
 });
 

--- a/test/ui/templates/components/data-table.test.tsx
+++ b/test/ui/templates/components/data-table.test.tsx
@@ -77,39 +77,51 @@ describe("dataTable", () => {
   });
 
   test("wraps the table in a plain table-scroll div by default", () => {
+    // No scrollClass and no tableClass — the wrapper opens exactly here.
     const html = String(dataTable(columns)(rows));
-    expect(html).toContain('<div class="table-scroll">');
+    expect(html.startsWith('<div class="table-scroll"><table><thead>')).toBe(
+      true,
+    );
   });
 
-  test("renders a tfoot only when foot content is given", () => {
-    expect(String(dataTable(columns)(rows))).not.toContain("<tfoot>");
+  test("renders a tfoot, in its exact place, only when foot content is given", () => {
+    // Without foot the table closes straight after the body — no tfoot node.
+    expect(
+      String(dataTable(columns)(rows)).endsWith("</tbody></table></div>"),
+    ).toBe(true);
 
     const withFoot = String(
       dataTable(columns)(rows, { foot: <tr>{<td>Total</td>}</tr> }),
     );
-    expect(withFoot).toContain("<tfoot><tr><td>Total</td></tr></tfoot>");
+    expect(withFoot).toContain(
+      "</tbody><tfoot><tr><td>Total</td></tr></tfoot></table></div>",
+    );
   });
 });
 
 describe("DataTable row shapes", () => {
   const cols: Column[] = [{ header: "H" }];
+  // The full serialisation for a single "H" column, parameterised by the tbody
+  // contents — asserted exactly so a stray or misplaced node fails the test.
+  const table = (body: string): string =>
+    `<div class="table-scroll"><table><thead><tr><th>H</th></tr></thead>` +
+    `<tbody>${body}</tbody></table></div>`;
 
   test("wraps positional cell arrays in tr/td", () => {
-    const html = String(DataTable({ columns: cols, rows: [["cell-a"]] }));
-    expect(html).toContain("<tbody><tr><td>cell-a</td></tr></tbody>");
+    expect(String(DataTable({ columns: cols, rows: [["cell-a"]] }))).toBe(
+      table("<tr><td>cell-a</td></tr>"),
+    );
   });
 
   test("renders pre-built <tr> elements as-is", () => {
-    const html = String(
-      DataTable({ columns: cols, rows: [<tr>{<td>pre</td>}</tr>] }),
-    );
-    expect(html).toContain("<tbody><tr><td>pre</td></tr></tbody>");
+    expect(
+      String(DataTable({ columns: cols, rows: [<tr>{<td>pre</td>}</tr>] })),
+    ).toBe(table("<tr><td>pre</td></tr>"));
   });
 
   test("passes a pre-rendered HTML string straight into the tbody", () => {
-    const html = String(
-      DataTable({ columns: cols, rows: "<tr><td>raw</td></tr>" }),
-    );
-    expect(html).toContain("<tbody><tr><td>raw</td></tr></tbody>");
+    expect(
+      String(DataTable({ columns: cols, rows: "<tr><td>raw</td></tr>" })),
+    ).toBe(table("<tr><td>raw</td></tr>"));
   });
 });


### PR DESCRIPTION
## What

`src/ui/templates/components/data-table.tsx` was among the thinnest-tested source files per `deno task unit-tests-report` (a 2.24 src:test line ratio). Running the mutation suite over it confirmed the gap:

```
deno task mutation 'src/ui/templates/components/data-table.tsx' \
                   'test/ui/templates/components/data-table.test.tsx' --harness
```

**Before:** score 75% — 5 of 20 mutants survived. The existing test only drove the typed `dataTable` builder (which always produces positional cell rows), leaving `DataTable`'s row-shape dispatch (`isCellRows`), the default scroll wrapper, and the `tfoot` guard unverified.

## Changes

Test-only changes in `test/ui/templates/components/data-table.test.tsx`:

- **`DataTable` row shapes**: positional cell arrays wrap in `tr`/`td`; pre-built `<tr>` elements render as-is; a pre-rendered HTML string passes straight into the `tbody` — pinning each arm of the `isCellRows` discriminator.
- Assert the default plain `table-scroll` wrapper (when no `scrollClass` is given).
- Assert a `tfoot` renders only when `foot` content is provided.

**After:** score 100% — all 20 mutants killed.

Note: no source changes; `deno task cpd` reports 0 clones and the file typechecks/lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgTfkjf2X9LhxVbP8DF8Wb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for the default outer table wrapper behavior.
  * Added tests verifying optional footer (`tfoot`) rendering and its DOM placement.
  * Expanded coverage for supported row inputs, including positional cell arrays, pre-built table row elements, and HTML strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->