### PR TITLE
Stop re-scanning the ledger for a listing's profit

### DIFF
--- a/src/shared/db/listings.ts
+++ b/src/shared/db/listings.ts
@@ -282,18 +282,17 @@ export const listingIncomeSubquery = (idExpr: string): string =>
 const listingCostSubquery = (idExpr: string): string =>
   `-${accountBalanceSubquery("cost", idExpr)} AS cost`;
 
-const listingProfitSubquery = (idExpr: string): string =>
-  `(${creditsLessWriteoffDebits("revenue", idExpr)} + ${accountBalanceSubquery(
-    "cost",
-    idExpr,
-  )}) AS profit`;
-
+/**
+ * Income and cost only — profit is NOT selected. Profit is exactly
+ * `income − cost` (both integer minor-unit sums), so it is derived in TS by
+ * {@link decryptStoredListingWithCount} rather than re-projected. A profit
+ * subquery would inline the whole income revenue-scan and cost scan a second
+ * time (SQLite does not dedupe identical correlated subqueries), doubling the
+ * `transfers` scans per listing row for a value already fully determined by the
+ * other two columns.
+ */
 const listingMoneySubqueries = (idExpr: string): string =>
-  [
-    listingIncomeSubquery(idExpr),
-    listingCostSubquery(idExpr),
-    listingProfitSubquery(idExpr),
-  ].join(", ");
+  [listingIncomeSubquery(idExpr), listingCostSubquery(idExpr)].join(", ");
 
 /**
  * Project a listing's per-day-count prices as a JSON object from its `day_count`
@@ -423,12 +422,16 @@ const decryptStoredListingWithCount = async (
   row: ListingWithCount,
 ): Promise<ListingWithCount> => {
   const listing = await rawListingsTable.fromDb(row);
+  const income = Number(row.income);
+  const cost = Number(row.cost);
   return {
     ...listing,
     attendee_count: row.attendee_count,
-    cost: Number(row.cost),
-    income: Number(row.income),
-    profit: Number(row.profit),
+    cost,
+    income,
+    // profit = income − cost (both integer minor-unit sums, so exact). Derived
+    // here rather than re-projected in SQL — see listingMoneySubqueries.
+    profit: income - cost,
     tickets_count: Number(row.tickets_count),
   };
 };
@@ -684,9 +687,12 @@ export const deleteListing = async (listingId: number): Promise<void> => {
 };
 
 /** The aggregate columns a listing-load row carries: `booked_quantity` and
- *  `tickets_count` are trigger-maintained columns on `listings`; money fields are
- *  projected from the ledger by {@link listingMoneySubqueries}, which every
- *  loader must select alongside `listings.*` (the columns themselves are gone). */
+ *  `tickets_count` are trigger-maintained columns on `listings`; `income` and
+ *  `cost` are projected from the ledger by {@link listingMoneySubqueries}, which
+ *  every loader must select alongside `listings.*` (the columns themselves are
+ *  gone). `profit` is not selected — {@link decryptStoredListingWithCount}
+ *  derives it as `income − cost`; it is kept on the entity type the decrypt path
+ *  returns. */
 type ListingAggregateColumns = {
   booked_quantity: number;
   cost: number;

--- a/test/shared/db/attendees/servicing/ledger-accounts.test.ts
+++ b/test/shared/db/attendees/servicing/ledger-accounts.test.ts
@@ -102,10 +102,10 @@ describeWithEnv(
     });
 
     test("listing row profit stays gross after a refund", async () => {
-      // The listing row projects profit as recognised (gross) income − costs
-      // (listingProfitSubquery). An older reader used the NET revenue balance
-      // (`accountBalance(revenue) − cost`), so after a refund — which lowers the
-      // net balance but not recognised income — it diverged from the listing row.
+      // The listing entity derives profit as recognised (gross) income − cost
+      // (in decryptStoredListingWithCount). An older reader used the NET revenue
+      // balance (`accountBalance(revenue) − cost`), so after a refund — which
+      // lowers the net balance but not recognised income — it diverged.
       const { postAttendeeRefund } = await import("#test-utils/ledger.ts");
       const listing = await createTestListing({ maxAttendees: 10, name: "L" });
       const { attendee } = await createTestAttendeeDirect(
@@ -138,7 +138,7 @@ describeWithEnv(
       expect(breakdown.netBalance).toBe(0);
       expect(await listingCostOf(listing.id)).toBe(9000);
       expect(await listingProfitOf(listing.id)).toBe(11000); // 200 − 90
-      expect(row?.profit).toBe(11000); // SQL listingProfitSubquery (the listing row)
+      expect(row?.profit).toBe(11000); // derived income − cost on the entity
     });
 
     test("listing detail surfaces service costs and profit", async () => {


### PR DESCRIPTION
## What changed

The calendar view loads the whole catalogue in one query (`getAllListings`). For every listing that query worked out three money figures from the accounting ledger: **income**, **cost**, and **profit**.

The problem was the profit figure. It was calculated by re-doing the *entire* income sum and the *entire* cost sum a second time. The database does not notice that it has already worked those out, so every listing added up its ledger records **four times** when only two different sums are actually needed.

Profit is always just **income minus cost**, and both are whole-penny sums, so there is nothing to lose by working it out directly. This change drops the extra profit sum from the query and does the simple subtraction in code instead. Each listing now reads the ledger **twice instead of four times** on this page.

## Why it's safe

Nothing about the numbers changes — profit is the same value it always was. The existing tests that check "profit equals income minus cost" and "profit stays the same after a refund" still pass without any change to what they expect.

## Not done here

I also looked at the three image lookups in the same query (each finds the same "first picture for this listing" but reads a different field off it). Collapsing those into one lookup would fight the tidy one-column-per-field way images are read today, and would have to change a helper shared by four different pages — more tangle than it's worth for three cheap, index-backed lookups on a page that is already cached. Left as-is on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbKsdpW7qrKYasBZFNvtbu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listing financial calculations by deriving profit consistently from income minus cost.
  * Ensured refunds do not incorrectly alter the listing’s gross profit value.

* **Documentation**
  * Clarified how listing income, costs, and profit are calculated and represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->