### PR TITLE
Add a test for the shared "send us a message" form helpers

### DIFF
--- a/test/shared/inbound-message.test.ts
+++ b/test/shared/inbound-message.test.ts
@@ -7,7 +7,7 @@
  * most importantly — that every caller-supplied value is HTML-escaped in the
  * HTML body so a submitted message can't inject markup into the notification
  * email. The IO helpers lock the provider fallback (settings → host env, with a
- * logged miss) and that a send is judged delivered only on a 2xx response.
+ * logged miss) and that a send is judged delivered only on a below-300 response.
  */
 
 import { expect } from "@std/expect";
@@ -66,12 +66,17 @@ describe("inbound-message", () => {
       );
     });
 
-    test("prepends a bold warning when one is given", () => {
+    test("prepends a bold warning paragraph when one is given", () => {
       const html = buildMessageHtml(
         { fromLabel: "a@b.com", message: "hello", warning: "Heads up" },
         "New message",
       );
-      expect(html.startsWith("<p><strong>Heads up</strong></p>")).toBe(true);
+      expect(html).toBe(
+        "<p><strong>Heads up</strong></p>" +
+          "<p>New message</p>" +
+          "<p><strong>From:</strong> a@b.com</p>" +
+          "<p><strong>Message:</strong></p><p>hello</p>",
+      );
     });
 
     test("turns newlines in the message into <br>", () => {
@@ -79,7 +84,11 @@ describe("inbound-message", () => {
         { fromLabel: "a@b.com", message: "line1\nline2", warning: null },
         "New message",
       );
-      expect(html).toContain("<p>line1<br>line2</p>");
+      expect(html).toBe(
+        "<p>New message</p>" +
+          "<p><strong>From:</strong> a@b.com</p>" +
+          "<p><strong>Message:</strong></p><p>line1<br>line2</p>",
+      );
     });
 
     test("HTML-escapes the intro, from label, message, and warning", () => {
@@ -129,20 +138,36 @@ describe("inbound-message", () => {
     const errors = setupErrorSpy();
     afterEach(sandbox.teardown);
 
+    const hostConfig: EmailConfig = {
+      apiKey: "host-key",
+      fromAddress: validEmail("host-sender@sending.test"),
+      provider: "resend",
+    };
+
     test("falls back to the host provider config when settings has none", async () => {
-      const hostConfig: EmailConfig = {
-        apiKey: "host-key",
-        fromAddress: validEmail("sender@sending.test"),
-        provider: "resend",
-      };
+      settings.setForTest({ email_api_key: "", email_provider: "" });
       setHostEmailConfigForTest(hostConfig);
       expect(await resolveMessageEmailConfig()).toEqual(hostConfig);
       // The "no provider" miss must not be logged when one was resolved.
       expect(errors.contains("no email provider configured")).toBe(false);
     });
 
+    test("prefers the settings provider config over the host one", async () => {
+      settings.setForTest({
+        business_email: "owner@example.com",
+        email_api_key: "settings-key",
+        email_provider: "resend",
+      });
+      setHostEmailConfigForTest(hostConfig);
+      expect(await resolveMessageEmailConfig()).toEqual({
+        apiKey: "settings-key",
+        fromAddress: validEmail("owner@example.com"),
+        provider: "resend",
+      });
+    });
+
     test("returns null and logs the miss when no provider is configured", async () => {
-      settings.setForTest({ email_provider: "" });
+      settings.setForTest({ email_api_key: "", email_provider: "" });
       setHostEmailConfigForTest(null);
       expect(await resolveMessageEmailConfig()).toBeNull();
       expect(
@@ -171,22 +196,38 @@ describe("inbound-message", () => {
       to: validEmail("dest@example.com"),
     });
 
-    test("sends the built bodies and returns true on a 2xx response", async () => {
+    /** Stub the provider to answer `status` and return deliverMessage's verdict. */
+    const deliverWith = (status: number): Promise<boolean> => {
+      sandbox.captureFetchCall(status);
+      return deliverMessage(config, opts());
+    };
+
+    test("sends the full built payload to the provider on success", async () => {
       const captured = sandbox.captureFetchCall(200);
       expect(await deliverMessage(config, opts())).toBe(true);
       expect(captured.url).toBe("https://api.resend.com/emails");
       expect(captured.body.to).toEqual(["dest@example.com"]);
-      expect(String(captured.body.html)).toContain(
-        "<strong>From:</strong> visitor@example.com",
+      expect(captured.body.from).toBe("sender@sending.test");
+      expect(captured.body.subject).toBe("A subject");
+      expect(captured.body.html).toBe(
+        "<p>New message</p>" +
+          "<p><strong>From:</strong> visitor@example.com</p>" +
+          "<p><strong>Message:</strong></p><p>Hello</p>",
       );
-      expect(String(captured.body.text)).toContain("From: visitor@example.com");
+      expect(captured.body.text).toBe(
+        "New message\n\nFrom: visitor@example.com\n\nMessage:\nHello",
+      );
+    });
+
+    test("counts a response below 300 as delivered, 300 and above as failed", async () => {
+      // The contract is `status < 300`, so 299 delivers and 300 does not — this
+      // pins the exact boundary rather than a vaguer "2xx" range.
+      expect(await deliverWith(299)).toBe(true);
+      expect(await deliverWith(300)).toBe(false);
     });
 
     test("returns false when the provider responds with a 5xx error", async () => {
-      sandbox.stubFetch(() =>
-        Promise.resolve(new Response("nope", { status: 500 })),
-      );
-      expect(await deliverMessage(config, opts())).toBe(false);
+      expect(await deliverWith(500)).toBe(false);
     });
   });
 });

--- a/test/shared/inbound-message.test.ts
+++ b/test/shared/inbound-message.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The shared pieces of the "send us a message" email forms: the message-field
+ * validator, the HTML/plain-text notification body builders, provider
+ * resolution, and the low-level send.
+ *
+ * The builders lock the free-text length rule, the exact body layout, and —
+ * most importantly — that every caller-supplied value is HTML-escaped in the
+ * HTML body so a submitted message can't inject markup into the notification
+ * email. The IO helpers lock the provider fallback (settings → host env, with a
+ * logged miss) and that a send is judged delivered only on a 2xx response.
+ */
+
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { settings } from "#shared/db/settings.ts";
+import { type EmailConfig, setHostEmailConfigForTest } from "#shared/email.ts";
+import {
+  buildMessageHtml,
+  buildMessageText,
+  deliverMessage,
+  MESSAGE_SEND_FAILED,
+  resolveMessageEmailConfig,
+  validateMessageText,
+} from "#shared/inbound-message.ts";
+import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
+import { emailTestSandbox, validEmail } from "#test-utils/email.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
+
+describe("inbound-message", () => {
+  test("MESSAGE_SEND_FAILED is the submitter-facing failure copy", () => {
+    expect(MESSAGE_SEND_FAILED).toBe(
+      "Sorry, your message could not be sent. Please try again later.",
+    );
+  });
+
+  describe("validateMessageText", () => {
+    test("rejects an empty message", () => {
+      expect(validateMessageText("")).toBe("Please enter a message.");
+    });
+
+    test("accepts a normal message", () => {
+      expect(validateMessageText("Hello there")).toBeNull();
+    });
+
+    test("accepts a message exactly at the length limit", () => {
+      expect(validateMessageText("a".repeat(MAX_TEXTAREA_LENGTH))).toBeNull();
+    });
+
+    test("rejects a message one character over the limit", () => {
+      expect(validateMessageText("a".repeat(MAX_TEXTAREA_LENGTH + 1))).toBe(
+        `Message must be ${MAX_TEXTAREA_LENGTH} characters or fewer.`,
+      );
+    });
+  });
+
+  describe("buildMessageHtml", () => {
+    test("lays out intro, from, and message with no warning", () => {
+      const html = buildMessageHtml(
+        { fromLabel: "a@b.com", message: "hello", warning: null },
+        "New message",
+      );
+      expect(html).toBe(
+        "<p>New message</p>" +
+          "<p><strong>From:</strong> a@b.com</p>" +
+          "<p><strong>Message:</strong></p><p>hello</p>",
+      );
+    });
+
+    test("prepends a bold warning when one is given", () => {
+      const html = buildMessageHtml(
+        { fromLabel: "a@b.com", message: "hello", warning: "Heads up" },
+        "New message",
+      );
+      expect(html.startsWith("<p><strong>Heads up</strong></p>")).toBe(true);
+    });
+
+    test("turns newlines in the message into <br>", () => {
+      const html = buildMessageHtml(
+        { fromLabel: "a@b.com", message: "line1\nline2", warning: null },
+        "New message",
+      );
+      expect(html).toContain("<p>line1<br>line2</p>");
+    });
+
+    test("HTML-escapes the intro, from label, message, and warning", () => {
+      const html = buildMessageHtml(
+        { fromLabel: "<a>", message: '1 < 2 & "q"', warning: "<b>" },
+        "in<ro",
+      );
+      expect(html).toBe(
+        "<p><strong>&lt;b&gt;</strong></p>" +
+          "<p>in&lt;ro</p>" +
+          "<p><strong>From:</strong> &lt;a&gt;</p>" +
+          "<p><strong>Message:</strong></p><p>1 &lt; 2 &amp; &quot;q&quot;</p>",
+      );
+    });
+  });
+
+  describe("buildMessageText", () => {
+    test("lays out intro, from, and message with no warning", () => {
+      const text = buildMessageText(
+        { fromLabel: "a@b.com", message: "hello", warning: null },
+        "New message",
+      );
+      expect(text).toBe("New message\n\nFrom: a@b.com\n\nMessage:\nhello");
+    });
+
+    test("prepends the warning followed by a blank line", () => {
+      const text = buildMessageText(
+        { fromLabel: "a@b.com", message: "hello", warning: "Heads up" },
+        "New message",
+      );
+      expect(text).toBe(
+        "Heads up\n\nNew message\n\nFrom: a@b.com\n\nMessage:\nhello",
+      );
+    });
+
+    test("leaves the plain-text body unescaped", () => {
+      const text = buildMessageText(
+        { fromLabel: "<a>", message: "1 < 2", warning: null },
+        "intro",
+      );
+      expect(text).toBe("intro\n\nFrom: <a>\n\nMessage:\n1 < 2");
+    });
+  });
+
+  describe("resolveMessageEmailConfig", () => {
+    const sandbox = emailTestSandbox();
+    const errors = setupErrorSpy();
+    afterEach(sandbox.teardown);
+
+    test("falls back to the host provider config when settings has none", async () => {
+      const hostConfig: EmailConfig = {
+        apiKey: "host-key",
+        fromAddress: validEmail("sender@sending.test"),
+        provider: "resend",
+      };
+      setHostEmailConfigForTest(hostConfig);
+      expect(await resolveMessageEmailConfig()).toEqual(hostConfig);
+      // The "no provider" miss must not be logged when one was resolved.
+      expect(errors.contains("no email provider configured")).toBe(false);
+    });
+
+    test("returns null and logs the miss when no provider is configured", async () => {
+      settings.setForTest({ email_provider: "" });
+      setHostEmailConfigForTest(null);
+      expect(await resolveMessageEmailConfig()).toBeNull();
+      expect(
+        errors.contains("message form: no email provider configured"),
+      ).toBe(true);
+    });
+  });
+
+  describe("deliverMessage", () => {
+    const sandbox = emailTestSandbox();
+    afterEach(sandbox.teardown);
+
+    const config: EmailConfig = {
+      apiKey: "key",
+      fromAddress: validEmail("sender@sending.test"),
+      provider: "resend",
+    };
+    const opts = () => ({
+      body: {
+        fromLabel: "visitor@example.com",
+        message: "Hello",
+        warning: null,
+      },
+      intro: "New message",
+      subject: "A subject",
+      to: validEmail("dest@example.com"),
+    });
+
+    test("sends the built bodies and returns true on a 2xx response", async () => {
+      const captured = sandbox.captureFetchCall(200);
+      expect(await deliverMessage(config, opts())).toBe(true);
+      expect(captured.url).toBe("https://api.resend.com/emails");
+      expect(captured.body.to).toEqual(["dest@example.com"]);
+      expect(String(captured.body.html)).toContain(
+        "<strong>From:</strong> visitor@example.com",
+      );
+      expect(String(captured.body.text)).toContain("From: visitor@example.com");
+    });
+
+    test("returns false when the provider responds with a 5xx error", async () => {
+      sandbox.stubFetch(() =>
+        Promise.resolve(new Response("nope", { status: 500 })),
+      );
+      expect(await deliverMessage(config, opts())).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Our unit-tests report flagged `src/shared/inbound-message.ts` as having no test of its own. It's the shared code behind two forms — the public "contact us" form and the admin "support" form — which both turn a short typed message into an email. Until now those helpers were only ever run as a side effect of testing the whole form flows.

This adds a direct test for them.

## What it checks

- **The message length rule.** An empty message is rejected, a normal one is accepted, and the limit is exact: a message right at the maximum length is allowed, one character over is refused with the right message.
- **The email body layout.** Both the HTML and plain-text versions of the notification email are built in the expected shape, with an optional bold warning line at the top, and line breaks in the message shown correctly.
- **Safety of what people type.** The important one: anything a visitor types is escaped in the HTML email, so a message containing things that look like web markup can't inject anything into the email that's sent. The plain-text version is deliberately left as typed.
- **Choosing where to send from.** It uses the site's own email settings first and falls back to the host's settings, and when nothing is configured it sends nothing and records why.
- **Judging success.** A message counts as delivered only when the email provider actually accepts it, and is treated as failed when the provider errors.

No behaviour changes — this is a test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011GrobXJsoo8StWaWFbwFo1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for message validation, formatting (HTML/plain text), escaping of user-provided fields, newline handling, and warning behavior.
  * Added length-limit tests, including exact error messaging at the maximum allowed input.
  * Added email configuration resolution tests for fallback, preference, and missing-provider handling.
  * Added delivery tests that verify outbound request details and success/failure based on provider response status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->