### PR TITLE
Widen the public site to 1080px

### DIFF
--- a/src/ui/static/style.scss
+++ b/src/ui/static/style.scss
@@ -40,7 +40,7 @@
 
 /* Public-facing pages (no admin nav) get a narrower reading width */
 body:not(:has(#main-nav)) {
-  --width-content: 800px;
+  --width-content: 1080px;
 }
 
 :root[data-theme="dark"] {

--- a/src/ui/templates/public/shared.tsx
+++ b/src/ui/templates/public/shared.tsx
@@ -80,7 +80,7 @@ const rootItems = (
  * shared `leveledNav` the admin nav uses. It must NOT carry the admin nav's
  * `#main-nav` id: the stylesheet reads that id as "this is an admin page"
  * (full-bleed main, admin textarea sizing), while a public page keeps the
- * shared 800px reading width.
+ * shared 1080px reading width.
  */
 export const PublicNav = (props: PublicNavProps): JSX.Element =>
   leveledNav({


### PR DESCRIPTION
## What changed

The public-facing pages of the site — everything a visitor sees that isn't the admin area — used to be capped at an 800px reading width. This makes them wider, capping them at 1080px instead, so the public site uses more of the screen.

## Why

The public content column felt narrow on larger screens. Widening it to 1080px gives listings, order pages, and other public content more room without going full-bleed.

## What is *not* affected

- **Admin pages** stay exactly as they are. The stylesheet already treats a page as "admin" when it carries the `#main-nav` id and lets those pages span the full width, so they never used the 800px value in the first place.
- The **markdown preview dialog** only appears in the admin editor, so it keeps the admin width too.
- `--width-card-wide` (a separate 800px value used for form labels and cards) is untouched — only the page content width moved.
- On mobile the fluid side padding is unchanged; the wider cap only takes effect once the screen is bigger than the content.

## How it was checked

- The stylesheet compiles cleanly and the built CSS now carries the new 1080px value for public pages.
- The public page tests and the stylesheet-serving tests all pass.
- No test relied on the old 800px number, so nothing depended on the previous width.

Also refreshed a code comment in the public navigation that still mentioned the old 800px figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wRAZyt6mHLiboep7sN3BH

---
_Generated by [Claude Code](https://claude.ai/code/session_018wRAZyt6mHLiboep7sN3BH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded the content width of public-facing pages from 800px to 1080px, providing more room for page content.

* **Documentation**
  * Updated public page guidance to reflect the new 1080px reading width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->