### PR TITLE
Strengthen the overlap test and add a test for the order-option builders

### DIFF
--- a/test/shared/db/attendees/overlap.test.ts
+++ b/test/shared/db/attendees/overlap.test.ts
@@ -2,14 +2,17 @@
  * `getOverlappingBookings` — the Logistics tab's "Other Attendees" query.
  *
  * Locks the half-open overlap contract (`start_at < windowEnd AND end_at >
- * windowStart`), the exclusions (the queried attendee itself, no-quantity rows,
- * date-less bookings) and the earliest-first ordering directly, rather than
- * only through the logistics-tab route test that renders it.
+ * windowStart`), the exclusions (the queried attendee itself, servicing-kind
+ * rows, no-quantity rows, date-less bookings), that overlaps are found across
+ * every listing and every booking row, and the earliest-first ordering —
+ * directly, rather than only through the logistics-tab route test that renders
+ * it.
  */
 
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { createAttendeeAtomic } from "#shared/db/attendees/api.ts";
+import { SERVICING_KIND } from "#shared/db/attendees/kind.ts";
 import { getOverlappingBookings } from "#shared/db/attendees/overlap.ts";
 import { dateToRange } from "#shared/db/capacity.ts";
 import { execute } from "#shared/db/client.ts";
@@ -19,55 +22,82 @@ import {
   createTestListing,
 } from "#test-utils/db-helpers/listings.ts";
 
-/** The window every test queries against: 2030-03-10 (inclusive) to 2030-03-12
- *  (exclusive), built the same way the booked ranges are so the boundary
- *  comparisons use matching stored formats. */
-const WINDOW = dateToRange("2030-03-10", 2);
+/**
+ * The query window, with each bound made byte-for-byte equal to the stored
+ * range column of the exactly-adjacent booking it must tie with. SQLite
+ * compares TEXT byte-by-byte, and a stored `start_at` ("…T00:00:00Z") and
+ * `end_at` ("…T00:00:00.000Z") use different suffixes — so a window built the
+ * obvious way (`dateToRange("2030-03-10", 2)`) would exclude the adjacent rows
+ * on a *formatting* mismatch instead of on the strict `<`/`>` overlap check,
+ * and a change of those operators to inclusive ones would slip through. Anchor
+ * the bounds instead:
+ *   - startAt === adjacentBefore.end_at  ("2030-03-10T00:00:00.000Z")
+ *   - endAt   === adjacentAfter.start_at ("2030-03-12T00:00:00Z")
+ * so at each boundary the row's instant equals the window's exactly, and only
+ * the strictness of the operator decides inclusion.
+ */
+const WINDOW = {
+  endAt: dateToRange("2030-03-12", 1).startAt,
+  startAt: dateToRange("2030-03-08", 2).endAt,
+};
 
-/** Book one attendee onto `listingId` and return their id. `date`/`durationDays`
- *  make it a dated range; omit `date` for a date-less booking. */
-const book = async (
-  name: string,
-  listingId: number,
-  booking: { date?: string; durationDays?: number; quantity?: number } = {},
-): Promise<number> => {
-  const result = await createAttendeeAtomic({
-    bookings: [{ listingId, ...booking }],
-    email: "",
-    name,
-  });
+type BookingLine = {
+  listingId: number;
+  date?: string;
+  durationDays?: number;
+  quantity?: number;
+};
+
+/** Book one attendee with the given booking line(s) and return their id. */
+const book = async (name: string, bookings: BookingLine[]): Promise<number> => {
+  const result = await createAttendeeAtomic({ bookings, email: "", name });
   // The fixtures always have capacity, so the create always succeeds.
   return (result as Extract<typeof result, { success: true }>).attendees[0]!.id;
 };
 
+/** Book one attendee onto a single listing. Omit `date` for a date-less
+ *  booking. */
+const bookOne = (
+  name: string,
+  listingId: number,
+  booking: Omit<BookingLine, "listingId"> = {},
+): Promise<number> => book(name, [{ listingId, ...booking }]);
+
+const overlappingIds = async (excludeId: number): Promise<number[]> =>
+  (await getOverlappingBookings(excludeId, WINDOW.startAt, WINDOW.endAt)).map(
+    (row) => row.attendee_id,
+  );
+
 describeWithEnv("db > attendees > overlap", { db: true }, () => {
   /** A daily listing with a cast of bookings around the query window: one for
    *  the "current" attendee (excluded), two genuine overlappers, and three that
-   *  must be filtered out (two exactly adjacent, one far away). */
+   *  must be filtered out (two exactly adjacent, one far away). The later-dated
+   *  overlapper is created first so booking ids run opposite to booking dates —
+   *  the earliest-first assertion then fails if the query orders by id. */
   const overlapFixture = async () => {
     const daily = await createDailyTestListing({ maxAttendees: 50 });
-    const self = await book("Self", daily.id, {
+    const self = await bookOne("Self", daily.id, {
       date: "2030-03-10",
       durationDays: 2,
     });
-    const before = await book("Before Overlap", daily.id, {
-      date: "2030-03-08",
-      durationDays: 3,
-    });
-    const inside = await book("Inside", daily.id, {
+    const inside = await bookOne("Inside", daily.id, {
       date: "2030-03-11",
       durationDays: 1,
       quantity: 2,
     });
-    const adjacentBefore = await book("Adjacent Before", daily.id, {
+    const before = await bookOne("Before Overlap", daily.id, {
+      date: "2030-03-08",
+      durationDays: 3,
+    });
+    const adjacentBefore = await bookOne("Adjacent Before", daily.id, {
       date: "2030-03-08",
       durationDays: 2,
     });
-    const adjacentAfter = await book("Adjacent After", daily.id, {
+    const adjacentAfter = await bookOne("Adjacent After", daily.id, {
       date: "2030-03-12",
       durationDays: 1,
     });
-    const far = await book("Far Away", daily.id, {
+    const far = await bookOne("Far Away", daily.id, {
       date: "2030-05-01",
       durationDays: 1,
     });
@@ -91,6 +121,8 @@ describeWithEnv("db > attendees > overlap", { db: true }, () => {
 
   test("lists other attendees' overlapping bookings, earliest start first", async () => {
     const f = await overlapFixture();
+    // `before` was created after `inside`, so it has the higher id but the
+    // earlier date — this only equals [before, inside] under a start_at sort.
     expect(f.ids).toEqual([f.before, f.inside]);
   });
 
@@ -128,9 +160,56 @@ describeWithEnv("db > attendees > overlap", { db: true }, () => {
     );
   });
 
+  test("excludes an overlapping booking held by a servicing (non-attendee) row", async () => {
+    const daily = await createDailyTestListing({ maxAttendees: 50 });
+    const servicing = await bookOne("Servicing Hold", daily.id, {
+      date: "2030-03-10",
+      durationDays: 2,
+    });
+    // Turn the booking into a servicing hold — a real non-customer row the
+    // overlap query filters out with `attendee.kind = 'attendee'`.
+    await execute("UPDATE attendees SET kind = ? WHERE id = ?", [
+      SERVICING_KIND,
+      servicing,
+    ]);
+    expect(await overlappingIds(0)).not.toContain(servicing);
+  });
+
+  test("includes an overlapper booked on a different listing", async () => {
+    const listingA = await createDailyTestListing({ maxAttendees: 50 });
+    const listingB = await createDailyTestListing({ maxAttendees: 50 });
+    const current = await bookOne("Current On A", listingA.id, {
+      date: "2030-03-10",
+      durationDays: 1,
+    });
+    const onB = await bookOne("Other On B", listingB.id, {
+      date: "2030-03-11",
+      durationDays: 1,
+    });
+    // The window is date-based, not listing-scoped: someone booked on a
+    // different listing in the same days is still an "other attendee".
+    expect(await overlappingIds(current)).toContain(onB);
+  });
+
+  test("returns every overlapping row of an attendee with several bookings", async () => {
+    const listingA = await createDailyTestListing({ maxAttendees: 50 });
+    const listingB = await createDailyTestListing({ maxAttendees: 50 });
+    const multi = await book("Two Bookings", [
+      { date: "2030-03-10", durationDays: 1, listingId: listingA.id },
+      { date: "2030-03-11", durationDays: 1, listingId: listingB.id },
+    ]);
+    const rows = (
+      await getOverlappingBookings(0, WINDOW.startAt, WINDOW.endAt)
+    ).filter((row) => row.attendee_id === multi);
+    // Both booking lines overlap, so both rows come back — not one per attendee.
+    expect(rows.map((row) => row.listing_id).sort()).toEqual(
+      [listingA.id, listingB.id].sort(),
+    );
+  });
+
   test("excludes a no-quantity booking that would otherwise overlap", async () => {
     const daily = await createDailyTestListing({ maxAttendees: 50 });
-    const zero = await book("Zero Quantity", daily.id, {
+    const zero = await bookOne("Zero Quantity", daily.id, {
       date: "2030-03-10",
       durationDays: 2,
     });
@@ -140,28 +219,19 @@ describeWithEnv("db > attendees > overlap", { db: true }, () => {
       "UPDATE listing_attendees SET quantity = 0 WHERE attendee_id = ?",
       [zero],
     );
-    const results = await getOverlappingBookings(
-      0,
-      WINDOW.startAt,
-      WINDOW.endAt,
-    );
-    expect(results.map((row) => row.attendee_id)).not.toContain(zero);
+    expect(await overlappingIds(0)).not.toContain(zero);
   });
 
   test("excludes a date-less booking, keeping only the dated overlapper", async () => {
     const standard = await createTestListing({ maxAttendees: 10 });
-    const dateless = await book("Dateless", standard.id);
+    const dateless = await bookOne("Dateless", standard.id);
     const daily = await createDailyTestListing({ maxAttendees: 50 });
-    const dated = await book("Dated", daily.id, {
+    const dated = await bookOne("Dated", daily.id, {
       date: "2030-03-11",
       durationDays: 1,
     });
-    const results = await getOverlappingBookings(
-      0,
-      WINDOW.startAt,
-      WINDOW.endAt,
-    );
-    expect(results.map((row) => row.attendee_id)).toEqual([dated]);
-    expect(results.map((row) => row.attendee_id)).not.toContain(dateless);
+    const ids = await overlappingIds(0);
+    expect(ids).toEqual([dated]);
+    expect(ids).not.toContain(dateless);
   });
 });

--- a/test/shared/order/options.test.ts
+++ b/test/shared/order/options.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The order selection model's option builders — the pure `listingOption` /
+ * `packageOption` shapes and their key helpers. These feed the availability
+ * evaluator (tested in order-evaluate.test.ts); this file locks their own
+ * data-in/data-out contract directly: the wire keys, the "needs a date" rule,
+ * and the per-listing unit counts a single selection books.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  listingOption,
+  listingOptionKey,
+  packageOption,
+  packageOptionKey,
+} from "#shared/order/options.ts";
+
+describe("order > options", () => {
+  describe("key helpers", () => {
+    test("listingOptionKey namespaces a listing id", () => {
+      expect(listingOptionKey(5)).toBe("listing:5");
+    });
+
+    test("packageOptionKey namespaces a group id", () => {
+      expect(packageOptionKey(3)).toBe("package:3");
+    });
+  });
+
+  describe("listingOption", () => {
+    const standard = { id: 5, listing_type: "standard", name: "Workshop" };
+
+    test("books one unit of its own listing under the listing key", () => {
+      const option = listingOption(standard, true);
+      expect(option.key).toBe("listing:5");
+      expect(option.name).toBe("Workshop");
+      expect([...option.unitsByListingId]).toEqual([[5, 1]]);
+    });
+
+    test("a standard listing does not need a date", () => {
+      expect(listingOption(standard, true).needsDate).toBe(false);
+    });
+
+    test("a daily listing needs a date", () => {
+      const daily = { id: 7, listing_type: "daily", name: "Day Pass" };
+      expect(listingOption(daily, true).needsDate).toBe(true);
+    });
+
+    test("carries the caller's bookable-alone verdict through unchanged", () => {
+      expect(listingOption(standard, true).bookableAlone).toBe(true);
+      expect(listingOption(standard, false).bookableAlone).toBe(false);
+    });
+  });
+
+  describe("packageOption", () => {
+    const group = { id: 3, name: "Weekend Bundle" };
+    const members = [
+      { id: 10, listing_type: "standard" },
+      { id: 11, listing_type: "standard" },
+    ];
+
+    test("books each member at its per-package quantity under the package key", () => {
+      const option = packageOption(
+        group,
+        members,
+        new Map([
+          [10, 2],
+          [11, 3],
+        ]),
+        true,
+      );
+      expect(option.key).toBe("package:3");
+      expect(option.name).toBe("Weekend Bundle");
+      expect([...option.unitsByListingId]).toEqual([
+        [10, 2],
+        [11, 3],
+      ]);
+    });
+
+    test("a member without a listed quantity defaults to one unit", () => {
+      const option = packageOption(group, members, new Map([[10, 2]]), true);
+      // Member 11 is absent from the quantities map, so it falls back to 1.
+      expect([...option.unitsByListingId]).toEqual([
+        [10, 2],
+        [11, 1],
+      ]);
+    });
+
+    test("keeps an explicit zero quantity instead of defaulting it to one", () => {
+      const option = packageOption(
+        group,
+        members,
+        new Map([
+          [10, 0],
+          [11, 4],
+        ]),
+        true,
+      );
+      // A listed 0 is a real per-package quantity — distinct from an absent
+      // member, which would fall back to 1.
+      expect([...option.unitsByListingId]).toEqual([
+        [10, 0],
+        [11, 4],
+      ]);
+    });
+
+    test("needs a date when any member is a daily listing", () => {
+      const withDaily = [
+        { id: 10, listing_type: "standard" },
+        { id: 11, listing_type: "daily" },
+      ];
+      expect(packageOption(group, withDaily, new Map(), true).needsDate).toBe(
+        true,
+      );
+    });
+
+    test("does not need a date when every member is non-daily", () => {
+      expect(packageOption(group, members, new Map(), true).needsDate).toBe(
+        false,
+      );
+    });
+
+    test("carries the caller's bookable-alone verdict through unchanged", () => {
+      expect(
+        packageOption(group, members, new Map(), false).bookableAlone,
+      ).toBe(false);
+      expect(packageOption(group, members, new Map(), true).bookableAlone).toBe(
+        true,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Two test-only follow-ups from the unit-tests report's "flagged example" work.

## Stronger "other attendees on these days" test

The previous PR added a test for the Logistics tab's overlap query. An automated review pointed out a few ways that test could pass even if the query broke, so this tightens it up:

- **The "just touching" cases now genuinely test the rule.** Two bookings where one ends on the exact day the other begins should *not* count as overlapping. It turns out the old test excluded them for an incidental reason (a difference in how timestamps are written), so it would have kept passing even if that rule were flipped. The window is now lined up exactly with those edge bookings, so the test only passes when the day range really is treated as "up to but not including" the end. Confirmed by temporarily flipping the rule and watching these tests fail.
- **The earliest-first ordering is really checked.** The bookings are now created in an order that makes their internal ids run opposite to their dates, so the "earliest first" check only passes if the results are actually sorted by date.
- **Three gaps are now covered:** a staff "servicing" hold is left out of the list, someone booked on a *different* listing on the same days is still included, and an attendee with two bookings in the window shows both.

## New test for the order-option builders

The report also flagged `src/shared/order/options.ts` as having no test of its own. It's the small, pure piece that describes each thing you can pick when ordering (a listing or a whole package). This adds a direct test covering the buyer-facing keys, the "needs a date chosen first" rule, how many units each pick books, and that a package member explicitly set to zero stays zero rather than defaulting to one.

No behaviour changes — both are tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011GrobXJsoo8StWaWFbwFo1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded booking overlap coverage for date boundaries, filtering, ordering, cross-listing results, and multiple booking rows.
  * Added validation that servicing and date-less bookings, as well as bookings with no quantity, are excluded.
  * Added comprehensive tests for listing and package order options, including identifiers, dates, quantities, and standalone booking settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->