### PR TITLE
Fix two servicing tests that weren't actually testing anything

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -746,27 +746,24 @@ diagnostic above) makes it pay for itself.
 db-module tests into `test/shared/db/attendees/servicing/` (plus a 4-line cwd
 fix in `code-quality.test.ts`). CodeRabbit reviewed the moved content as if new
 and raised 13 findings; every one is on **pre-existing** test code carried over
-unchanged from `main`, so they're out of scope for a rename-only PR and recorded
-here. Two of them look like genuinely ineffective tests — verify those first.*
+unchanged from `main`, so they were out of scope for a rename-only PR and
+recorded here.*
 
-**Likely-vacuous tests (check these first):**
+**Done — the two vacuous tests + the corruption-repair cleanups (a follow-up
+PR).** Both suspects were confirmed and fixed:
 
-- **`test/shared/db/attendees/servicing/corruption-repair.test.ts` (~lines 38-42,
-  assertions ~57-81)** — the setup does `UPDATE attendees SET kind = 'staff'`,
-  but `attendees.kind` has `CHECK (kind IN ('attendee','servicing'))`, so the
-  UPDATE throws and a `catch { return }` swallows it — the repair/exclusion
-  assertions after it may never run. Confirm whether the test is passing
-  vacuously; if so, either assert the UPDATE failure explicitly, or build the
-  corrupted row from a schema without that CHECK so the corrupted state actually
-  exists before the repair/exclusion checks.
-- **`test/shared/db/attendees/servicing/lifecycle-concurrency.test.ts`
-  (~lines 87-110)** — "deleting a listing that holds a servicing event orphans
-  the attendee" uses raw SQL deletes on `listings`/`listing_attendees`, bypassing
-  the production `deleteListing` (or `performListingDelete` for admin side
-  effects). It therefore doesn't exercise the deletion path it names. Route it
-  through the production helper.
+- `corruption-repair.test.ts` — the `UPDATE … kind = 'staff'` did throw under the
+  CHECK and was swallowed by `catch { return }`, so the exclusion assertions
+  never ran (confirmed empirically). Now the corrupt row is written past the
+  CHECK via `PRAGMA ignore_check_constraints` (libsql supports it), so the reader
+  predicates are genuinely exercised — and a separate test asserts the CHECK
+  rejects the write directly. The dead `queryOne` import, the `string | null`
+  param on `insertRowWithKind`, and the redundant dynamic imports were removed.
+- `lifecycle-concurrency.test.ts` (~87-110) — the raw SQL deletes were replaced
+  with the production `deleteListing`, and the orphan assertion strengthened
+  (attendee row survives; its booking on the deleted listing is gone).
 
-**Assertion-strengthening (all in
+**Remaining — assertion-strengthening (all in
 `test/shared/db/attendees/servicing/ledger.test.ts`):**
 
 - **Split the file (~741 lines, >400 guideline)** into focused modules
@@ -801,15 +798,6 @@ here. Two of them look like genuinely ineffective tests — verify those first.*
   passes even if the listing filter is ignored; add a second listing + cost and
   assert the result is exactly the requested listing's cost, excluding the other.
 
-**Trivial cleanups in
-`test/shared/db/attendees/servicing/corruption-repair.test.ts`:**
-
-- **`queryOne` import (~17, ~137-138)** — imported then `void`-ed with a comment
-  claiming `kindOf` needs it; `kindOf` is imported directly from
-  `#test-utils/servicing.ts`, so the import is dead — remove it.
-- **`insertRowWithKind` (~31-35)** — its only caller passes `"attendee"`, so the
-  `string | null` param and `kind ?? "null"` branch are dead; narrow to `string`.
-- **Dynamic imports (~77-80, ~109-117, ~129-131)** — `createRealAttendee`,
-  `renderAdminPage`, and `getServicingEvent` are `await import`-ed from
-  `#test-utils/servicing.ts`, which is already statically imported at the top;
-  none are heavy SDKs, so fold them into the static import.
+(The line numbers above are from before the two fixes landed; re-locate by the
+described symbols when picking these up. This ledger split + strengthening is the
+heavy remaining piece.)

--- a/test/shared/db/attendees/servicing/corruption-repair.test.ts
+++ b/test/shared/db/attendees/servicing/corruption-repair.test.ts
@@ -14,40 +14,48 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { SERVICING_KIND } from "#shared/db/attendees/kind.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
-import { getDb, queryOne } from "#shared/db/client.ts";
+import { getServicingEvent } from "#shared/db/attendees/servicing.ts";
+import { getDb } from "#shared/db/client.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import {
+  createRealAttendee,
   createServicingHold,
   kindOf,
+  renderAdminPage,
   servicingRowsForListing,
 } from "#test-utils/servicing.ts";
 
 // jscpd:ignore-end
 
-/** Insert a corrupted attendee row (bypassing the CHECK constraint is not
- *  possible at the SQL layer, so we simulate the post-migration state where
- *  a row somehow has an unexpected kind value). */
+/**
+ * Insert an attendee row with an arbitrary `kind` and a booking on `listingId`,
+ * returning its id. `attendees.kind` has a `CHECK (kind IN ('attendee',
+ * 'servicing'))`, so an unexpected value can't be written normally — this
+ * bypasses CHECK enforcement for the write (the SQLite/libsql
+ * `ignore_check_constraints` pragma) to reproduce the corrupt state a direct-DB
+ * repair, partial migration, or bad backup would leave, then restores it. Only
+ * the readers' `kind = ?` predicates then stand between that row and a surface.
+ */
 const insertRowWithKind = async (
-  kind: string | null,
+  kind: string,
   listingId: number,
 ): Promise<number> => {
-  const tokenIdx = `corrupt-${kind ?? "null"}-${crypto.randomUUID()}`;
-  const res = await getDb().execute({
-    args: [tokenIdx, kind],
-    // Only run this against a DB where the CHECK constraint is absent or
-    // the kind is valid — the test DB is created from the current SCHEMA,
-    // which (per §1) declares the CHECK. We insert with a valid kind and
-    // then UPDATE to the corrupted value, so the constraint is bypassed
-    // the way a direct-DB repair would bypass it.
-    sql: "INSERT INTO attendees (created, ticket_token_index, pii_blob, kind) VALUES ('2026-01-01T00:00:00Z', ?, '', ?)",
-  });
-  const id = Number(res.lastInsertRowid);
-  await getDb().execute({
-    args: [listingId, id],
-    sql: "INSERT INTO listing_attendees (listing_id, attendee_id, quantity, start_at, end_at) VALUES (?, ?, 1, '2026-07-01T00:00:00Z', '2026-07-02T00:00:00Z')",
-  });
-  return id;
+  await getDb().execute("PRAGMA ignore_check_constraints = true");
+  try {
+    const res = await getDb().execute({
+      args: [`corrupt-${kind}-${crypto.randomUUID()}`, kind],
+      sql: "INSERT INTO attendees (created, ticket_token_index, pii_blob, kind) VALUES ('2026-01-01T00:00:00Z', ?, '', ?)",
+    });
+    const id = Number(res.lastInsertRowid);
+    await getDb().execute({
+      args: [listingId, id],
+      sql: "INSERT INTO listing_attendees (listing_id, attendee_id, quantity, start_at, end_at) VALUES (?, ?, 1, '2026-07-01T00:00:00Z', '2026-07-02T00:00:00Z')",
+    });
+    return id;
+  } finally {
+    await getDb().execute("PRAGMA ignore_check_constraints = false");
+  }
 };
 
 describeWithEnv(
@@ -56,28 +64,34 @@ describeWithEnv(
   () => {
     test("an unknown kind value is excluded from both attendee and servicing readers", async () => {
       // A 'staff' row (neither 'attendee' nor 'servicing') must appear in NO
-      // reader — every surface filters on one of the two valid kinds.
+      // reader — every surface filters on one of the two valid kinds. The row
+      // is written past the CHECK so this exercises the reader predicates, not
+      // the constraint (which is tested by rejecting the write elsewhere).
       const listing = await createTestListing({ maxAttendees: 10, name: "L" });
-      // We can't insert 'staff' directly if the CHECK constraint is enforced;
-      // instead, insert as 'attendee' then corrupt it via UPDATE (the way a
-      // direct-DB repair would).
-      const id = await insertRowWithKind("attendee", listing.id);
-      try {
-        await getDb().execute({
-          args: ["staff", id],
-          sql: "UPDATE attendees SET kind = ? WHERE id = ?",
-        });
-      } catch {
-        return;
-      }
-      // The corrupted row does not appear in the attendee reader.
+      const id = await insertRowWithKind("staff", listing.id);
+
+      // The corrupted row does not appear in the attendee reader…
       const attendeeRows = await getAttendeesRaw(listing.id);
       expect(attendeeRows.some((a) => a.id === id)).toBe(false);
-      // It also does not appear in the servicing reader.
-      const { getServicingEvent } = await import(
-        "#shared/db/attendees/servicing.ts"
-      );
+      // …nor in the servicing reader.
       expect(await getServicingEvent(id)).toBeNull();
+    });
+
+    test("the CHECK constraint rejects writing an unknown kind directly", async () => {
+      // The first line of defence: without the pragma bypass, the DB itself
+      // refuses an out-of-range kind, so a corrupt row can't be created through
+      // normal SQL at all.
+      const res = await getDb().execute({
+        args: [`reject-${crypto.randomUUID()}`],
+        sql: "INSERT INTO attendees (created, ticket_token_index, pii_blob, kind) VALUES ('2026-01-01T00:00:00Z', ?, '', 'attendee')",
+      });
+      const id = Number(res.lastInsertRowid);
+      await expect(
+        getDb().execute({
+          args: ["staff", id],
+          sql: "UPDATE attendees SET kind = ? WHERE id = ?",
+        }),
+      ).rejects.toThrow();
     });
 
     test("an operator flipping kind from servicing to attendee via direct SQL flips the route guard", async () => {
@@ -107,7 +121,6 @@ describeWithEnv(
       // The upcoming-events table on the admin home must exclude real
       // attendees even when they're future-dated — it's a servicing-only view.
       await createTestListing({ maxAttendees: 10, name: "L" });
-      const { createRealAttendee } = await import("#test-utils/servicing.ts");
       const { attendee } = await createRealAttendee(
         "Future Real",
         "f@example.com",
@@ -126,13 +139,9 @@ describeWithEnv(
         listing: { name: "L" },
         name: "Future Service",
       });
-      const { renderAdminPage } = await import("#test-utils/servicing.ts");
       const body = await renderAdminPage("/admin/");
       expect(body).toContain(`/admin/servicing/${service.id}`);
       expect(body).not.toContain(`/admin/servicing/${attendee.id}`);
     });
   },
 );
-
-// `queryOne` imported for the kindOf helper's underlying query; keep it live.
-void queryOne;

--- a/test/shared/db/attendees/servicing/lifecycle-concurrency.test.ts
+++ b/test/shared/db/attendees/servicing/lifecycle-concurrency.test.ts
@@ -16,6 +16,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
+import { deleteListing } from "#shared/db/listings.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import {
@@ -94,19 +95,14 @@ describeWithEnv(
         name: "Doomed",
       });
       const { id } = await createServicingHold({ listing: { name: "Doomed" } });
-      // Delete the listing the real way (the admin route does this via a
-      // table rebuild that drops the row and cascades its listing_attendees).
-      const { getDb } = await import("#shared/db/client.ts");
-      await getDb().execute({
-        args: [listing.id],
-        sql: "DELETE FROM listings WHERE id = ?",
-      });
-      await getDb().execute({
-        args: [id],
-        sql: "DELETE FROM listing_attendees WHERE attendee_id = ?",
-      });
-      // The attendee row still exists (orphaned) until the purge sweeps it.
+      // Delete the listing through the production path — the same helper the
+      // admin delete route calls, which drops the listing and its
+      // listing_attendees bookings in one batch.
+      await deleteListing(listing.id);
+      // The attendee row survives — orphaned — until the purge sweeps it, but
+      // its booking on the deleted listing is gone.
       expect(await kindOf(id)).not.toBeNull();
+      expect(await servicingRowsForListing(listing.id)).toHaveLength(0);
     });
 
     test("duplicate while deleting: the delete wins, the duplicate rejects cleanly", async () => {

--- a/test/shared/db/attendees/servicing/lifecycle-concurrency.test.ts
+++ b/test/shared/db/attendees/servicing/lifecycle-concurrency.test.ts
@@ -15,6 +15,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { SERVICING_KIND } from "#shared/db/attendees/kind.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import { deleteListing } from "#shared/db/listings.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -99,9 +100,9 @@ describeWithEnv(
       // admin delete route calls, which drops the listing and its
       // listing_attendees bookings in one batch.
       await deleteListing(listing.id);
-      // The attendee row survives — orphaned — until the purge sweeps it, but
-      // its booking on the deleted listing is gone.
-      expect(await kindOf(id)).not.toBeNull();
+      // The servicing attendee row survives — orphaned — until the purge sweeps
+      // it, but its booking on the deleted listing is gone.
+      expect(await kindOf(id)).toBe(SERVICING_KIND);
       expect(await servicingRowsForListing(listing.id)).toHaveLength(0);
     });
 


### PR DESCRIPTION
When CodeRabbit reviewed the servicing test relocation (#1772), it flagged a batch of pre-existing issues that we recorded in `TODO.md` rather than fix in a rename-only PR. Two of them looked like tests that quietly weren't checking anything. I dug into both — they were real — and this fixes them.

## "An unknown kind value is excluded from both readers" (corruption-repair)

Every attendee row is either a real `attendee` or a `servicing` hold, and the database enforces that with a constraint. This test meant to prove that *if* a bad row with some other value ever slipped in (a botched restore, a hand-edit), none of the app's screens would show it.

But the test created the bad row by updating a normal row to the invalid value — which the database constraint **rejects**. That error was being silently caught and the test returned early, so none of its checks ever ran. It was passing by doing nothing (I verified this with a throwaway probe).

Now the test writes the bad row by temporarily switching off constraint-checking (the way a real corrupt backup would have bypassed it), so the actual "hide it from every screen" checks run for real — and they pass. I also added a small companion test confirming the database itself refuses to write an invalid value in the first place.

## "Deleting a listing orphans its servicing hold (real deleteListing path)" (lifecycle-concurrency)

This test's name and comment say it exercises the *real* listing-deletion path, but it was hand-writing its own `DELETE` statements — so it never actually ran the production deletion code. It now calls the real `deleteListing` helper and checks the outcome properly: the servicing attendee survives (orphaned) while its booking on the now-deleted listing is gone.

## Also

Cleaned up three small things in the corruption-repair file that were flagged alongside (a dead import, an unused nullable parameter, some needless lazy imports), and updated `TODO.md` to mark these done — the larger `ledger.test.ts` split and assertion-strengthening items are still listed as remaining.

No production code changed; these are test fixes. All servicing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011GrobXJsoo8StWaWFbwFo1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of corrupted attendee records and handling of unknown attendee kinds.
  * Corrected deletion behavior for listings so attendee/orphaning and servicing cleanup match expected lifecycle behavior.

* **Tests**
  * Updated database constraint simulations and clarified assertions for corrupted and future-dated attendees.
  * Adjusted concurrency/deletion coverage to use production-style deletion logic and stronger validations.

* **Documentation**
  * Refreshed the TODO notes to mark the related test areas as completed and updated guidance for remaining assertion work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->