### PR TITLE
Address CodeRabbit review feedback on the Money rename

### DIFF
--- a/src/locales/en/attendees.json
+++ b/src/locales/en/attendees.json
@@ -23,7 +23,7 @@
   "attendee_detail.whatsapp": "whatsapp",
   "attendee_detail.answers": "Answers",
   "attendee_detail.activity_log": "Activity Log",
-  "attendee_detail.view_full_ledger": "View full money",
+  "attendee_detail.view_full_ledger": "View all money changes",
   "attendee_detail.total": "Total",
   "attendee_detail.addon_under": "Add-on chosen under {parent}",
   "attendee_detail.includes_addon": "Includes add-on: {children}",

--- a/src/locales/en/errors.json
+++ b/src/locales/en/errors.json
@@ -45,7 +45,7 @@
   "error.no_payment_provider": "No payment provider configured.",
   "error.no_attendees_to_refund": "No attendees have payments to refund.",
   "error.refund_failed": "Refund failed. The payment may have already been refunded.",
-  "error.refund_not_recorded": "The payment provider sent the refund. Money could not record it. Add a correction. Do not send the refund again.",
+  "error.refund_not_recorded": "The payment provider sent the refund. It could not be recorded in Money. Add a correction. Do not send the refund again.",
   "error.already_refunded": "This attendee has already been refunded.",
   "error.attendee_name_mismatch_delete": "Attendee name does not match. Please type the exact name to confirm deletion.",
   "error.attendee_name_mismatch_refund": "Attendee name does not match. Please type the exact name to confirm refund.",

--- a/src/locales/en/groups.json
+++ b/src/locales/en/groups.json
@@ -45,5 +45,5 @@
   "groups.money.external_costs": "Costs paid outside checkout",
   "groups.money.net": "Net after refunds and costs",
   "groups.money.note": "These totals combine the group's current listings. View every change in the group's money.",
-  "groups.money.view_ledger": "View group money"
+  "groups.money.view_ledger": "View this group's money changes"
 }

--- a/src/locales/en/listings-table.json
+++ b/src/locales/en/listings-table.json
@@ -125,7 +125,7 @@
   "listings_table.income_ledger_external_costs": "Costs paid outside checkout",
   "listings_table.income_ledger_net_balance": "Net after refunds and costs",
   "listings_table.income_ledger_recognised_note": "Income is what this listing earned before refunds. Profit subtracts service event costs. Net also subtracts refunds and other costs. Every change stays visible in Money.",
-  "listings_table.income_ledger_view_full": "View full money",
+  "listings_table.income_ledger_view_full": "View all money changes",
   "listings_table.income_ledger_link": "Money in and out →",
   "listings_table.duration_warning_message": "Changing booking duration will update existing bookings for this listing.",
   "listings_table.i_understand": "I understand",

--- a/src/locales/en/servicing.json
+++ b/src/locales/en/servicing.json
@@ -29,7 +29,7 @@
   "servicing.action.delete_event": "Delete service event",
   "servicing.action.record_cost": "Record service event cost",
   "servicing.action.edit": "Edit",
-  "servicing.action.view_money_history": "View money",
+  "servicing.action.view_money_history": "View money changes",
   "servicing.error.daily_start_date": "Choose a start date for daily listings.",
   "servicing.error.invalid_cost": "Enter a valid positive cost amount. Choose a listing.",
   "servicing.error.invalid_cost_amount": "Enter a valid positive cost amount.",

--- a/test/lib/server-attendee-refresh-payment.test.ts
+++ b/test/lib/server-attendee-refresh-payment.test.ts
@@ -194,7 +194,7 @@ describeWithEnv("server (admin attendee refresh payment)", { db: true }, () => {
       await submitRefreshPayment(
         attendee,
         () => Promise.resolve(true),
-        expect.stringContaining("It could not be recorded in Money"),
+        "The payment provider sent the refund. It could not be recorded in Money. Add a correction. Do not send the refund again.",
         false,
       );
     });

--- a/test/lib/server-attendee-refresh-payment.test.ts
+++ b/test/lib/server-attendee-refresh-payment.test.ts
@@ -194,7 +194,7 @@ describeWithEnv("server (admin attendee refresh payment)", { db: true }, () => {
       await submitRefreshPayment(
         attendee,
         () => Promise.resolve(true),
-        expect.stringContaining("Money could not record it"),
+        expect.stringContaining("It could not be recorded in Money"),
         false,
       );
     });

--- a/test/lib/server-attendees/payment.test.ts
+++ b/test/lib/server-attendees/payment.test.ts
@@ -266,7 +266,7 @@ describeWithEnv(
         expect(response.status).toBe(302);
         expectFlash(
           response,
-          expect.stringContaining("It could not be recorded in Money"),
+          "The payment provider sent the refund. It could not be recorded in Money. Add a correction. Do not send the refund again.",
           false,
         );
         // The error must not silently flip the payment to refunded: with no

--- a/test/lib/server-attendees/payment.test.ts
+++ b/test/lib/server-attendees/payment.test.ts
@@ -266,7 +266,7 @@ describeWithEnv(
         expect(response.status).toBe(302);
         expectFlash(
           response,
-          expect.stringContaining("Money could not record it"),
+          expect.stringContaining("It could not be recorded in Money"),
           false,
         );
         // The error must not silently flip the payment to refunded: with no

--- a/test/lib/server-ledger/list-views.test.ts
+++ b/test/lib/server-ledger/list-views.test.ts
@@ -28,6 +28,7 @@ describeWithEnv("server (admin ledger list views)", { db: true }, () => {
     expect(response.status).toBe(200);
     const html = await response.text();
     expect(html).toContain("Money");
+    expect(html).not.toContain("Money history");
     // The sale leg credits the listing's revenue account, linked by its name.
     expect(html).toContain("Summer Concert");
     expect(html).toContain("/admin/ledger?listing=");

--- a/test/lib/server-ledger/statements.test.ts
+++ b/test/lib/server-ledger/statements.test.ts
@@ -21,6 +21,7 @@ describeWithEnv(
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Money");
+      expect(html).not.toContain("Money history");
       // The attendee's own label heads the page; a fully-paid sale nets to zero.
       expect(html).toContain("Ada Lovelace");
       expect(html).toContain("Amount still owed:");
@@ -64,6 +65,7 @@ describeWithEnv(
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Money");
+      expect(html).not.toContain("Money history");
       // No modifier row exists, so the account falls back to "Modifier #1".
       expect(html).toContain("Modifier #1");
     });
@@ -98,6 +100,7 @@ describeWithEnv(
       expect(response.status).toBe(200);
       const html = await response.text();
       expect(html).toContain("Money");
+      expect(html).not.toContain("Money history");
       // The writeoff singleton renders its label, not a raw "writeoff:default".
       expect(html).toContain("Corrections");
       // The correction's counterparty is the listing's revenue account.

--- a/test/lib/server-modifiers/crud.test.ts
+++ b/test/lib/server-modifiers/crud.test.ts
@@ -328,6 +328,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
       const response = await adminGet(`/admin/modifiers/${id}/edit`);
       const html = await response.text();
       expect(html).toContain("Money");
+      expect(html).not.toContain("Money history");
       expect(html).toContain("Add money change");
       expect(html).toContain(
         `/admin/ledger/modifier/${id}/add?return_url=%2Fadmin%2Fmodifiers%2F${id}%2Fedit`,

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -277,7 +277,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
         const response = await submitRefund(ctx);
         await expectFlashRedirect(
           `/admin/attendees/${attendee.id}/refund`,
-          expect.stringContaining("It could not be recorded in Money"),
+          "The payment provider sent the refund. It could not be recorded in Money. Add a correction. Do not send the refund again.",
           false,
         )(response);
         expect(mockRefund.calls.length).toBeGreaterThan(0);

--- a/test/lib/server-refunds.test.ts
+++ b/test/lib/server-refunds.test.ts
@@ -277,7 +277,7 @@ describeWithEnv("server (admin refunds)", { db: true }, () => {
         const response = await submitRefund(ctx);
         await expectFlashRedirect(
           `/admin/attendees/${attendee.id}/refund`,
-          expect.stringContaining("Money could not record it"),
+          expect.stringContaining("It could not be recorded in Money"),
           false,
         )(response);
         expect(mockRefund.calls.length).toBeGreaterThan(0);

--- a/test/shared/db/attendees/servicing/ledger-history-ui.test.ts
+++ b/test/shared/db/attendees/servicing/ledger-history-ui.test.ts
@@ -66,7 +66,7 @@ describeWithEnv("servicing §22 - cost history and pages", { db: true }, () => {
     expect(body).toContain(listing.name);
     expect(body).toContain("Money out");
     expect(body).toContain(`href="/admin/ledger?listing=${listing.id}"`);
-    expect(body).toContain("View money");
+    expect(body).toContain("View money changes");
     expect(body).toContain(`/admin/servicing/${id}/cost/`);
   });
 
@@ -79,7 +79,7 @@ describeWithEnv("servicing §22 - cost history and pages", { db: true }, () => {
     const body = await response.text();
     expect(body).toContain(listing.name);
     expect(body).not.toContain(`/admin/ledger?listing=${listing.id}`);
-    expect(body).not.toContain("View money");
+    expect(body).not.toContain("View money changes");
   });
 
   test("shows a deleted cost listing as plain text without a dead ledger link", async () => {
@@ -91,7 +91,7 @@ describeWithEnv("servicing §22 - cost history and pages", { db: true }, () => {
 
     expect(body).toContain("Deleted listing");
     expect(body).not.toContain(`/admin/ledger?listing=${listing.id}`);
-    expect(body).not.toContain("View money");
+    expect(body).not.toContain("View money changes");
   });
 
   test("getServicingCosts returns records in (occurred_at, transfer_id) order with each memo on its own row", async () => {

--- a/test/templates/admin/listings/income-and-helpers.test.ts
+++ b/test/templates/admin/listings/income-and-helpers.test.ts
@@ -60,8 +60,8 @@ describe("adminListingPage money breakdown", () => {
     // ledger, preselected to this listing (no arrow glyph, button-styled).
     expect(html).toContain("Income is what this listing earned before refunds");
     expect(html).toContain('href="/admin/ledger?listing=7"');
-    expect(html).toContain("View full money");
-    expect(html).not.toContain("View full money →");
+    expect(html).toContain("View all money changes");
+    expect(html).not.toContain("View all money changes →");
   });
 
   test("makes a refund-driven divergence between income and net balance visible", () => {

--- a/test/ui/templates/admin/groups.test.ts
+++ b/test/ui/templates/admin/groups.test.ts
@@ -169,7 +169,7 @@ describe("GroupOverviewPanel", () => {
     expect(html).toContain("Net after refunds and costs");
     expect(html).toContain("£160");
     expect(html).toContain('href="/admin/ledger?group=8"');
-    expect(html).toContain("View group money");
+    expect(html).toContain("View this group's money changes");
     expect(html).toContain("View every change in the group's money.");
   });
 

--- a/test/ui/templates/admin/ledger/filter-page.test.ts
+++ b/test/ui/templates/admin/ledger/filter-page.test.ts
@@ -42,6 +42,7 @@ describe("adminLedgerPage", () => {
   test("renders the money heading, nav, stats, filters, and simple list", () => {
     const html = adminLedgerPage(pageData(), SESSION);
     expect(html).toContain("Money");
+    expect(html).not.toContain("Money history");
     expect(html).toContain('href="/admin/ledger"');
     expect(html).toContain("<th>Activity</th>");
     expect(html).toContain("Simple view");

--- a/test/ui/templates/admin/ledger/statement.test.ts
+++ b/test/ui/templates/admin/ledger/statement.test.ts
@@ -240,7 +240,7 @@ describe("adminAccountStatementPage", () => {
     expect(html).toContain(
       'href="/admin/ledger/attendee/7/add?return_url=%2Fadmin%2Fledger%2Fattendee%2F7"',
     );
-    expect(html).not.toContain("View full money");
+    expect(html).not.toContain("View all money changes");
   });
 
   test("shows a zero balance for an account with no history", () => {
@@ -289,7 +289,7 @@ describe("adminAccountStatementPage", () => {
       }),
     );
     expect(html).toContain(
-      'href="/admin/ledger/writeoff/default"><span>View full money</span></a>',
+      'href="/admin/ledger/writeoff/default"><span>View all money changes</span></a>',
     );
     expect(html).not.toContain("/admin/ledger/writeoff/default/add");
   });

--- a/test/ui/templates/admin/nav.test.tsx
+++ b/test/ui/templates/admin/nav.test.tsx
@@ -264,6 +264,7 @@ describeWithEnv("AdminNav", {}, () => {
     );
     expect(ownerHtml).toContain('href="/admin/ledger"');
     expect(ownerHtml).toContain("Money");
+    expect(ownerHtml).not.toContain("Money history");
     const managerHtml = String(
       AdminNav({ active: "/admin/", session: { adminLevel: "manager" } }),
     );


### PR DESCRIPTION
## Summary

PR #1799 (renaming "Money history" to "Money") merged before CodeRabbit's review comments could be addressed. This follow-up applies that feedback:

- Clearer link labels: the "View full money" / "View money" / "View group money" button labels read awkwardly, so they now say "View all money changes" / "View money changes" / "View this group's money changes" — reusing the existing "money changes" wording already used elsewhere in the catalog (e.g. "No money changes yet."), rather than reintroducing the "ledger" jargon this rename was removing.
- Grammar fix: the refund error message read "Money could not record it", which made "Money" sound like the actor. It now reads "It could not be recorded in Money."
- Stronger test assertions: several tests asserted `toContain("Money")`, which would also pass if a regression reintroduced "Money history". They now also assert `not.toContain("Money history")` so a real regression would fail the test.

## Test plan

- [x] `deno task precommit` (typecheck, lint, i18n coverage, full test suite) — all green


---
_Generated by [Claude Code](https://claude.ai/code/session_01NGKs7uJs7fuX2xhstFyyco)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Interface**
  * Updated money-related action labels to consistently say “money changes” (including “View all money changes” and “View this group’s money changes”) across attendee, group, listings, and servicing views.
  * Refreshed ledger/refund error wording to use clearer guidance when a refund can’t be recorded.
  * Removed “Money history” text from admin ledger and navigation surfaces where it shouldn’t appear.

* **Tests**
  * Adjusted assertions to match the updated labels and full refund messages.
  * Added/strengthened checks that “Money history” is not rendered in the relevant admin views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->