### PR TITLE
Add a script that splits a branch's diff into code vs imports, comments and blanks

### DIFF
--- a/scripts/diff-code-lines-lib.ts
+++ b/scripts/diff-code-lines-lib.ts
@@ -1,0 +1,225 @@
+/**
+ * Classify the changed lines of a `git diff` by area (src / test / other) and
+ * by kind (real code vs import / comment / blank), then format the tallies.
+ *
+ * "Real code" is what's left after dropping import lines (including multi-line
+ * `import { … } from …` blocks and multi-line `export { … } from …`
+ * re-exports), comment lines (`//`, and `/* … *\/` block comments including
+ * their `*` continuation lines), and blank lines. Added and removed files are
+ * both counted against their real area: a deletion names its path only on the
+ * `--- a/…` header, so both file headers are read.
+ *
+ * This module is pure — it takes the diff text and returns strings — so the CLI
+ * shell (diff-code-lines.ts) only has to run `git diff` and print.
+ *
+ * The classifier is a line-based heuristic, not a parser, so treat the numbers
+ * as a close estimate rather than an exact AST count. Its one known blind spot:
+ * `git diff --unified=0` shows only the changed lines, so adding or removing a
+ * single member inside an existing multi-line import (the `import {` opener
+ * stays unchanged and off-diff) reads as a plain identifier and counts as code.
+ */
+
+export type Area = "src" | "test" | "other";
+export type Kind = "code" | "import" | "comment" | "blank";
+
+export type Tally = Record<Kind, number>;
+const emptyTally = (): Tally => ({ blank: 0, code: 0, comment: 0, import: 0 });
+
+/** A fresh per-area tally set (one empty tally for each area). */
+export const emptyAreaTally = (): Record<Area, Tally> => ({
+  other: emptyTally(),
+  src: emptyTally(),
+  test: emptyTally(),
+});
+
+/** Running state for one side of the diff (added lines vs removed lines), so a
+ * multi-line import block or block comment keeps its kind across its lines. */
+export type SideState = { inImport: boolean; inBlockComment: boolean };
+export const freshState = (): SideState => ({
+  inBlockComment: false,
+  inImport: false,
+});
+
+const areaOf = (path: string): Area =>
+  path.startsWith("src/") ? "src" : path.startsWith("test/") ? "test" : "other";
+
+/** The area a `git diff` file header names, or `null` for its `/dev/null`
+ * side. A created or deleted file names its real path on only one of its two
+ * headers (`--- a/…` for a deletion, `+++ b/…` for a creation), so both header
+ * lines are read and the `/dev/null` side is skipped. Returns `undefined` when
+ * the line is not a file header. */
+const fileHeaderArea = (line: string): Area | null | undefined => {
+  if (line === "--- /dev/null" || line === "+++ /dev/null") return null;
+  if (line.startsWith("--- a/")) return areaOf(line.slice("--- a/".length));
+  if (line.startsWith("+++ b/")) return areaOf(line.slice("+++ b/".length));
+  return;
+};
+
+/** A line opens a multi-line block if it starts one it doesn't also close. */
+const opensBlock = (line: string, open: string, close: string): boolean =>
+  line.includes(open) && !line.includes(close);
+
+/** While a block comment or import block is open, classify its continuation
+ * lines and close the run when its terminator arrives. Returns null when no run
+ * is open, so the caller falls through to single-line classification. */
+const continueOpenRun = (line: string, state: SideState): Kind | null => {
+  if (state.inBlockComment) {
+    if (line.includes("*/")) state.inBlockComment = false;
+    return "comment";
+  }
+  if (state.inImport) {
+    if (line.includes("}")) state.inImport = false;
+    return "import";
+  }
+  return null;
+};
+
+/** True when a changed line is (or opens) an import / re-export statement:
+ *  - `import …` in any form;
+ *  - a single-line `export … from "…"` re-export — the quoted module name after
+ *    `from` is what tells a real re-export apart from code that merely mentions
+ *    the word, like `export const pick = (view, from) => …`;
+ *  - an `export {` / `export type {` that opens a multi-line block, which barrel
+ *    files close with `} from "…"` on a later line (that closing line is counted
+ *    by the open-run handler, so the opener only needs to start the run). */
+const isImportLine = (line: string): boolean =>
+  /^import\b/.test(line) ||
+  /^export\b.*\bfrom\s+["']/.test(line) ||
+  (/^export\s+(type\s+)?\{/.test(line) && opensBlock(line, "{", "}"));
+
+/** Classify one changed line, advancing `state` for multi-line constructs. */
+export const classify = (raw: string, state: SideState): Kind => {
+  const line = raw.trim();
+
+  const open = continueOpenRun(line, state);
+  if (open !== null) return open;
+
+  if (line.startsWith("/*")) {
+    state.inBlockComment = opensBlock(line, "/*", "*/");
+    return "comment";
+  }
+  if (line === "") return "blank";
+  if (line.startsWith("//") || line.startsWith("*")) return "comment";
+
+  if (isImportLine(line)) {
+    state.inImport = opensBlock(line, "{", "}");
+    return "import";
+  }
+  return "code";
+};
+
+export type Counts = {
+  added: Record<Area, Tally>;
+  removed: Record<Area, Tally>;
+};
+
+/** Everything the diff walk carries from one line to the next: the tallies, the
+ * current file's area, the add/remove classification runs, and whether we are
+ * still in a file's header section. */
+type WalkState = {
+  counts: Counts;
+  area: Area;
+  addState: SideState;
+  removeState: SideState;
+  inHeader: boolean;
+};
+
+/** Handle a file-header or hunk-boundary line, updating the walk state. Returns
+ * true when the line was header/boundary metadata the caller should skip.
+ *
+ * `--- a/…` / `+++ b/…` only name the file inside the header section between a
+ * `diff --git` marker and the first `@@` hunk. Scoping header handling to that
+ * section keeps a dash-prefixed content line (e.g. a removed SQL `-- comment`,
+ * which diffs to `--- comment`) from being mistaken for a header and dropped. */
+const applyBoundaryLine = (line: string, state: WalkState): boolean => {
+  if (line.startsWith("diff --git ")) {
+    state.inHeader = true;
+    return true;
+  }
+  if (state.inHeader) {
+    const headerArea = fileHeaderArea(line);
+    if (headerArea !== undefined) {
+      // A real path updates the area; a `/dev/null` side keeps the area set by
+      // the file's other header, so a deletion still counts as its real area
+      // rather than inheriting the previous file's.
+      if (headerArea !== null) state.area = headerArea;
+      return true;
+    }
+  }
+  if (line.startsWith("@@")) {
+    // The first hunk ends the header; a new hunk also breaks any open
+    // import/comment run carried over from the previous hunk.
+    state.inHeader = false;
+    state.addState = freshState();
+    state.removeState = freshState();
+    return true;
+  }
+  return false;
+};
+
+/** Tally one changed content line under the current area, by its kind. */
+const tallyContentLine = (line: string, state: WalkState): void => {
+  if (line.startsWith("+")) {
+    const kind = classify(line.slice(1), state.addState);
+    state.counts.added[state.area][kind] += 1;
+  } else if (line.startsWith("-")) {
+    const kind = classify(line.slice(1), state.removeState);
+    state.counts.removed[state.area][kind] += 1;
+  }
+};
+
+export const tallyDiff = (diff: string): Counts => {
+  const state: WalkState = {
+    addState: freshState(),
+    area: "other",
+    counts: { added: emptyAreaTally(), removed: emptyAreaTally() },
+    inHeader: false,
+    removeState: freshState(),
+  };
+  for (const line of diff.split("\n")) {
+    if (!applyBoundaryLine(line, state)) tallyContentLine(line, state);
+  }
+  return state.counts;
+};
+
+const codeCount = (t: Tally): number => t.code;
+
+const pad = (s: string, n: number): string => s.padEnd(n);
+const num = (n: number): string => String(n).padStart(6);
+
+const areaRow = (a: Area, counts: Counts): string => {
+  const add = counts.added[a];
+  const rem = counts.removed[a];
+  return (
+    `${pad(a, 7)}` +
+    `${num(add.code)}/${num(rem.code)}    ` +
+    `${num(add.import)}/${num(rem.import)}  ` +
+    `${num(add.comment)}/${num(rem.comment)}  ` +
+    `${num(add.blank)}/${num(rem.blank)}`
+  );
+};
+
+/** Format the whole report — per-area table plus the code-only src/test totals
+ * and their ratio — as one string ready to print. */
+export const formatReport = (counts: Counts): string => {
+  const areas: Area[] = ["src", "test", "other"];
+  const srcCode = codeCount(counts.added.src) + codeCount(counts.removed.src);
+  const testCode =
+    codeCount(counts.added.test) + codeCount(counts.removed.test);
+
+  const lines = [
+    `${pad("area", 7)}${pad("code +/-", 18)}${pad("import +/-", 16)}${pad(
+      "comment +/-",
+      16,
+    )}${pad("blank +/-", 14)}`,
+    ...areas.map((a) => areaRow(a, counts)),
+    "",
+    "Code lines changed (added + removed), imports/comments/blanks excluded:",
+    `  src : ${srcCode}`,
+    `  test: ${testCode}`,
+  ];
+  if (srcCode > 0) {
+    lines.push(`  test/src ratio: ${(testCode / srcCode).toFixed(2)}`);
+  }
+  return lines.join("\n");
+};

--- a/scripts/diff-code-lines-lib.ts
+++ b/scripts/diff-code-lines-lib.ts
@@ -19,6 +19,8 @@
  * stays unchanged and off-diff) reads as a plain identifier and counts as code.
  */
 
+import { reduce } from "#fp";
+
 export type Area = "src" | "test" | "other";
 export type Kind = "code" | "import" | "comment" | "blank";
 
@@ -74,18 +76,28 @@ const continueOpenRun = (line: string, state: SideState): Kind | null => {
   return null;
 };
 
+/** A line begins a re-export: `export {` / `export * ` / `export type {` /
+ * `export type *`. Requiring `*` or `{` right after `export` (optionally
+ * `type`) is what keeps ordinary exported code out — `export const note =
+ * 'from "x"'` starts with `const`, so it never counts as a re-export even
+ * though it contains the word `from`. */
+const startsReExport = (line: string): boolean =>
+  /^export\s+(type\s+)?[*{]/.test(line);
+
 /** True when a changed line is (or opens) an import / re-export statement:
- *  - `import …` in any form;
- *  - a single-line `export … from "…"` re-export — the quoted module name after
- *    `from` is what tells a real re-export apart from code that merely mentions
- *    the word, like `export const pick = (view, from) => …`;
+ *  - a static `import` declaration — `import x from …`, `import { … } from …`,
+ *    `import * as …`, or a side-effect `import "…"`. The character after
+ *    `import` must be a space or quote, so `import.meta` and dynamic `import(…)`
+ *    (both executable code) stay classified as code;
+ *  - a single-line `export … from "…"` re-export (the quoted module name is the
+ *    real module specifier);
  *  - an `export {` / `export type {` that opens a multi-line block, which barrel
  *    files close with `} from "…"` on a later line (that closing line is counted
  *    by the open-run handler, so the opener only needs to start the run). */
 const isImportLine = (line: string): boolean =>
-  /^import\b/.test(line) ||
-  /^export\b.*\bfrom\s+["']/.test(line) ||
-  (/^export\s+(type\s+)?\{/.test(line) && opensBlock(line, "{", "}"));
+  /^import["'\s]/.test(line) ||
+  (startsReExport(line) &&
+    (/\bfrom\s+["']/.test(line) || opensBlock(line, "{", "}")));
 
 /** Classify one changed line, advancing `state` for multi-line constructs. */
 export const classify = (raw: string, state: SideState): Kind => {
@@ -168,19 +180,23 @@ const tallyContentLine = (line: string, state: WalkState): void => {
   }
 };
 
-export const tallyDiff = (diff: string): Counts => {
-  const state: WalkState = {
-    addState: freshState(),
-    area: "other",
-    counts: { added: emptyAreaTally(), removed: emptyAreaTally() },
-    inHeader: false,
-    removeState: freshState(),
-  };
-  for (const line of diff.split("\n")) {
-    if (!applyBoundaryLine(line, state)) tallyContentLine(line, state);
-  }
-  return state.counts;
+/** Fold one diff line into the running walk state: boundary lines update the
+ * state and are skipped, content lines are tallied. */
+const foldLine = (state: WalkState, line: string): WalkState => {
+  if (!applyBoundaryLine(line, state)) tallyContentLine(line, state);
+  return state;
 };
+
+const freshWalkState = (): WalkState => ({
+  addState: freshState(),
+  area: "other",
+  counts: { added: emptyAreaTally(), removed: emptyAreaTally() },
+  inHeader: false,
+  removeState: freshState(),
+});
+
+export const tallyDiff = (diff: string): Counts =>
+  reduce(foldLine, freshWalkState())(diff.split("\n")).counts;
 
 const codeCount = (t: Tally): number => t.code;
 

--- a/scripts/diff-code-lines-lib.ts
+++ b/scripts/diff-code-lines-lib.ts
@@ -135,11 +135,17 @@ export type Counts = {
 };
 
 /** Everything the diff walk carries from one line to the next: the tallies, the
- * current file's area, the add/remove classification runs, and whether we are
- * still in a file's header section. */
+ * current file's area for each side, the add/remove classification runs, and
+ * whether we are still in a file's header section.
+ *
+ * The added and removed sides get their own area because a cross-area rename
+ * with edits (e.g. `src/a.ts` → `test/a.test.ts`) names one area on `--- a/…`
+ * and the other on `+++ b/…`, so removed lines must count against the old area
+ * and added lines against the new. */
 type WalkState = {
   counts: Counts;
-  area: Area;
+  addArea: Area;
+  removeArea: Area;
   addState: SideState;
   removeState: SideState;
   inHeader: boolean;
@@ -160,10 +166,14 @@ const applyBoundaryLine = (line: string, state: WalkState): boolean => {
   if (state.inHeader) {
     const headerArea = fileHeaderArea(line);
     if (headerArea !== undefined) {
-      // A real path updates the area; a `/dev/null` side keeps the area set by
-      // the file's other header, so a deletion still counts as its real area
-      // rather than inheriting the previous file's.
-      if (headerArea !== null) state.area = headerArea;
+      // Each header sets its own side's area: `+++ b/…` the added side, `--- a/…`
+      // the removed side. A `/dev/null` side (null) leaves that side's area as
+      // set by the file's other header — a deletion has no added lines and a
+      // creation no removed lines, so the stale side is never tallied against.
+      if (headerArea !== null) {
+        if (line.startsWith("+++")) state.addArea = headerArea;
+        else state.removeArea = headerArea;
+      }
       return true;
     }
   }
@@ -178,14 +188,14 @@ const applyBoundaryLine = (line: string, state: WalkState): boolean => {
   return false;
 };
 
-/** Tally one changed content line under the current area, by its kind. */
+/** Tally one changed content line under its side's current area, by its kind. */
 const tallyContentLine = (line: string, state: WalkState): void => {
   if (line.startsWith("+")) {
     const kind = classify(line.slice(1), state.addState);
-    state.counts.added[state.area][kind] += 1;
+    state.counts.added[state.addArea][kind] += 1;
   } else if (line.startsWith("-")) {
     const kind = classify(line.slice(1), state.removeState);
-    state.counts.removed[state.area][kind] += 1;
+    state.counts.removed[state.removeArea][kind] += 1;
   }
 };
 
@@ -197,10 +207,11 @@ const foldLine = (state: WalkState, line: string): WalkState => {
 };
 
 const freshWalkState = (): WalkState => ({
+  addArea: "other",
   addState: freshState(),
-  area: "other",
   counts: { added: emptyAreaTally(), removed: emptyAreaTally() },
   inHeader: false,
+  removeArea: "other",
   removeState: freshState(),
 });
 

--- a/scripts/diff-code-lines-lib.ts
+++ b/scripts/diff-code-lines-lib.ts
@@ -13,10 +13,15 @@
  * shell (diff-code-lines.ts) only has to run `git diff` and print.
  *
  * The classifier is a line-based heuristic, not a parser, so treat the numbers
- * as a close estimate rather than an exact AST count. Its one known blind spot:
- * `git diff --unified=0` shows only the changed lines, so adding or removing a
- * single member inside an existing multi-line import (the `import {` opener
- * stays unchanged and off-diff) reads as a plain identifier and counts as code.
+ * as a close estimate rather than an exact AST count. Its known blind spots:
+ *  - `git diff --unified=0` shows only the changed lines, so adding or removing
+ *    a single member inside an existing multi-line import (the `import {` opener
+ *    stays unchanged and off-diff) reads as a plain identifier and counts as
+ *    code;
+ *  - a multi-line *local* `export { … }` block with no `from` counts as import,
+ *    not code: its opener is identical to a barrel re-export's, and telling them
+ *    apart would need line lookahead this single-pass classifier does not do.
+ *    Both are rare, and this stays a rough estimate rather than a parser.
  */
 
 import { reduce } from "#fp";
@@ -86,16 +91,20 @@ const startsReExport = (line: string): boolean =>
 
 /** True when a changed line is (or opens) an import / re-export statement:
  *  - a static `import` declaration — `import x from …`, `import { … } from …`,
- *    `import * as …`, or a side-effect `import "…"`. The character after
- *    `import` must be a space or quote, so `import.meta` and dynamic `import(…)`
- *    (both executable code) stay classified as code;
+ *    `import * as …`, a side-effect `import "…"`, or `import type …`. The
+ *    `import.meta` property and a dynamic `import(…)` / `import (…)` call are
+ *    executable code, so a `.` or `(` after `import` (any spacing) keeps them as
+ *    code;
  *  - a single-line `export … from "…"` re-export (the quoted module name is the
  *    real module specifier);
  *  - an `export {` / `export type {` that opens a multi-line block, which barrel
  *    files close with `} from "…"` on a later line (that closing line is counted
- *    by the open-run handler, so the opener only needs to start the run). */
+ *    by the open-run handler, so the opener only needs to start the run). A
+ *    multi-line *local* `export { … }` with no `from` is indistinguishable from
+ *    a barrel opener without lookahead, so it also counts as import — see the
+ *    module docstring's known blind spots. */
 const isImportLine = (line: string): boolean =>
-  /^import["'\s]/.test(line) ||
+  (/^import\b/.test(line) && !/^import\s*[.(]/.test(line)) ||
   (startsReExport(line) &&
     (/\bfrom\s+["']/.test(line) || opensBlock(line, "{", "}")));
 

--- a/scripts/diff-code-lines.ts
+++ b/scripts/diff-code-lines.ts
@@ -2,12 +2,8 @@
 /**
  * Count the changed lines of a branch's diff, split by area (src / test / other)
  * and by whether the line is real code or just an import / comment / blank.
- *
- * "Real code" is what's left after dropping import lines (including multi-line
- * `import { … } from …` blocks and `export … from` re-exports), comment lines
- * (`//`, and `/* … *\/` block comments including their `*` continuation lines),
- * and blank lines. The classifier is a line-based heuristic, not a parser, so
- * treat the numbers as a close estimate rather than an exact AST count.
+ * The classifying and formatting live in ./diff-code-lines-lib.ts; this shell
+ * only runs `git diff` and prints.
  *
  * Usage:
  *   deno run --allow-run scripts/diff-code-lines.ts [baseRef]
@@ -16,148 +12,22 @@
  * branch's own changes since it forked, ignoring later commits on the base).
  */
 
-type Area = "src" | "test" | "other";
-type Kind = "code" | "import" | "comment" | "blank";
-
-type Tally = Record<Kind, number>;
-const emptyTally = (): Tally => ({ blank: 0, code: 0, comment: 0, import: 0 });
-
-/** Running state for one side of the diff (added lines vs removed lines), so a
- * multi-line import block or block comment keeps its kind across its lines. */
-type SideState = { inImport: boolean; inBlockComment: boolean };
-const freshState = (): SideState => ({
-  inBlockComment: false,
-  inImport: false,
-});
-
-const areaOf = (path: string): Area =>
-  path.startsWith("src/") ? "src" : path.startsWith("test/") ? "test" : "other";
-
-/** A line opens a multi-line block if it starts one it doesn't also close. */
-const opensBlock = (line: string, open: string, close: string): boolean =>
-  line.includes(open) && !line.includes(close);
-
-/** While a block comment or import block is open, classify its continuation
- * lines and close the run when its terminator arrives. Returns null when no run
- * is open, so the caller falls through to single-line classification. */
-const continueOpenRun = (line: string, state: SideState): Kind | null => {
-  if (state.inBlockComment) {
-    if (line.includes("*/")) state.inBlockComment = false;
-    return "comment";
-  }
-  if (state.inImport) {
-    if (line.includes("}")) state.inImport = false;
-    return "import";
-  }
-  return null;
-};
-
-/** Classify one changed line, advancing `state` for multi-line constructs. */
-const classify = (raw: string, state: SideState): Kind => {
-  const line = raw.trim();
-
-  const open = continueOpenRun(line, state);
-  if (open !== null) return open;
-
-  if (line.startsWith("/*")) {
-    state.inBlockComment = opensBlock(line, "/*", "*/");
-    return "comment";
-  }
-  if (line === "") return "blank";
-  if (line.startsWith("//") || line.startsWith("*")) return "comment";
-
-  if (/^import\b/.test(line) || /^export\b.*\bfrom\b/.test(line)) {
-    state.inImport = opensBlock(line, "{", "}");
-    return "import";
-  }
-  return "code";
-};
+import { formatReport, tallyDiff } from "./diff-code-lines-lib.ts";
+import { runCommand } from "./precommit/git.ts";
 
 const runGitDiff = async (base: string): Promise<string> => {
   // --unified=0: only changed lines, no surrounding context to misclassify.
-  const command = new Deno.Command("git", {
-    args: ["diff", "--unified=0", `${base}...HEAD`],
-    stderr: "piped",
-    stdout: "piped",
-  });
-  const { code, stdout, stderr } = await command.output();
-  if (code !== 0) {
-    throw new Error(`git diff failed: ${new TextDecoder().decode(stderr)}`);
+  const result = await runCommand([
+    "git",
+    "diff",
+    "--unified=0",
+    `${base}...HEAD`,
+  ]);
+  if (!result.success) {
+    throw new Error(`git diff failed: ${result.stderr}`);
   }
-  return new TextDecoder().decode(stdout);
-};
-
-type Counts = { added: Record<Area, Tally>; removed: Record<Area, Tally> };
-
-const tallyDiff = (diff: string): Counts => {
-  const added: Record<Area, Tally> = {
-    other: emptyTally(),
-    src: emptyTally(),
-    test: emptyTally(),
-  };
-  const removed: Record<Area, Tally> = {
-    other: emptyTally(),
-    src: emptyTally(),
-    test: emptyTally(),
-  };
-  let area: Area = "other";
-  let addState = freshState();
-  let removeState = freshState();
-
-  for (const line of diff.split("\n")) {
-    if (line.startsWith("+++ b/")) {
-      area = areaOf(line.slice("+++ b/".length));
-      continue;
-    }
-    if (line.startsWith("--- ")) continue;
-    // A new hunk breaks any open import/comment run from the previous hunk.
-    if (line.startsWith("@@")) {
-      addState = freshState();
-      removeState = freshState();
-      continue;
-    }
-    if (line.startsWith("+")) {
-      added[area][classify(line.slice(1), addState)] += 1;
-    } else if (line.startsWith("-")) {
-      removed[area][classify(line.slice(1), removeState)] += 1;
-    }
-  }
-  return { added, removed };
-};
-
-const netCode = (t: Tally): number => t.code;
-
-const report = (counts: Counts): void => {
-  const areas: Area[] = ["src", "test", "other"];
-  const pad = (s: string, n: number) => s.padEnd(n);
-  const num = (n: number) => String(n).padStart(6);
-
-  console.log(
-    `${pad("area", 7)}${pad("code +/-", 18)}${pad("import +/-", 16)}${pad("comment +/-", 16)}${pad("blank +/-", 14)}`,
-  );
-  for (const a of areas) {
-    const add = counts.added[a];
-    const rem = counts.removed[a];
-    console.log(
-      `${pad(a, 7)}` +
-        `${num(add.code)}/${num(rem.code)}    ` +
-        `${num(add.import)}/${num(rem.import)}  ` +
-        `${num(add.comment)}/${num(rem.comment)}  ` +
-        `${num(add.blank)}/${num(rem.blank)}`,
-    );
-  }
-
-  const srcCode = netCode(counts.added.src) + netCode(counts.removed.src);
-  const testCode = netCode(counts.added.test) + netCode(counts.removed.test);
-  console.log(
-    "\nCode lines changed (added + removed), imports/comments/blanks excluded:",
-  );
-  console.log(`  src : ${srcCode}`);
-  console.log(`  test: ${testCode}`);
-  if (srcCode > 0) {
-    console.log(`  test/src ratio: ${(testCode / srcCode).toFixed(2)}`);
-  }
+  return result.stdout;
 };
 
 const base = Deno.args[0] ?? "origin/main";
-report(tallyDiff(await runGitDiff(base)));
+console.log(formatReport(tallyDiff(await runGitDiff(base))));

--- a/scripts/diff-code-lines.ts
+++ b/scripts/diff-code-lines.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S deno run --allow-run
+/**
+ * Count the changed lines of a branch's diff, split by area (src / test / other)
+ * and by whether the line is real code or just an import / comment / blank.
+ *
+ * "Real code" is what's left after dropping import lines (including multi-line
+ * `import { … } from …` blocks and `export … from` re-exports), comment lines
+ * (`//`, and `/* … *\/` block comments including their `*` continuation lines),
+ * and blank lines. The classifier is a line-based heuristic, not a parser, so
+ * treat the numbers as a close estimate rather than an exact AST count.
+ *
+ * Usage:
+ *   deno run --allow-run scripts/diff-code-lines.ts [baseRef]
+ *
+ * `baseRef` defaults to `origin/main`; the diff is `baseRef...HEAD` (the
+ * branch's own changes since it forked, ignoring later commits on the base).
+ */
+
+type Area = "src" | "test" | "other";
+type Kind = "code" | "import" | "comment" | "blank";
+
+type Tally = Record<Kind, number>;
+const emptyTally = (): Tally => ({ blank: 0, code: 0, comment: 0, import: 0 });
+
+/** Running state for one side of the diff (added lines vs removed lines), so a
+ * multi-line import block or block comment keeps its kind across its lines. */
+type SideState = { inImport: boolean; inBlockComment: boolean };
+const freshState = (): SideState => ({
+  inBlockComment: false,
+  inImport: false,
+});
+
+const areaOf = (path: string): Area =>
+  path.startsWith("src/") ? "src" : path.startsWith("test/") ? "test" : "other";
+
+/** A line opens a multi-line block if it starts one it doesn't also close. */
+const opensBlock = (line: string, open: string, close: string): boolean =>
+  line.includes(open) && !line.includes(close);
+
+/** While a block comment or import block is open, classify its continuation
+ * lines and close the run when its terminator arrives. Returns null when no run
+ * is open, so the caller falls through to single-line classification. */
+const continueOpenRun = (line: string, state: SideState): Kind | null => {
+  if (state.inBlockComment) {
+    if (line.includes("*/")) state.inBlockComment = false;
+    return "comment";
+  }
+  if (state.inImport) {
+    if (line.includes("}")) state.inImport = false;
+    return "import";
+  }
+  return null;
+};
+
+/** Classify one changed line, advancing `state` for multi-line constructs. */
+const classify = (raw: string, state: SideState): Kind => {
+  const line = raw.trim();
+
+  const open = continueOpenRun(line, state);
+  if (open !== null) return open;
+
+  if (line.startsWith("/*")) {
+    state.inBlockComment = opensBlock(line, "/*", "*/");
+    return "comment";
+  }
+  if (line === "") return "blank";
+  if (line.startsWith("//") || line.startsWith("*")) return "comment";
+
+  if (/^import\b/.test(line) || /^export\b.*\bfrom\b/.test(line)) {
+    state.inImport = opensBlock(line, "{", "}");
+    return "import";
+  }
+  return "code";
+};
+
+const runGitDiff = async (base: string): Promise<string> => {
+  // --unified=0: only changed lines, no surrounding context to misclassify.
+  const command = new Deno.Command("git", {
+    args: ["diff", "--unified=0", `${base}...HEAD`],
+    stderr: "piped",
+    stdout: "piped",
+  });
+  const { code, stdout, stderr } = await command.output();
+  if (code !== 0) {
+    throw new Error(`git diff failed: ${new TextDecoder().decode(stderr)}`);
+  }
+  return new TextDecoder().decode(stdout);
+};
+
+type Counts = { added: Record<Area, Tally>; removed: Record<Area, Tally> };
+
+const tallyDiff = (diff: string): Counts => {
+  const added: Record<Area, Tally> = {
+    other: emptyTally(),
+    src: emptyTally(),
+    test: emptyTally(),
+  };
+  const removed: Record<Area, Tally> = {
+    other: emptyTally(),
+    src: emptyTally(),
+    test: emptyTally(),
+  };
+  let area: Area = "other";
+  let addState = freshState();
+  let removeState = freshState();
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ b/")) {
+      area = areaOf(line.slice("+++ b/".length));
+      continue;
+    }
+    if (line.startsWith("--- ")) continue;
+    // A new hunk breaks any open import/comment run from the previous hunk.
+    if (line.startsWith("@@")) {
+      addState = freshState();
+      removeState = freshState();
+      continue;
+    }
+    if (line.startsWith("+")) {
+      added[area][classify(line.slice(1), addState)] += 1;
+    } else if (line.startsWith("-")) {
+      removed[area][classify(line.slice(1), removeState)] += 1;
+    }
+  }
+  return { added, removed };
+};
+
+const netCode = (t: Tally): number => t.code;
+
+const report = (counts: Counts): void => {
+  const areas: Area[] = ["src", "test", "other"];
+  const pad = (s: string, n: number) => s.padEnd(n);
+  const num = (n: number) => String(n).padStart(6);
+
+  console.log(
+    `${pad("area", 7)}${pad("code +/-", 18)}${pad("import +/-", 16)}${pad("comment +/-", 16)}${pad("blank +/-", 14)}`,
+  );
+  for (const a of areas) {
+    const add = counts.added[a];
+    const rem = counts.removed[a];
+    console.log(
+      `${pad(a, 7)}` +
+        `${num(add.code)}/${num(rem.code)}    ` +
+        `${num(add.import)}/${num(rem.import)}  ` +
+        `${num(add.comment)}/${num(rem.comment)}  ` +
+        `${num(add.blank)}/${num(rem.blank)}`,
+    );
+  }
+
+  const srcCode = netCode(counts.added.src) + netCode(counts.removed.src);
+  const testCode = netCode(counts.added.test) + netCode(counts.removed.test);
+  console.log(
+    "\nCode lines changed (added + removed), imports/comments/blanks excluded:",
+  );
+  console.log(`  src : ${srcCode}`);
+  console.log(`  test: ${testCode}`);
+  if (srcCode > 0) {
+    console.log(`  test/src ratio: ${(testCode / srcCode).toFixed(2)}`);
+  }
+};
+
+const base = Deno.args[0] ?? "origin/main";
+report(tallyDiff(await runGitDiff(base)));

--- a/test/scripts/diff-code-lines.test.ts
+++ b/test/scripts/diff-code-lines.test.ts
@@ -43,6 +43,7 @@ describe("diff-code-lines classify", () => {
     expect(classify('import defaultExport from "./d.ts";', fresh())).toBe(
       "import",
     );
+    expect(classify('import "./side-effect.ts";', fresh())).toBe("import");
     expect(classify('export { a } from "./a.ts";', fresh())).toBe("import");
     expect(classify('export * from "./a.ts";', fresh())).toBe("import");
     expect(classify('export type { T } from "./t.ts";', fresh())).toBe(
@@ -59,12 +60,29 @@ describe("diff-code-lines classify", () => {
   });
 
   test("does not mistake code that merely mentions `from` for an import", () => {
-    // A quoted module name after `from` is required, so an exported helper with
-    // a `from` parameter and a single-line local export block stay as code.
+    // A re-export must start with `export {` / `export *` / `export type`, so an
+    // exported helper with a `from` parameter, an export whose string value
+    // contains "from", and a single-line local export block all stay as code.
     expect(
       classify("export const pick = (view, from) => view;", freshState()),
     ).toBe("code");
+    expect(classify(`export const note = 'from "x"';`, freshState())).toBe(
+      "code",
+    );
     expect(classify("export { a };", freshState())).toBe("code");
+  });
+
+  test("treats import.meta and dynamic import() as code, not import", () => {
+    // Static import declarations have a space or quote after `import`; the
+    // `import.meta` property and a dynamic `import(...)` call are executable
+    // code, so both stay classified as code.
+    expect(classify("import.meta.url;", freshState())).toBe("code");
+    expect(classify('const m = await import("./m.ts");', freshState())).toBe(
+      "code",
+    );
+    expect(classify('import("./lazy.ts").then(run);', freshState())).toBe(
+      "code",
+    );
   });
 });
 

--- a/test/scripts/diff-code-lines.test.ts
+++ b/test/scripts/diff-code-lines.test.ts
@@ -1,0 +1,172 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  classify,
+  emptyAreaTally,
+  formatReport,
+  freshState,
+  tallyDiff,
+} from "../../scripts/diff-code-lines-lib.ts";
+
+describe("diff-code-lines classify", () => {
+  test("treats a multi-line import block as import across its lines", () => {
+    const state = freshState();
+    expect(classify("import {", state)).toBe("import");
+    expect(state.inImport).toBe(true);
+    expect(classify("  member,", state)).toBe("import");
+    expect(classify('} from "./x.ts";', state)).toBe("import");
+    expect(state.inImport).toBe(false);
+  });
+
+  test("treats a multi-line block comment as comment across its lines", () => {
+    const state = freshState();
+    expect(classify("/*", state)).toBe("comment");
+    expect(state.inBlockComment).toBe(true);
+    expect(classify(" * middle", state)).toBe("comment");
+    expect(classify(" closing */", state)).toBe("comment");
+    expect(state.inBlockComment).toBe(false);
+  });
+
+  test("classifies single-line kinds", () => {
+    const state = freshState();
+    expect(classify("/* one liner */", state)).toBe("comment");
+    expect(state.inBlockComment).toBe(false);
+    expect(classify("", state)).toBe("blank");
+    expect(classify("// a note", state)).toBe("comment");
+    expect(classify(" * jsdoc line", state)).toBe("comment");
+    expect(classify("const x = 1;", state)).toBe("code");
+  });
+
+  test("recognises imports and re-exports, single- and multi-line", () => {
+    const fresh = () => freshState();
+    expect(classify('import { a } from "./a.ts";', fresh())).toBe("import");
+    expect(classify('import defaultExport from "./d.ts";', fresh())).toBe(
+      "import",
+    );
+    expect(classify('export { a } from "./a.ts";', fresh())).toBe("import");
+    expect(classify('export * from "./a.ts";', fresh())).toBe("import");
+    expect(classify('export type { T } from "./t.ts";', fresh())).toBe(
+      "import",
+    );
+
+    const barrel = freshState();
+    expect(classify("export {", barrel)).toBe("import");
+    expect(barrel.inImport).toBe(true);
+
+    const typeBarrel = freshState();
+    expect(classify("export type {", typeBarrel)).toBe("import");
+    expect(typeBarrel.inImport).toBe(true);
+  });
+
+  test("does not mistake code that merely mentions `from` for an import", () => {
+    // A quoted module name after `from` is required, so an exported helper with
+    // a `from` parameter and a single-line local export block stay as code.
+    expect(
+      classify("export const pick = (view, from) => view;", freshState()),
+    ).toBe("code");
+    expect(classify("export { a };", freshState())).toBe("code");
+  });
+});
+
+describe("diff-code-lines tallyDiff", () => {
+  const DIFF = [
+    "diff --git a/src/foo.ts b/src/foo.ts",
+    "new file mode 100644",
+    "index 0000000..1111111",
+    "--- /dev/null",
+    "+++ b/src/foo.ts",
+    "@@ -0,0 +1,4 @@",
+    '+import { a } from "./a.ts";',
+    "+const x = 1;",
+    "+// note",
+    "+",
+    "diff --git a/test/bar.test.ts b/test/bar.test.ts",
+    "deleted file mode 100644",
+    "index 2222222..0000000",
+    "--- a/test/bar.test.ts",
+    "+++ /dev/null",
+    "@@ -1,2 +0,0 @@",
+    "-const y = 2;",
+    "-const z = 3;",
+    "\\ No newline at end of file",
+    "diff --git a/other/baz.md b/other/baz.md",
+    "index 3333333..4444444 100644",
+    "--- a/other/baz.md",
+    "+++ b/other/baz.md",
+    "@@ -1 +1 @@",
+    "-old line",
+    "+new line",
+    "@@ -5,0 +6 @@",
+    "+extra line",
+    "",
+  ].join("\n");
+
+  test("tallies added lines of a new file by kind under its area", () => {
+    const counts = tallyDiff(DIFF);
+    expect(counts.added.src).toEqual({
+      blank: 1,
+      code: 1,
+      comment: 1,
+      import: 1,
+    });
+    expect(counts.removed.src).toEqual({
+      blank: 0,
+      code: 0,
+      comment: 0,
+      import: 0,
+    });
+  });
+
+  test("attributes a deleted file's removed lines to its real area", () => {
+    // The deleted file names its path only on `--- a/test/…`; the `+dev/null`
+    // side must not leave the removed lines under the previous file's area.
+    const counts = tallyDiff(DIFF);
+    expect(counts.removed.test.code).toBe(2);
+    expect(counts.added.test.code).toBe(0);
+  });
+
+  test("resets state per hunk and tallies both sides of an edit", () => {
+    const counts = tallyDiff(DIFF);
+    expect(counts.added.other.code).toBe(2);
+    expect(counts.removed.other.code).toBe(1);
+  });
+
+  test("classifies a dash-prefixed content line instead of dropping it", () => {
+    // A removed SQL `-- comment` diffs to `--- comment`; outside the file
+    // header it must be tallied as content, not mistaken for a `--- a/` header.
+    const sqlDiff = [
+      "diff --git a/src/q.sql b/src/q.sql",
+      "index aaaaaaa..bbbbbbb 100644",
+      "--- a/src/q.sql",
+      "+++ b/src/q.sql",
+      "@@ -1 +1 @@",
+      "--- old sql comment",
+      "+-- new sql comment",
+      "",
+    ].join("\n");
+    const counts = tallyDiff(sqlDiff);
+    expect(counts.removed.src.code).toBe(1);
+    expect(counts.added.src.code).toBe(1);
+  });
+});
+
+describe("diff-code-lines formatReport", () => {
+  test("shows the test/src ratio when src code changed", () => {
+    const counts = { added: emptyAreaTally(), removed: emptyAreaTally() };
+    counts.added.src.code = 4;
+    counts.added.test.code = 8;
+    const out = formatReport(counts);
+    expect(out).toContain("  src : 4");
+    expect(out).toContain("  test: 8");
+    expect(out).toContain("  test/src ratio: 2.00");
+  });
+
+  test("omits the ratio when no src code changed", () => {
+    const counts = { added: emptyAreaTally(), removed: emptyAreaTally() };
+    counts.added.test.code = 3;
+    const out = formatReport(counts);
+    expect(out).not.toContain("ratio");
+    expect(out).toContain("  src : 0");
+    expect(out).toContain("  test: 3");
+  });
+});

--- a/test/scripts/diff-code-lines.test.ts
+++ b/test/scripts/diff-code-lines.test.ts
@@ -73,16 +73,16 @@ describe("diff-code-lines classify", () => {
   });
 
   test("treats import.meta and dynamic import() as code, not import", () => {
-    // Static import declarations have a space or quote after `import`; the
-    // `import.meta` property and a dynamic `import(...)` call are executable
-    // code, so both stay classified as code.
+    // A static import declaration has an identifier, `{`, `*` or a quote after
+    // `import`; the `import.meta` property and a dynamic `import(...)` call —
+    // with or without a space before the paren — are executable code, so all
+    // stay classified as code.
     expect(classify("import.meta.url;", freshState())).toBe("code");
     expect(classify('const m = await import("./m.ts");', freshState())).toBe(
       "code",
     );
-    expect(classify('import("./lazy.ts").then(run);', freshState())).toBe(
-      "code",
-    );
+    expect(classify('import("./lazy.ts");', freshState())).toBe("code");
+    expect(classify('import ("./spaced.ts");', freshState())).toBe("code");
   });
 });
 

--- a/test/scripts/diff-code-lines.test.ts
+++ b/test/scripts/diff-code-lines.test.ts
@@ -166,6 +166,29 @@ describe("diff-code-lines tallyDiff", () => {
     expect(counts.removed.src.code).toBe(1);
     expect(counts.added.src.code).toBe(1);
   });
+
+  test("attributes each side of a cross-area rename to its own area", () => {
+    // A rename with edits names the old area on `--- a/src/…` and the new area
+    // on `+++ b/test/…`; the removed line must count as src and the added as
+    // test, not both under whichever header was read last.
+    const renameDiff = [
+      "diff --git a/src/old.ts b/test/new.test.ts",
+      "similarity index 60%",
+      "rename from src/old.ts",
+      "rename to test/new.test.ts",
+      "--- a/src/old.ts",
+      "+++ b/test/new.test.ts",
+      "@@ -1 +1 @@",
+      "-const removed = 1;",
+      "+const added = 2;",
+      "",
+    ].join("\n");
+    const counts = tallyDiff(renameDiff);
+    expect(counts.removed.src.code).toBe(1);
+    expect(counts.added.test.code).toBe(1);
+    expect(counts.added.src.code).toBe(0);
+    expect(counts.removed.test.code).toBe(0);
+  });
 });
 
 describe("diff-code-lines formatReport", () => {


### PR DESCRIPTION
## What this adds

A small developer tool that measures how much of a branch's change is actual logic versus documentation, imports, and blank lines.

Given a base ref (defaults to `origin/main`), it reads `git diff --unified=0 …HEAD` and reports the changed lines broken down by:

- **area** — `src` / `test` / `other`
- **kind** — code, import, comment, blank

It then prints the code-only src-vs-test comparison and their ratio.

The classifier tracks state across lines, so it counts as imports/comments (not code):

- multi-line `import { … } from …` blocks
- multi-line `export { … } from …` / `export type { … } from …` barrel re-exports
- `/* … */` block comments and their `*` continuation lines

Added and removed files are both counted against their real area — a deletion names its path only on the `--- a/…` header, so both file headers are read.

## How it's built

The logic lives in `scripts/diff-code-lines-lib.ts` as pure, data-in/data-out functions (classify a line, tally a diff, format the report) behind a thin CLI shell (`scripts/diff-code-lines.ts`) that only runs `git diff` and prints — the same split as the existing `line-counts` tool. `test/scripts/diff-code-lines.test.ts` covers the classifier and diff tally at 100% line and branch coverage.

## Why

Raw diff line counts overstate how much real code changed when a codebase documents heavily (as this one does). This makes it easy to see, for any branch, how much is new logic versus comments and tests.

## Usage

```bash
deno run --allow-run scripts/diff-code-lines.ts [baseRef]
```

The classifier is a line-based heuristic, not a full parser, so the numbers are a close estimate rather than an exact count. Its one known blind spot: with `--unified=0` the unchanged `import {` opener stays off-diff, so adding or removing a single member inside an existing multi-line import reads as code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Deno command-line tool that analyzes `git diff` and outputs a formatted report of changed lines.
  * Reports added/removed counts split by area (source, tests, other) and by type (code, imports, comments, blank lines), including multi-hunk and rename handling.
  * Includes a test/source ratio in the report when source code changes are present.
* **Tests**
  * Added a comprehensive test suite covering multi-line import/comment parsing, misclassification edge cases, correct per-area add/remove tallies, and report formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->