### PR TITLE
Show a red pixel for broken images, and delete the broken records left by the images migration

### DIFF
--- a/src/features/images.ts
+++ b/src/features/images.ts
@@ -1,12 +1,22 @@
 /**
  * Image proxy route — serves encrypted images from Bunny CDN.
  * GET /image/:filename — downloads, decrypts, and serves the image.
+ * A broken image (the broken-image marker, a file missing from storage, or a
+ * stored file that will not decrypt) serves a 1×1 red pixel instead of failing,
+ * and the missing/unreadable cases are reported as errors.
  */
 
 import { notFoundResponse } from "#routes/response.ts";
 import type { createRouter } from "#routes/router.ts";
+import { decryptBytes } from "#shared/crypto/encryption.ts";
 import {
-  downloadImage,
+  BROKEN_IMAGE_FILENAME,
+  BROKEN_IMAGE_PNG,
+  reportBrokenImage,
+} from "#shared/images/broken.ts";
+import {
+  downloadRaw,
+  getImageProxyUrl,
   getMimeTypeFromFilename,
   isStorageEnabled,
 } from "#shared/storage.ts";
@@ -16,25 +26,50 @@ type RouterFn = ReturnType<typeof createRouter>;
 /** One year cache (images are immutable, filenames are random UUIDs) */
 const IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 
+/** The red-pixel fallback for a broken image. Never cached, so a repaired
+ * image serves for real on the very next request. */
+const brokenImageResponse = (): Response =>
+  new Response(BROKEN_IMAGE_PNG.buffer as BodyInit, {
+    headers: { "cache-control": "no-store", "content-type": "image/png" },
+  });
+
 /** Serve a decrypted image */
 const handleImageRequest = async (filename: string): Promise<Response> => {
   const mimeType = getMimeTypeFromFilename(filename);
   if (!mimeType) return notFoundResponse();
 
-  const data = await downloadImage(filename);
-  if (!data) return notFoundResponse();
+  // Only a definitively missing or unreadable file falls back to the red
+  // pixel. A transient storage failure (bad credentials, an outage) still
+  // throws and surfaces as the generic 503, so it keeps looking transient.
+  const encrypted = await downloadRaw(filename);
+  if (!encrypted) {
+    reportBrokenImage(`image file ${filename} is missing from storage`);
+    return brokenImageResponse();
+  }
 
-  return new Response(data.buffer as BodyInit, {
-    headers: {
-      "cache-control": IMAGE_CACHE_CONTROL,
-      "content-type": mimeType,
-    },
-  });
+  try {
+    const data = await decryptBytes(encrypted);
+    return new Response(data.buffer as BodyInit, {
+      headers: {
+        "cache-control": IMAGE_CACHE_CONTROL,
+        "content-type": mimeType,
+      },
+    });
+  } catch (error) {
+    reportBrokenImage(`image file ${filename} could not be decrypted`, error);
+    return brokenImageResponse();
+  }
 };
 
 /** Route image requests: GET /image/:filename */
 export const routeImage: RouterFn = async (_, path, method) => {
   if (method !== "GET") return null;
+
+  // The broken-image marker has no stored file behind it — serve its red
+  // pixel directly, even when storage is not configured.
+  if (path === getImageProxyUrl(BROKEN_IMAGE_FILENAME)) {
+    return brokenImageResponse();
+  }
 
   const match = path.match(/^\/image\/([a-f0-9-]+\.\w+)$/);
   if (!match?.[1]) return null;

--- a/src/shared/db/encrypted-text.ts
+++ b/src/shared/db/encrypted-text.ts
@@ -1,0 +1,15 @@
+import { decrypt } from "#shared/crypto/encryption.ts";
+import type { EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
+
+/**
+ * Decrypt a stored encrypted-text value, honouring the `''` = "no value"
+ * convention (matches `col.encryptedText`'s read — an empty column never
+ * decrypts). For encrypted-text values read outside the table layer, e.g.
+ * projected columns and narrow hand-written SELECTs. A missing projection
+ * (undefined) reads as "" too, so a stray un-projected SELECT degrades
+ * gracefully.
+ */
+export const decryptTextOrEmpty = (
+  value: EnvKeyEncrypted | "" | undefined,
+): Promise<string> | string =>
+  value === "" || value === undefined ? "" : decrypt(value);

--- a/src/shared/db/images.ts
+++ b/src/shared/db/images.ts
@@ -11,6 +11,7 @@ import {
   type SqlStatement,
 } from "#shared/db/client.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
+import { decryptTextOrEmpty } from "#shared/db/encrypted-text.ts";
 import { type ColumnDef, col } from "#shared/db/table.ts";
 import { decryptImageFilename } from "#shared/images/broken.ts";
 import type {
@@ -120,7 +121,7 @@ export const getImageFilenamesForItem = async (
   if (!row) return { image_alt_text: "", image_thumb_url: "", image_url: "" };
   const imageRef = `image ${row.id} (first image of ${itemType} ${itemId})`;
   return {
-    image_alt_text: row.alt_text === "" ? "" : await decrypt(row.alt_text),
+    image_alt_text: await decryptTextOrEmpty(row.alt_text),
     image_thumb_url: await decryptImageFilename(
       row.filename_thumb,
       `${imageRef} thumbnail filename`,

--- a/src/shared/db/images.ts
+++ b/src/shared/db/images.ts
@@ -12,16 +12,14 @@ import {
 } from "#shared/db/client.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
 import { type ColumnDef, col } from "#shared/db/table.ts";
+import { decryptImageFilename } from "#shared/images/broken.ts";
 import type {
   Image,
   ImageUse,
   ImageUseItemType,
   ItemImageProjection,
 } from "#shared/types.ts";
-import {
-  isNonEmptyString,
-  type NonEmptyString,
-} from "#shared/validation/string.ts";
+import type { NonEmptyString } from "#shared/validation/string.ts";
 
 export type ImageInput = {
   name: string;
@@ -39,27 +37,21 @@ export type OrderedImage = Image & { sort_order: number };
 
 const IMAGE_COLUMNS = "id, name, filename, filename_thumb, alt_text";
 
-const decryptedNonEmptyString = async (
-  encrypted: EnvKeyEncrypted,
-  name: string,
-): Promise<NonEmptyString> => {
-  const decrypted = await decrypt(encrypted);
-  if (isNonEmptyString(decrypted)) return decrypted;
-  throw new Error(`${name} must be non-empty`);
-};
-
-/** Encrypted NonEmptyString column: sealed on write, decrypted and re-checked
- * non-empty on read. col.encrypted carries the read-boundary assertion. */
-const encryptedNonEmptyText = (name: string): ColumnDef<NonEmptyString> =>
-  col.encrypted<NonEmptyString, EnvKeyEncrypted<NonEmptyString>>(
-    (value) => encrypt(value),
-    (value) => decryptedNonEmptyString(value, name),
-  );
+/** Encrypted filename column: sealed on write; on read, a value that will not
+ * decrypt to a real filename becomes the broken-image marker (reported, never
+ * thrown — one broken record must not take down every page that lists images).
+ * The `as` cast is the same sanctioned read boundary as col.encrypted. */
+const encryptedFilenameText = (label: string): ColumnDef<NonEmptyString> =>
+  ({
+    read: (raw: string, rowId?: unknown) =>
+      decryptImageFilename(raw, `image ${String(rowId)} ${label}`),
+    write: (value: NonEmptyString) => encrypt(value),
+  }) as unknown as ColumnDef<NonEmptyString>;
 
 export const imagesTable = defineIdTable<Image, ImageInput>("images", {
   alt_text: col.encryptedText(encrypt, decrypt),
-  filename: encryptedNonEmptyText("image filename"),
-  filename_thumb: encryptedNonEmptyText("image thumbnail filename"),
+  filename: encryptedFilenameText("filename"),
+  filename_thumb: encryptedFilenameText("thumbnail filename"),
   id: col.generated<number>(),
   name: col.encryptedText(encrypt, decrypt),
 });
@@ -114,8 +106,9 @@ export const getImageFilenamesForItem = async (
     alt_text: EnvKeyEncrypted | "";
     filename: EnvKeyEncrypted;
     filename_thumb: EnvKeyEncrypted;
+    id: number;
   }>(
-    `SELECT image.filename, image.filename_thumb, image.alt_text
+    `SELECT image.id, image.filename, image.filename_thumb, image.alt_text
        FROM image_uses AS imageUse
        JOIN images AS image ON image.id = imageUse.image_id
       WHERE imageUse.item_type = ? AND imageUse.item_id = ?
@@ -125,13 +118,14 @@ export const getImageFilenamesForItem = async (
   );
   const row = rows[0];
   if (!row) return { image_alt_text: "", image_thumb_url: "", image_url: "" };
+  const imageRef = `image ${row.id} (first image of ${itemType} ${itemId})`;
   return {
     image_alt_text: row.alt_text === "" ? "" : await decrypt(row.alt_text),
-    image_thumb_url: await decryptedNonEmptyString(
+    image_thumb_url: await decryptImageFilename(
       row.filename_thumb,
-      "image thumbnail filename",
+      `${imageRef} thumbnail filename`,
     ),
-    image_url: await decryptedNonEmptyString(row.filename, "image filename"),
+    image_url: await decryptImageFilename(row.filename, `${imageRef} filename`),
   };
 };
 

--- a/src/shared/db/listings/table.ts
+++ b/src/shared/db/listings/table.ts
@@ -9,6 +9,7 @@ import {
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
 } from "#shared/db/common-schema.ts";
+import { decryptTextOrEmpty } from "#shared/db/encrypted-text.ts";
 import { col } from "#shared/db/table.ts";
 import { decryptImageFilenameOrEmpty } from "#shared/images/broken.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
@@ -116,8 +117,10 @@ const readClosesAt = async (value: string | null): Promise<string | null> => {
 const writeListingDate = (value: string): Promise<EnvKeyEncrypted> =>
   encryptDatetime(value, "date");
 
+// The `as` cast is the sanctioned read boundary for a projected encrypted
+// column — the raw SELECT value re-enters the typed world here.
 const readProjectedAltText = (value: unknown): string | Promise<string> =>
-  value === "" || value === undefined ? "" : decrypt(value as EnvKeyEncrypted);
+  decryptTextOrEmpty(value as EnvKeyEncrypted | "" | undefined);
 
 /** Read one of the projected first-image filename columns. A filename that
  * will not read back becomes the broken-image marker (reported, not thrown)

--- a/src/shared/db/listings/table.ts
+++ b/src/shared/db/listings/table.ts
@@ -10,6 +10,7 @@ import {
   idAndEncryptedSlugSchema,
 } from "#shared/db/common-schema.ts";
 import { col } from "#shared/db/table.ts";
+import { decryptImageFilenameOrEmpty } from "#shared/images/broken.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
 import { nowIso } from "#shared/now.ts";
 import {
@@ -115,8 +116,19 @@ const readClosesAt = async (value: string | null): Promise<string | null> => {
 const writeListingDate = (value: string): Promise<EnvKeyEncrypted> =>
   encryptDatetime(value, "date");
 
-const readProjectedImage = (value: unknown): string | Promise<string> =>
+const readProjectedAltText = (value: unknown): string | Promise<string> =>
   value === "" || value === undefined ? "" : decrypt(value as EnvKeyEncrypted);
+
+/** Read one of the projected first-image filename columns. A filename that
+ * will not read back becomes the broken-image marker (reported, not thrown)
+ * so a listing page still renders — see #shared/images/broken.ts. */
+const readProjectedImageFilename =
+  (label: string) =>
+  (value: unknown, rowId?: unknown): string | Promise<string> =>
+    decryptImageFilenameOrEmpty(
+      value as string | undefined,
+      `listing ${String(rowId)} ${label}`,
+    );
 
 /** Raw listings table. Records adds cache-aware CRUD and price syncing. */
 export const rawListingsTable = defineIdTable<Listing, ListingInput>(
@@ -152,9 +164,11 @@ export const rawListingsTable = defineIdTable<Listing, ListingInput>(
     duration_days: { default: () => 1, write: normalizeDurationDays },
     fields: col.withDefault<ListingFields>(() => "email"),
     hidden: col.boolean(false),
-    image_alt_text: col.projected<string>(readProjectedImage),
-    image_thumb_url: col.projected<string>(readProjectedImage),
-    image_url: col.projected<string>(readProjectedImage),
+    image_alt_text: col.projected<string>(readProjectedAltText),
+    image_thumb_url: col.projected<string>(
+      readProjectedImageFilename("thumbnail image"),
+    ),
+    image_url: col.projected<string>(readProjectedImageFilename("image")),
     initial_site_months: col.withDefault(() => 0),
     listing_type: col.withDefault<ListingType>(() => "standard"),
     location: col.encryptedText(encrypt, decrypt),

--- a/src/shared/db/migrations/2026-07-03_attendee_listings_tag.ts
+++ b/src/shared/db/migrations/2026-07-03_attendee_listings_tag.ts
@@ -1,4 +1,4 @@
-import { schemaMigration } from "./define.ts";
+import { bareSchemaMigration } from "./define.ts";
 
 /** Matches the old {{listing}} column tag (with optional inner whitespace and
  * an optional trailing filter) without touching the new {{listings}} tag —
@@ -14,10 +14,9 @@ const LISTING_TAG = /\{\{(\s*)listing(\s*[|}])/g;
  * default order). Data-only — no schema requirement — and a no-op when the
  * setting is unset or never used the tag.
  */
-export default schemaMigration(
+export default bareSchemaMigration(
   "2026-07-03_attendee_listings_tag",
   "Rename the {{listing}} tag to {{listings}} in the stored attendee column-order template.",
-  {},
   async ({ getDb }) => {
     const result = await getDb().execute(
       "SELECT value FROM settings WHERE key = 'attendee_column_order'",

--- a/src/shared/db/migrations/2026-07-12_remove_broken_image_records.ts
+++ b/src/shared/db/migrations/2026-07-12_remove_broken_image_records.ts
@@ -1,0 +1,52 @@
+import { decrypt } from "#shared/crypto/encryption.ts";
+import type { EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
+import { executeBatch } from "#shared/db/client.ts";
+import { bareSchemaMigration } from "./define.ts";
+
+/**
+ * Delete image records that never pointed at a real file.
+ *
+ * Until April 2026 (#914), saving a listing with no image stored its empty
+ * image_url ENCRYPTED — a real ciphertext whose plaintext is "". Those values
+ * decrypted back to "" on read, so every page treated them as "no image" and
+ * they sat harmless for months. The first-class images migration
+ * (2026-07-05_first_class_images) then gated its backfill on the SQL check
+ * `image_url <> ''` — a comparison against the CIPHERTEXT, which is non-empty
+ * for an encrypted "" — so each of those no-image listings got an `images` row
+ * whose filename (and, via the thumbnail CASE, filename_thumb) decrypts to
+ * nothing. There is no stored file behind such a record, so deleting it (and
+ * its item links) is the whole repair; pages fall back to "no image" exactly
+ * as they did before the backfill.
+ *
+ * Finding the rows requires decrypting every filename — a sanctioned one-off
+ * scan-decrypt: the images table is a small operator-curated library, and the
+ * ciphertext length alone cannot prove a plaintext is "". A filename that will
+ * not decrypt at all is a different, unknown corruption: the migration throws
+ * on it (and rolls nothing back — deletes only run after the scan) rather
+ * than guessing that deleting data is safe.
+ */
+export default bareSchemaMigration(
+  "2026-07-12_remove_broken_image_records",
+  "Delete image records whose stored filename is an encrypted empty string, plus their item links.",
+  async ({ getDb }) => {
+    const result = await getDb().execute("SELECT id, filename FROM images");
+    const brokenIds: number[] = [];
+    for (const row of result.rows) {
+      const filename = await decrypt(row.filename as EnvKeyEncrypted);
+      if (filename === "") brokenIds.push(Number(row.id));
+    }
+    if (brokenIds.length === 0) return;
+
+    const placeholders = brokenIds.map(() => "?").join(", ");
+    await executeBatch([
+      {
+        args: brokenIds,
+        sql: `DELETE FROM image_uses WHERE image_id IN (${placeholders})`,
+      },
+      {
+        args: brokenIds,
+        sql: `DELETE FROM images WHERE id IN (${placeholders})`,
+      },
+    ]);
+  },
+);

--- a/src/shared/db/migrations/2026-07-12_remove_broken_image_records.ts
+++ b/src/shared/db/migrations/2026-07-12_remove_broken_image_records.ts
@@ -29,7 +29,11 @@ export default bareSchemaMigration(
   "2026-07-12_remove_broken_image_records",
   "Delete image records whose stored filename is an encrypted empty string, plus their item links.",
   async ({ getDb }) => {
-    const result = await getDb().execute("SELECT id, filename FROM images");
+    // Scanned in id order, so an aborted run's behaviour is deterministic:
+    // everything before the record that failed was identified, nothing after.
+    const result = await getDb().execute(
+      "SELECT id, filename FROM images ORDER BY id",
+    );
     const brokenIds: number[] = [];
     for (const row of result.rows) {
       const filename = await decrypt(row.filename as EnvKeyEncrypted);

--- a/src/shared/db/migrations/define.ts
+++ b/src/shared/db/migrations/define.ts
@@ -45,10 +45,11 @@ export const schemaMigration =
 
 /**
  * A migration that owns no additive object — it carries `{}` requires and the
- * schema-hash guard covers the change — and just runs `work` in its `up()`. The
- * shared shape of the column-drop family below.
+ * schema-hash guard covers the change — and just runs `work` in its `up()`.
+ * The shared shape of the column-drop family below and of the data-only
+ * migrations that rewrite or delete rows without touching the schema.
  */
-const bareSchemaMigration = (
+export const bareSchemaMigration = (
   id: string,
   description: string,
   work: SchemaMigrationAfter,

--- a/src/shared/db/migrations/registry.ts
+++ b/src/shared/db/migrations/registry.ts
@@ -329,6 +329,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     "2026-07-10_processed_payments_attendee_index",
     () => import("./2026-07-10_processed_payments_attendee_index.ts"),
   ),
+  // Data-only repair: delete image records whose filename decrypts to "" —
+  // legacy encrypted-empty listing image_urls the first-class images backfill
+  // mistook for real filenames.
+  entry(
+    "2026-07-12_remove_broken_image_records",
+    () => import("./2026-07-12_remove_broken_image_records.ts"),
+  ),
 ];
 /* jscpd:ignore-end */
 

--- a/src/shared/db/migrations/schema/version.ts
+++ b/src/shared/db/migrations/schema/version.ts
@@ -1,6 +1,6 @@
 /** Schema version label and the migrations bookkeeping table name. */
 
 export const LATEST_UPDATE =
-  "Index processed_payments by attendee for roster, export, and refund lookups.";
+  "Delete image records whose stored filename is an encrypted empty string.";
 
 export const SCHEMA_MIGRATIONS_TABLE = "schema_migrations";

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -29,6 +29,7 @@ import {
   encryptedSlugSchema,
   idAndCreatedSchema,
 } from "#shared/db/common-schema.ts";
+import { decryptTextOrEmpty } from "#shared/db/encrypted-text.ts";
 import {
   clearImageUsesForItemStatement,
   imageFilenameSubqueries,
@@ -117,11 +118,6 @@ registerTableInvalidation(["news_posts"], () => existenceCache.invalidate());
 export const hasNewsPosts = async (): Promise<boolean> =>
   (await existenceCache.getAll()).length > 0;
 
-/** Decrypt an encrypted-text value, honouring the `''` = "no value" convention
- * (matches `col.encryptedText`'s read — an empty column never decrypts). */
-const decryptText = (value: EnvKeyEncrypted | ""): Promise<string> | string =>
-  value === "" ? value : decrypt(value);
-
 /** A summary row as stored: slug, name, and snippet still sealed. */
 type SealedSummaryRow = Omit<NewsPostSummary, "slug" | "name" | "snippet"> & {
   slug: EnvKeyEncrypted;
@@ -141,7 +137,7 @@ const decryptSummary = async (
   created: row.created,
   id: row.id,
   ...(await decryptNameSlug(row, decrypt)),
-  snippet: await decryptText(row.snippet),
+  snippet: await decryptTextOrEmpty(row.snippet),
 });
 
 /** Load the summary projection for every post, newest first: id, created,
@@ -169,7 +165,7 @@ export const getNewsPostCards = async (): Promise<NewsPostCard[]> => {
   );
   return mapParallel(async (row: SealedCardRow) => ({
     ...(await decryptSummary(row)),
-    image_alt_text: await decryptText(row.image_alt_text),
+    image_alt_text: await decryptTextOrEmpty(row.image_alt_text),
     image_thumb_url: await decryptImageFilenameOrEmpty(
       row.image_thumb_url,
       `news post ${row.id} thumbnail image`,

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -36,6 +36,7 @@ import {
 import { decryptNameSlug } from "#shared/db/query.ts";
 import type { SluggedContentInput } from "#shared/db/slugged-content-input.ts";
 import { col } from "#shared/db/table.ts";
+import { decryptImageFilenameOrEmpty } from "#shared/images/broken.ts";
 import { nowIso } from "#shared/now.ts";
 import { requestCache } from "#shared/request-cache.ts";
 import { slugify, uniqueSlugFromBase } from "#shared/slug.ts";
@@ -169,8 +170,14 @@ export const getNewsPostCards = async (): Promise<NewsPostCard[]> => {
   return mapParallel(async (row: SealedCardRow) => ({
     ...(await decryptSummary(row)),
     image_alt_text: await decryptText(row.image_alt_text),
-    image_thumb_url: await decryptText(row.image_thumb_url),
-    image_url: await decryptText(row.image_url),
+    image_thumb_url: await decryptImageFilenameOrEmpty(
+      row.image_thumb_url,
+      `news post ${row.id} thumbnail image`,
+    ),
+    image_url: await decryptImageFilenameOrEmpty(
+      row.image_url,
+      `news post ${row.id} image`,
+    ),
   }))(rows);
 };
 

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -37,8 +37,10 @@ export type ColumnDef<T = unknown> = {
   default?: (() => T) | undefined;
   /** Transform value before writing to DB (e.g., encrypt) */
   write?: ((v: T) => Promise<T> | T) | undefined;
-  /** Transform value after reading from DB (e.g., decrypt) */
-  read?: ((v: T) => Promise<T> | T) | undefined;
+  /** Transform value after reading from DB (e.g., decrypt). Row reads pass the
+   * row's primary-key value as `rowId` so a read failure can name the record
+   * (single-column reads via `readColumn` may omit it). */
+  read?: ((v: T, rowId?: unknown) => Promise<T> | T) | undefined;
 };
 
 /**
@@ -51,10 +53,12 @@ export type TableSchema<Row> = {
 
 /** Run one column's declared read transform (e.g. decrypt) on a stored value —
  * identity when the column declares none or the value is null. For reading a
- * single column back without building a whole row. */
+ * single column back without building a whole row. `rowId` (when known) lets
+ * the transform name the record in error reports. */
 export type ReadColumn<Row> = <K extends keyof Row & string>(
   col: K,
   value: Row[K],
+  rowId?: unknown,
 ) => Promise<Row[K]>;
 
 // Case conversion is delegated to valibot's `toCamelCase`/`toSnakeCase` actions
@@ -222,10 +226,10 @@ export const defineTable = <Row, Input = Row>(
   // Run one column's read transform on a stored value (identity when the
   // column declares none or the value is null) — the per-column read logic
   // shared by fromDb and the single-column readColumn.
-  const readColumn: ReadColumn<Row> = async (col, value) => {
+  const readColumn: ReadColumn<Row> = async (col, value, rowId) => {
     const def = schema[col];
     if (def.read && value !== null) {
-      return (await def.read(value as never)) as typeof value;
+      return (await def.read(value as never, rowId)) as typeof value;
     }
     return value;
   };
@@ -234,7 +238,7 @@ export const defineTable = <Row, Input = Row>(
   const fromDb = async (row: Row): Promise<Row> => {
     const entries = await mapParallel(
       async (col: keyof Row & string) =>
-        [col, await readColumn(col, row[col])] as const,
+        [col, await readColumn(col, row[col], row[primaryKey])] as const,
     )(allColumns);
     return Object.fromEntries(entries) as Row;
   };
@@ -573,7 +577,7 @@ export const col = {
    * from the `day_count` rows of `listing_prices`. `read` must tolerate a missing
    * projection (undefined) so a stray un-projected SELECT degrades gracefully. */
   projected: <App>(
-    read: (raw: InValue | undefined) => Promise<App> | App,
+    read: (raw: InValue | undefined, rowId?: unknown) => Promise<App> | App,
   ): ColumnDef<App> => ({
     generated: true,
     projected: true,

--- a/src/shared/images/broken.ts
+++ b/src/shared/images/broken.ts
@@ -1,0 +1,79 @@
+/**
+ * The broken-image fallback.
+ *
+ * An image record whose stored filename cannot be read is a data problem to
+ * repair, not a reason to take the whole page down. Every place that decrypts
+ * an image filename goes through the helpers here: a filename that reads back
+ * fine is returned as-is, and a broken one is reported loudly (error log,
+ * ntfy, Sentry, activity log — via `logError`) and swapped for
+ * {@link BROKEN_IMAGE_FILENAME}, whose image URL serves {@link BROKEN_IMAGE_PNG}
+ * — a 1×1 red pixel — so the page still renders and the red pixel points an
+ * operator at the record to fix.
+ */
+
+import { decrypt } from "#shared/crypto/encryption.ts";
+import type { EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
+import { fromBase64 } from "#shared/crypto/utils.ts";
+import { errorMessage } from "#shared/error-message.ts";
+import { ErrorCode, logError } from "#shared/logger.ts";
+import {
+  isNonEmptyString,
+  type NonEmptyString,
+  nonEmptyString,
+} from "#shared/validation/string.ts";
+
+/** The stand-in filename a broken image record reads back as. Uploaded files
+ * are always `<uuid>.webp`, so this name can never collide with a real one. */
+export const BROKEN_IMAGE_FILENAME: NonEmptyString & "broken-image.png" =
+  nonEmptyString("broken-image.png");
+
+/** A 1×1 red pixel PNG (69 bytes) — served for {@link BROKEN_IMAGE_FILENAME}
+ * and for a stored file that is missing or unreadable. */
+export const BROKEN_IMAGE_PNG: Uint8Array = fromBase64(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+);
+
+/** Report a broken image through the classified error log (which also reaches
+ * ntfy, Sentry, and the admin activity log). Images should never go missing or
+ * become unreadable, so every fallback to the red pixel is reported this way. */
+export const reportBrokenImage = (detail: string, error?: unknown): void => {
+  logError({
+    code: ErrorCode.IMAGE_BROKEN,
+    detail: error === undefined ? detail : `${detail} (${errorMessage(error)})`,
+    error,
+  });
+};
+
+/**
+ * Decrypt a stored image filename that must exist. When the stored value will
+ * not decrypt, or decrypts to an empty value, this reports the broken record
+ * (naming `source`, e.g. "image 12 filename") and returns
+ * {@link BROKEN_IMAGE_FILENAME} instead of failing the page.
+ */
+export const decryptImageFilename = async (
+  stored: string,
+  source: string,
+): Promise<NonEmptyString> => {
+  try {
+    const filename = await decrypt(stored as EnvKeyEncrypted);
+    if (isNonEmptyString(filename)) return filename;
+    reportBrokenImage(`${source} decrypted to an empty value`);
+  } catch (error) {
+    reportBrokenImage(`${source} could not be decrypted`, error);
+  }
+  return BROKEN_IMAGE_FILENAME;
+};
+
+/**
+ * Decrypt a projected image filename where "" (or a missing projection) is the
+ * expected "this item has no image" case and passes through unchanged. A
+ * non-empty stored value must read back as a real filename, so it takes the
+ * same broken-image fallback as {@link decryptImageFilename}.
+ */
+export const decryptImageFilenameOrEmpty = (
+  stored: string | undefined,
+  source: string,
+): Promise<string> | string =>
+  stored === undefined || stored === ""
+    ? ""
+    : decryptImageFilename(stored, source);

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -102,6 +102,9 @@ const ERROR_DEFS = {
     "Email template render failed",
   ],
   ENCRYPT_FAILED: ["E_ENCRYPT_FAILED", "Encryption failed"],
+
+  // Broken image records/files (fallback red pixel served instead)
+  IMAGE_BROKEN: ["E_IMAGE_BROKEN", "Broken image"],
   KEY_DERIVATION: ["E_KEY_DERIVATION", "Key derivation failed"],
   // Ledger errors
   LEDGER_POST: ["E_LEDGER_POST", "Ledger post failed"],

--- a/test/lib/db/migration-restore/verify.test.ts
+++ b/test/lib/db/migration-restore/verify.test.ts
@@ -46,9 +46,10 @@ describeWithEnv(
       // rebuild), the attendees.kind NOT NULL tightening (an empty-`requires`
       // constraint rebuild owning no additive objects to drop/restore), and the
       // attendee-listings-tag settings rewrite (data-only; covered by its own
-      // data test), and listing_image_thumb (historically added a column that
-      // first_class_images now drops).
-      expect(additiveMigrations.length).toBe(MIGRATIONS.length - 17);
+      // data test), listing_image_thumb (historically added a column that
+      // first_class_images now drops), and remove_broken_image_records
+      // (data-only; covered by its own data test).
+      expect(additiveMigrations.length).toBe(MIGRATIONS.length - 18);
     });
 
     test("verify reads the live schema from the primary, not a replica", async () => {

--- a/test/lib/db/migration-schema-guard.test.ts
+++ b/test/lib/db/migration-schema-guard.test.ts
@@ -83,6 +83,7 @@ describe("db > migrations > schema change guard", () => {
         "2026-07-07_contact_attendee_tokens",
         "2026-07-09_listing_attributes",
         "2026-07-10_processed_payments_attendee_index",
+        "2026-07-12_remove_broken_image_records",
       ],
       schemaHash: "n2axyb",
     });

--- a/test/lib/server-admin-images.test.ts
+++ b/test/lib/server-admin-images.test.ts
@@ -3,10 +3,12 @@ import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { getDb } from "#shared/db/client.ts";
 import { getAllImages } from "#shared/db/images.ts";
+import { BROKEN_IMAGE_FILENAME } from "#shared/images/broken.ts";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
 import {
   adminGet,
   imageUploadRequest,
+  insertBrokenImage,
   makeImage,
   postImageUpload,
 } from "#test-utils/admin-images.ts";
@@ -46,6 +48,17 @@ describeWithEnv(
           "Hero",
           'href="/admin/images/',
           "/image/hero-thumb.webp",
+        );
+      });
+
+      test("renders the red-pixel marker for an image whose filenames are broken", async () => {
+        await insertBrokenImage({ name: "Broken library image" });
+
+        await expectHtmlResponse(
+          await adminGet("/admin/images"),
+          200,
+          "Broken library image",
+          `/image/${BROKEN_IMAGE_FILENAME}`,
         );
       });
 

--- a/test/lib/server-images/proxy.test.ts
+++ b/test/lib/server-images/proxy.test.ts
@@ -2,8 +2,13 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { encryptBytes } from "#shared/crypto/encryption.ts";
-import { expectHtmlResponse } from "#test-utils/assertions.ts";
+import { BROKEN_IMAGE_FILENAME } from "#shared/images/broken.ts";
+import {
+  expectBrokenImageResponse,
+  expectHtmlResponse,
+} from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
 import { JPEG_HEADER } from "#test-utils/factories.ts";
 import {
   mockRequest,
@@ -30,6 +35,8 @@ describeWithEnv(
   },
   () => {
     describe("GET /image/:filename (proxy route)", () => {
+      const errors = setupErrorSpy();
+
       test("serves decrypted image with correct content type", async () => {
         const imageData = JPEG_HEADER;
         const encrypted = await encryptBytes(imageData);
@@ -50,13 +57,39 @@ describeWithEnv(
         );
       });
 
-      test("returns 404 when file does not exist in storage", async () => {
+      test("serves the red pixel and reports when the file is missing from storage", async () => {
         await withCdnProxy(
           () => new Response("Not Found", { status: 404 }),
           async () => {
-            expect((await proxyRequest()).status).toBe(404);
+            await expectBrokenImageResponse(await proxyRequest());
+            expect(errors.lastMessage()).toContain("E_IMAGE_BROKEN");
+            expect(errors.lastMessage()).toContain(
+              "abc123-def4-5678-9abc-def012345678.jpg is missing from storage",
+            );
           },
         );
+      });
+
+      test("serves the red pixel and reports when the stored file will not decrypt", async () => {
+        await withCdnProxy(
+          () => new Response("not encrypted bytes", { status: 200 }),
+          async () => {
+            await expectBrokenImageResponse(await proxyRequest());
+            expect(errors.lastMessage()).toContain("E_IMAGE_BROKEN");
+            expect(errors.lastMessage()).toContain(
+              "abc123-def4-5678-9abc-def012345678.jpg could not be decrypted",
+            );
+          },
+        );
+      });
+
+      test("serves the red pixel for the broken-image marker path", async () => {
+        const response = await handleRequest(
+          mockRequest(`/image/${BROKEN_IMAGE_FILENAME}`),
+        );
+        await expectBrokenImageResponse(response);
+        // The marker is a fallback, not a broken record in itself.
+        expect(errors.calls.length).toBe(0);
       });
 
       test("propagates non-404 storage errors as 503", async () => {
@@ -85,6 +118,16 @@ describeWithEnv(
           test("returns 404", async () => {
             await withStorageDisabled(async () => {
               expect((await proxyRequest()).status).toBe(404);
+            });
+          });
+
+          test("still serves the red pixel for the broken-image marker", async () => {
+            await withStorageDisabled(async () => {
+              await expectBrokenImageResponse(
+                await handleRequest(
+                  mockRequest(`/image/${BROKEN_IMAGE_FILENAME}`),
+                ),
+              );
             });
           });
         },

--- a/test/lib/server-public/ticket-slug-get.test.ts
+++ b/test/lib/server-public/ticket-slug-get.test.ts
@@ -2,6 +2,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
+import { setImagesForItem } from "#shared/db/images.ts";
+import { BROKEN_IMAGE_FILENAME } from "#shared/images/broken.ts";
+import { insertBrokenImage } from "#test-utils/admin-images.ts";
 import {
   assertPublicHtml,
   expectFlash,
@@ -38,6 +41,24 @@ describeWithEnv(
           `/ticket/${listing.slug}`,
           "Continue",
           `action="/ticket/${listing.slug}"`,
+        );
+      });
+
+      test("still renders when the listing's image record is broken", async () => {
+        const listing = await createTestListing({
+          maxAttendees: 50,
+          thankYouUrl: "https://example.com",
+        });
+        await setImagesForItem("listing", listing.id, [
+          await insertBrokenImage(),
+        ]);
+
+        // The page renders (no 503) and shows the red-pixel marker in place
+        // of the unreadable image.
+        await assertPublicHtml(
+          `/ticket/${listing.slug}`,
+          "Continue",
+          `/image/${BROKEN_IMAGE_FILENAME}`,
         );
       });
 

--- a/test/lib/server-settings/header-image.test.ts
+++ b/test/lib/server-settings/header-image.test.ts
@@ -6,6 +6,7 @@ import { settings } from "#shared/db/settings.ts";
 import { MAX_IMAGE_SIZE } from "#shared/limits.ts";
 import {
   assertAdminHtml,
+  expectBrokenImageResponse,
   expectFlashRedirect,
   expectHtmlResponse,
   expectRedirectWithFlash,
@@ -318,12 +319,13 @@ describeWithEnv("server (header image settings)", { db: true }, () => {
       });
     });
 
-    test("returns 404 when CDN reports the object missing", async () => {
+    test("serves the uncached red pixel when CDN reports the object missing", async () => {
       await withCdnProxy(
         () => new Response(null, { status: 404 }),
         async () => {
-          const response = await handleRequest(mockRequest(PROXY_URL));
-          expect(response.status).toBe(404);
+          await expectBrokenImageResponse(
+            await handleRequest(mockRequest(PROXY_URL)),
+          );
         },
       );
     });

--- a/test/shared/db/images.test.ts
+++ b/test/shared/db/images.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { encrypt } from "#shared/crypto/encryption.ts";
-import { execute, executeBatch, queryAll } from "#shared/db/client.ts";
+import { executeBatch, queryAll } from "#shared/db/client.ts";
 import {
   appendImageToItem,
   clearImageUsesForItemStatement,
@@ -15,11 +14,14 @@ import {
   setItemsForImage,
 } from "#shared/db/images.ts";
 import { getListingWithCount } from "#shared/db/listings/records.ts";
+import { BROKEN_IMAGE_FILENAME } from "#shared/images/broken.ts";
 import type { Image } from "#shared/types.ts";
 import { nonEmptyString } from "#shared/validation/string.ts";
+import { insertBrokenImage } from "#test-utils/admin-images.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
 
 const makeImage = (
   name: string,
@@ -48,7 +50,14 @@ const linkedImageIds = async (
 ): Promise<number[]> =>
   (await getImagesForItem(itemType, itemId)).map((image) => image.id);
 
+/** A broken image row with a working thumbnail, so tests can see that only
+ * the unreadable column falls back to the marker. */
+const insertBrokenImageWithGoodThumb = (): Promise<number> =>
+  insertBrokenImage({ thumbFilename: "broken-thumb.webp" });
+
 describeWithEnv("db > images", { db: true }, () => {
+  const errors = setupErrorSpy();
+
   describe("image metadata", () => {
     test("stores free text encrypted and decrypts image reads", async () => {
       const image = await makeImage("Hero", {
@@ -77,21 +86,46 @@ describeWithEnv("db > images", { db: true }, () => {
       expect(await getImageById(9999)).toBeNull();
     });
 
-    test("rejects stored images whose filename decrypts to an empty string", async () => {
-      await execute(
-        `INSERT INTO images (name, filename, filename_thumb, alt_text)
-         VALUES (?, ?, ?, ?)`,
-        [
-          await encrypt("Broken"),
-          await encrypt(""),
-          await encrypt("broken-thumb.webp"),
-          "",
-        ],
-      );
+    test("swaps in the broken-image marker when a filename decrypts empty", async () => {
+      const id = await insertBrokenImageWithGoodThumb();
 
-      await expect(getAllImages()).rejects.toThrow(
-        "image filename must be non-empty",
+      const images = await getAllImages();
+      expect(images.map((image) => image.id)).toEqual([id]);
+      expect(images[0]?.filename).toBe(BROKEN_IMAGE_FILENAME);
+      expect(images[0]?.filename_thumb).toBe("broken-thumb.webp");
+      expect(images[0]?.name).toBe("Broken");
+      expect(errors.lastMessage()).toContain("E_IMAGE_BROKEN");
+      expect(errors.lastMessage()).toContain(
+        `image ${id} filename decrypted to an empty value`,
       );
+    });
+
+    test("projects the broken-image marker for an item's first image", async () => {
+      const listing = await createTestListing({ name: "Broken poster" });
+      const id = await insertBrokenImageWithGoodThumb();
+      await setImagesForItem("listing", listing.id, [id]);
+
+      expect(await getImageFilenamesForItem("listing", listing.id)).toEqual({
+        image_alt_text: "",
+        image_thumb_url: "broken-thumb.webp",
+        image_url: BROKEN_IMAGE_FILENAME,
+      });
+      expect(errors.lastMessage()).toContain(
+        `image ${id} (first image of listing ${listing.id}) filename decrypted to an empty value`,
+      );
+    });
+
+    test("projects the broken-image marker through listing reads", async () => {
+      const listing = await createTestListing({ name: "Broken projection" });
+      const id = await insertBrokenImageWithGoodThumb();
+      await setImagesForItem("listing", listing.id, [id]);
+
+      expect(await getListingWithCount(listing.id)).toMatchObject({
+        image_alt_text: "",
+        image_thumb_url: "broken-thumb.webp",
+        image_url: BROKEN_IMAGE_FILENAME,
+      });
+      expect(errors.contains(`listing ${listing.id} image`)).toBe(true);
     });
   });
 

--- a/test/shared/db/migrations.test.ts
+++ b/test/shared/db/migrations.test.ts
@@ -23,6 +23,7 @@ import {
   markCurrentSchemaMigrationPending,
   markMigrationsForRerun,
 } from "#test/lib/db/migration-test-helpers.ts";
+import { insertBrokenImage } from "#test-utils/admin-images.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import {
   assertSchemaEmpty,
@@ -127,6 +128,26 @@ describeWithEnv("db > migrations", { db: true }, () => {
       return result.rows[0]?.value as string | undefined;
     };
 
+    /** Put the database in the "site upgrading from an older release" state:
+     * the stored marker is that release's, and `migrationId` has not run.
+     * The marker must differ from the current one — a matching marker would
+     * read as up_to_date and the upgrade scenario couldn't arise. */
+    const simulateUpgradeFromRelease = async (
+      previousMarker: string,
+      migrationId: string,
+    ): Promise<void> => {
+      expect(previousMarker).not.toBe(LATEST_UPDATE);
+      await getDb().execute({
+        args: [previousMarker],
+        sql: "UPDATE settings SET value = ? WHERE key = 'latest_db_update'",
+      });
+      await getDb().execute({
+        args: [migrationId],
+        sql: "DELETE FROM schema_migrations WHERE id = ?",
+      });
+      invalidateInitDbCache();
+    };
+
     const bootstrapSettingsTable = async (
       preInit?: () => Promise<unknown>,
     ): Promise<void> => {
@@ -217,24 +238,14 @@ describeWithEnv("db > migrations", { db: true }, () => {
       // running its up() — the {{listing}} → {{listings}} rewrite would silently
       // never happen on real upgrades. Bumping LATEST_UPDATE flips the state to
       // "needs_migration" so the migration actually runs.
-      const PREVIOUS_RELEASE_MARKER =
-        "Migrate listings.day_prices into the listing_prices 'day_count' dimension and drop the column.";
-      // Sanity: the previous marker must differ from the current one, else the
-      // upgrade would read as up_to_date and this scenario couldn't arise.
-      expect(PREVIOUS_RELEASE_MARKER).not.toBe(LATEST_UPDATE);
-
-      await getDb().execute({
-        args: [PREVIOUS_RELEASE_MARKER],
-        sql: "UPDATE settings SET value = ? WHERE key = 'latest_db_update'",
-      });
-      await getDb().execute(
-        "DELETE FROM schema_migrations WHERE id = '2026-07-03_attendee_listings_tag'",
-      );
       await getDb().execute({
         args: ["{{name}}, {{listing}}, {{email}}"],
         sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('attendee_column_order', ?)",
       });
-      invalidateInitDbCache();
+      await simulateUpgradeFromRelease(
+        "Migrate listings.day_prices into the listing_prices 'day_count' dimension and drop the column.",
+        "2026-07-03_attendee_listings_tag",
+      );
 
       await initDb();
 
@@ -247,6 +258,29 @@ describeWithEnv("db > migrations", { db: true }, () => {
         "2026-07-03_attendee_listings_tag",
       );
       // ...and the markers are refreshed to the current release.
+      expect(await settingValue("latest_db_update")).toBe(LATEST_UPDATE);
+    });
+
+    test("runs the broken-image cleanup on a site upgrading from the previous release", async () => {
+      // The same trap as the data-migration test above: without the
+      // LATEST_UPDATE bump shipped alongside remove_broken_image_records, an
+      // already-up-to-date site would read as up_to_date and baseline the new
+      // migration id WITHOUT deleting the broken image records.
+      await insertBrokenImage();
+      await simulateUpgradeFromRelease(
+        "Index processed_payments by attendee for roster, export, and refund lookups.",
+        "2026-07-12_remove_broken_image_records",
+      );
+
+      await initDb();
+
+      // The cleanup ran: the broken record is gone...
+      const images = await getDb().execute("SELECT id FROM images");
+      expect(images.rows.map((row) => row.id)).toEqual([]);
+      // ...the migration is recorded, and the marker is the current release's.
+      expect(await appliedMigrationIds()).toContain(
+        "2026-07-12_remove_broken_image_records",
+      );
       expect(await settingValue("latest_db_update")).toBe(LATEST_UPDATE);
     });
 

--- a/test/shared/db/migrations/2026-07-12_remove_broken_image_records.test.ts
+++ b/test/shared/db/migrations/2026-07-12_remove_broken_image_records.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { queryAll } from "#shared/db/client.ts";
+import { encrypt } from "#shared/crypto/encryption.ts";
+import { execute, queryAll } from "#shared/db/client.ts";
 import {
   getAllImages,
   getImageUsesForImage,
@@ -24,7 +25,7 @@ describeWithEnv(
       const listing = await createTestListing({ name: "Repaired listing" });
       const real = await makeImage("Real");
       const brokenId = await insertBrokenImage();
-      const secondBrokenId = await insertBrokenImage({ name: "Also broken" });
+      await insertBrokenImage({ name: "Also broken" });
       await setImagesForItem("listing", listing.id, [brokenId, real.id]);
 
       await runMigration();
@@ -35,7 +36,6 @@ describeWithEnv(
         "SELECT id FROM images ORDER BY id",
       );
       expect(remainingIds.map((row) => row.id)).toEqual([real.id]);
-      expect(remainingIds.map((row) => row.id)).not.toContain(secondBrokenId);
       expect(await getImageUsesForImage(brokenId)).toEqual([]);
       expect(await getImageUsesForImage(real.id)).toEqual([
         {
@@ -49,6 +49,26 @@ describeWithEnv(
       expect((await getAllImages()).map((image) => image.name)).toEqual([
         "Real",
       ]);
+    });
+
+    test("fails loudly on a filename that will not decrypt, deleting nothing", async () => {
+      const kept = await makeImage("Kept");
+      await execute(
+        `INSERT INTO images (name, filename, filename_thumb, alt_text)
+         VALUES (?, 'not-a-ciphertext', 'not-a-ciphertext', '')`,
+        [await encrypt("Unknown corruption")],
+      );
+
+      // Unknown corruption is not the known encrypted-empty shape, so the
+      // migration must stop rather than guess that deleting data is safe.
+      await expect(runMigration()).rejects.toThrow(
+        "Invalid encrypted data format",
+      );
+      const remaining = await queryAll<{ id: number }>(
+        "SELECT id FROM images ORDER BY id",
+      );
+      expect(remaining.length).toBe(2);
+      expect(remaining[0]?.id).toBe(kept.id);
     });
 
     test("is a no-op when every image record is readable (idempotent re-run)", async () => {

--- a/test/shared/db/migrations/2026-07-12_remove_broken_image_records.test.ts
+++ b/test/shared/db/migrations/2026-07-12_remove_broken_image_records.test.ts
@@ -52,23 +52,43 @@ describeWithEnv(
     });
 
     test("fails loudly on a filename that will not decrypt, deleting nothing", async () => {
+      const listing = await createTestListing({ name: "Aborted repair" });
       const kept = await makeImage("Kept");
-      await execute(
+      // Seeded BEFORE the malformed row, so the scan (which walks ids in
+      // order) has already identified this broken record when the malformed
+      // one throws — a regression that deletes as it scans would remove it.
+      const brokenId = await insertBrokenImage();
+      await setImagesForItem("listing", listing.id, [brokenId]);
+      const malformed = await execute(
         `INSERT INTO images (name, filename, filename_thumb, alt_text)
          VALUES (?, 'not-a-ciphertext', 'not-a-ciphertext', '')`,
         [await encrypt("Unknown corruption")],
       );
+      const malformedId = Number(malformed.lastInsertRowid);
 
       // Unknown corruption is not the known encrypted-empty shape, so the
       // migration must stop rather than guess that deleting data is safe.
       await expect(runMigration()).rejects.toThrow(
         "Invalid encrypted data format",
       );
+      // Every record survives — including the already-identified broken one
+      // and its item link, because deletes only run after the full scan.
       const remaining = await queryAll<{ id: number }>(
         "SELECT id FROM images ORDER BY id",
       );
-      expect(remaining.length).toBe(2);
-      expect(remaining[0]?.id).toBe(kept.id);
+      expect(remaining.map((row) => row.id)).toEqual([
+        kept.id,
+        brokenId,
+        malformedId,
+      ]);
+      expect(await getImageUsesForImage(brokenId)).toEqual([
+        {
+          image_id: brokenId,
+          item_id: listing.id,
+          item_type: "listing",
+          sort_order: 0,
+        },
+      ]);
     });
 
     test("is a no-op when every image record is readable (idempotent re-run)", async () => {

--- a/test/shared/db/migrations/2026-07-12_remove_broken_image_records.test.ts
+++ b/test/shared/db/migrations/2026-07-12_remove_broken_image_records.test.ts
@@ -1,0 +1,63 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { queryAll } from "#shared/db/client.ts";
+import {
+  getAllImages,
+  getImageUsesForImage,
+  setImagesForItem,
+} from "#shared/db/images.ts";
+import removeBrokenImageRecords from "#shared/db/migrations/2026-07-12_remove_broken_image_records.ts";
+import { insertBrokenImage, makeImage } from "#test-utils/admin-images.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { buildMigrationContext } from "#test-utils/migrations.ts";
+
+// Data-only migration: it scans and deletes image rows via getDb.
+const context = buildMigrationContext({});
+const runMigration = () => removeBrokenImageRecords(context).up();
+
+describeWithEnv(
+  "db > migrations > 2026-07-12_remove_broken_image_records",
+  { db: true },
+  () => {
+    test("deletes broken image records and their item links, keeping real ones", async () => {
+      const listing = await createTestListing({ name: "Repaired listing" });
+      const real = await makeImage("Real");
+      const brokenId = await insertBrokenImage();
+      const secondBrokenId = await insertBrokenImage({ name: "Also broken" });
+      await setImagesForItem("listing", listing.id, [brokenId, real.id]);
+
+      await runMigration();
+
+      // Both broken records and the one's link are gone; the real image and
+      // its link survive at its original sort order.
+      const remainingIds = await queryAll<{ id: number }>(
+        "SELECT id FROM images ORDER BY id",
+      );
+      expect(remainingIds.map((row) => row.id)).toEqual([real.id]);
+      expect(remainingIds.map((row) => row.id)).not.toContain(secondBrokenId);
+      expect(await getImageUsesForImage(brokenId)).toEqual([]);
+      expect(await getImageUsesForImage(real.id)).toEqual([
+        {
+          image_id: real.id,
+          item_id: listing.id,
+          item_type: "listing",
+          sort_order: 1,
+        },
+      ]);
+      // The library reads clean afterwards — nothing left to fall back on.
+      expect((await getAllImages()).map((image) => image.name)).toEqual([
+        "Real",
+      ]);
+    });
+
+    test("is a no-op when every image record is readable (idempotent re-run)", async () => {
+      const image = await makeImage("Healthy");
+
+      await runMigration();
+      await runMigration();
+
+      expect((await getAllImages()).map((row) => row.id)).toEqual([image.id]);
+    });
+  },
+);

--- a/test/shared/db/news-posts.test.ts
+++ b/test/shared/db/news-posts.test.ts
@@ -13,13 +13,16 @@ import {
   isNewsSlugTaken,
   updateNewsPost,
 } from "#shared/db/news-posts.ts";
+import { BROKEN_IMAGE_FILENAME } from "#shared/images/broken.ts";
 import { runWithRequestCache } from "#shared/request-cache.ts";
-import { makeImage } from "#test-utils/admin-images.ts";
+import { insertBrokenImage, makeImage } from "#test-utils/admin-images.ts";
 import { expectEncryptedAtRest } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestNewsPost } from "#test-utils/db-helpers/misc.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
 
 describeWithEnv("db > news-posts", { db: true }, () => {
+  const errors = setupErrorSpy();
   describe("encryption + single reads", () => {
     test("stores every free-text column encrypted and decrypts on read", async () => {
       const created = await createTestNewsPost("Launch day", {
@@ -145,6 +148,28 @@ describeWithEnv("db > news-posts", { db: true }, () => {
       expect(cards[1]?.image_url).toBe("");
       expect(cards[1]?.image_thumb_url).toBe("");
       expect(cards[1]?.image_alt_text).toBe("");
+    });
+
+    test("projects the broken-image marker for a broken linked image", async () => {
+      const post = await createTestNewsPost("Broken picture post");
+      await appendImageToItem(await insertBrokenImage(), {
+        itemId: post.id,
+        itemType: "news",
+      });
+
+      const cards = await getNewsPostCards();
+      expect(cards[0]?.image_url).toBe(BROKEN_IMAGE_FILENAME);
+      expect(cards[0]?.image_thumb_url).toBe(BROKEN_IMAGE_FILENAME);
+      expect(
+        errors.contains(
+          `news post ${post.id} image decrypted to an empty value`,
+        ),
+      ).toBe(true);
+      expect(
+        errors.contains(
+          `news post ${post.id} thumbnail image decrypted to an empty value`,
+        ),
+      ).toBe(true);
     });
 
     test("same-day posts tie-break by id, newest insert first", async () => {

--- a/test/shared/images/broken.test.ts
+++ b/test/shared/images/broken.test.ts
@@ -1,0 +1,109 @@
+import { inflateSync } from "node:zlib";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { encrypt } from "#shared/crypto/encryption.ts";
+import {
+  BROKEN_IMAGE_FILENAME,
+  BROKEN_IMAGE_PNG,
+  decryptImageFilename,
+  decryptImageFilenameOrEmpty,
+} from "#shared/images/broken.ts";
+import { getMimeTypeFromFilename } from "#shared/storage.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
+
+/** Read a big-endian 32-bit number out of the PNG bytes. */
+const pngNumberAt = (offset: number): number =>
+  new DataView(BROKEN_IMAGE_PNG.buffer, BROKEN_IMAGE_PNG.byteOffset).getUint32(
+    offset,
+  );
+
+describe("images > broken image fallback", () => {
+  describe("the red pixel", () => {
+    test("marker filename maps to the PNG content type", () => {
+      expect(getMimeTypeFromFilename(BROKEN_IMAGE_FILENAME)).toBe("image/png");
+    });
+
+    test("bytes are a valid 1x1 PNG", () => {
+      expect([...BROKEN_IMAGE_PNG.slice(0, 8)]).toEqual([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
+      // IHDR: width and height 1, 8-bit depth, color type 2 (plain RGB).
+      expect(pngNumberAt(16)).toBe(1);
+      expect(pngNumberAt(20)).toBe(1);
+      expect(BROKEN_IMAGE_PNG[24]).toBe(8);
+      expect(BROKEN_IMAGE_PNG[25]).toBe(2);
+    });
+
+    test("pixel is pure red", () => {
+      // The IDAT chunk holds the one deflated scanline: filter byte 0, then
+      // the RGB bytes — red means exactly [255, 0, 0].
+      const marker = new TextEncoder().encode("IDAT");
+      const dataStart = BROKEN_IMAGE_PNG.findIndex((_, index) =>
+        marker.every((byte, i) => BROKEN_IMAGE_PNG[index + i] === byte),
+      );
+      const length = pngNumberAt(dataStart - 4);
+      const scanline = inflateSync(
+        BROKEN_IMAGE_PNG.slice(dataStart + 4, dataStart + 4 + length),
+      );
+      expect([...new Uint8Array(scanline)]).toEqual([0, 255, 0, 0]);
+    });
+  });
+
+  describeWithEnv("filename reads", { encryptionKey: true }, () => {
+    const errors = setupErrorSpy();
+
+    test("returns a readable filename unchanged without reporting", async () => {
+      const stored = await encrypt("hero.webp");
+      expect(await decryptImageFilename(stored, "image 1 filename")).toBe(
+        "hero.webp",
+      );
+      expect(errors.calls.length).toBe(0);
+    });
+
+    test("falls back and reports when the filename decrypts to empty", async () => {
+      const stored = await encrypt("");
+      expect(await decryptImageFilename(stored, "image 2 filename")).toBe(
+        BROKEN_IMAGE_FILENAME,
+      );
+      expect(errors.lastMessage()).toContain("E_IMAGE_BROKEN");
+      expect(errors.lastMessage()).toContain(
+        "image 2 filename decrypted to an empty value",
+      );
+    });
+
+    test("falls back and reports when the filename will not decrypt", async () => {
+      expect(await decryptImageFilename("garbage", "image 3 filename")).toBe(
+        BROKEN_IMAGE_FILENAME,
+      );
+      expect(errors.lastMessage()).toContain("E_IMAGE_BROKEN");
+      expect(errors.lastMessage()).toContain(
+        "image 3 filename could not be decrypted",
+      );
+      expect(errors.lastMessage()).toContain("Invalid encrypted data format");
+    });
+
+    test("treats an empty or missing projection as no image, not broken", async () => {
+      expect(await decryptImageFilenameOrEmpty("", "listing 4 image")).toBe("");
+      expect(
+        await decryptImageFilenameOrEmpty(undefined, "listing 4 image"),
+      ).toBe("");
+      expect(errors.calls.length).toBe(0);
+    });
+
+    test("routes a non-empty projection through the broken fallback", async () => {
+      expect(
+        await decryptImageFilenameOrEmpty(
+          await encrypt("poster.webp"),
+          "listing 5 image",
+        ),
+      ).toBe("poster.webp");
+      expect(
+        await decryptImageFilenameOrEmpty(await encrypt(""), "listing 5 image"),
+      ).toBe(BROKEN_IMAGE_FILENAME);
+      expect(errors.lastMessage()).toContain(
+        "listing 5 image decrypted to an empty value",
+      );
+    });
+  });
+});

--- a/test/test-utils/admin-images.ts
+++ b/test/test-utils/admin-images.ts
@@ -1,4 +1,6 @@
 import { handleRequest } from "#routes";
+import { encrypt } from "#shared/crypto/encryption.ts";
+import { execute } from "#shared/db/client.ts";
 import { getImagesForItem, imagesTable } from "#shared/db/images.ts";
 import type { Image, ImageUseItemType } from "#shared/types.ts";
 import { nonEmptyString } from "#shared/validation/string.ts";
@@ -13,6 +15,28 @@ export const makeImage = (name: string): Promise<Image> =>
     filenameThumb: nonEmptyString(`${name.toLowerCase()}-thumb.webp`),
     name,
   });
+
+/** Store an image row whose filename is an encrypted empty string — the broken
+ * shape the first-class images migration copied from a legacy listing whose
+ * image_url was an encrypted "". The thumbnail is broken the same way unless a
+ * working `thumbFilename` is given. Returns the row id. */
+export const insertBrokenImage = async (
+  options: { name?: string; thumbFilename?: string } = {},
+): Promise<number> => {
+  const brokenFilename = await encrypt("");
+  const result = await execute(
+    `INSERT INTO images (name, filename, filename_thumb, alt_text)
+     VALUES (?, ?, ?, '')`,
+    [
+      await encrypt(options.name ?? "Broken"),
+      brokenFilename,
+      options.thumbFilename === undefined
+        ? brokenFilename
+        : await encrypt(options.thumbFilename),
+    ],
+  );
+  return Number(result.lastInsertRowid);
+};
 
 export const adminGet = async (path: string): Promise<Response> =>
   handleRequest(mockRequest(path, { headers: { cookie: await testCookie() } }));

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { it } from "@std/testing/bdd";
 import { once } from "#fp";
 import { getSessionCookieName, parseFlashValue } from "#shared/cookies.ts";
+import { BROKEN_IMAGE_PNG } from "#shared/images/broken.ts";
 
 export const FLASH_TEST_ID = "t001";
 
@@ -644,4 +645,16 @@ export const expectEncryptedAtRest = (
   for (const value of values) {
     expect(value?.startsWith("enc:")).toBe(true);
   }
+};
+
+/** Assert a response is the uncached red-pixel fallback for a broken image. */
+export const expectBrokenImageResponse = async (
+  response: Response,
+): Promise<void> => {
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("image/png");
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+    BROKEN_IMAGE_PNG,
+  );
 };


### PR DESCRIPTION
## What was wrong

Some stored image records have a filename that reads back as nothing. Every page that read one — the booking page and the admin image library — crashed with a "Temporary Error" and logged `E_CDN_REQUEST: image filename must be non-empty`.

**Where those records came from:** until April 2026 (#914), saving a listing with no image stored its empty image address in encrypted form — a real-looking sealed value whose content is nothing. The images migration in July (#1563) checked "does this listing have an image?" by looking at the *sealed* value, which is never empty, so every one of those no-image listings was given a broken image record (with the same broken value copied as its thumbnail).

## What changes

**Broken images can no longer take a page down:**

- Anywhere an image filename is read (the image library, ticket pages, listings, groups, news posts), a filename that cannot be read is swapped for a stand-in name, `broken-image.png`, and the page renders normally.
- That stand-in shows a 1×1 red pixel, so a broken image is visible on the page and the operator can see exactly which one it is.
- Every broken image is reported loudly — error log, ntfy, Sentry, and the admin activity log — naming the exact record, for example "image 12 filename decrypted to an empty value".
- A stored file that has gone missing, or whose bytes will not read, also serves the red pixel (uncached, so a repaired file shows immediately) with a report. A passing storage outage still shows as a temporary error.
- An item with no picture set still shows nothing, as before.

**And the bad records are cleaned up:**

- A new migration (`2026-07-12_remove_broken_image_records`) finds image records whose filename reads back as nothing and deletes them, along with their links to listings, groups, pages, and news posts. There was never a real file behind them, so affected items simply go back to showing no image — exactly how they looked before July's migration.

## How it is tested

Regression tests seed the exact broken record from production and check that `/admin/images`, `/ticket/:slug`, listing reads, item image lookups, and news cards all render (with the red pixel) and report the record. The migration is tested to delete only the broken records and their links, keep real images untouched, and be safe to run twice. The red pixel is checked byte-by-byte: a valid 1×1 PNG whose one pixel is pure red. The full `deno task precommit` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TaWaA5GQvjEyQJMjQmGPH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broken, missing, or undecryptable images now return a consistent 1×1 red placeholder, including uncached placeholder responses.
  * Image rendering in listings, tickets, and news remains functional by substituting a broken-image marker URL instead of erroring.
  * Added dedicated handling so the broken-image marker path works even when image storage isn’t enabled.
* **Chores**
  * Added a repair migration to remove legacy broken image records and their associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->