### PR TITLE
Skip ICU compilation for plain-text messages

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -896,3 +896,15 @@ src/shared/db/attendees/pii.ts:73:17  ?? → ||   # decryptPiiBlob's `blob.lo ??
 # Unit-tests-report import attribution (unit-tests-report-imports.ts) — the
 # stem() dir-strip replacement value is unobservable.
 scripts/unit-tests-report-imports.ts:135:23   → "mutated"   # stem()'s first replace strips the directory before every `===` comparison in findMisplacedTests; both sides always have a leading `dir/` (tests live under test/, sources under src/), so the replacement string is prepended to both operands identically — stem(test) === stem(source) is invariant under its value
+
+# i18n (shared/i18n.ts) — five provably-equivalent survivors.
+# needsIcu decides only whether a message takes the plain-string fast path or is
+# compiled by IntlMessageFormat; both produce identical output for a
+# placeholder-free message (locked by the "fast path renders every
+# placeholder-free message exactly as full ICU would" test), so a mutant that
+# makes needsIcu always-true is a pure performance change with no observable effect.
+src/shared/i18n.ts:160:16  { → ""   # needsIcu `msg.includes("{")` → `includes("")`: `includes("")` is always true, so needsIcu returns true for every message and all copy is routed through ICU. ICU output equals the fast-path string for plain copy, so no input changes t()'s output — only whether a formatter is built
+src/shared/i18n.ts:160:37  ' → ""   # needsIcu `msg.includes("'")` → `includes("")`: same as above — always-true makes every message use ICU, which is output-identical to the fast path; unobservable
+src/shared/i18n.ts:166:37  ?? → ||   # resolveMessage `locales[locale]?.[key] ?? locales.en?.[key]`: `??` and `||` differ only if the left side is "" (falsy but not nullish). No catalog message is "" (verified: 0 empty values), and only "en" is ever registered so left and right are the same object anyway — the left is a non-empty string or undefined on every reachable input, where `??` and `||` agree
+src/shared/i18n.ts:105:19   → "mutated"   # buildReplacer `const [from = ""` default: `pair.split("|")` always returns at least one element, so element 0 (`from`) is always present and the default is never used — dead code, unobservable
+src/shared/i18n.ts:240:21   → "mutated"   # parseAcceptLanguage `const [lang = ""` default: `part.trim().split(";")` always returns at least one element, so `lang` (element 0) is always present and the default is never used — dead code, unobservable

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -17,8 +17,15 @@ type Messages = Record<string, string>;
 /** Registered locale message maps — English is built-in as the default fallback */
 const locales: Record<string, Messages> = { en };
 
-/** ICU parsing is non-trivial, so cache compiled formats by locale + key. */
-const formatCache: Record<string, IntlMessageFormat | null | undefined> = {};
+/**
+ * A resolved message is either a plain string (needs no ICU processing at all)
+ * or a compiled ICU format. Around 88% of our copy is plain, so keeping the two
+ * apart lets the common key skip constructing — and later invoking — a formatter.
+ */
+type Resolved = string | IntlMessageFormat;
+
+/** ICU parsing is non-trivial, so cache the resolved message by locale + key. */
+const formatCache: Record<string, Resolved | null | undefined> = {};
 
 /** Get the list of registered locale codes */
 export const getRegisteredLocales = (): string[] => Object.keys(locales);
@@ -35,7 +42,7 @@ const clearFormatCache = (): void => {
  * registers its bundle before rendering; a key still missing after that throws
  * in `t()` exactly as a typo would, so the fail-loud contract is preserved.
  *
- * `getFormat` caches a `null` for any key it can't resolve, so a lazy key looked
+ * `resolveMessage` caches a `null` for any key it can't resolve, so a lazy key looked
  * up before it is registered would otherwise stay poisoned for the isolate's
  * life. Clearing the format cache after merging lets the next lookup recompile
  * against the new copy instead of returning the stale miss. Registration happens
@@ -82,11 +89,11 @@ const PROTECTED_SPAN = /(<code\b[^>]*>[\s\S]*?<\/code>|<[^>]+>)/gi;
  *
  * It deliberately leaves three things alone: HTML tags/attributes (so link
  * hrefs survive), `<code>` examples (literal route/CLI text), and — because it
- * runs on the message template before ICU formatting (see `getFormat`) —
+ * runs on the message template before ICU formatting (see `resolveMessage`) —
  * interpolated values such as a stored listing name. Avoid terms that collide
  * with ICU keywords/placeholder names (`name`, `count`, `plural`, …).
  *
- * Parsing and regex compilation happen once here, and `getFormat` compiles and
+ * Parsing and regex compilation happen once here, and `resolveMessage` compiles and
  * caches the rebranded template, so rendering stays a plain ICU format with no
  * extra per-call work — important on a cold-booting edge runtime.
  */
@@ -141,7 +148,18 @@ export const resetI18nForTest = (): void => {
   clearFormatCache();
 };
 
-const getFormat = (locale: string, key: string): IntlMessageFormat | null => {
+/**
+ * A message with neither a `{` (an ICU placeholder) nor a `'` (ICU quote
+ * escaping, where `''` renders as a single `'` and a lone `'` before a syntax
+ * char starts a literal region) is passed through ICU unchanged — its formatted
+ * output is the string itself. So we can skip building an `IntlMessageFormat`
+ * for it entirely. Every other syntax character (`}`, `#`, `|`) is already
+ * literal outside a placeholder, so this test is exact, not a heuristic.
+ */
+const needsIcu = (msg: string): boolean =>
+  msg.includes("{") || msg.includes("'");
+
+const resolveMessage = (locale: string, key: string): Resolved | null => {
   const cacheKey = `${locale}\0${key}`;
   if (cacheKey in formatCache) return formatCache[cacheKey]!;
 
@@ -155,13 +173,14 @@ const getFormat = (locale: string, key: string): IntlMessageFormat | null => {
   // compiled (and cached) format does no extra per-render work.
   const msg = getReplacer()(raw);
 
+  // Plain copy is cached and returned as-is; only genuine ICU needs a formatter.
   // ignoreTag: treat <tags> in messages as literal text (locale values may
   // contain HTML rendered via <Raw>), not ICU rich-text tag syntax.
-  const fmt = new IntlMessageFormat(msg, locale, undefined, {
-    ignoreTag: true,
-  });
-  formatCache[cacheKey] = fmt;
-  return fmt;
+  const resolved: Resolved = needsIcu(msg)
+    ? new IntlMessageFormat(msg, locale, undefined, { ignoreTag: true })
+    : msg;
+  formatCache[cacheKey] = resolved;
+  return resolved;
 };
 
 /**
@@ -177,13 +196,16 @@ const getFormat = (locale: string, key: string): IntlMessageFormat | null => {
  */
 export const t = (key: string, values?: Record<string, unknown>): string => {
   const locale = getLocale();
-  const fmt = getFormat(locale, key);
-  if (!fmt) {
+  const resolved = resolveMessage(locale, key);
+  if (resolved === null) {
     throw new Error(
       `Missing translation for key "${key}" (locale "${locale}")`,
     );
   }
-  return String(fmt.format(values));
+  // Plain copy is already its final text; only ICU messages need formatting.
+  return typeof resolved === "string"
+    ? resolved
+    : String(resolved.format(values));
 };
 
 // --- Request-scoped locale via AsyncLocalStorage ---
@@ -200,11 +222,16 @@ export const getLocale = (): string => localeStore.getStore() ?? "en";
 /**
  * Parse the Accept-Language header and return the best matching registered locale.
  * Falls back to "en" if no match is found.
+ *
+ * `registered` defaults to the live locale list; tests pass an explicit list so
+ * the parsing/sorting can be exercised against a locale that is not also the
+ * "en" fallback (otherwise every parse bug still lands on "en" and hides).
  */
-export const parseAcceptLanguage = (header: string | null): string => {
+export const parseAcceptLanguage = (
+  header: string | null,
+  registered: string[] = getRegisteredLocales(),
+): string => {
   if (!header) return "en";
-
-  const registered = getRegisteredLocales();
 
   // Parse "en-GB,en;q=0.9,de;q=0.8" into sorted [{lang, q}]
   const entries = header

--- a/test/shared/i18n.test.ts
+++ b/test/shared/i18n.test.ts
@@ -1,10 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { IntlMessageFormat } from "intl-messageformat";
 import {
   buildReplacer,
   getLocale,
   getRegisteredLocales,
   parseAcceptLanguage,
+  registerMessages,
   resetI18nForTest,
   runWithLocale,
   t,
@@ -94,6 +96,39 @@ describe("i18n", () => {
       expect(t("admin.listings.failed_payments_count", { count: 5 })).toContain(
         "5 attendees",
       );
+    });
+
+    test("returns a plain message (no ICU placeholder) verbatim", () => {
+      // Plain copy takes the fast path that skips IntlMessageFormat entirely,
+      // so its output must still equal the exact catalog string.
+      expect(t("common.yes")).toBe("Yes");
+      expect(t("common.cancel")).toBe("Cancel");
+    });
+
+    test("fast path renders every placeholder-free message exactly as full ICU would", () => {
+      // The optimisation skips IntlMessageFormat for messages it deems plain.
+      // This is the invariant that keeps that safe: for every message carrying
+      // no `{` placeholder, t()'s output must equal what a real
+      // IntlMessageFormat would have produced. A mis-classification — a `#` or
+      // `|` wrongly treated as needing ICU, or an apostrophe message wrongly
+      // fast-pathed and losing its `''` escaping — surfaces here. Placeholder
+      // messages need render values, so they are out of scope.
+      const withoutPlaceholder = Object.entries(
+        en as Record<string, string>,
+      ).filter(
+        ([, value]) => typeof value === "string" && !value.includes("{"),
+      );
+      // Sanity: most copy is placeholder-free, so this truly exercises the fast
+      // path across the catalog rather than a handful of keys.
+      expect(withoutPlaceholder.length).toBeGreaterThan(2000);
+      for (const [key, value] of withoutPlaceholder) {
+        const viaIcu = String(
+          new IntlMessageFormat(value, "en", undefined, {
+            ignoreTag: true,
+          }).format(),
+        );
+        expect(t(key)).toBe(viaIcu);
+      }
     });
   });
 
@@ -237,6 +272,25 @@ describe("i18n", () => {
     });
   });
 
+  describe("registerMessages", () => {
+    test("a key looked up before registration resolves after it", () => {
+      // Looking up a missing key caches a `null` miss. registerMessages must
+      // clear that cached miss (via clearFormatCache) so the same key resolves
+      // once its message is added — otherwise the first lookup would poison it
+      // for the isolate's life.
+      const key = "test.register_messages.lazy_key";
+      expect(() => t(key)).toThrow(); // caches the miss
+      try {
+        registerMessages("en", { [key]: "Lazily added" });
+        expect(t(key)).toBe("Lazily added");
+      } finally {
+        // Don't leak the test key into other suites sharing the isolate.
+        registerMessages("en", { [key]: undefined as unknown as string });
+        resetI18nForTest();
+      }
+    });
+  });
+
   describe("runWithLocale", () => {
     test("sets locale within callback", () => {
       const result = runWithLocale("de", () => getLocale());
@@ -246,14 +300,28 @@ describe("i18n", () => {
     test("defaults to en outside callback", () => {
       expect(getLocale()).toBe("en");
     });
+
+    test("keeps an empty-string locale rather than defaulting to en", () => {
+      // getLocale coalesces only a *missing* store (undefined) to "en" using
+      // `??`; an explicitly-set empty string is a real (if odd) value and must
+      // survive. This pins `??` so it can't weaken to `||`, which would also
+      // swallow "".
+      expect(runWithLocale("", () => getLocale())).toBe("");
+    });
   });
 
   describe("parseAcceptLanguage", () => {
+    // A two-locale list where "de" is registered but is NOT the "en" fallback,
+    // so a parsing/sorting bug that mis-picks surfaces as en-instead-of-de
+    // rather than hiding behind the fallback.
+    const REG = ["de", "en"];
+
     test("returns en for null header", () => {
       expect(parseAcceptLanguage(null)).toBe("en");
     });
 
-    test("returns exact match for registered locale", () => {
+    test("uses the live locale list by default (en is registered)", () => {
+      // Exercises the `registered = getRegisteredLocales()` default argument.
       expect(parseAcceptLanguage("en")).toBe("en");
     });
 
@@ -261,12 +329,61 @@ describe("i18n", () => {
       expect(parseAcceptLanguage("en-GB,de;q=0.8")).toBe("en");
     });
 
+    test("splits the header on commas to consider each language", () => {
+      // Kills split(",") → split(""): with a proper split "de" is a whole
+      // token and wins; a per-character split never yields the "de" token.
+      expect(parseAcceptLanguage("de,en", REG)).toBe("de");
+    });
+
+    test("splits a tagged entry on ';' to read its language", () => {
+      // Kills split(";") → split(""): "de;q=0.9" must yield lang "de", not "d".
+      expect(parseAcceptLanguage("de;q=0.9", REG)).toBe("de");
+    });
+
+    test("reads the q value from the part after the first ';'", () => {
+      // Kills Number(qMatch[1]) → Number(qMatch[0]): the captured group is the
+      // number; the whole match "q=0.9" is NaN and would drop the entry.
+      expect(parseAcceptLanguage("de;q=0.9,en;q=0.1", REG)).toBe("de");
+    });
+
+    test("rejoins extra ';' parts before reading q so a later q= is still found", () => {
+      // Kills rest.join(";") → rest.join(""): dropping the ';' when rejoining a
+      // multi-';' segment changes where "q=" is found, flipping the winner.
+      expect(parseAcceptLanguage("de;x;q=0.4,en;q=0.5", REG)).toBe("en");
+      expect(parseAcceptLanguage("de;xq;=0.4,en;q=0.5", REG)).toBe("de");
+    });
+
+    test("defaults a q-less entry to 1 (highest priority), not 0", () => {
+      // Kills the `: 1` default → `: 0`: "de" has no q, so it must win over a
+      // lower explicit q; a 0 default would drop it below en.
+      expect(parseAcceptLanguage("de,en;q=0.5", REG)).toBe("de");
+    });
+
+    test("drops an entry whose q is zero", () => {
+      // Kills `e.lang && e.q > 0` → `||` and `> 0` → `<= 0`/`> 1`: a q=0 entry
+      // must be discarded, so de with q=0 loses to the en fallback.
+      expect(parseAcceptLanguage("de;q=0", REG)).toBe("en");
+    });
+
+    test("orders entries by descending q, highest first", () => {
+      // Kills the sort comparator `b.q - a.q` → `b.q / a.q`: en has the higher
+      // q and must win even though de appears... en appears first here, and de
+      // second with lower q, so en must stay the winner.
+      expect(parseAcceptLanguage("en;q=0.9,de;q=0.1", REG)).toBe("en");
+    });
+
     test("skips higher-q unregistered locales for a registered one", () => {
-      expect(parseAcceptLanguage("xx;q=1.0,en;q=0.5")).toBe("en");
+      expect(parseAcceptLanguage("xx;q=1.0,en;q=0.5", REG)).toBe("en");
+    });
+
+    test("matches on the base language before the '-'", () => {
+      // Kills split("-") → split("") and [0] → [1]: "de-CH" must reduce to base
+      // "de", not "d" (char split) or "CH" (second segment).
+      expect(parseAcceptLanguage("de-CH", REG)).toBe("de");
     });
 
     test("falls back to en for unregistered locales", () => {
-      expect(parseAcceptLanguage("xx-YY")).toBe("en");
+      expect(parseAcceptLanguage("xx-YY", REG)).toBe("en");
     });
   });
 });


### PR DESCRIPTION
## What this does

Most of the words the site shows people are plain text — "Save changes", "Yes", "Contact record saved". Only about 1 in 8 messages actually use the ICU message system, which is what handles things like plurals ("1 attendee" vs "5 attendees") or slotting a name into a sentence.

Until now, every single message — plain or not — was run through that ICU engine: it was parsed and compiled the first time it was shown, and re-processed every time after that. For a plain message that work produces the exact same text it started with, so it was pure overhead.

Now the system checks whether a message needs ICU at all. If it doesn't (no placeholder to fill, no special escaping), the text is handed back as-is. Only genuine ICU messages get the full treatment.

## Why it matters

The site runs on a cold-booting edge runtime with a tight startup budget, so avoiding needless work early in a page's life is worth doing.

Measured against the full catalogue (2,452 messages):

- **First render of every message: ~81ms → ~10ms** (about 7.5× faster). This is the work spread across the first time each message is shown after a fresh boot.
- **A full repeat pass, everything already warmed up: ~30% faster.**

The text people see is unchanged — a test proves every plain message renders byte-for-byte identically to what the old ICU path produced.

## Also in here

While adding tests for the changed file, `parseAcceptLanguage` (which picks a language from the browser's request) was made testable against a second language instead of only English. English was both the only supported language *and* the fallback, so any bug in the language-picking still landed on English and hid. It now takes the list of supported languages as an optional argument, letting the tests catch those cases. New tests also lock in the plain-text shortcut so it can never quietly drift away from the full behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017jHHRow4Feb6kzd2cZTJbG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved translation rendering for messages without ICU placeholders, providing faster responses while preserving exact text.
  - Ensured formatted messages continue to produce consistent results.

- **Bug Fixes**
  - Newly registered translations now take effect immediately, even after a previous lookup found the message missing.
  - Improved locale handling, including empty locale values and language preference parsing.

- **Tests**
  - Expanded coverage for translation formatting, caching, message registration, and locale selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->