### PR TITLE
Use one shared method for simple record links

### DIFF
--- a/src/features/admin/attributes.ts
+++ b/src/features/admin/attributes.ts
@@ -37,8 +37,8 @@ import {
   getAttributeListingUse,
   getAttributeWithOptions,
   getNextAttributeOptionSortOrder,
+  listingAttributeOptions,
   pruneInvalidAttributeOptionIds,
-  setListingAttributeOptions,
   swapAttributeOptionOrder,
   swapAttributeOrder,
 } from "#shared/db/attributes.ts";
@@ -361,7 +361,7 @@ const handleListingAttributesPost = createListingChoicePost({
       await getAllAttributeOptionIds(),
       form.getNumberArray("option_ids"),
     ),
-  saveIds: setListingAttributeOptions,
+  saveIds: listingAttributeOptions.setIds,
   tab: "attributes",
 });
 

--- a/src/features/admin/listings-form.ts
+++ b/src/features/admin/listings-form.ts
@@ -10,7 +10,7 @@
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
 import { toMinorUnits } from "#shared/currency.ts";
 import { normalizeDatetime } from "#shared/dates.ts";
-import { copyListingAttributeOptionsTx } from "#shared/db/attributes.ts";
+import { listingAttributeOptions } from "#shared/db/attributes.ts";
 import type { TxScope } from "#shared/db/client.ts";
 import {
   copyPackageMemberOverridesTx,
@@ -271,7 +271,7 @@ const writeCreateListingGroups =
     const sourceId = form.getOptionalInt("duplicated_from");
     if (sourceId !== null) {
       await copyPackageMemberOverridesTx(tx, sourceId, id);
-      await copyListingAttributeOptionsTx(tx, sourceId, id);
+      await listingAttributeOptions.copyLinksTx(tx, sourceId, id);
     }
   };
 

--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -28,6 +28,7 @@ import {
   createAuthedHandler,
 } from "#shared/app-forms.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
+import { writeRowInTransaction } from "#shared/db/client.ts";
 import { getAllListings } from "#shared/db/listings.ts";
 import { getAllModifiers } from "#shared/db/modifiers.ts";
 import {
@@ -51,12 +52,10 @@ import {
 import { deleteAnswer, deleteQuestion } from "#shared/db/questions/delete.ts";
 import { findAnswerById } from "#shared/db/questions/parsing.ts";
 import {
-  getAllQuestionListingIds,
   getAllQuestionsWithAnswers,
-  getQuestionListingIds,
   getQuestionWithAnswers,
-  setListingQuestions,
-  setQuestionListings,
+  listingQuestions,
+  questionListings,
 } from "#shared/db/questions/queries.ts";
 import {
   assignNextQuestionSortOrder,
@@ -134,11 +133,13 @@ export const answerTextForm = defineForm({
 /** Handle GET /admin/questions */
 const handleQuestionsGet = ownerPage(async (session) => {
   const flash = getFlash();
-  const [questions, questionListingIds, allListings] = await Promise.all([
+  const [questions, allListings] = await Promise.all([
     getAllQuestionsWithAnswers(),
-    getAllQuestionListingIds(),
     getAllListings(),
   ]);
+  const questionListingIds = await questionListings.getIdsByKeys(
+    questions.map((question) => question.id),
+  );
   // Resolve listing ids to their decrypted names for the Listings column,
   // dropping any ids whose listing has since been deleted (listing_questions
   // rows are not pruned on listing deletion, so orphans can linger).
@@ -186,7 +187,7 @@ const handleQuestionGet = ownerGetById(
     const [answerCounts, allListings, assignedListingIds] = await Promise.all([
       getAnswerSelectionTotals(q.id),
       getAllListings(),
-      getQuestionListingIds(q.id),
+      questionListings.getIds(q.id),
     ]);
     return htmlResponse(
       adminQuestionPage(
@@ -240,8 +241,11 @@ const handleQuestionListings = ownerFormById(async (id, _session, form) => {
   if (!question) return notFoundResponse();
   const assignAll = form.get("assign_all") === "on";
   const listingIds = form.getNumberArray("listing_ids");
-  await questionsTable.update(id, { assignAll });
-  await setQuestionListings(id, listingIds);
+  await writeRowInTransaction(
+    await questionsTable.updateStatement!(id, { assignAll }),
+    id,
+    (tx) => questionListings.setIdsTx(tx, id, listingIds),
+  );
   await logActivity(
     assignAll
       ? `Question '${question.text}' assigned to all listings`
@@ -557,7 +561,7 @@ const handleListingQuestionsPost = createListingChoicePost({
   fieldName: "question_ids",
   label: "Questions",
   noun: "question",
-  saveIds: setListingQuestions,
+  saveIds: listingQuestions.setIds,
   tab: "questions",
 });
 

--- a/src/shared/db/attributes.ts
+++ b/src/shared/db/attributes.ts
@@ -14,7 +14,6 @@ import {
   inPlaceholders,
   queryAll,
   queryOne,
-  type TxScope,
 } from "#shared/db/client.ts";
 import { linkTableSide } from "#shared/db/link-table.ts";
 import type { ListingOption } from "#shared/db/listings.ts";
@@ -405,19 +404,6 @@ export const getSelectedAttributesForListings = async (
     )([...selectedRowsForListing(rows)]),
   );
 };
-
-export const setListingAttributeOptions = async (
-  listingId: number,
-  optionIds: number[],
-): Promise<void> =>
-  listingAttributeOptions.setIds(listingId, unique(optionIds));
-
-export const copyListingAttributeOptionsTx = (
-  tx: TxScope,
-  sourceListingId: number,
-  newListingId: number,
-): Promise<void> =>
-  listingAttributeOptions.copyLinksTx(tx, sourceListingId, newListingId);
 
 export const pruneInvalidAttributeOptionIds = (
   validOptionIds: Set<number>,

--- a/src/shared/db/link-table.ts
+++ b/src/shared/db/link-table.ts
@@ -15,7 +15,7 @@
  * constants, never user input.
  */
 
-import { unique } from "#fp";
+import { reduce, unique } from "#fp";
 import {
   deleteByField,
   executeBatch,
@@ -123,8 +123,16 @@ export const linkTableSide = (
          ORDER BY ${keyColumn}, ${valueColumn}`,
         keys,
       );
-      for (const row of rows) idsByKey.get(row.key_id)!.push(row.value_id);
-      return idsByKey;
+      return reduce(
+        (
+          acc: Map<number, number[]>,
+          row: { key_id: number; value_id: number },
+        ) => {
+          acc.get(row.key_id)!.push(row.value_id);
+          return acc;
+        },
+        idsByKey,
+      )(rows);
     },
     setIds: (keyId, ids) => executeBatch(replaceStatements(keyId, ids)),
     setIdsTx: async (tx, keyId, ids) => {

--- a/src/shared/db/link-table.ts
+++ b/src/shared/db/link-table.ts
@@ -19,6 +19,8 @@ import { unique } from "#fp";
 import {
   deleteByField,
   executeBatch,
+  inPlaceholders,
+  queryAll,
   queryIdColumn,
   type SqlStatement,
   type TxScope,
@@ -46,6 +48,9 @@ export type LinkTableSide = {
   ) => Promise<void>;
   /** The linked ids for a key, ascending. */
   getIds: (keyId: number) => Promise<number[]>;
+  /** The linked ids for several keys in one bounded query. Every requested key
+   * is present in the map, including keys with no links. */
+  getIdsByKeys: (keyIds: readonly number[]) => Promise<Map<number, number[]>>;
   /** Replace a key's linked set with exactly `ids` (deduped): delete the key's
    * rows, then insert the new ones, as a single batch so a failure never
    * leaves a partial set. */
@@ -107,6 +112,20 @@ export const linkTableSide = (
         `SELECT ${valueColumn} AS id FROM ${table} WHERE ${keyColumn} = ? ORDER BY ${valueColumn} ASC`,
         [keyId],
       ),
+    getIdsByKeys: async (keyIds) => {
+      const keys = unique([...keyIds]);
+      const idsByKey = new Map(keys.map((id) => [id, [] as number[]]));
+      if (keys.length === 0) return idsByKey;
+      const rows = await queryAll<{ key_id: number; value_id: number }>(
+        `SELECT ${keyColumn} AS key_id, ${valueColumn} AS value_id
+         FROM ${table}
+         WHERE ${keyColumn} IN (${inPlaceholders(keys)})
+         ORDER BY ${keyColumn}, ${valueColumn}`,
+        keys,
+      );
+      for (const row of rows) idsByKey.get(row.key_id)!.push(row.value_id);
+      return idsByKey;
+    },
     setIds: (keyId, ids) => executeBatch(replaceStatements(keyId, ids)),
     setIdsTx: async (tx, keyId, ids) => {
       for (const stmt of replaceStatements(keyId, ids)) {

--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -21,10 +21,10 @@ import {
 import { modifierUsedQuantities } from "#shared/db/modifier-usage.ts";
 import {
   getActiveModifiers,
-  getModifierGroupIdsByModifierId,
   getModifierGroupListingIdsByModifierId,
-  getModifierListingIdsByModifierId,
+  modifierGroups,
   modifierIdsByAnswerId,
+  modifierListings,
 } from "#shared/db/modifiers.ts";
 import type {
   CheckoutItem,
@@ -70,7 +70,7 @@ const listingIdsByModifierId = async (
     if (modifier.scope === "all") scopes.set(modifier.id, null);
   }
   const [listingLinks, groupLinks] = await Promise.all([
-    getModifierListingIdsByModifierId(listingScoped.map((m) => m.id)),
+    modifierListings.getIdsByKeys(listingScoped.map((m) => m.id)),
     resolveGroupScopes(groupScoped.map((m) => m.id)),
   ]);
   // Each lookup seeds an entry for every id it was given, so these maps cover
@@ -569,7 +569,7 @@ export const listingIdsInGroups = (
 const inMemoryGroupScopeResolver =
   (allListings: ListingGroupMembership[]): GroupScopeResolver =>
   async (groupScopedIds) => {
-    const groupLinks = await getModifierGroupIdsByModifierId(groupScopedIds);
+    const groupLinks = await modifierGroups.getIdsByKeys(groupScopedIds);
     return new Map(
       [...groupLinks].map(([id, groupIds]) => [
         id,

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -252,13 +252,6 @@ const modifierScopeListingIdsLookup =
     return appendModifierListingLinks(emptyModifierScopeMap(modifierIds), rows);
   };
 
-/** Listing ids directly linked to each listing-scoped modifier id. */
-export const getModifierListingIdsByModifierId = modifierScopeListingIdsLookup(
-  (placeholders) =>
-    `SELECT modifier_id, listing_id FROM modifier_listings
-     WHERE modifier_id IN (${placeholders})`,
-);
-
 /** Listing ids belonging to linked groups for each group-scoped modifier id. */
 export const getModifierGroupListingIdsByModifierId =
   modifierScopeListingIdsLookup(
@@ -268,16 +261,6 @@ export const getModifierGroupListingIdsByModifierId =
          JOIN group_listings AS groupListing ON groupListing.group_id = modifierGroup.group_id
        WHERE modifierGroup.modifier_id IN (${placeholders})`,
   );
-
-/** Group ids linked to each group-scoped modifier id (batched), so a caller can
- * resolve a modifier's group scope against *in-memory* listings (e.g. a listing
- * save's would-be `group_id`) instead of the live join. Seeds an entry for every
- * id it was given. */
-export const getModifierGroupIdsByModifierId = modifierScopeListingIdsLookup(
-  (placeholders) =>
-    `SELECT modifier_id, group_id AS listing_id FROM modifier_groups
-     WHERE modifier_id IN (${placeholders})`,
-);
 
 /** Answer ids an "answer"-triggered modifier is linked to (for the admin
  * editor) — i.e. the answers whose modifier_id points at this modifier. */

--- a/src/shared/db/questions/queries.ts
+++ b/src/shared/db/questions/queries.ts
@@ -7,15 +7,23 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { filter, groupBy, groupToMap, map, mapParallel, reduce } from "#fp";
-import {
-  executeBatch,
-  inPlaceholders,
-  insert,
-  queryAll,
-} from "#shared/db/client.ts";
+import { filter, groupBy, map, mapParallel, reduce } from "#fp";
+import { inPlaceholders, queryAll } from "#shared/db/client.ts";
+import { linkTableSide } from "#shared/db/link-table.ts";
 import type { Answer, QuestionWithAnswers } from "#shared/db/question-types.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
+
+/** Direct question-to-listing assignments, viewed from either side. */
+export const questionListings = linkTableSide(
+  "listing_questions",
+  "question_id",
+  "listing_id",
+);
+export const listingQuestions = linkTableSide(
+  "listing_questions",
+  "listing_id",
+  "question_id",
+);
 
 /** Flat row from a question ← LEFT JOIN answers query. `q_assign_all` is the
  * stored form (INTEGER 0/1) — {@link decryptQuestion} turns it into a boolean
@@ -143,58 +151,6 @@ export const getListingQuestionIds = async (
     ),
   );
 
-/** Map from question id to the ids of the listings it is directly assigned to,
- * for the questions list table's Listings column. Assign-all questions are
- * omitted (the caller renders "All" for them). The caller resolves ids to
- * (decrypted) names from its already-loaded listing list. */
-export const getAllQuestionListingIds = async (): Promise<
-  Map<number, number[]>
-> => {
-  const rows = await queryAll<{ question_id: number; listing_id: number }>(
-    `SELECT question_id, listing_id FROM listing_questions
-     ORDER BY question_id, listing_id`,
-  );
-  return groupToMap(
-    (r: (typeof rows)[number]) => r.question_id,
-    (r) => r.listing_id,
-  )(rows);
-};
-
-/** Get the IDs of the listings a question is assigned to */
-export const getQuestionListingIds = async (
-  questionId: number,
-): Promise<number[]> =>
-  map((r: { listing_id: number }) => r.listing_id)(
-    await queryAll<{ listing_id: number }>(
-      "SELECT listing_id FROM listing_questions WHERE question_id = ? ORDER BY listing_id",
-      [questionId],
-    ),
-  );
-
-/** Set which listings a question is assigned to: add it to newly-checked
- * listings and remove it from unchecked ones. Membership only — display order
- * is the question's global `sort_order`, so no per-listing ordering is written. */
-export const setQuestionListings = async (
-  questionId: number,
-  listingIds: number[],
-): Promise<void> => {
-  const current = new Set(await getQuestionListingIds(questionId));
-  const target = new Set(listingIds);
-  const toRemove = [...current].filter((id) => !target.has(id));
-  const toAdd = listingIds.filter((id) => !current.has(id));
-  const statements = [
-    ...toRemove.map((listingId) => ({
-      args: [listingId, questionId],
-      sql: "DELETE FROM listing_questions WHERE listing_id = ? AND question_id = ?",
-    })),
-    ...toAdd.map((listingId) => ({
-      args: [listingId, questionId],
-      sql: "INSERT INTO listing_questions (listing_id, question_id) VALUES (?, ?)",
-    })),
-  ];
-  if (statements.length > 0) await executeBatch(statements);
-};
-
 /** Map from question ID to the set of listing IDs that use it */
 export type QuestionListingMap = Map<number, number[]>;
 
@@ -243,26 +199,6 @@ export const getQuestionsWithListingIds = async (
 
   const questions = withAnswers(await groupJoinedRows(rows));
   return { questionListingMap, questions };
-};
-
-/** Set which questions are assigned to an listing (replaces existing) */
-export const setListingQuestions = async (
-  listingId: number,
-  questionIds: number[],
-): Promise<void> => {
-  const statements = [
-    {
-      args: [listingId],
-      sql: "DELETE FROM listing_questions WHERE listing_id = ?",
-    },
-    ...questionIds.map((qid) =>
-      insert("listing_questions", {
-        listing_id: listingId,
-        question_id: qid,
-      }),
-    ),
-  ];
-  await executeBatch(statements);
 };
 
 /** Get question with answers by ID */

--- a/src/shared/db/questions/tables.ts
+++ b/src/shared/db/questions/tables.ts
@@ -1,8 +1,7 @@
 /**
  * Table definitions for custom questions and their answers. The
- * `listing_questions` link table has no definition here: production reads and
- * writes it only through the raw SQL in `questions/queries.ts`
- * (`setQuestionListings` and the membership joins).
+ * `listing_questions` link table is declared in `questions/queries.ts`, beside
+ * the membership joins that consume it.
  */
 
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";

--- a/test/e2e/n-plus-one-guard.test.ts
+++ b/test/e2e/n-plus-one-guard.test.ts
@@ -12,7 +12,7 @@ import { it as test } from "@std/testing/bdd";
 import { createAttendeeAtomic } from "#shared/db/attendees/api.ts";
 import { N_PLUS_ONE_THRESHOLD } from "#shared/db/query-log.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
@@ -75,7 +75,7 @@ const createProtectedFixture = async (): Promise<ProtectedFixture> => {
     });
     answerIds.push(answer.id);
 
-    await setListingQuestions(listing.id, [question.id]);
+    await listingQuestions.setIds(listing.id, [question.id]);
 
     const booking = await bookAttendee(listing, {
       email: `n-plus-one-${index}@example.com`,
@@ -104,7 +104,7 @@ const createProtectedFixture = async (): Promise<ProtectedFixture> => {
     sortOrder: 0,
     text: "N+1 protected crowded answer",
   });
-  await setListingQuestions(crowdedListing.id, [crowdedQuestion.id]);
+  await listingQuestions.setIds(crowdedListing.id, [crowdedQuestion.id]);
 
   for (const index of range(RELATION_COUNT)) {
     const booking = await bookAttendee(crowdedListing, {

--- a/test/integration/servicing/atomicity.test.ts
+++ b/test/integration/servicing/atomicity.test.ts
@@ -59,9 +59,7 @@ const attachTextAndChoiceQuestions = async (
   const { answersTable, questionsTable } = await import(
     "#shared/db/questions/tables.ts"
   );
-  const { setQuestionListings } = await import(
-    "#shared/db/questions/queries.ts"
-  );
+  const { questionListings } = await import("#shared/db/questions/queries.ts");
   const textQuestion = await questionsTable.insert({
     assignAll: false,
     displayType: "free_text",
@@ -78,7 +76,7 @@ const attachTextAndChoiceQuestions = async (
     text: "Vaillant",
   });
   for (const q of [textQuestion.id, choiceQuestion.id]) {
-    await setQuestionListings(q, [listingId]);
+    await questionListings.setIds(q, [listingId]);
   }
   return {
     choiceAnswerId: choiceAnswer.id,

--- a/test/integration/servicing/custom-questions.test.ts
+++ b/test/integration/servicing/custom-questions.test.ts
@@ -18,7 +18,7 @@ import { it as test } from "@std/testing/bdd";
 import { queryAll } from "#shared/db/client.ts";
 import {
   getQuestionsWithListingIds,
-  setQuestionListings,
+  questionListings,
 } from "#shared/db/questions/queries.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -46,7 +46,7 @@ const attachQuestion = async (
     sortOrder: 0,
     text: "Vaillant",
   });
-  await setQuestionListings(question.id, [listingId]);
+  await questionListings.setIds(question.id, [listingId]);
   const questionId = question.id;
   const answerId = answer.id;
   return { answerId, questionId };

--- a/test/lib/server-attendee-form/questions.test.ts
+++ b/test/lib/server-attendee-form/questions.test.ts
@@ -3,7 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { createAttendeeAtomic } from "#shared/db/attendees/api.ts";
 import { getAttendeeAnswersBatch } from "#shared/db/questions/attendee-answers/reads.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { buildAttendeeEditForm } from "#test-utils/db-helpers/attendees.ts";
@@ -37,7 +37,7 @@ describeWithEnv(
           sortOrder: 0,
           text: "Medium",
         });
-        await setListingQuestions(eventA.id, [qA.id]);
+        await listingQuestions.setIds(eventA.id, [qA.id]);
 
         const qB = await questionsTable.insert({
           displayType: "radio",
@@ -48,7 +48,7 @@ describeWithEnv(
           sortOrder: 0,
           text: "Vegan",
         });
-        await setListingQuestions(eventB.id, [qB.id]);
+        await listingQuestions.setIds(eventB.id, [qB.id]);
 
         const created = await createAttendeeAtomic({
           bookings: [
@@ -151,7 +151,7 @@ describeWithEnv(
           sortOrder: 1,
           text: "L",
         });
-        await setListingQuestions(event.id, [q.id]);
+        await listingQuestions.setIds(event.id, [q.id]);
 
         const makeAttendee = async (name: string, email: string) => {
           const result = await createAttendeeAtomic({

--- a/test/lib/server-attendees/helpers.ts
+++ b/test/lib/server-attendees/helpers.ts
@@ -3,7 +3,7 @@ import { handleRequest } from "#routes";
 import type { Answer, Question } from "#shared/db/question-types.ts";
 import { getAttendeeAnswersBatch } from "#shared/db/questions/attendee-answers/reads.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import type { Attendee, Listing } from "#shared/types.ts";
 import {
@@ -183,7 +183,7 @@ export const setupListingWithQuestion = async (
     sortOrder: 1,
     text: a2Text,
   });
-  await setListingQuestions(listing.id, [q.id]);
+  await listingQuestions.setIds(listing.id, [q.id]);
   return { a1, a2, attendee, listing, q };
 };
 

--- a/test/lib/server-attendees/merge.ts
+++ b/test/lib/server-attendees/merge.ts
@@ -3,7 +3,7 @@ import { getAttendeesByTokens } from "#shared/db/attendees/tokens.ts";
 import type { Answer, Question } from "#shared/db/question-types.ts";
 import { getAttendeeAnswersByQuestion } from "#shared/db/questions/attendee-answers/reads.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import type { Attendee, Listing } from "#shared/types.ts";
 import { extractInputValue } from "#test-utils/csrf.ts";
@@ -121,8 +121,8 @@ export const mergePairWithQuestion = async (
       }),
     );
   }
-  await setListingQuestions(listing1.id, [q.id]);
-  if (listing2) await setListingQuestions(listing2.id, [q.id]);
+  await listingQuestions.setIds(listing1.id, [q.id]);
+  if (listing2) await listingQuestions.setIds(listing2.id, [q.id]);
   return {
     a1: answers[0]!,
     a2: answers[1],

--- a/test/lib/server-attributes.test.ts
+++ b/test/lib/server-attributes.test.ts
@@ -5,7 +5,6 @@ import {
   getAllAttributesWithOptions,
   getAttributeWithOptions,
   listingAttributeOptions,
-  setListingAttributeOptions,
 } from "#shared/db/attributes.ts";
 import {
   expectFlash,
@@ -349,7 +348,9 @@ describeWithEnv("server (admin attributes)", { db: true }, () => {
         "Easy",
         "Hard",
       ]);
-      await setListingAttributeOptions(listing.id, [attribute.options[1]!.id]);
+      await listingAttributeOptions.setIds(listing.id, [
+        attribute.options[1]!.id,
+      ]);
 
       const html = await expectHtmlResponse(
         await adminGet(`/admin/listing/${listing.id}/attributes`),

--- a/test/lib/server-calculate.test.ts
+++ b/test/lib/server-calculate.test.ts
@@ -8,7 +8,7 @@ import { attendeeStatuses } from "#shared/db/attendee-statuses.ts";
 import { getDb } from "#shared/db/client.ts";
 import { setGroupPackageMembers } from "#shared/db/groups.ts";
 import { modifiersTable, setModifierAnswers } from "#shared/db/modifiers.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { settings } from "#shared/db/settings.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
@@ -393,7 +393,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       sortOrder: 0,
       text: "Small",
     });
-    await setListingQuestions(listing.id, [question.id]);
+    await listingQuestions.setIds(listing.id, [question.id]);
     // A stock-limited answer tier with no stock left, selected by the quote.
     const tier = await modifiersTable.insert({
       calcKind: "fixed",

--- a/test/lib/server-groups/attendees.test.ts
+++ b/test/lib/server-groups/attendees.test.ts
@@ -161,7 +161,7 @@ describeWithEnv("server (admin groups) — attendee stats", { db: true }, () => 
       const { questionsTable, answersTable } = await import(
         "#shared/db/questions/tables.ts"
       );
-      const { setListingQuestions } = await import(
+      const { listingQuestions } = await import(
         "#shared/db/questions/queries.ts"
       );
       const q = await questionsTable.insert({
@@ -173,7 +173,7 @@ describeWithEnv("server (admin groups) — attendee stats", { db: true }, () => 
         sortOrder: 0,
         text: "Veg",
       });
-      await setListingQuestions(listing.id, [q.id]);
+      await listingQuestions.setIds(listing.id, [q.id]);
 
       const html = await (
         await adminGet(`/admin/groups/${group.id}/attendees`)
@@ -202,7 +202,7 @@ describeWithEnv("server (admin groups) — attendee stats", { db: true }, () => 
       const { questionsTable, answersTable } = await import(
         "#shared/db/questions/tables.ts"
       );
-      const { setListingQuestions } = await import(
+      const { listingQuestions } = await import(
         "#shared/db/questions/queries.ts"
       );
       const q = await questionsTable.insert({
@@ -214,7 +214,7 @@ describeWithEnv("server (admin groups) — attendee stats", { db: true }, () => 
         sortOrder: 0,
         text: "Red",
       });
-      await setListingQuestions(listing.id, [q.id]);
+      await listingQuestions.setIds(listing.id, [q.id]);
 
       const response = await adminGet(`/admin/groups/${group.id}`);
       expectStatus(200)(response);

--- a/test/lib/server-listing-export-checkin.test.ts
+++ b/test/lib/server-listing-export-checkin.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { updateCheckedIn } from "#shared/db/attendees/update.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestAttendeeDirect } from "#test-utils/db-helpers/attendees.ts";
@@ -87,7 +87,7 @@ describeWithEnv("server (listing export check-in filter)", { db: true }, () => {
       displayType: "free_text",
       text: "Allergies?",
     });
-    await setListingQuestions(listing.id, [
+    await listingQuestions.setIds(listing.id, [
       question.id,
       choiceQuestion.id,
       unanswered.id,

--- a/test/lib/server-listings/export.test.ts
+++ b/test/lib/server-listings/export.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import {
   expectCsvDownloadHeaders,
@@ -146,7 +146,7 @@ describeWithEnv("server listings > export", { db: true }, () => {
         sortOrder: 1,
         text: "Large",
       });
-      await setListingQuestions(listing.id, [q.id]);
+      await listingQuestions.setIds(listing.id, [q.id]);
       await saveAttendeeAnswers(new Map([[attendee.id, [a1.id]]]));
 
       const csv = await fetchListingExportCsv(listing.id, cookie);

--- a/test/lib/server-listings/show-groups-and-answers.test.ts
+++ b/test/lib/server-listings/show-groups-and-answers.test.ts
@@ -4,7 +4,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { addDays } from "#shared/dates.ts";
 import { assignListingsToGroup } from "#shared/db/groups.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
@@ -45,7 +45,7 @@ describeWithEnv(
           sortOrder: 0,
           text: "Small",
         });
-        await setListingQuestions(listing.id, [q.id]);
+        await listingQuestions.setIds(listing.id, [q.id]);
         await saveAttendeeAnswers(new Map([[attendee.id, [small.id]]]));
         return attendee;
       };

--- a/test/lib/server-misc-admin-handlers.test.ts
+++ b/test/lib/server-misc-admin-handlers.test.ts
@@ -572,7 +572,7 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
       const { answersTable, questionsTable } = await import(
         "#shared/db/questions/tables.ts"
       );
-      const { setQuestionListings } = await import(
+      const { questionListings } = await import(
         "#shared/db/questions/queries.ts"
       );
 
@@ -581,7 +581,7 @@ describeWithEnv("server (misc: admin handlers)", { db: true }, () => {
         displayType: "radio",
         text: "Food preference",
       });
-      await setQuestionListings(question.id, [listing.id]);
+      await questionListings.setIds(question.id, [listing.id]);
       await answersTable.insert({
         questionId: question.id,
         sortOrder: 0,

--- a/test/lib/server-parents-gate/questions-thank-you.test.ts
+++ b/test/lib/server-parents-gate/questions-thank-you.test.ts
@@ -3,7 +3,7 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import { getAttendeeAnswersBatch } from "#shared/db/questions/attendee-answers/reads.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { assignQuestion } from "#test/shared/db/questions/helpers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { deactivateTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -75,7 +75,7 @@ describeWithEnv(
         "Shared child question?",
         "Maybe",
       );
-      await setListingQuestions(childB.id, [sharedQ.id]);
+      await listingQuestions.setIds(childB.id, [sharedQ.id]);
 
       const html = await bookingPageHtml(parent.slug);
       // Page question renders required.

--- a/test/lib/server-public/custom-questions-multi.test.ts
+++ b/test/lib/server-public/custom-questions-multi.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { getAttendeeAnswersBatch } from "#shared/db/questions/attendee-answers/reads.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import {
   expectAttendeeCounts,
@@ -49,7 +49,7 @@ describeWithEnv(
           text: "Vegetarian",
         });
         for (const eid of listingIds) {
-          await setListingQuestions(eid, [q.id]);
+          await listingQuestions.setIds(eid, [q.id]);
         }
         return { answer1: a1, answer2: a2, question: q };
       };
@@ -108,7 +108,7 @@ describeWithEnv(
           sortOrder: 0,
           text: "A answer",
         });
-        await setListingQuestions(listing1.id, [q1.id]);
+        await listingQuestions.setIds(listing1.id, [q1.id]);
 
         // Question 2 assigned to listing2 only
         const q2 = await questionsTable.insert({
@@ -120,7 +120,7 @@ describeWithEnv(
           sortOrder: 0,
           text: "B answer",
         });
-        await setListingQuestions(listing2.id, [q2.id]);
+        await listingQuestions.setIds(listing2.id, [q2.id]);
 
         const slug = `${listing1.slug}+${listing2.slug}`;
         const response = await submitMultiTicketForm(slug, {
@@ -161,8 +161,8 @@ describeWithEnv(
           sortOrder: 0,
           text: "Shared answer",
         });
-        await setListingQuestions(listing1.id, [q1.id]);
-        await setListingQuestions(listing2.id, [q1.id]);
+        await listingQuestions.setIds(listing1.id, [q1.id]);
+        await listingQuestions.setIds(listing2.id, [q1.id]);
 
         const slug = `${listing1.slug}+${listing2.slug}`;
         // Only select listing1, skip listing2
@@ -202,7 +202,7 @@ describeWithEnv(
           sortOrder: 0,
           text: "Yes",
         });
-        await setListingQuestions(listing1.id, [q.id]);
+        await listingQuestions.setIds(listing1.id, [q.id]);
 
         // Select only listing2 (no question assigned) - should succeed without answer
         const slug = `${listing1.slug}+${listing2.slug}`;

--- a/test/lib/server-public/custom-questions-single.test.ts
+++ b/test/lib/server-public/custom-questions-single.test.ts
@@ -8,7 +8,7 @@ import {
   setModifierAnswers,
 } from "#shared/db/modifiers.ts";
 import { getAttendeeAnswersBatch } from "#shared/db/questions/attendee-answers/reads.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import {
@@ -43,7 +43,7 @@ describeWithEnv(
           sortOrder: 1,
           text: "Large",
         });
-        await setListingQuestions(listingId, [q.id]);
+        await listingQuestions.setIds(listingId, [q.id]);
         return { answer1: a1, answer2: a2, question: q };
       };
 

--- a/test/lib/server-questions/listing-questions.test.ts
+++ b/test/lib/server-questions/listing-questions.test.ts
@@ -10,6 +10,7 @@ import {
 } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { withPoisonedTransactionExecute } from "#test-utils/db-poison.ts";
 import { mockFormRequest } from "#test-utils/mocks.ts";
 import {
   adminFormPost,
@@ -53,20 +54,20 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         "Listings updated",
       )(response);
 
-      const { getQuestionListingIds } = await import(
+      const { questionListings } = await import(
         "#shared/db/questions/queries.ts"
       );
-      expect(await getQuestionListingIds(qId)).toEqual([listing.id]);
+      expect(await questionListings.getIds(qId)).toEqual([listing.id]);
     });
 
     test("removes question from unchecked listings", async () => {
       const listing = await createTestListing({ name: "Unassign listing" });
       const qId = await createQuestion("Unassign me?");
 
-      const { setQuestionListings, getQuestionListingIds } = await import(
+      const { questionListings } = await import(
         "#shared/db/questions/queries.ts"
       );
-      await setQuestionListings(qId, [listing.id]);
+      await questionListings.setIds(qId, [listing.id]);
 
       const { response } = await adminFormPost(
         `/admin/questions/${qId}/listings`,
@@ -76,7 +77,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${qId}`,
         "Listings updated",
       )(response);
-      expect(await getQuestionListingIds(qId)).toEqual([]);
+      expect(await questionListings.getIds(qId)).toEqual([]);
     });
 
     test("stores assign-all and logs all-listings assignment", async () => {
@@ -93,6 +94,30 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       const response = await adminGet("/admin/log");
       const body = await response.text();
       expect(body).toContain("assigned to all listings");
+    });
+
+    test("rolls back assign-all when saving listing links fails", async () => {
+      const listing = await createTestListing({ name: "Rollback listing" });
+      const qId = await createQuestion("Rollback assignment?");
+      const failLinkInsert = withPoisonedTransactionExecute(
+        (sql) => sql.includes("INSERT INTO listing_questions"),
+        "link insert failed",
+      );
+
+      await expect(
+        failLinkInsert(async () => {
+          await adminFormPost(`/admin/questions/${qId}/listings`, {
+            assign_all: "on",
+            listing_ids: String(listing.id),
+          });
+        }),
+      ).rejects.toThrow("link insert failed");
+
+      const { getQuestionWithAnswers, questionListings } = await import(
+        "#shared/db/questions/queries.ts"
+      );
+      expect((await getQuestionWithAnswers(qId))!.assign_all).toBe(false);
+      expect(await questionListings.getIds(qId)).toEqual([]);
     });
 
     test("logs singular when assigned to one listing", async () => {
@@ -173,10 +198,10 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       const qId = await createQuestion("Shirt size?");
 
       // Assign the question to the listing
-      const { setListingQuestions } = await import(
+      const { listingQuestions } = await import(
         "#shared/db/questions/queries.ts"
       );
-      await setListingQuestions(listing.id, [qId]);
+      await listingQuestions.setIds(listing.id, [qId]);
 
       const response = await adminGet(`/admin/listing/${listing.id}/questions`);
       await expectHtmlResponse(
@@ -263,10 +288,10 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       const q2 = await createQuestion("New question?");
 
       // Assign q1 first
-      const { setListingQuestions, getListingQuestionIds } = await import(
+      const { getListingQuestionIds, listingQuestions } = await import(
         "#shared/db/questions/queries.ts"
       );
-      await setListingQuestions(listing.id, [q1]);
+      await listingQuestions.setIds(listing.id, [q1]);
 
       // Now assign q2 via the route
       const cookie = await testCookie();

--- a/test/lib/server-questions/questions.test.ts
+++ b/test/lib/server-questions/questions.test.ts
@@ -42,10 +42,10 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
     test("shows a Listings cell titled with the assigned listing names", async () => {
       const qId = await createQuestion("Listings column?");
       const listing = await createTestListing({ name: "Gala Night" });
-      const { setQuestionListings } = await import(
+      const { questionListings } = await import(
         "#shared/db/questions/queries.ts"
       );
-      await setQuestionListings(qId, [listing.id]);
+      await questionListings.setIds(qId, [listing.id]);
 
       const response = await adminGet("/admin/questions");
       const body = await response.text();

--- a/test/lib/server-webhooks/custom-questions-multi.test.ts
+++ b/test/lib/server-webhooks/custom-questions-multi.test.ts
@@ -6,7 +6,7 @@ import {
   getAttendeeAnswersBatch,
   getAttendeeTextAnswers,
 } from "#shared/db/questions/attendee-answers/reads.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { getOrCreateStringIds } from "#shared/db/questions/strings.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
@@ -77,7 +77,7 @@ describeWithEnv(
       const { questionsTable, answersTable } = await import(
         "#shared/db/questions/tables.ts"
       );
-      const { setListingQuestions } = await import(
+      const { listingQuestions } = await import(
         "#shared/db/questions/queries.ts"
       );
       const { getAttendeeAnswersBatch } = await import(
@@ -92,7 +92,7 @@ describeWithEnv(
         sortOrder: 0,
         text: "Large",
       });
-      await setListingQuestions(listing1.id, [q.id]);
+      await listingQuestions.setIds(listing1.id, [q.id]);
 
       const mockVerify = await stubWebhookVerify(
         checkoutSessionEvent({
@@ -165,7 +165,7 @@ describeWithEnv(
         sortOrder: 1,
         text: "Vegetarian",
       });
-      await setListingQuestions(listing1.id, [q.id]);
+      await listingQuestions.setIds(listing1.id, [q.id]);
 
       // Submit multi-ticket form with a question answer selected.
       // One listing is paid, so this triggers the payment flow.
@@ -240,8 +240,8 @@ describeWithEnv(
         displayType: "free_text",
         text: "Dietary needs?",
       });
-      await setListingQuestions(listing1.id, [q1.id]);
-      await setListingQuestions(listing2.id, [q2.id]);
+      await listingQuestions.setIds(listing1.id, [q1.id]);
+      await listingQuestions.setIds(listing2.id, [q2.id]);
 
       // Drive the real checkout so ticket-submit parses the free-text answers and
       // packs them into the checkout intent (encrypting the strings on the way).

--- a/test/lib/server-webhooks/custom-questions-single.test.ts
+++ b/test/lib/server-webhooks/custom-questions-single.test.ts
@@ -5,7 +5,7 @@ import {
   getAttendeeAnswersBatch,
   getAttendeeTextAnswers,
 } from "#shared/db/questions/attendee-answers/reads.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { getOrCreateStringIds } from "#shared/db/questions/strings.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { resetStripeClient } from "#shared/stripe.ts";
@@ -48,7 +48,7 @@ describeWithEnv(
         sortOrder: 1,
         text: "Vegan",
       });
-      await setListingQuestions(listing.id, [q.id]);
+      await listingQuestions.setIds(listing.id, [q.id]);
 
       await expectWebhookProcessed(
         checkoutSessionEvent({
@@ -95,7 +95,7 @@ describeWithEnv(
         displayType: "free_text",
         text: "Access needs?",
       });
-      await setListingQuestions(listing.id, [question.id]);
+      await listingQuestions.setIds(listing.id, [question.id]);
 
       // Drive the REAL checkout so ticket-submit resolves the free-text answer
       // to a string id and packs it into the intent. Capture that intent: its
@@ -177,7 +177,7 @@ describeWithEnv(
         displayType: "free_text",
         text: "Dietary needs?",
       });
-      await setListingQuestions(listing.id, [goodQ.id, lostQ.id]);
+      await listingQuestions.setIds(listing.id, [goodQ.id, lostQ.id]);
 
       const stringIds = await getOrCreateStringIds(["Step-free entrance"]);
 

--- a/test/shared/db/attributes.test.ts
+++ b/test/shared/db/attributes.test.ts
@@ -9,7 +9,6 @@ import {
   getSelectedAttributesForListings,
   listingAttributeOptions,
   pruneInvalidAttributeOptionIds,
-  setListingAttributeOptions,
   swapAttributeOptionOrder,
   swapAttributeOrder,
 } from "#shared/db/attributes.ts";
@@ -67,7 +66,7 @@ describeWithEnv("db > attributes", { db: true }, () => {
       "Intense",
     ]);
 
-    await setListingAttributeOptions(listing.id, [
+    await listingAttributeOptions.setIds(listing.id, [
       attribute.options[1]!.id,
       attribute.options[1]!.id,
       attribute.options[0]!.id,
@@ -77,7 +76,9 @@ describeWithEnv("db > attributes", { db: true }, () => {
       attribute.options[1]!.id,
     ]);
 
-    await setListingAttributeOptions(listing.id, [attribute.options[0]!.id]);
+    await listingAttributeOptions.setIds(listing.id, [
+      attribute.options[0]!.id,
+    ]);
     expect(await listingAttributeOptions.getIds(listing.id)).toEqual([
       attribute.options[0]!.id,
     ]);
@@ -95,11 +96,13 @@ describeWithEnv("db > attributes", { db: true }, () => {
       "Online",
     ]);
 
-    await setListingAttributeOptions(morning.id, [
+    await listingAttributeOptions.setIds(morning.id, [
       difficulty.options[1]!.id,
       place.options[0]!.id,
     ]);
-    await setListingAttributeOptions(evening.id, [difficulty.options[0]!.id]);
+    await listingAttributeOptions.setIds(evening.id, [
+      difficulty.options[0]!.id,
+    ]);
 
     const byListing = await getSelectedAttributesForListings([
       morning.id,
@@ -127,7 +130,7 @@ describeWithEnv("db > attributes", { db: true }, () => {
       "Spring",
       "Autumn",
     ]);
-    await setListingAttributeOptions(
+    await listingAttributeOptions.setIds(
       listing.id,
       attribute.options.map((option) => option.id),
     );
@@ -149,7 +152,7 @@ describeWithEnv("db > attributes", { db: true }, () => {
       "Adults",
       "Families",
     ]);
-    await setListingAttributeOptions(
+    await listingAttributeOptions.setIds(
       listing.id,
       attribute.options.map((option) => option.id),
     );

--- a/test/shared/db/link-table.test.ts
+++ b/test/shared/db/link-table.test.ts
@@ -14,6 +14,24 @@ describeWithEnv("db link-table", { db: true }, () => {
     expect(await byUser.getIds(99)).toEqual([]);
   });
 
+  test("getIdsByKeys buckets links and seeds unlinked keys", async () => {
+    await byUser.setIds(1, [5, 3]);
+    await byUser.setIds(2, [4]);
+    expect(await byUser.getIdsByKeys([2, 3, 1])).toEqual(
+      new Map([
+        [2, [4]],
+        [3, []],
+        [1, [3, 5]],
+      ]),
+    );
+  });
+
+  test("getIdsByKeys dedupes keys and short-circuits an empty list", async () => {
+    await byUser.setIds(1, [2]);
+    expect(await byUser.getIdsByKeys([1, 1])).toEqual(new Map([[1, [2]]]));
+    expect(await byUser.getIdsByKeys([])).toEqual(new Map());
+  });
+
   test("setIds stores the set; getIds reads it back ascending", async () => {
     await byUser.setIds(1, [3, 1, 2]);
     expect(await byUser.getIds(1)).toEqual([1, 2, 3]);

--- a/test/shared/db/listings/delete.test.ts
+++ b/test/shared/db/listings/delete.test.ts
@@ -23,7 +23,7 @@ import {
 } from "#shared/db/processed-payments.ts";
 import { getAttendeeAnswersBatch } from "#shared/db/questions/attendee-answers/reads.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import {
@@ -185,8 +185,8 @@ describeWithEnv("db > listings", { db: true, triggers: true }, () => {
         displayType: "radio",
         text: "Meal choice?",
       });
-      await setListingQuestions(listing1.id, [question.id]);
-      await setListingQuestions(listing2.id, [question.id]);
+      await listingQuestions.setIds(listing1.id, [question.id]);
+      await listingQuestions.setIds(listing2.id, [question.id]);
 
       await deleteListing(listing1.id);
 

--- a/test/shared/db/modifiers/links.test.ts
+++ b/test/shared/db/modifiers/links.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   getModifierAnswerIds,
-  getModifierListingIdsByModifierId,
   modifierGroups,
   modifierIdsByAnswerId,
   modifierListings,
@@ -50,10 +49,10 @@ describeWithEnv("db modifier links", { db: true }, () => {
     });
   });
 
-  describe("getModifierListingIdsByModifierId (batched scope lookup)", () => {
+  describe("modifierListings.getIdsByKeys", () => {
     test("buckets listing links by modifier id, seeding [] for unlinked ids", async () => {
       await modifierListings.setIds(1, [4, 6]);
-      expect(await getModifierListingIdsByModifierId([1, 2])).toEqual(
+      expect(await modifierListings.getIdsByKeys([1, 2])).toEqual(
         new Map([
           [1, [4, 6]],
           [2, []],
@@ -64,13 +63,13 @@ describeWithEnv("db modifier links", { db: true }, () => {
     test("a single-id lookup returns that modifier's links", async () => {
       // One id is not the empty case: the query must still run for it.
       await modifierListings.setIds(3, [5]);
-      expect(await getModifierListingIdsByModifierId([3])).toEqual(
+      expect(await modifierListings.getIdsByKeys([3])).toEqual(
         new Map([[3, [5]]]),
       );
     });
 
     test("no ids short-circuits to an empty map", async () => {
-      expect(await getModifierListingIdsByModifierId([])).toEqual(new Map());
+      expect(await modifierListings.getIdsByKeys([])).toEqual(new Map());
     });
   });
 

--- a/test/shared/db/questions/crud.test.ts
+++ b/test/shared/db/questions/crud.test.ts
@@ -13,7 +13,7 @@ import {
   getAllQuestionsWithAnswers,
   getQuestionsForListing,
   getQuestionWithAnswers,
-  setListingQuestions,
+  listingQuestions,
 } from "#shared/db/questions/queries.ts";
 import {
   assignNextQuestionSortOrder,
@@ -66,7 +66,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       const a = await addAnswer(q.id, 0, "Opt A");
 
       const listing = await createTestListing();
-      await setListingQuestions(listing.id, [q.id]);
+      await listingQuestions.setIds(listing.id, [q.id]);
 
       const attendee = await createAttendee(listing.id);
       await saveAttendeeAnswers(new Map([[attendee.id, [a.id]]]));

--- a/test/shared/db/questions/helpers.ts
+++ b/test/shared/db/questions/helpers.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import type { Question, TextAnswer } from "#shared/db/question-types.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { assignNextQuestionSortOrder } from "#shared/db/questions/sort-order.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import type { Attendee, Listing } from "#shared/types.ts";
@@ -96,14 +96,14 @@ export const seedQuestionWithAndWithoutAnswers = async (): Promise<{
   const qWithAnswers = await createQuestionWithAnswers("Has answers", ["Yes"]);
   const qNoAnswers = await createQuestion("No answers");
   const listing = await createTestListing();
-  await setListingQuestions(listing.id, [qWithAnswers.id, qNoAnswers.id]);
+  await listingQuestions.setIds(listing.id, [qWithAnswers.id, qNoAnswers.id]);
   return { listing, qNoAnswers, qWithAnswers };
 };
 
 /** Create a "radio" question with one answer and assign it to `listingId` —
  *  the shared trio behind every parent-gate and booking-preserve question
  *  test. Composes {@link createQuestion} + {@link addAnswer} +
- *  {@link setListingQuestions} so the insert pair is declared once.
+ *  {@link listingQuestions} so the insert pair is declared once.
  *  `active` defaults true (pass false for the all-deactivated-choice-question
  *  case). */
 export const assignQuestion = async (
@@ -119,6 +119,6 @@ export const assignQuestion = async (
     answerText,
     active ? {} : { active: false },
   );
-  await setListingQuestions(listingId, [question.id]);
+  await listingQuestions.setIds(listingId, [question.id]);
   return { answer, question };
 };

--- a/test/shared/db/questions/listing-mapping.test.ts
+++ b/test/shared/db/questions/listing-mapping.test.ts
@@ -1,12 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
-  getAllQuestionListingIds,
   getListingQuestionIds,
-  getQuestionListingIds,
   getQuestionsForListing,
-  setListingQuestions,
-  setQuestionListings,
+  listingQuestions,
+  questionListings,
 } from "#shared/db/questions/queries.ts";
 import { swapQuestionOrder } from "#shared/db/questions/sort-order.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -29,7 +27,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       // Assign in reverse; the listing ignores assignment order and uses the
       // global question order (here creation/id order, since both are at the
       // default sort_order 0).
-      await setListingQuestions(listing.id, [q2.id, q1.id]);
+      await listingQuestions.setIds(listing.id, [q2.id, q1.id]);
 
       const questions = await getQuestionsForListing(listing.id);
       expectQuestionTexts(questions, ["Q1", "Q2"]);
@@ -42,7 +40,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       await swapQuestionOrder(q1.id, q2.id);
 
       const listing = await createTestListing();
-      await setListingQuestions(listing.id, [q1.id, q2.id]);
+      await listingQuestions.setIds(listing.id, [q1.id, q2.id]);
 
       const questions = await getQuestionsForListing(listing.id);
       expectQuestionTexts(questions, ["Q2", "Q1"]);
@@ -53,12 +51,21 @@ describeWithEnv("custom questions", { db: true }, () => {
       const q2 = await createQuestionWithAnswers("Q2", ["A2"]);
 
       const listing = await createTestListing();
-      await setListingQuestions(listing.id, [q1.id, q2.id]);
-      await setListingQuestions(listing.id, [q2.id]);
+      await listingQuestions.setIds(listing.id, [q1.id, q2.id]);
+      await listingQuestions.setIds(listing.id, [q2.id]);
 
       const questions = await getQuestionsForListing(listing.id);
       expect(questions).toHaveLength(1);
       expect(questions[0]!.text).toBe("Q2");
+    });
+
+    test("dedupes repeated question ids", async () => {
+      const q = await createQuestionWithAnswers("Q", ["A"]);
+      const listing = await createTestListing();
+
+      await listingQuestions.setIds(listing.id, [q.id, q.id]);
+
+      expect(await getListingQuestionIds(listing.id)).toEqual([q.id]);
     });
 
     test("includes assign-all questions for every listing", async () => {
@@ -95,7 +102,7 @@ describeWithEnv("custom questions", { db: true }, () => {
       const q2 = await createQuestion("Q2");
 
       const listing = await createTestListing();
-      await setListingQuestions(listing.id, [q2.id, q1.id]);
+      await listingQuestions.setIds(listing.id, [q2.id, q1.id]);
 
       // Returned in the global question order, not the assignment order.
       const ids = await getListingQuestionIds(listing.id);
@@ -107,39 +114,46 @@ describeWithEnv("custom questions", { db: true }, () => {
       expect(await getListingQuestionIds(listing.id)).toEqual([]);
     });
   });
-  describe("getQuestionListingIds", () => {
+  describe("questionListings.getIds", () => {
     test("returns the listings a question is assigned to", async () => {
       const q = await createQuestion("Q");
       const listing1 = await createTestListing();
       const listing2 = await createTestListing({ name: "Listing 2" });
-      await setListingQuestions(listing1.id, [q.id]);
-      await setListingQuestions(listing2.id, [q.id]);
+      await listingQuestions.setIds(listing1.id, [q.id]);
+      await listingQuestions.setIds(listing2.id, [q.id]);
 
-      const ids = await getQuestionListingIds(q.id);
+      const ids = await questionListings.getIds(q.id);
       expect(ids.sort()).toEqual([listing1.id, listing2.id].sort());
     });
 
     test("returns empty array when assigned to no listings", async () => {
       const q = await createQuestion("Lonely Q");
-      expect(await getQuestionListingIds(q.id)).toEqual([]);
+      expect(await questionListings.getIds(q.id)).toEqual([]);
     });
   });
-  describe("setQuestionListings", () => {
+  describe("questionListings.setIds", () => {
     /** A question already assigned to both listings — the shared starting
      *  point for the assign/unassign tests below. */
     const seedQuestionAssignedToTwoListings = async () => {
       const q = await createQuestion("Q");
       const listing1 = await createTestListing();
       const listing2 = await createTestListing({ name: "Listing 2" });
-      await setQuestionListings(q.id, [listing1.id, listing2.id]);
+      await questionListings.setIds(q.id, [listing1.id, listing2.id]);
       return { listing1, listing2, q };
+    };
+
+    const seedQuestionAssignedToListing = async () => {
+      const q = await createQuestion("Q");
+      const listing = await createTestListing();
+      await questionListings.setIds(q.id, [listing.id]);
+      return { listing, q };
     };
 
     test("assigns a question to the selected listings", async () => {
       const { listing1, listing2, q } =
         await seedQuestionAssignedToTwoListings();
 
-      expect((await getQuestionListingIds(q.id)).sort()).toEqual(
+      expect((await questionListings.getIds(q.id)).sort()).toEqual(
         [listing1.id, listing2.id].sort(),
       );
     });
@@ -147,9 +161,9 @@ describeWithEnv("custom questions", { db: true }, () => {
     test("removes the question from unchecked listings", async () => {
       const { listing1, q } = await seedQuestionAssignedToTwoListings();
 
-      await setQuestionListings(q.id, [listing1.id]);
+      await questionListings.setIds(q.id, [listing1.id]);
 
-      expect(await getQuestionListingIds(q.id)).toEqual([listing1.id]);
+      expect(await questionListings.getIds(q.id)).toEqual([listing1.id]);
     });
 
     test("lists a listing's assigned questions in the global question order", async () => {
@@ -157,49 +171,45 @@ describeWithEnv("custom questions", { db: true }, () => {
       const added = await createQuestionWithAnswers("Added", ["B"]);
 
       const listing = await createTestListing();
-      await setListingQuestions(listing.id, [existing.id]);
+      await listingQuestions.setIds(listing.id, [existing.id]);
 
-      await setQuestionListings(added.id, [listing.id]);
+      await questionListings.setIds(added.id, [listing.id]);
 
       const ids = await getListingQuestionIds(listing.id);
       expect(ids).toEqual([existing.id, added.id]);
     });
 
     test("does nothing when the assignment is unchanged", async () => {
-      const q = await createQuestion("Q");
-      const listing = await createTestListing();
-      await setQuestionListings(q.id, [listing.id]);
+      const { listing, q } = await seedQuestionAssignedToListing();
 
-      await setQuestionListings(q.id, [listing.id]);
+      await questionListings.setIds(q.id, [listing.id]);
 
-      expect(await getQuestionListingIds(q.id)).toEqual([listing.id]);
+      expect(await questionListings.getIds(q.id)).toEqual([listing.id]);
     });
 
     test("clears all listings when given an empty list", async () => {
-      const q = await createQuestion("Q");
-      const listing = await createTestListing();
-      await setQuestionListings(q.id, [listing.id]);
+      const { q } = await seedQuestionAssignedToListing();
 
-      await setQuestionListings(q.id, []);
+      await questionListings.setIds(q.id, []);
 
-      expect(await getQuestionListingIds(q.id)).toEqual([]);
+      expect(await questionListings.getIds(q.id)).toEqual([]);
     });
   });
-  describe("getAllQuestionListingIds", () => {
+  describe("questionListings.getIdsByKeys", () => {
     test("maps each question to its assigned listing ids", async () => {
       const q = await createQuestion("Q");
       const l1 = await createTestListing({ name: "Alpha" });
       const l2 = await createTestListing({ name: "Beta" });
-      await setQuestionListings(q.id, [l1.id, l2.id]);
+      await questionListings.setIds(q.id, [l1.id, l2.id]);
 
-      const map = await getAllQuestionListingIds();
+      const map = await questionListings.getIdsByKeys([q.id]);
       expect(map.get(q.id)!.sort()).toEqual([l1.id, l2.id].sort());
     });
 
-    test("omits questions assigned to no listings", async () => {
+    test("seeds an empty list for questions with no listings", async () => {
       const q = await createQuestion("Lonely");
-      const map = await getAllQuestionListingIds();
-      expect(map.has(q.id)).toBe(false);
+      const map = await questionListings.getIdsByKeys([q.id]);
+      expect(map.get(q.id)).toEqual([]);
     });
   });
 });

--- a/test/shared/db/questions/with-listings.test.ts
+++ b/test/shared/db/questions/with-listings.test.ts
@@ -10,7 +10,7 @@ import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.
 import {
   getAllQuestionsWithAnswers,
   getQuestionsWithListingIds,
-  setListingQuestions,
+  listingQuestions,
 } from "#shared/db/questions/queries.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -33,8 +33,8 @@ describeWithEnv("custom questions", { db: true }, () => {
       const q2 = await createQuestionWithAnswers("Q2", ["A2"]);
       const listing1 = await createTestListing();
       const listing2 = await createTestListing({ name: "Listing 2" });
-      await setListingQuestions(listing1.id, [q1.id, q2.id]);
-      await setListingQuestions(listing2.id, [q2.id]);
+      await listingQuestions.setIds(listing1.id, [q1.id, q2.id]);
+      await listingQuestions.setIds(listing2.id, [q2.id]);
       return { listing1, listing2, q1, q2 };
     };
 

--- a/test/shared/merge/attendee-merge/diff.test.ts
+++ b/test/shared/merge/attendee-merge/diff.test.ts
@@ -7,7 +7,7 @@ import {
 import { KIND } from "#shared/accounting/kinds.ts";
 import { postTransfers } from "#shared/accounting/store.ts";
 import { getDb } from "#shared/db/client.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import { bookingKey } from "#shared/merge/attendee-merge.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -334,7 +334,7 @@ describeWithEnv("attendee merge service", { db: true }, () => {
       sortOrder: 0,
       text: "Yes",
     });
-    await setListingQuestions(listing.id, [q.id]);
+    await listingQuestions.setIds(listing.id, [q.id]);
     await saveChoice(source.id, a1.id);
 
     // Pass no questions — question text won't be found.

--- a/test/shared/merge/attendee-merge/helpers.ts
+++ b/test/shared/merge/attendee-merge/helpers.ts
@@ -8,7 +8,7 @@ import { LISTING_ATTENDEE_ROW_COLS } from "#shared/db/attendees/queries.ts";
 import { queryAll } from "#shared/db/client.ts";
 import type { QuestionWithAnswers } from "#shared/db/question-types.ts";
 import { saveAttendeeAnswers } from "#shared/db/questions/attendee-answers/save.ts";
-import { setListingQuestions } from "#shared/db/questions/queries.ts";
+import { listingQuestions } from "#shared/db/questions/queries.ts";
 import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 import {
   applyAttendeeMerge,
@@ -80,7 +80,7 @@ export const createQuestionWithAnswers = async (
     });
     answers.push(a);
   }
-  await setListingQuestions(listingId, [q.id]);
+  await listingQuestions.setIds(listingId, [q.id]);
   return { answers, question: q };
 };
 

--- a/test/test-utils/db-helpers/attributes.ts
+++ b/test/test-utils/db-helpers/attributes.ts
@@ -4,7 +4,7 @@ import {
   assignNextAttributeSortOrder,
   attributeOptionsTable,
   attributesTable,
-  setListingAttributeOptions,
+  listingAttributeOptions,
 } from "#shared/db/attributes.ts";
 
 export const createTestAttribute = async (
@@ -43,7 +43,7 @@ export const assignTestAttributeOptions = (
   listingId: number,
   options: AttributeOption[],
 ): Promise<void> =>
-  setListingAttributeOptions(
+  listingAttributeOptions.setIds(
     listingId,
     options.map((option) => option.id),
   );


### PR DESCRIPTION
## What changed

- use the shared link-table relationship for question assignments, modifier scopes, and listing attributes
- add one bounded batch lookup for loading links for several records
- remove the older domain-specific wrappers and migrate every caller
- save a question's all-listings setting and direct listing links in one transaction
- fold batch results through the project's shared functional utilities

## Why

These relationships had separate implementations with different deduplication and failure behavior. One shared path prevents them drifting, avoids duplicate-link constraint failures, and ensures a failed assignment cannot leave question settings and links disagreeing.

## Testing

- `deno task precommit`
- `deno task mutation src/shared/db/link-table.ts test/shared/db/link-table.test.ts` (18/18 mutants detected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving question-to-listing assignments, including safer rollback on failures during bulk “assign all”.
  * Improved loading of linked questions and listing attribute selections across multiple listings.
  * Preserved consistent ordering and correct linking behavior for both question lists and attribute options.
* **Performance**
  * Reduced repeated database lookups when retrieving linked questions, attributes, and modifiers for multiple listings.
* **Tests**
  * Expanded coverage for bulk relationship loading, deduplication, empty results, ordering, and transactional rollback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->