### PR TITLE
Add a test for the ledger "adjust this figure" corrections

### DIFF
--- a/test/shared/accounting/ledger-tx.test.ts
+++ b/test/shared/accounting/ledger-tx.test.ts
@@ -64,6 +64,14 @@ describe("db > accounting > ledger-tx", () => {
     expect(await readIncome(1)).toBe(8000);
   });
 
+  test("correct.income lowers income onto a lower target", async () => {
+    await postListingSale({ attendeeId: 1, gross: 5000, listingId: 1 });
+    // Steering down to 2000 posts a negative delta (a write-off debit) — the
+    // reverse direction of the raise above.
+    await inOwnTx(ledgerTx.correct.income)(1, 2000);
+    expect(await readIncome(1)).toBe(2000);
+  });
+
   test("correct.owed lowers what an attendee owes onto the target", async () => {
     // An unpaid sale leaves attendee 1 owing 5000.
     await postTransfers([
@@ -81,11 +89,32 @@ describe("db > accounting > ledger-tx", () => {
     expect(await readOwed(1)).toBe(2000);
   });
 
-  test("correct.modifierRevenue moves a modifier's net revenue onto the target", async () => {
+  test("correct.owed raises what an attendee owes onto a higher target", async () => {
+    await postTransfers([
+      tx({
+        destination: account("revenue", 1),
+        reference: "unpaid-sale",
+        source: account("attendee", 1),
+      }),
+    ]);
+    // Raising owed 5000 → 7000 is the reverse direction: it debits the attendee
+    // (owed moves against the target, so a higher target posts a negative credit).
+    await inOwnTx(ledgerTx.correct.owed)(1, 7000);
+    expect(await readOwed(1)).toBe(7000);
+  });
+
+  test("correct.modifierRevenue raises a modifier's net revenue onto the target", async () => {
     await postModifierLeg({ delta: 1000, modifierId: 3 });
     expect(await readModifierRevenue(3)).toBe(1000);
 
     await inOwnTx(ledgerTx.correct.modifierRevenue)(3, 2500);
     expect(await readModifierRevenue(3)).toBe(2500);
+  });
+
+  test("correct.modifierRevenue lowers a modifier's net revenue onto the target", async () => {
+    await postModifierLeg({ delta: 2500, modifierId: 3 });
+    // The reverse direction: steering revenue down to 1000 posts a negative delta.
+    await inOwnTx(ledgerTx.correct.modifierRevenue)(3, 1000);
+    expect(await readModifierRevenue(3)).toBe(1000);
   });
 });

--- a/test/shared/accounting/ledger-tx.test.ts
+++ b/test/shared/accounting/ledger-tx.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `ledgerTx` — the in-transaction ledger facade — and `inOwnTx`.
+ *
+ * The leaf `…Tx` reads/writes are tested in their own modules; this locks the
+ * facade's own behaviour: that each `correct.X` reads its paired figure and
+ * posts the single adjustment that moves it onto the target, that the sign is
+ * right (income/revenue move WITH the target, what's owed moves AGAINST it),
+ * that re-submitting the same target posts nothing (the read-then-write
+ * idempotency the corrections rely on), and that `inOwnTx` runs a correction in
+ * its own transaction.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { inOwnTx, ledgerTx } from "#shared/accounting/ledger-tx.ts";
+import { allTransfers } from "#shared/accounting/queries.ts";
+import { postTransfers } from "#shared/accounting/store.ts";
+import { withTransaction } from "#shared/db/client.ts";
+import { account } from "#shared/ledger/account.ts";
+import {
+  postListingSale,
+  postModifierLeg,
+  tx,
+  useTransactionalDb,
+} from "#test-utils/ledger.ts";
+
+const readIncome = (listingId: number): Promise<number> =>
+  withTransaction((scope) => ledgerTx.read.income(scope, listingId));
+const readOwed = (attendeeId: number): Promise<number> =>
+  withTransaction((scope) => ledgerTx.read.owed(scope, attendeeId));
+const readModifierRevenue = (modifierId: number): Promise<number> =>
+  withTransaction((scope) => ledgerTx.read.modifierRevenue(scope, modifierId));
+
+describe("db > accounting > ledger-tx", () => {
+  useTransactionalDb();
+
+  test("read.income reflects sales and correct.income moves it onto the target", async () => {
+    await postListingSale({ attendeeId: 1, gross: 5000, listingId: 1 });
+    expect(await readIncome(1)).toBe(5000);
+
+    await inOwnTx(ledgerTx.correct.income)(1, 8000);
+    expect(await readIncome(1)).toBe(8000);
+  });
+
+  test("correct.income raises a figure from zero when nothing was posted yet", async () => {
+    // A correction from a zero baseline: the credit posted is the whole target.
+    await inOwnTx(ledgerTx.correct.income)(9, 700);
+    expect(await readIncome(9)).toBe(700);
+  });
+
+  test("a correction posts one adjustment leg; re-correcting to it posts none", async () => {
+    await postListingSale({ attendeeId: 1, gross: 5000, listingId: 1 });
+    const beforeCorrection = (await allTransfers()).length;
+
+    // Moving income onto a new target posts exactly one adjustment leg…
+    await inOwnTx(ledgerTx.correct.income)(1, 8000);
+    const afterFirst = (await allTransfers()).length;
+    expect(afterFirst).toBe(beforeCorrection + 1);
+
+    // …and re-submitting the same target computes a zero delta, so nothing else
+    // is posted and the figure holds.
+    await inOwnTx(ledgerTx.correct.income)(1, 8000);
+    expect((await allTransfers()).length).toBe(afterFirst);
+    expect(await readIncome(1)).toBe(8000);
+  });
+
+  test("correct.owed lowers what an attendee owes onto the target", async () => {
+    // An unpaid sale leaves attendee 1 owing 5000.
+    await postTransfers([
+      tx({
+        destination: account("revenue", 1),
+        reference: "unpaid-sale",
+        source: account("attendee", 1),
+      }),
+    ]);
+    expect(await readOwed(1)).toBe(5000);
+
+    // Owed is the account balance's NEGATION, so it moves AGAINST the target —
+    // steering it to 2000 credits the attendee, it does not bill them 3000 more.
+    await inOwnTx(ledgerTx.correct.owed)(1, 2000);
+    expect(await readOwed(1)).toBe(2000);
+  });
+
+  test("correct.modifierRevenue moves a modifier's net revenue onto the target", async () => {
+    await postModifierLeg({ delta: 1000, modifierId: 3 });
+    expect(await readModifierRevenue(3)).toBe(1000);
+
+    await inOwnTx(ledgerTx.correct.modifierRevenue)(3, 2500);
+    expect(await readModifierRevenue(3)).toBe(2500);
+  });
+});


### PR DESCRIPTION
Our unit-tests report flagged `src/shared/accounting/ledger-tx.ts` as having no test of its own. It's the small "menu" of accounting corrections behind the admin *adjust this figure* forms — the ones that let an operator set a listing's recognised income, what an attendee owes, or a discount/surcharge's revenue to a specific number.

Each correction reads the current figure, works out the difference from the number the operator typed, and posts a single balancing entry to reach it. The individual read and write steps are already tested elsewhere; this adds a test for the corrections themselves.

## What it checks

- **Setting a listing's income to a target works** — both when there's already income and when starting from zero.
- **Re-entering the same number does nothing.** A correction posts exactly one balancing entry; submitting the same target again works out a difference of zero and posts nothing, so an operator saving the form twice can't double it up. (This "read then write in one go" is also what keeps two people saving at once from both adding the difference.)
- **Clearing what someone owes goes the right way.** This is the money-safety check: "what's owed" moves in the opposite direction to income, so steering an attendee's balance to a lower number must *credit* them (reduce the debt), not bill them more. A wiring mistake here would inflate the debt instead of clearing it — the test would catch it.
- **Setting a discount/surcharge's revenue to a target works.**

No behaviour changes — this is a test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011GrobXJsoo8StWaWFbwFo1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for accounting corrections covering income, owed balances, and modifier revenue.
  * Verified corrections move each figure to the specified target, including from zero baseline cases.
  * Confirmed corrections are idempotent (reapplying the same target doesn’t add extra transfer legs).
  * Added assertions for owed behavior and ensured correction operations run within the helper’s own transaction context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->