### PR TITLE
Run new Bunny databases on every region, not just Europe

### DIFF
--- a/src/shared/bunny-db.ts
+++ b/src/shared/bunny-db.ts
@@ -6,6 +6,7 @@
  * Auth: AccessKey header (same BUNNY_API_KEY as CDN API)
  */
 
+import * as v from "valibot";
 import { parseBunnyError } from "#shared/bunny-cdn.ts";
 import { getBunnyApiKey } from "#shared/config.ts";
 import { type ApiResult, fetchText } from "#shared/fetch.ts";
@@ -20,14 +21,16 @@ const DB_API_BASE = "https://api.bunny.net/database";
  */
 export const STORAGE_REGION = "eu-west-1";
 
-interface RegionConfig {
-  id: string;
-}
+/** One region Bunny reports it can host a database node in. */
+const RegionConfigSchema = v.object({ id: v.string() });
 
-interface DbConfigResponse {
-  primary_regions: RegionConfig[];
-  replica_regions: RegionConfig[];
-}
+/** The regions Bunny will accept, from GET /database/v1/config. */
+const DbConfigResponseSchema = v.object({
+  primary_regions: v.array(RegionConfigSchema),
+  replica_regions: v.array(RegionConfigSchema),
+});
+
+type RegionConfig = v.InferOutput<typeof RegionConfigSchema>;
 
 interface CreateDbResponse {
   db_id: string;
@@ -78,7 +81,7 @@ const getAllRegions = async (): Promise<
     return parseBunnyError(res, "Get database config");
   }
 
-  const config: DbConfigResponse = JSON.parse(res.text);
+  const config = v.parse(DbConfigResponseSchema, JSON.parse(res.text));
   return {
     ok: true,
     primaryRegions: regionIds(config.primary_regions),

--- a/src/shared/bunny-db.ts
+++ b/src/shared/bunny-db.ts
@@ -20,23 +20,14 @@ const DB_API_BASE = "https://api.bunny.net/database";
  */
 export const STORAGE_REGION = "eu-west-1";
 
-/** All European Bunny database node IDs. */
-export const EUROPEAN_REGIONS = [
-  "AMS",
-  "AT",
-  "BU",
-  "CZ",
-  "DE",
-  "DK",
-  "ES",
-  "FR",
-  "GR",
-  "HR",
-  "IT",
-  "PL",
-  "SE",
-  "UK",
-];
+interface RegionConfig {
+  id: string;
+}
+
+interface DbConfigResponse {
+  primary_regions: RegionConfig[];
+  replica_regions: RegionConfig[];
+}
 
 interface CreateDbResponse {
   db_id: string;
@@ -66,6 +57,35 @@ const dbApiHeaders = (): Record<string, string> => ({
   "Content-Type": "application/json",
 });
 
+/** Just the node IDs from a list of regions Bunny reported. */
+const regionIds = (regions: RegionConfig[]): string[] =>
+  regions.map((region) => region.id);
+
+/**
+ * Ask Bunny which database regions it will accept right now, so a new database
+ * runs on every one of Bunny's servers instead of a fixed list. Reading the
+ * live config means new Bunny regions are used automatically, with no code
+ * change needed when Bunny adds a server.
+ */
+const getAllRegions = async (): Promise<
+  ApiResult<{ primaryRegions: string[]; replicaRegions: string[] }>
+> => {
+  const res = await fetchText(`${DB_API_BASE}/v1/config`, {
+    headers: dbApiHeaders(),
+  });
+
+  if (!res.ok) {
+    return parseBunnyError(res, "Get database config");
+  }
+
+  const config: DbConfigResponse = JSON.parse(res.text);
+  return {
+    ok: true,
+    primaryRegions: regionIds(config.primary_regions),
+    replicaRegions: regionIds(config.replica_regions),
+  };
+};
+
 /**
  * Create a new Bunny database with the given name.
  * Returns the database URL and a full-access token.
@@ -73,12 +93,18 @@ const dbApiHeaders = (): Record<string, string> => ({
 const createDatabaseImpl = async (
   name: string,
 ): Promise<ApiResult<CreateDatabaseResult>> => {
-  // 1. Create the database with all European nodes as primaries and replicas
+  // 1. Find every region Bunny will accept, so the database runs everywhere
+  const regions = await getAllRegions();
+  if (!regions.ok) {
+    return regions;
+  }
+
+  // 2. Create the database with all of Bunny's nodes as primaries and replicas
   const createRes = await fetchText(`${DB_API_BASE}/v2/databases`, {
     body: JSON.stringify({
       name,
-      primary_regions: EUROPEAN_REGIONS,
-      replicas_regions: EUROPEAN_REGIONS,
+      primary_regions: regions.primaryRegions,
+      replicas_regions: regions.replicaRegions,
       storage_region: STORAGE_REGION,
     }),
     headers: dbApiHeaders(),
@@ -92,7 +118,7 @@ const createDatabaseImpl = async (
   const createData: CreateDbResponse = JSON.parse(createRes.text);
   const dbId = createData.db_id;
 
-  // 2. Fetch database details to get the connection URL
+  // 3. Fetch database details to get the connection URL
   const getRes = await fetchText(
     `${DB_API_BASE}/v2/databases/${encodeURIComponent(dbId)}`,
     { headers: dbApiHeaders() },
@@ -105,7 +131,7 @@ const createDatabaseImpl = async (
   const getData: GetDbResponse = JSON.parse(getRes.text);
   const dbUrl = getData.db.url;
 
-  // 3. Generate a full-access token
+  // 4. Generate a full-access token
   const tokenRes = await fetchText(
     `${DB_API_BASE}/v2/databases/${encodeURIComponent(dbId)}/auth/generate`,
     {

--- a/test/shared/bunny-db.test.ts
+++ b/test/shared/bunny-db.test.ts
@@ -202,18 +202,25 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
     );
   });
 
-  test("createDatabase returns error when the config endpoint fails", async () => {
+  test("createDatabase stops and returns error when the config endpoint fails", async () => {
+    const fetchCalls: string[] = [];
+
     await withMocks(
       () =>
-        stub(globalThis, "fetch", () =>
-          Promise.resolve(new Response("Forbidden", { status: 403 })),
-        ),
+        stub(globalThis, "fetch", (input: string | URL | Request) => {
+          fetchCalls.push(String(input));
+          return Promise.resolve(new Response("Forbidden", { status: 403 }));
+        }),
       async () => {
         const result = await bunnyDbApi.createDatabase("Bad");
         expect(result.ok).toBe(false);
         if (!result.ok) {
           expect(result.error).toContain("Get database config failed (403)");
         }
+
+        // A failed config lookup must not go on to create anything.
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0]).toContain("/v1/config");
       },
     );
   });

--- a/test/shared/bunny-db.test.ts
+++ b/test/shared/bunny-db.test.ts
@@ -3,24 +3,71 @@ import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import {
   bunnyDbProvider as bunnyDbApi,
-  EUROPEAN_REGIONS,
   STORAGE_REGION,
 } from "#shared/bunny-db.ts";
-import { testCreateDatabaseReturnsErrorOn403 } from "#test-utils/builder-mocks.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { withMocks } from "#test-utils/mocks.ts";
 
+/** Bunny's live region config, as returned by GET /database/v1/config. */
+const CONFIG_RESPONSE = {
+  primary_regions: [{ id: "DE" }, { id: "UK" }, { id: "NY" }, { id: "SG" }],
+  replica_regions: [{ id: "DE" }, { id: "UK" }, { id: "NY" }, { id: "SG" }],
+  storage_region_available: [{ id: "eu-west-1" }, { id: "us-east-1" }],
+};
+
+const PRIMARY_REGION_IDS = CONFIG_RESPONSE.primary_regions.map((r) => r.id);
+const REPLICA_REGION_IDS = CONFIG_RESPONSE.replica_regions.map((r) => r.id);
+
+/** A 200 response carrying Bunny's region config JSON. */
+const configResponse = (): Response =>
+  new Response(JSON.stringify(CONFIG_RESPONSE), { status: 200 });
+
+interface DbDetail {
+  name: string;
+  token: string;
+  url: string;
+}
+
+const DEFAULT_DETAIL: DbDetail = {
+  name: "Test",
+  token: "tok",
+  url: "libsql://x.bunnydb.net",
+};
+
+/** Happy-path responses for the get-details and token steps of a create. */
+const getAndAuthResponse = (
+  url: string,
+  dbId: string,
+  detail: DbDetail = DEFAULT_DETAIL,
+): Response =>
+  url.includes(`/v2/databases/${dbId}`) && !url.includes("/auth")
+    ? new Response(
+        JSON.stringify({
+          db: { db_id: dbId, name: detail.name, url: detail.url },
+        }),
+        { status: 200 },
+      )
+    : new Response(JSON.stringify({ token: detail.token }), { status: 200 });
+
+/**
+ * Stub fetch so the config endpoint returns Bunny's live regions and every
+ * other URL is answered by `fallback`.
+ */
+const stubFetchAfterConfig = (fallback: (url: string) => Response) =>
+  stub(globalThis, "fetch", (input: string | URL | Request) => {
+    const url = String(input);
+    return Promise.resolve(
+      url.endsWith("/v1/config") ? configResponse() : fallback(url),
+    );
+  });
+
 describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
   const dbCreateFetch = (dbId: string, fallback: (url: string) => Response) =>
-    stub(globalThis, "fetch", (input: string | URL | Request) => {
-      const url = String(input);
-      if (url.endsWith("/v2/databases")) {
-        return Promise.resolve(
-          new Response(JSON.stringify({ db_id: dbId }), { status: 200 }),
-        );
-      }
-      return Promise.resolve(fallback(url));
-    });
+    stubFetchAfterConfig((url) =>
+      url.endsWith("/v2/databases")
+        ? new Response(JSON.stringify({ db_id: dbId }), { status: 200 })
+        : fallback(url),
+    );
 
   test("createDatabase calls create, get, and token endpoints", async () => {
     const fetchCalls: string[] = [];
@@ -31,6 +78,10 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
           const url = String(input);
           fetchCalls.push(url);
 
+          if (url.endsWith("/v1/config")) {
+            return Promise.resolve(configResponse());
+          }
+
           if (url.endsWith("/v2/databases") && !url.includes("/auth")) {
             return Promise.resolve(
               new Response(JSON.stringify({ db_id: "db_test123" }), {
@@ -39,34 +90,13 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
             );
           }
 
-          if (
-            url.includes("/v2/databases/db_test123") &&
-            !url.includes("/auth")
-          ) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  db: {
-                    db_id: "db_test123",
-                    name: "My Site",
-                    url: "libsql://my-site.lite.bunnydb.net",
-                  },
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-
-          if (url.includes("/auth/generate")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({ expires_at: null, token: "bny_token_abc" }),
-                { status: 200 },
-              ),
-            );
-          }
-
-          return Promise.resolve(new Response("unexpected", { status: 500 }));
+          return Promise.resolve(
+            getAndAuthResponse(url, "db_test123", {
+              name: "My Site",
+              token: "bny_token_abc",
+              url: "libsql://my-site.lite.bunnydb.net",
+            }),
+          );
         }),
       async () => {
         const result = await bunnyDbApi.createDatabase("My Site");
@@ -78,12 +108,13 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
           expect(result.dbId).toBe("db_test123");
         }
 
-        expect(fetchCalls.length).toBe(3);
+        expect(fetchCalls.length).toBe(4);
+        expect(fetchCalls[0]).toContain("/v1/config");
       },
     );
   });
 
-  test("createDatabase sends EU storage region with all European primaries and replicas", async () => {
+  test("createDatabase sends every region Bunny reported as primaries and replicas", async () => {
     let createBody: unknown;
 
     await withMocks(
@@ -94,6 +125,10 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
           (input: string | URL | Request, init?: RequestInit) => {
             const url = String(input);
 
+            if (url.endsWith("/v1/config")) {
+              return Promise.resolve(configResponse());
+            }
+
             if (url.endsWith("/v2/databases")) {
               createBody = JSON.parse(init?.body as string);
               return Promise.resolve(
@@ -103,31 +138,7 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
               );
             }
 
-            if (
-              url.includes("/v2/databases/db_abc") &&
-              !url.includes("/auth")
-            ) {
-              return Promise.resolve(
-                new Response(
-                  JSON.stringify({
-                    db: {
-                      db_id: "db_abc",
-                      name: "Test",
-                      url: "libsql://x.bunnydb.net",
-                    },
-                  }),
-                  { status: 200 },
-                ),
-              );
-            }
-
-            if (url.includes("/auth/generate")) {
-              return Promise.resolve(
-                new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
-              );
-            }
-
-            return Promise.resolve(new Response("unexpected", { status: 500 }));
+            return Promise.resolve(getAndAuthResponse(url, "db_abc"));
           },
         ),
       async () => {
@@ -135,8 +146,8 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
 
         expect(createBody).toEqual({
           name: "Test",
-          primary_regions: EUROPEAN_REGIONS,
-          replicas_regions: EUROPEAN_REGIONS,
+          primary_regions: PRIMARY_REGION_IDS,
+          replicas_regions: REPLICA_REGION_IDS,
           storage_region: STORAGE_REGION,
         });
       },
@@ -147,6 +158,9 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
     const headers: string[] = [];
 
     const respondForHeaderTest = (url: string): Response => {
+      if (url.endsWith("/v1/config")) {
+        return configResponse();
+      }
       if (url.endsWith("/v2/databases")) {
         return new Response(JSON.stringify({ db_id: "db_hdr" }), {
           status: 200,
@@ -188,8 +202,34 @@ describeWithEnv("bunny-db", { env: { BUNNY_API_KEY: "test-api-key" } }, () => {
     );
   });
 
+  test("createDatabase returns error when the config endpoint fails", async () => {
+    await withMocks(
+      () =>
+        stub(globalThis, "fetch", () =>
+          Promise.resolve(new Response("Forbidden", { status: 403 })),
+        ),
+      async () => {
+        const result = await bunnyDbApi.createDatabase("Bad");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toContain("Get database config failed (403)");
+        }
+      },
+    );
+  });
+
   test("createDatabase returns error when create endpoint fails", async () => {
-    await testCreateDatabaseReturnsErrorOn403(bunnyDbApi);
+    await withMocks(
+      () =>
+        stubFetchAfterConfig(() => new Response("Forbidden", { status: 403 })),
+      async () => {
+        const result = await bunnyDbApi.createDatabase("Bad");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toContain("Create database failed (403)");
+        }
+      },
+    );
   });
 
   test("createDatabase returns error when get database endpoint fails with JSON Message", async () => {

--- a/test/shared/bunny-db.test.ts
+++ b/test/shared/bunny-db.test.ts
@@ -11,7 +11,7 @@ import { withMocks } from "#test-utils/mocks.ts";
 /** Bunny's live region config, as returned by GET /database/v1/config. */
 const CONFIG_RESPONSE = {
   primary_regions: [{ id: "DE" }, { id: "UK" }, { id: "NY" }, { id: "SG" }],
-  replica_regions: [{ id: "DE" }, { id: "UK" }, { id: "NY" }, { id: "SG" }],
+  replica_regions: [{ id: "LA" }, { id: "SYD" }, { id: "BR" }, { id: "JH" }],
   storage_region_available: [{ id: "eu-west-1" }, { id: "us-east-1" }],
 };
 


### PR DESCRIPTION
## What changed

When the site builder creates a new site backed by a Bunny database, that database now runs on **all** of Bunny's servers instead of a fixed list of European ones.

Before creating the database, we ask Bunny which regions it will accept right now (`GET /database/v1/config`) and use every primary and replica region it reports. Previously the code sent a hardcoded list of European node IDs.

## Why

- New sites get databases on the full worldwide set of Bunny nodes, so people are served from a server near them wherever they are.
- Reading Bunny's live region list means the list never goes stale: when Bunny adds a new server, new sites use it automatically with no code change needed.

The storage zone is unchanged (Bunny only offers two, and it stays `eu-west-1`) — this change is about the database servers, which are what "all of them" refers to.

## Tests

The `bunny-db` tests were updated to cover the new config lookup: the happy path now checks the config endpoint is called first and that the create request carries every region Bunny reported, and there are separate tests for the config endpoint failing and the create endpoint failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xjjo3MC6ztBrYWDV1WbxB

---
_Generated by [Claude Code](https://claude.ai/code/session_016xjjo3MC6ztBrYWDV1WbxB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Database provisioning now dynamically selects primary and replica regions from the latest retrieved region configuration, instead of using a fixed region list.

- **Bug Fixes**
  - Improved failure handling when the region configuration request fails (including correctly failing when access is denied).

- **Tests**
  - Updated Bunny database provisioning tests to explicitly mock the configuration endpoint first, align request expectations with config-derived region IDs, and added coverage for create failures when configuration returns 403.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->