### PR TITLE
Let developers use a newer Deno locally, keep CI on the pinned 2.5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ deploy/certs/*.pem
 # Test artifacts from storage tests run without LOCAL_STORAGE_PATH set
 /undefined/
 /null/
+
+# Local mise override for running a newer Deno alongside the pinned toolchain
+# (see AGENTS.md "Running a newer Deno locally"). Keeps the pinned .mise.toml clean.
+mise.local.toml
+.mise.local.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ one:
 
 ```bash
 mise use --env local deno@latest   # writes mise.local.toml, which is git-ignored
-deno check --unstable-tsgo src/**/*.ts   # fast type-check on the newer Deno
+deno check --unstable-tsgo "src/**/*.ts"   # fast type-check on the newer Deno
 ```
 
 Use `--env local` so the newer version lands in `mise.local.toml` (git-ignored),
@@ -50,14 +50,16 @@ not the tracked `.mise.toml`. A plain `mise use deno@latest` would edit the
 tracked config and move the pinned floor for everyone — the opposite of what you
 want.
 
+(Quote the `"src/**/*.ts"` glob so Deno expands it recursively — an unquoted
+`src/**/*.ts` is expanded by the shell first and misses deeper files.)
+
 Two things to keep in mind, because a newer Deno's type checker differs from the
 pinned one and can disagree with CI:
 
-- **A newer Deno includes `@types/node` by default and ships a newer
-  TypeScript.** That makes some Node globals resolve differently — most
-  notably `setTimeout` returns a `Timeout` object, not a `number`. Type timer
-  handles as `ReturnType<typeof setTimeout>` (not `number`) so the code checks
-  clean on both versions. See `scripts/process.ts` for the pattern.
+- **A newer Deno adopts Node-compatible global timers**, so `setTimeout` returns
+  a `Timeout` object rather than a `number`. Type timer handles as
+  `ReturnType<typeof setTimeout>` (not `number`) so the code checks clean on both
+  the pinned and newer runtimes. See `scripts/process.ts` for the pattern.
 - **The pinned 2.5.6 is the authority.** Before finishing, always run the full
   gate on the pinned version — `mise exec deno@2.5.6 -- deno task precommit` —
   since only that mirrors CI. The newer Deno is for speed while you iterate, not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@ Code must work in both environments. The edge runtime is Deno-based, so developm
 ## Deno Version
 
 This repo pins Deno 2.5.6, the lowest Bunny Edge Scripting runtime version this
-project is expected to run on. Local development should use that version too.
+project is expected to run on. **CI and every authoritative check run on this
+pinned version** — it is the build/production-parity floor, so it is the version
+that decides whether a change is green.
 
 This repo pins Deno with mise:
 
@@ -26,7 +28,36 @@ mise install
 mise exec -- deno --version
 ```
 
-The `.tool-versions` file is kept in sync for asdf-compatible tooling.
+The `.tool-versions` file is kept in sync for asdf-compatible tooling, and it is
+what CI reads (`.github/actions/setup-deno`). Do **not** bump it for local
+convenience — bumping it moves CI and the production-parity floor with it.
+
+### Running a newer Deno locally
+
+You may install a newer Deno alongside the pinned one for a faster inner loop —
+newer releases type-check much faster, and Deno 2.6+ adds the experimental Go
+type checker (`deno check --unstable-tsgo`), which is several times faster again.
+mise can hold both versions, so a quick edit/type-check cycle can use the newer
+one:
+
+```bash
+mise use deno@latest          # writes to a local (git-ignored) mise config
+deno check --unstable-tsgo src/**/*.ts   # fast type-check on the newer Deno
+```
+
+Two things to keep in mind, because a newer Deno's type checker differs from the
+pinned one and can disagree with CI:
+
+- **A newer Deno includes `@types/node` by default and ships a newer
+  TypeScript.** That makes some Node globals resolve differently — most
+  notably `setTimeout` returns a `Timeout` object, not a `number`. Type timer
+  handles as `ReturnType<typeof setTimeout>` (not `number`) so the code checks
+  clean on both versions. See `scripts/process.ts` for the pattern.
+- **The pinned 2.5.6 is the authority.** Before finishing, always run the full
+  gate on the pinned version — `mise exec deno@2.5.6 -- deno task precommit` —
+  since only that mirrors CI. The newer Deno is for speed while you iterate, not
+  for deciding pass/fail. The full parallel test suite in particular is only
+  known-good on the pinned version; run `deno task test` under 2.5.6.
 
 ## stripe-mock
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ one:
 
 ```bash
 mise use --env local deno@latest   # writes mise.local.toml, which is git-ignored
-deno check --unstable-tsgo "src/**/*.ts"   # fast type-check on the newer Deno
+deno check --unstable-tsgo "src/**/*.ts" "src/**/*.tsx"   # fast type-check on the newer Deno
 ```
 
 Use `--env local` so the newer version lands in `mise.local.toml` (git-ignored),
@@ -64,7 +64,8 @@ pinned one and can disagree with CI:
   gate on the pinned version — `mise exec deno@2.5.6 -- deno task precommit` —
   since only that mirrors CI. The newer Deno is for speed while you iterate, not
   for deciding pass/fail. The full parallel test suite in particular is only
-  known-good on the pinned version; run `deno task test` under 2.5.6.
+  known-good on the pinned version; run it explicitly through 2.5.6 with
+  `mise exec deno@2.5.6 -- deno task test`.
 
 ## stripe-mock
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,14 @@ mise can hold both versions, so a quick edit/type-check cycle can use the newer
 one:
 
 ```bash
-mise use deno@latest          # writes to a local (git-ignored) mise config
+mise use --env local deno@latest   # writes mise.local.toml, which is git-ignored
 deno check --unstable-tsgo src/**/*.ts   # fast type-check on the newer Deno
 ```
+
+Use `--env local` so the newer version lands in `mise.local.toml` (git-ignored),
+not the tracked `.mise.toml`. A plain `mise use deno@latest` would edit the
+tracked config and move the pinned floor for everyone — the opposite of what you
+want.
 
 Two things to keep in mind, because a newer Deno's type checker differs from the
 pinned one and can disagree with CI:

--- a/scripts/process.ts
+++ b/scripts/process.ts
@@ -4,7 +4,9 @@ const beforeTimeout = async (
   status: Promise<unknown>,
   timeoutMs: number,
 ): Promise<boolean> => {
-  let timeout = 0;
+  // Typed via ReturnType so it works on both the pinned runtime (number) and
+  // newer Deno, where node types make setTimeout return a Timeout object.
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   const delayed = new Promise<boolean>((resolve) => {
     timeout = setTimeout(() => resolve(false), timeoutMs);
   });

--- a/scripts/stripe-mock.ts
+++ b/scripts/stripe-mock.ts
@@ -93,7 +93,9 @@ const raceWithDelay = async <T>(
   delayMs: number,
   delayedValue: () => T,
 ): Promise<T> => {
-  let timeout = 0;
+  // Typed via ReturnType so it works on both the pinned runtime (number) and
+  // newer Deno, where node types make setTimeout return a Timeout object.
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   const delayed = new Promise<T>((resolve) => {
     timeout = setTimeout(() => resolve(delayedValue()), delayMs);
   });

--- a/test/scripts/mutation-isolation-supervisor.test.ts
+++ b/test/scripts/mutation-isolation-supervisor.test.ts
@@ -130,7 +130,9 @@ const withCapturedStopChild = async (
   await run(() => stopChild);
 };
 
-type KillCall = { pid: number; signal: Deno.Signal | undefined };
+// Newer Deno widens Deno.kill's signal parameter to also accept integer
+// signals, so the recorded signal can be a number on those runtimes.
+type KillCall = { pid: number; signal: number | Deno.Signal | undefined };
 type DenoCommandShim = { Command: (...args: unknown[]) => unknown };
 
 const denoCommand = Deno as unknown as DenoCommandShim;


### PR DESCRIPTION
## What this does

Newer Deno versions type-check a lot faster (Deno 2.6+ adds an experimental Go type checker that is several times quicker again). This change lets you use a newer Deno day-to-day for a faster edit/check loop, while keeping the pinned Deno 2.5.6 as the version that CI, the full test suite, and production all use.

Nothing about the pinned version changes. 2.5.6 stays the floor that decides whether a change is green — this just removes the small things that stopped the code type-checking on a newer Deno, and writes down how to use both.

## Why the code needed a few tweaks

A newer Deno brings in Node's type definitions by default and ships a newer TypeScript. That changes three types that were fine on 2.5.6 but failed on a newer Deno. Each is fixed in a way that still passes on 2.5.6:

- `setTimeout` now hands back a timer object instead of a plain number. The two timer handles in `scripts/process.ts` and `scripts/stripe-mock.ts` are now typed as "whatever `setTimeout` returns", so they are correct on both versions.
- `Deno.kill` now also accepts a plain number as the signal, so the recorded signal in one test can be a number too. The test's type was widened to allow it.

## What I checked

- The whole project type-checks cleanly on both the pinned 2.5.6 and the latest Deno (2.9.2).
- Lint passes, and the affected tests pass on 2.5.6.
- The full test suite passes on the pinned 2.5.6. On the very latest Deno the parallel test runner does not finish cleanly yet, so the docs are clear that the full suite and every final check must run on the pinned version — the newer Deno is only for a faster type-check while you work.

## Docs

`AGENTS.md` now explains the two-version setup: install a newer Deno alongside for speed, but always run the final checks (`deno task precommit`, the full test suite) on the pinned 2.5.6, which is also what CI reads. It calls out the `setTimeout` gotcha so the next timer added doesn't reintroduce the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPtPHKRs7FE9yY2Xdfxvh6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPtPHKRs7FE9yY2Xdfxvh6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pinned Deno version as the CI/build production-parity floor.
  * Expanded instructions for using a newer local Deno (including faster type-checking) without changing the pinned floor, and reiterated running the full precommit gate under the pinned version.
* **Bug Fixes**
  * Improved timeout handle typing to ensure `setTimeout`/`clearTimeout` work consistently across supported runtimes.
  * Adjusted a test to account for runtime differences in `Deno.kill` signal typing.
* **Chores**
  * Updated version control ignore rules for local Deno/tooling override files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->