### PR TITLE
Fold repeated code onto shared helpers across the app

### DIFF
--- a/src/features/admin/attendees-list.ts
+++ b/src/features/admin/attendees-list.ts
@@ -28,10 +28,8 @@ import {
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getAllListings } from "#shared/db/listings/records.ts";
 import { settings } from "#shared/db/settings.ts";
-import {
-  attendeeNameMap,
-  loadNotesForAttendees,
-} from "#shared/db/system-notes.ts";
+import { loadNotesForAttendees } from "#shared/db/system-notes.ts";
+import { idNameMap } from "#shared/id-name-map.ts";
 import {
   type ListingFilter,
   listingCategory,
@@ -145,7 +143,7 @@ export const handleAttendeesListGet: TypedRouteHandler<
         hasNext,
         listingId,
         listings,
-        names: attendeeNameMap(decrypted),
+        names: idNameMap(decrypted),
         page,
         phonePrefix: settings.phonePrefix,
         rows: built,

--- a/src/features/admin/attributes.ts
+++ b/src/features/admin/attributes.ts
@@ -1,4 +1,5 @@
 import { handlersFor } from "#routes/admin/handlers.ts";
+import { planReorder } from "#shared/reorder.ts";
 /**
  * Admin routes for listing attributes.
  */
@@ -335,22 +336,24 @@ const optionActionHandler = (
     loadContext: loadAttributeOption,
   });
 
-const moveOptionHandler = (direction: -1 | 1) =>
+const moveOptionHandler = (dir: "up" | "down") =>
   optionActionHandler(async ({ context: { attribute, option } }) => {
-    const index = attribute.options.findIndex((item) => item.id === option.id);
-    const neighbor = attribute.options[index + direction];
-    if (neighbor) await swapAttributeOptionOrder(option.id, neighbor.id);
+    const pair = planReorder(
+      attribute.options.map((item) => item.id),
+      option.id,
+      dir,
+    );
+    if (pair) await swapAttributeOptionOrder(pair[0], pair[1]);
     return redirect(`/admin/attributes/${attribute.id}`, "Option moved", true);
   });
 
-const moveAttributeHandler = (direction: -1 | 1) =>
+const moveAttributeHandler = (dir: "up" | "down") =>
   createAuthedHandler<AttributeParams, number>({
     auth: OWNER_FORM,
     handle: async ({ context: attributeId }) => {
       const attributeIds = await getAttributeIdsOrdered();
-      const index = attributeIds.indexOf(attributeId);
-      const neighborId = attributeIds[index + direction];
-      if (neighborId) await swapAttributeOrder(attributeId, neighborId);
+      const pair = planReorder(attributeIds, attributeId, dir);
+      if (pair) await swapAttributeOrder(pair[0], pair[1]);
       return redirect("/admin/attributes", "Attribute moved", true);
     },
     loadContext: ({ id }) => getAttributeId(id),
@@ -380,12 +383,12 @@ export const adminHandlers = handlersFor("attributes")({
   postAttributesByIdDelete: (request, { id }) =>
     attributeDelete.post(request, id),
   postAttributesByIdEdit: handleAttributeEdit,
-  postAttributesByIdMoveDown: moveAttributeHandler(1),
-  postAttributesByIdMoveUp: moveAttributeHandler(-1),
+  postAttributesByIdMoveDown: moveAttributeHandler("down"),
+  postAttributesByIdMoveUp: moveAttributeHandler("up"),
   postAttributesByIdOptions: handleAddOption,
   postAttributesByIdOptionsByOptionIdDelete: handleDeleteOptionPost,
   postAttributesByIdOptionsByOptionIdEdit: handleEditOptionPost,
-  postAttributesByIdOptionsByOptionIdMoveDown: moveOptionHandler(1),
-  postAttributesByIdOptionsByOptionIdMoveUp: moveOptionHandler(-1),
+  postAttributesByIdOptionsByOptionIdMoveDown: moveOptionHandler("down"),
+  postAttributesByIdOptionsByOptionIdMoveUp: moveOptionHandler("up"),
   postListingByIdAttributes: handleListingAttributesPost,
 });

--- a/src/features/admin/backup.ts
+++ b/src/features/admin/backup.ts
@@ -1,4 +1,5 @@
 import { handlersFor } from "#routes/admin/handlers.ts";
+import { namedError } from "#shared/named-error.ts";
 /**
  * Admin backup/restore routes — owner only
  *
@@ -57,7 +58,7 @@ const RESTORE_PENDING_PREFIX = "restore-pending-";
 /** Thrown by the restore execute block so onError can send post-reset failures
  *  (sessions and settings wiped) to /setup/, while pre-restore validation errors
  *  (DB intact) stay on /admin/backup. */
-class PostResetRestoreError extends Error {}
+class PostResetRestoreError extends namedError("PostResetRestoreError") {}
 
 /** A full git commit SHA (40 lowercase hex) — what restore-deploy requires and
  *  the only shape we echo back from restored (possibly untrusted) settings. */

--- a/src/features/admin/catalog-transfer/export.ts
+++ b/src/features/admin/catalog-transfer/export.ts
@@ -26,6 +26,7 @@ import {
   getStoredListingWithCount,
   listingsTable,
 } from "#shared/db/listings/records.ts";
+import { namedError } from "#shared/named-error.ts";
 import type { AdminLevel } from "#shared/types.ts";
 import { withGroupOrNull } from "../find-group.ts";
 import { getListingGroupMemberships } from "./membership.ts";
@@ -44,7 +45,7 @@ import {
  * can't represent — e.g. a bookable-day name or contact field the admin JSON API
  * accepted but the transfer schema rejects. The export route surfaces it as an
  * operator-facing 4xx rather than letting a raw parse error become a 500. */
-export class CatalogExportError extends Error {}
+export class CatalogExportError extends namedError("CatalogExportError") {}
 
 /** Project a stored row onto its transfer shape, or a {@link CatalogExportError}
  * (with an intelligible per-field message) when the row can't be represented. */

--- a/src/features/admin/questions.ts
+++ b/src/features/admin/questions.ts
@@ -1,5 +1,6 @@
 import { handlersFor } from "#routes/admin/handlers.ts";
 import { idNameMap } from "#shared/id-name-map.ts";
+import { planReorder } from "#shared/reorder.ts";
 /**
  * Admin routes for custom questions management (owner-only)
  */
@@ -522,42 +523,46 @@ const handleAnswerRecalculatePost = answerActionHandler(
 );
 
 /** Factory for move-up/move-down handlers */
-const moveAnswerHandler = (direction: -1 | 1) =>
+const moveAnswerHandler = (dir: "up" | "down") =>
   answerActionHandler(async ({ context: { answer, question } }) => {
-    const idx = question.answers.findIndex((a) => a.id === answer.id);
-    const neighbor = question.answers[idx + direction];
-    if (neighbor) {
-      await swapAnswerOrder(answer.id, neighbor.id);
-    }
+    const pair = planReorder(
+      question.answers.map((a) => a.id),
+      answer.id,
+      dir,
+    );
+    if (pair) await swapAnswerOrder(pair[0], pair[1]);
     return redirect(`/admin/questions/${question.id}`, "Answer moved", true);
   });
 
 /** Handle POST /admin/questions/:id/answers/:answerId/move-up */
-const handleMoveAnswerUp = moveAnswerHandler(-1);
+const handleMoveAnswerUp = moveAnswerHandler("up");
 
 /** Handle POST /admin/questions/:id/answers/:answerId/move-down */
-const handleMoveAnswerDown = moveAnswerHandler(1);
+const handleMoveAnswerDown = moveAnswerHandler("down");
 
 /** Factory for question move-up/move-down handlers. Swaps the question's
  * global sort_order with its neighbour in the ordered list. */
-const moveQuestionHandler = (direction: -1 | 1) =>
+const moveQuestionHandler = (dir: "up" | "down") =>
   createAuthedHandler<QuestionIdParams, QuestionWithAnswers>({
     auth: OWNER_FORM,
     handle: async ({ context: question }) => {
       const all = await getAllQuestionsWithAnswers();
-      const idx = all.findIndex((q) => q.id === question.id);
-      const neighbor = all[idx + direction];
-      if (neighbor) await swapQuestionOrder(question.id, neighbor.id);
+      const pair = planReorder(
+        all.map((q) => q.id),
+        question.id,
+        dir,
+      );
+      if (pair) await swapQuestionOrder(pair[0], pair[1]);
       return redirect("/admin/questions", "Question moved", true);
     },
     loadContext: ({ id }) => getQuestionWithAnswers(id),
   });
 
 /** Handle POST /admin/questions/:id/move-up */
-const handleMoveQuestionUp = moveQuestionHandler(-1);
+const handleMoveQuestionUp = moveQuestionHandler("up");
 
 /** Handle POST /admin/questions/:id/move-down */
-const handleMoveQuestionDown = moveQuestionHandler(1);
+const handleMoveQuestionDown = moveQuestionHandler("down");
 
 const handleListingQuestionsPost = createListingChoicePost({
   fieldName: "question_ids",

--- a/src/features/admin/servicing.tsx
+++ b/src/features/admin/servicing.tsx
@@ -47,6 +47,7 @@ import {
   SERVICING_DEMO_FIELDS,
 } from "#shared/demo/overrides.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { nowIso } from "#shared/now.ts";
 import {
   selectedListingQuantities,
   selectedStartDate,
@@ -163,9 +164,7 @@ const handleCostPost = async (
     );
   }
   const serviceDate = event.bookings[0]?.date;
-  const occurredAt = serviceDate
-    ? `${serviceDate}T00:00:00.000Z`
-    : new Date().toISOString();
+  const occurredAt = serviceDate ? `${serviceDate}T00:00:00.000Z` : nowIso();
   try {
     await recordServiceCost({
       amount,

--- a/src/features/admin/settings-statuses.ts
+++ b/src/features/admin/settings-statuses.ts
@@ -1,4 +1,5 @@
 import { handlersFor } from "#routes/admin/handlers.ts";
+import { planReorder } from "#shared/reorder.ts";
 /**
  * Admin routes for managing attendee statuses (owner-only).
  *
@@ -232,13 +233,12 @@ const deletePost = ownerFormById(async (id, _session, form) => {
 });
 
 /** Factory for move-up / move-down handlers (swap with the ordered neighbour). */
-const moveHandler = (direction: -1 | 1) =>
+const moveHandler = (dir: "up" | "down") =>
   ownerFormById(async (id) => {
-    const all = await attendeeStatuses.getAll();
-    const idx = all.findIndex((s) => s.id === id);
-    if (idx === -1) return notFoundResponse();
-    const neighbor = all[idx + direction];
-    if (neighbor) await swapAttendeeStatusOrder(id, neighbor.id);
+    const ids = (await attendeeStatuses.getAll()).map((s) => s.id);
+    if (!ids.includes(id)) return notFoundResponse();
+    const pair = planReorder(ids, id, dir);
+    if (pair) await swapAttendeeStatusOrder(pair[0], pair[1]);
     return redirect(LIST_PATH, "Status moved", true);
   });
 
@@ -250,6 +250,6 @@ export const adminHandlers = handlersFor("settingsStatuses")({
   postSettingsStatuses: createPost,
   postSettingsStatusesByIdDelete: deletePost,
   postSettingsStatusesByIdEdit: editPost,
-  postSettingsStatusesByIdMoveDown: moveHandler(1),
-  postSettingsStatusesByIdMoveUp: moveHandler(-1),
+  postSettingsStatusesByIdMoveDown: moveHandler("down"),
+  postSettingsStatusesByIdMoveUp: moveHandler("up"),
 });

--- a/src/features/admin/site-pages.ts
+++ b/src/features/admin/site-pages.ts
@@ -38,11 +38,11 @@ import {
   updateSitePage,
 } from "#shared/db/site-pages.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { planReorder } from "#shared/reorder.ts";
 import {
   eligibleChildPages,
   isReservedSlug,
   parseTargetKey,
-  planReorder,
   targetKey,
 } from "#shared/site-pages/core.ts";
 import { loadPageForest } from "#shared/site-pages/load.ts";

--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -10,6 +10,7 @@
  */
 
 import * as v from "valibot";
+import { asString } from "#fp";
 import { apiErrorResponse } from "#routes/api/cors.ts";
 import { jsonResponse } from "#routes/response.ts";
 import { createRouter, defineRoutes } from "#routes/router.ts";
@@ -76,16 +77,13 @@ const tryDecrypt = async (
   }
 };
 
-const str = (value: unknown): string =>
-  typeof value === "string" ? value : "";
-
 /** Run `fn` with the row a status event refers to, if it exists. */
 const withReferencedRow = async (
   payload: Record<string, unknown>,
   fn: (row: SmsMessageRow) => Promise<void>,
 ): Promise<void> => {
   const row = await getSmsMessageByProviderId(
-    str(payload.messageId) || str(payload.id),
+    asString(payload.messageId) || asString(payload.id),
   );
   if (row) await fn(row);
 };
@@ -102,15 +100,15 @@ const handleStatus =
     });
 
 const inboundWebhookId = (payload: Record<string, unknown>): string =>
-  str(payload.messageId) || str(payload.id);
+  asString(payload.messageId) || asString(payload.id);
 
 const handleReceived = async (
   payload: Record<string, unknown>,
 ): Promise<void> => {
   const passphrase = settings.smsGatewayPassphrase;
   if (!(await claimProcessedSmsInbound(inboundWebhookId(payload)))) return;
-  const message = await tryDecrypt(str(payload.message), passphrase);
-  const sender = await tryDecrypt(str(payload.sender), passphrase);
+  const message = await tryDecrypt(asString(payload.message), passphrase);
+  const sender = await tryDecrypt(asString(payload.sender), passphrase);
   const attendeeId = await findAttendeeIdByPhoneIndex(
     await computePhoneIndex(sender),
   );
@@ -127,7 +125,7 @@ const smsEventHandlers: Record<
 > = {
   "sms:delivered": handleStatus(() => "SMS delivered"),
   "sms:failed": handleStatus(
-    (payload) => `SMS failed: ${str(payload.reason) || "unknown"}`,
+    (payload) => `SMS failed: ${asString(payload.reason) || "unknown"}`,
   ),
   "sms:received": handleReceived,
 };

--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -27,7 +27,7 @@ import {
   pruneSmsMessagesBefore,
   type SmsMessageRow,
 } from "#shared/db/sms-messages.ts";
-import { nowMs } from "#shared/now.ts";
+import { nowMs, nowSeconds } from "#shared/now.ts";
 import { hmacSha256Hex } from "#shared/payment-crypto.ts";
 import { decryptField } from "#shared/sms/e2e.ts";
 import { computePhoneIndex } from "#shared/sms/phone-index.ts";
@@ -48,8 +48,7 @@ const isFreshTimestamp = (timestamp: string): boolean => {
   if (!/^\d+$/.test(timestamp)) return false;
   const seconds = Number(timestamp);
   if (!Number.isSafeInteger(seconds)) return false;
-  const nowSeconds = Math.floor(nowMs() / 1000);
-  return Math.abs(nowSeconds - seconds) <= SMS_WEBHOOK_TOLERANCE_SECONDS;
+  return Math.abs(nowSeconds() - seconds) <= SMS_WEBHOOK_TOLERANCE_SECONDS;
 };
 
 /** Verify the X-Signature / X-Timestamp headers against the raw body. */

--- a/src/features/feeds.ts
+++ b/src/features/feeds.ts
@@ -31,6 +31,7 @@ import {
 import { getNewsPostSummaries } from "#shared/db/news-posts.ts";
 import { settings } from "#shared/db/settings.ts";
 import { userAgents } from "#shared/db/user-agents.ts";
+import { nowIso } from "#shared/now.ts";
 import { getRequestPrivateKey } from "#shared/session-private-key.ts";
 import {
   type ListingWithCount,
@@ -165,7 +166,7 @@ const buildVListing = (
 
 /** Build the full ICS calendar document */
 const buildIcs = ({ items, domain, title }: FeedData): string => {
-  const dtstamp = formatIcsDate(new Date().toISOString());
+  const dtstamp = formatIcsDate(nowIso());
   const vlistings = pipe(
     map((e: FeedItem) => buildVListing(e, domain, dtstamp)),
   )(items);
@@ -353,7 +354,7 @@ const buildCalendarFeed = async (request: Request): Promise<Response> => {
         session,
       );
       const domain = getEffectiveDomain();
-      const dtstamp = formatIcsDate(new Date().toISOString());
+      const dtstamp = formatIcsDate(nowIso());
       const events = attendees.flatMap((attendee) => {
         const listing = listingById.get(attendee.listing_id);
         return listing?.date

--- a/src/features/public/address-lookup.ts
+++ b/src/features/public/address-lookup.ts
@@ -15,7 +15,7 @@ import { t } from "#i18n";
 import { getAuthenticatedSession } from "#routes/auth.ts";
 import { jsonResponse, notFoundResponse } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
-import { getClientIp } from "#routes/url.ts";
+import { getClientIp, getSearchParam } from "#routes/url.ts";
 import { activeAddressLookupProvider } from "#shared/address-lookup/providers.ts";
 import { lookupAddresses } from "#shared/address-lookup/service.ts";
 import { makeIpRateLimiter } from "#shared/db/login-attempts.ts";
@@ -47,7 +47,7 @@ export const handleAddressLookupGet: TypedRouteHandler<
     await limiter.record(ip);
   }
 
-  const search = new URL(request.url).searchParams.get("search") ?? "";
+  const search = getSearchParam(request, "search");
   const outcome = await lookupAddresses(provider, search);
   if (!outcome.ok) return jsonResponse({ error: outcome.error }, 400);
   // `addresses` is the lines-only list the public booking form reads.

--- a/src/features/public/order.ts
+++ b/src/features/public/order.ts
@@ -29,7 +29,7 @@
  * child pool read as available here and are refused at the form instead.
  */
 
-import { compact, uniqueBy } from "#fp";
+import { compact, groupBy, uniqueBy } from "#fp";
 import { t } from "#i18n";
 import {
   htmlResponse,
@@ -188,11 +188,7 @@ const poolBySpan = async <T>(
   spanOf: (value: T) => number,
   query: (bucket: T[], span: number) => Promise<RemainingById>,
 ): Promise<RemainingById> => {
-  const bySpan = new Map<number, T[]>();
-  for (const value of values) {
-    const span = spanOf(value);
-    bySpan.set(span, [...(bySpan.get(span) ?? []), value]);
-  }
+  const bySpan = groupBy(values, spanOf);
   const maps = await Promise.all(
     [...bySpan].map(([span, bucket]) => query(bucket, span)),
   );

--- a/src/features/public/qr-book.ts
+++ b/src/features/public/qr-book.ts
@@ -9,6 +9,7 @@
 
 import { isRegistrationClosed } from "#routes/format.ts";
 import { htmlResponse } from "#routes/response.ts";
+import { getSearchParam } from "#routes/url.ts";
 import { buildTicketListing } from "#shared/booking/model.ts";
 import { capacityDateFor } from "#shared/capacity-rules.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
@@ -173,7 +174,7 @@ export const handleQrBookGet = async (
   params: { slug: string },
 ): Promise<Response> => {
   const { slug } = params;
-  const token = new URL(request.url).searchParams.get("t") ?? "";
+  const token = getSearchParam(request, "t");
   if (!token) return errorResponse(slug, 400);
   const payload = await verifyQrBookToken(slug, token);
   if (!payload) return errorResponse(slug, 400);

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -362,6 +362,21 @@ export const byId = <T extends { id: number }>(
 };
 
 /**
+ * Index items by their `id`, keeping one chosen value per item — the value
+ * form of {@link byId}. Curried so the value-picker is fixed once, e.g.
+ *   const idNameMap = mapById((item) => item.name)
+ * When two items share an id the later one wins, as building the Map by hand
+ * would.
+ */
+export const mapById =
+  <T extends { id: number }, V>(valueFrom: (item: T) => V) =>
+  (items: Iterable<T>): Map<number, V> => {
+    const map = new Map<number, V>();
+    for (const item of items) map.set(item.id, valueFrom(item));
+    return map;
+  };
+
+/**
  * A copy of `base` with `extra` entries merged on top (an `extra` key wins over
  * the same key in `base`). Curried so a fixed base — an auth header set, the
  * process environment — can be extended per call.

--- a/src/shared/balance-link.ts
+++ b/src/shared/balance-link.ts
@@ -10,7 +10,7 @@
  */
 
 import { defineSignedToken } from "#shared/crypto/define-signed-token.ts";
-import { nowMs } from "#shared/now.ts";
+import { expiresIn } from "#shared/now.ts";
 
 /** Balance links last 90 days — long enough to be a "pay when you can" link. */
 export const BALANCE_LINK_MAX_AGE_S = 90 * 24 * 60 * 60;
@@ -43,7 +43,7 @@ export const signBalanceToken = (
 ): Promise<string> =>
   balanceToken.sign(undefined, {
     a: attendeeId,
-    e: Math.floor(nowMs() / 1000) + maxAgeSeconds,
+    e: expiresIn(maxAgeSeconds),
   });
 
 /**

--- a/src/shared/booking.ts
+++ b/src/shared/booking.ts
@@ -15,6 +15,7 @@ import {
   hasAvailableSpots,
 } from "#shared/db/attendees/api.ts";
 import type { LedgerPoster } from "#shared/db/attendees/create.ts";
+import { nowIso } from "#shared/now.ts";
 import { singleListingAnswerIds } from "#shared/payment-helpers.ts";
 import { getActivePaymentProvider } from "#shared/payments.ts";
 import type { Attendee, ContactInfo, ListingWithCount } from "#shared/types.ts";
@@ -38,7 +39,7 @@ const owedBookingLedgerPoster =
       eventId: `booking-${attendeeId}`,
       lines: [{ gross, listingId }],
       modifiers: [],
-      occurredAt: new Date().toISOString(),
+      occurredAt: nowIso(),
     });
     await postBookingLegsTx(tx, attendeeId, legs);
   };

--- a/src/shared/crypto/signed-token.ts
+++ b/src/shared/crypto/signed-token.ts
@@ -14,7 +14,7 @@ import {
   fromBase64Url,
   toBase64Url,
 } from "#shared/crypto/utils.ts";
-import { nowMs } from "#shared/now.ts";
+import { nowSeconds } from "#shared/now.ts";
 
 /** Encode a JSON-serializable payload as a base64url string. */
 export const encodeTokenPayload = (payload: unknown): string =>
@@ -47,7 +47,7 @@ export const isTokenExpired = (
 /** Returns true when a token is expired as of right now, using the current
  * clock to compute nowS. Convenience wrapper over isTokenExpired. */
 export const isExpiredNow = (expiryUnixS: number, maxAgeS: number): boolean =>
-  isTokenExpired(expiryUnixS, maxAgeS, Math.floor(nowMs() / 1000));
+  isTokenExpired(expiryUnixS, maxAgeS, nowSeconds());
 
 /** Build a signed token from an encoded payload and its HMAC message. */
 export const buildSignedToken = async (

--- a/src/shared/db/attendees/create.ts
+++ b/src/shared/db/attendees/create.ts
@@ -49,6 +49,7 @@ import {
 import { batchFinalizeStatement } from "#shared/db/payment-finalize.ts";
 import type { TransferInput } from "#shared/ledger/types.ts";
 import { bestEffort } from "#shared/logger.ts";
+import { namedError } from "#shared/named-error.ts";
 import { nowIso } from "#shared/now.ts";
 import {
   type Attendee,
@@ -220,7 +221,7 @@ export type LedgerPoster = (tx: TxScope, attendeeId: number) => Promise<void>;
 
 /** Thrown to roll the transaction back when no booking could be created (the
  *  ledger-posting path has no final cleanup DELETE; it just rolls back). */
-class NoBookingsCreated extends Error {}
+class NoBookingsCreated extends namedError("NoBookingsCreated") {}
 
 /** Remove the just-inserted attendee when none of its capacity-checked booking
  *  inserts landed a row (the batch path's all-failed cleanup). */

--- a/src/shared/db/attendees/create.ts
+++ b/src/shared/db/attendees/create.ts
@@ -2,6 +2,7 @@
  * Atomic attendee creation across one or more listing bookings.
  */
 
+/* jscpd:ignore-start */
 import type { InValue } from "@libsql/client";
 import { bookingLegBatchInsert } from "#shared/accounting/rows.ts";
 import { assertPostable } from "#shared/accounting/store.ts";
@@ -56,6 +57,7 @@ import {
   type ContactInfo,
   normalizeDurationDays,
 } from "#shared/types.ts";
+/* jscpd:ignore-end */
 
 /**
  * Enforce all-or-nothing semantics on a (greedy) create result.

--- a/src/shared/db/attributes.ts
+++ b/src/shared/db/attributes.ts
@@ -6,7 +6,16 @@
  */
 
 /* jscpd:ignore-start */
-import { filter, map, mapParallel, reduce, sort, unique, uniqueBy } from "#fp";
+import {
+  filter,
+  groupToMap,
+  map,
+  mapParallel,
+  reduce,
+  sort,
+  unique,
+  uniqueBy,
+} from "#fp";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import type { EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
 import {
@@ -174,18 +183,6 @@ const decryptAttributeRows = async (
 
 const known = <T>(items: Map<number, T>, id: number): T => items.get(id)!;
 
-/** Group rows into a Map keyed by `key(row)`, keeping one `value(row)` per
- * row in query order — the shared shape behind every "rows → id-keyed lists"
- * read in this module. */
-const groupRows =
-  <R, V>(key: (row: R) => number, value: (row: R) => V) =>
-  (rows: R[]): Map<number, V[]> =>
-    reduce((acc: Map<number, V[]>, row: R) => {
-      const values = acc.get(key(row)) ?? [];
-      values.push(value(row));
-      return acc.set(key(row), values);
-    }, new Map<number, V[]>())(rows);
-
 const buildAttributeGroups = (
   rows: JoinedAttributeRow[],
   decrypted: DecryptedAttributeRows,
@@ -296,7 +293,7 @@ export const getAttributeListingUse = async (
     (a: OptionListingRow, b: OptionListingRow) => a.listing_id - b.listing_id,
   )(uniqueBy((row: OptionListingRow) => row.listing_id)(rows));
   return {
-    listingIdsByOption: groupRows(
+    listingIdsByOption: groupToMap(
       (row: OptionListingRow) => row.option_id,
       (row) => row.listing_id,
     )(rows),
@@ -366,8 +363,9 @@ const selectedOptionRows = (
         listingIds,
       );
 
-const selectedRowsForListing = groupRows<
+const selectedRowsForListing = groupToMap<
   SelectedAttributeRow,
+  number,
   JoinedAttributeRow
 >(
   (row) => row.listing_id,

--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -29,6 +29,8 @@ import {
 } from "#shared/db/restore-legacy-columns.ts";
 import { requireEnv } from "#shared/env.ts";
 import { MAX_BACKUPS, readLimit } from "#shared/limits.ts";
+import { namedError } from "#shared/named-error.ts";
+import { nowIso } from "#shared/now.ts";
 import {
   deleteFile,
   getBasename,
@@ -39,7 +41,7 @@ import {
 /** Thrown by restoreFromSql after resetDatabase() runs but a later step fails,
  *  so callers can distinguish a post-reset failure (DB wiped) from a pre-reset
  *  validation error (DB intact). */
-export class PostResetError extends Error {}
+export class PostResetError extends namedError("PostResetError") {}
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -248,7 +250,7 @@ const buildManifest = (
 /** Create a zip archive from table backups with manifest */
 export const createBackupZip = async (): Promise<Uint8Array> => {
   const encoder = new TextEncoder();
-  const timestamp = new Date().toISOString();
+  const timestamp = nowIso();
   const tables = await createBackup();
   const manifest = buildManifest(tables, timestamp);
 

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -27,6 +27,7 @@ import {
   trackQuery,
 } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
+import { namedError } from "#shared/named-error.ts";
 import { retryWithBackoff } from "#shared/retry.ts";
 
 /**
@@ -145,10 +146,9 @@ export const resultRows = <T>(result: ResultSet): T[] =>
 /** Raised when a write can't get through because the database stays locked after
  *  the retries below — too busy. The request layer turns this into a friendly
  *  auto-reloading page rather than a generic error. */
-export class DatabaseBusyError extends Error {
+export class DatabaseBusyError extends namedError("DatabaseBusyError") {
   constructor() {
     super("the database is too busy to complete this write");
-    this.name = "DatabaseBusyError";
   }
 }
 

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -13,7 +13,7 @@ import {
   inPlaceholders,
   queryAll,
   queryIdColumn,
-  queryOne,
+  rowExists,
   type SqlStatement,
   type TxScope,
 } from "#shared/db/client.ts";
@@ -248,11 +248,8 @@ export const getActiveListingsByGroupIds = (
 
 /** Does a group row exist? The add-item revalidation's single-row check — no
  * name decryption, never the whole table. */
-export const groupExists = async (id: number): Promise<boolean> =>
-  (await queryOne<{ id: number }>(
-    "SELECT id FROM groups WHERE id = ? LIMIT 1",
-    [id],
-  )) !== null;
+export const groupExists = (id: number): Promise<boolean> =>
+  rowExists("SELECT 1 FROM groups WHERE id = ? LIMIT 1", [id]);
 
 /**
  * Get all listings in a group with attendee counts (including inactive).
@@ -336,13 +333,12 @@ const anyGroupMatching = async (
   condition: string,
 ): Promise<boolean> => {
   if (groupIds.length === 0) return false;
-  const rows = await queryAll<{ id: number }>(
-    `SELECT id FROM groups WHERE id IN (${inPlaceholders(
+  return rowExists(
+    `SELECT 1 FROM groups WHERE id IN (${inPlaceholders(
       groupIds,
     )}) AND ${condition} LIMIT 1`,
     [...groupIds],
   );
-  return rows.length > 0;
 };
 
 /** Whether any of the given group ids names a HIDDEN package group
@@ -361,8 +357,8 @@ export const anyListingInPackageGroup = async (
   listingIds: readonly number[],
 ): Promise<boolean> => {
   if (listingIds.length === 0) return false;
-  const rows = await queryAll<{ listing_id: number }>(
-    `SELECT groupListing.listing_id
+  return rowExists(
+    `SELECT 1
        FROM group_listings AS groupListing
        JOIN groups AS groupRow ON groupRow.id = groupListing.group_id
       WHERE groupListing.listing_id IN (${inPlaceholders(listingIds)})
@@ -370,7 +366,6 @@ export const anyListingInPackageGroup = async (
       LIMIT 1`,
     [...listingIds],
   );
-  return rows.length > 0;
 };
 
 /** Of the given listing ids, those that belong to a HIDDEN package — a package
@@ -490,12 +485,12 @@ export const getPackageDisplayById = async (
 /** Whether any booking row is stamped with this package's group id — sold
  * tickets whose display (and hidden-member concealment) resolves through the
  * live package row. Refund placeholders (quantity 0) don't count. */
-export const hasPackageBookings = async (groupId: number): Promise<boolean> =>
-  (await queryOne<{ one: number }>(
-    `SELECT 1 AS one FROM listing_attendees
+export const hasPackageBookings = (groupId: number): Promise<boolean> =>
+  rowExists(
+    `SELECT 1 FROM listing_attendees
       WHERE package_group_id = ? AND quantity > 0 LIMIT 1`,
     [groupId],
-  )) !== null;
+  );
 
 /** The package displays for a set of (possibly repeated or zero)
  * `package_group_id`s — only ids naming a live package appear in the map. Lets

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -29,7 +29,7 @@
  * them.
  */
 
-import { compact, mapNotNullish } from "#fp";
+import { compact, groupBy, mapNotNullish } from "#fp";
 import {
   execute,
   executeBatch,
@@ -244,14 +244,14 @@ export const getGroupDayPricesByGroupIds = async (
       WHERE listingPrice.price_type = ?`,
     [PRICE_TYPE_GROUP_DAY],
   );
-  const rowsByGroup = new Map<number, GroupDayRow[]>();
-  for (const row of rows.rows as unknown as GroupDayRow[]) {
-    const groupId = Number(row.price_id.split("/")[0]);
-    if (!wanted.has(groupId)) continue;
-    const list = rowsByGroup.get(groupId);
-    if (list) list.push(row);
-    else rowsByGroup.set(groupId, [row]);
-  }
+  const groupIdOf = (row: GroupDayRow): number =>
+    Number(row.price_id.split("/")[0]);
+  const rowsByGroup = groupBy(
+    (rows.rows as unknown as GroupDayRow[]).filter((row) =>
+      wanted.has(groupIdOf(row)),
+    ),
+    groupIdOf,
+  );
   return new Map(
     [...rowsByGroup].map(([groupId, groupRows]) => [
       groupId,

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -70,10 +70,11 @@ type DbState =
   | "missing_settings"
   | "uninitialized_settings";
 
-export class MissingSettingsTableError extends Error {
+export class MissingSettingsTableError extends namedError(
+  "MissingSettingsTableError",
+) {
   constructor(message = "Database settings table does not exist") {
     super(message);
-    this.name = "MissingSettingsTableError";
   }
 }
 

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -16,10 +16,10 @@ import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
 import {
-  execute,
   executeBatch,
   queryAll,
   queryOne,
+  rowExists,
 } from "#shared/db/client.ts";
 // jscpd:ignore-end
 import {
@@ -93,16 +93,12 @@ export const isNewsSlugTaken = async (
   excludeId?: number,
 ): Promise<boolean> => {
   const slugIndex = await computeNewsSlugIndex(slug);
-  const result =
-    excludeId === undefined
-      ? await execute("SELECT 1 FROM news_posts WHERE slug_index = ? LIMIT 1", [
-          slugIndex,
-        ])
-      : await execute(
-          "SELECT 1 FROM news_posts WHERE slug_index = ? AND id != ? LIMIT 1",
-          [slugIndex, excludeId],
-        );
-  return result.rows.length > 0;
+  const excludeClause = excludeId === undefined ? "" : " AND id != ?";
+  const args = excludeId === undefined ? [slugIndex] : [slugIndex, excludeId];
+  return rowExists(
+    `SELECT 1 FROM news_posts WHERE slug_index = ?${excludeClause} LIMIT 1`,
+    args,
+  );
 };
 
 // The existence probe every public page's nav runs: one indexed LIMIT 1 read,

--- a/src/shared/db/settings/accessors.ts
+++ b/src/shared/db/settings/accessors.ts
@@ -21,6 +21,7 @@ import {
   setSnapshotField,
   snap,
 } from "#shared/db/settings/snapshot.ts";
+import { nowIso } from "#shared/now.ts";
 import type {
   AccessorSpec,
   StringAccessors,
@@ -114,7 +115,7 @@ export const boolUpdate = <K extends BoolSettingKey>(
 export const timestampUpdate =
   <K extends keyof SettingsData>(configKey: string, field: K) =>
   async (): Promise<void> => {
-    const ts = new Date().toISOString();
+    const ts = nowIso();
     await writeRaw(configKey, ts);
     setSnapshotField(field, ts as SettingsData[K]);
   };

--- a/src/shared/db/slug-registry.ts
+++ b/src/shared/db/slug-registry.ts
@@ -7,7 +7,7 @@
  */
 
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { execute } from "#shared/db/client.ts";
+import { rowExists } from "#shared/db/client.ts";
 import type { SitePageItemType } from "#shared/types.ts";
 
 /** The slug-owning tables (plural form, one per {@link SitePageItemType}). */
@@ -47,6 +47,5 @@ export const isSlugTakenAnywhere = async (
       args.push(slugIndex);
     }
   }
-  const result = await execute(`SELECT 1 WHERE ${clauses.join(" OR ")}`, args);
-  return result.rows.length > 0;
+  return rowExists(`SELECT 1 WHERE ${clauses.join(" OR ")}`, args);
 };

--- a/src/shared/db/system-notes.ts
+++ b/src/shared/db/system-notes.ts
@@ -210,17 +210,6 @@ export const groupNotesByAttendee = (
   notes: SystemNote[],
 ): Map<number, SystemNote[]> => Map.groupBy(notes, (note) => note.attendee_id);
 
-/**
- * Build the attendee id → display name map that {@link AttendeeNotesSummary}
- * labels each grouped note with. Accepts any attendee-shaped row, so the
- * listing and global attendee lists can both pass their decrypted rows
- * without each rebuilding the same `Map` literal at the call site.
- */
-export const attendeeNameMap = (
-  attendees: ReadonlyArray<{ id: number; name: string }>,
-): Map<number, string> =>
-  new Map(attendees.map((a) => [a.id, a.name] as const));
-
 /** Load one decrypted note scoped to its attendee, or null when it doesn't exist. */
 export const getAttendeeNote = async (
   attendeeId: number,

--- a/src/shared/id-name-map.ts
+++ b/src/shared/id-name-map.ts
@@ -1,3 +1,5 @@
+import { mapById } from "#fp";
+
 /**
  * Build a lookup from each item's id to its name. Used wherever a list of
  * records (listings, agents, pages, …) needs a quick id → name map for
@@ -5,4 +7,4 @@
  */
 export const idNameMap = <T extends { id: number; name: string }>(
   items: readonly T[],
-): Map<number, string> => new Map(items.map((item) => [item.id, item.name]));
+): Map<number, string> => mapById((item: T) => item.name)(items);

--- a/src/shared/merge/attendee-merge.ts
+++ b/src/shared/merge/attendee-merge.ts
@@ -6,7 +6,7 @@
  * 2. applyAttendeeMerge: apply explicit decisions from the admin
  */
 
-import { filter, map, mapParallel, reduce } from "#fp";
+import { filter, map, mapById, mapParallel, reduce } from "#fp";
 import {
   attendeeAccount,
   revenueAccount,
@@ -237,8 +237,9 @@ const buildAnswerDiffItems = (
   for (const [qid] of sourceAnswers) relevantQuestionIds.add(qid);
 
   // Build lookup for question text from the provided questions
-  const questionTextMap = new Map<number, string>();
-  for (const q of questions) questionTextMap.set(q.id, q.text);
+  const questionTextMap = mapById((q: QuestionWithAnswers) => q.text)(
+    questions,
+  );
 
   return reduce((acc: AttendeeMergeDiffAnswerItem[], qid: number) => {
     const ta = targetAnswers.get(qid) ?? null;

--- a/src/shared/named-error.ts
+++ b/src/shared/named-error.ts
@@ -6,9 +6,9 @@
  * The concrete subclass stays a real named class, so it works as both a value
  * (`new`, `instanceof`) and a type.
  */
-export const namedError = (name: string): (new (message: string) => Error) =>
+export const namedError = (name: string): (new (message?: string) => Error) =>
   class extends Error {
-    constructor(message: string) {
+    constructor(message?: string) {
       super(message);
       this.name = name;
     }

--- a/src/shared/now.ts
+++ b/src/shared/now.ts
@@ -18,6 +18,13 @@ export const nowMs = (): number => Date.now();
 /** Current time in whole epoch seconds — the unit signed-token expiry uses. */
 export const nowSeconds = (): number => Math.floor(nowMs() / 1000);
 
+/**
+ * Epoch seconds `maxAgeSeconds` from now — the expiry (`e`) that signed tokens
+ * carry, kept in one place so every builder computes it the same way.
+ */
+export const expiresIn = (maxAgeSeconds: number): number =>
+  nowSeconds() + maxAgeSeconds;
+
 /** Resolve after `ms` milliseconds — for retry backoff and similar waits. */
 export const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/shared/qr-token.ts
+++ b/src/shared/qr-token.ts
@@ -10,7 +10,7 @@
  */
 
 import { defineSignedToken } from "#shared/crypto/define-signed-token.ts";
-import { nowMs } from "#shared/now.ts";
+import { expiresIn } from "#shared/now.ts";
 
 /** QR token expiry in seconds from generation */
 export const QR_TOKEN_MAX_AGE_S = 300;
@@ -58,7 +58,7 @@ export const buildQrBookPayload = (input: {
   const maxAge = input.maxAgeSeconds ?? QR_TOKEN_MAX_AGE_S;
   return {
     d: input.date ?? "",
-    e: Math.floor(nowMs() / 1000) + maxAge,
+    e: expiresIn(maxAge),
     n: input.name ?? "",
     q: input.quantity ?? 1,
     v: input.value ?? -1,

--- a/src/shared/refund-ledger.ts
+++ b/src/shared/refund-ledger.ts
@@ -31,6 +31,7 @@ import { transfersByAccount } from "#shared/accounting/queries.ts";
 import { postTransferGroups, postTransfers } from "#shared/accounting/store.ts";
 import { balanceEventGroup } from "#shared/db/attendees/balance.ts";
 import type { RefundPaymentReference } from "#shared/db/payment-references.ts";
+import { sameAccount } from "#shared/ledger/account.ts";
 import { balanceOf } from "#shared/ledger/project.ts";
 import type { Transfer, TransferInput } from "#shared/ledger/types.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
@@ -44,11 +45,6 @@ type ComputedRefund = {
 
 const isRefundLeg = (kind: string | undefined): boolean =>
   kind?.startsWith("refund_") ?? false;
-
-const sameAccount = (
-  left: Transfer["source"],
-  right: Transfer["source"],
-): boolean => left.type === right.type && left.id === right.id;
 
 const isProviderPaymentLeg = (leg: Transfer): boolean =>
   leg.kind === KIND.payment && sameAccount(leg.source, WORLD);

--- a/src/shared/reorder.ts
+++ b/src/shared/reorder.ts
@@ -1,0 +1,19 @@
+/** Pure helper behind every "move up / move down" admin control. */
+
+/**
+ * Given an ordered list of keys and one target key, return the target paired
+ * with the neighbour it should trade places with when nudged one step `dir`,
+ * or null when it can't move — the target isn't in the list, or it's already
+ * at the end it's heading toward. Keeping the off-by-one here means every
+ * ordered-list surface reorders the same way.
+ */
+export const planReorder = <K>(
+  orderedKeys: readonly K[],
+  target: K,
+  dir: "up" | "down",
+): readonly [K, K] | null => {
+  const idx = orderedKeys.indexOf(target);
+  if (idx === -1) return null;
+  const neighbor = orderedKeys[idx + (dir === "up" ? -1 : 1)];
+  return neighbor === undefined ? null : [target, neighbor];
+};

--- a/src/shared/session-private-key.ts
+++ b/src/shared/session-private-key.ts
@@ -22,6 +22,7 @@
 import { getPrivateKeyFromSession } from "#shared/crypto/keys.ts";
 import type { WrappedKey } from "#shared/crypto/sealed.ts";
 import { settings } from "#shared/db/settings.ts";
+import { namedError } from "#shared/named-error.ts";
 import { getCachedSession } from "#shared/session-context.ts";
 
 /** Minimal session shape needed to derive the private key. */
@@ -29,7 +30,7 @@ type KeyedSession = { token: string; wrappedDataKey: WrappedKey | null };
 
 /** Thrown when the current session's private key cannot be derived (e.g.
  * wrappedDataKey missing, no key pair configured, or unwrap failure). */
-export class SessionKeyError extends Error {
+export class SessionKeyError extends namedError("SessionKeyError") {
   constructor() {
     super("Private key unavailable for session");
   }

--- a/src/shared/site-pages/core.ts
+++ b/src/shared/site-pages/core.ts
@@ -191,17 +191,6 @@ export const eligibleChildPages = (
  * function both root-page and within-page reorder flow through; the apply ring
  * executes the swap.
  */
-export const planReorder = (
-  orderedKeys: readonly TargetKey[],
-  target: TargetKey,
-  dir: "up" | "down",
-): readonly [TargetKey, TargetKey] | null => {
-  const idx = orderedKeys.indexOf(target);
-  if (idx === -1) return null;
-  const neighbor = orderedKeys[idx + (dir === "up" ? -1 : 1)];
-  return neighbor === undefined ? null : [target, neighbor];
-};
-
 /** Slugs that would shadow a core route or nav label — rejected for a page. */
 const RESERVED_SLUGS: ReadonlySet<string> = new Set([
   "admin",

--- a/src/shared/stripe.ts
+++ b/src/shared/stripe.ts
@@ -9,7 +9,7 @@ import { priceCheckout } from "#shared/checkout-pricing.ts";
 import { settings } from "#shared/db/settings.ts";
 import { getEnv } from "#shared/env.ts";
 import { ErrorCode, logDebug, logError } from "#shared/logger.ts";
-import { nowMs } from "#shared/now.ts";
+import { nowSeconds } from "#shared/now.ts";
 import { hmacSha256Hex, secureCompare } from "#shared/payment-crypto.ts";
 import {
   assembleCheckoutMetadata,
@@ -528,7 +528,7 @@ export const verifyWebhookSignature = async (
   const { timestamp, signatures } = parsed;
 
   // Check timestamp tolerance
-  const nowSecs = Math.floor(nowMs() / 1000);
+  const nowSecs = nowSeconds();
   const timestampDelta = nowSecs - timestamp;
   if (Math.abs(timestampDelta) > toleranceSeconds) {
     logError({
@@ -567,7 +567,7 @@ export const constructTestWebhookEvent = (
   secret: string,
 ): Promise<SignedTestWebhook> =>
   signedTestWebhook(listing, async (payload) => {
-    const timestamp = Math.floor(nowMs() / 1000);
+    const timestamp = nowSeconds();
     const sig = await hmacSha256Hex(`${timestamp}.${payload}`, secret);
     return `t=${timestamp},v1=${sig}`;
   });

--- a/src/shared/try-step.ts
+++ b/src/shared/try-step.ts
@@ -1,3 +1,5 @@
+import { errorMessage } from "#shared/error-message.ts";
+
 /**
  * Run a step that already reports success or failure as an `ok` outcome, and
  * turn a thrown exception into that same failure shape instead of crashing:
@@ -12,7 +14,6 @@ export const tryStep = async <Value extends { ok: boolean }>(
   try {
     return await step();
   } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    return { error: `${label}: ${message}`, ok: false };
+    return { error: `${label}: ${errorMessage(e)}`, ok: false };
   }
 };

--- a/src/ui/templates/admin/api-keys.tsx
+++ b/src/ui/templates/admin/api-keys.tsx
@@ -7,22 +7,19 @@ import { joinStrings, map, pipe } from "#fp";
 import { t } from "#i18n";
 import { apiKeyForm } from "#routes/admin/api-keys.ts";
 import type { EndpointDoc } from "#shared/admin-api-example.ts";
-import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { Flash } from "#shared/forms.tsx";
 import type { Child } from "#shared/jsx/jsx-runtime.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { renderAdminPage } from "#templates/admin/admin-page.tsx";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
 import { WritableOnly } from "#templates/admin/writable-only.tsx";
-import {
-  DeleteSection,
-  GuideFooter,
-  SubmitButton,
-} from "#templates/components/actions.tsx";
+import { DeleteSection, GuideFooter } from "#templates/components/actions.tsx";
 import { sectionsRenderer } from "#templates/components/aggregate-sections.tsx";
 import { DataTable, namedColumns } from "#templates/components/data-table.tsx";
 import { DetailTable } from "#templates/components/detail-table.tsx";
 import { PageBlock } from "#templates/components/page-structure.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 /* jscpd:ignore-end */
 
@@ -120,11 +117,14 @@ export const adminApiKeysPage = (
       <br />
 
       <WritableOnly>
-        <CsrfForm action="/admin/api-keys">
+        <SaveForm
+          action="/admin/api-keys"
+          submitIcon="plus"
+          submitLabel={t("api_keys.create_submit")}
+        >
           <h2>{t("api_keys.create_legend")}</h2>
           <Raw html={apiKeyForm.render()} />
-          <SubmitButton icon="plus">{t("api_keys.create_submit")}</SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       </WritableOnly>
 
       <GuideFooter href="/admin/guide#api">

--- a/src/ui/templates/admin/attendees.tsx
+++ b/src/ui/templates/admin/attendees.tsx
@@ -12,7 +12,7 @@ import type {
   QuestionWithAnswers,
   SelectedQuestionAnswers,
 } from "#shared/db/question-types.ts";
-import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { Flash } from "#shared/forms.tsx";
 import type { Child } from "#shared/jsx/jsx-runtime.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import {
@@ -51,6 +51,7 @@ import {
   RadioOption,
   type RadioOptionProps,
 } from "#templates/components/radio-option.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 /* jscpd:ignore-end */
 
@@ -361,14 +362,12 @@ export const PaymentDetails = ({
           </p>
         )}
       </div>
-      <CsrfForm
+      <SaveForm
         action={`/admin/attendees/${attendee.id}/refresh-payment`}
         class="inline"
-      >
-        <SubmitButton icon="rotate-ccw">
-          {t("admin.attendees.refresh_payment")}
-        </SubmitButton>
-      </CsrfForm>
+        submitIcon="rotate-ccw"
+        submitLabel={t("admin.attendees.refresh_payment")}
+      />
     </PageBlock>
   );
 };
@@ -718,7 +717,12 @@ export const AttendeeMergePanel = (
           </p>
         </div>
 
-        <CsrfForm action={`/admin/attendees/${target.id}/merge`}>
+        <SaveForm
+          action={`/admin/attendees/${target.id}/merge`}
+          submitClass="danger"
+          submitIcon="trash-2"
+          submitLabel="Merge and Delete Source Attendee"
+        >
           <input
             name="source_token"
             type="hidden"
@@ -770,10 +774,7 @@ export const AttendeeMergePanel = (
             <strong>Warning:</strong> This will permanently delete the source
             attendee. This action cannot be undone.
           </p>
-          <SubmitButton class="danger" icon="trash-2">
-            Merge and Delete Source Attendee
-          </SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       </div>
     )}
   </article>

--- a/src/ui/templates/admin/attributes.tsx
+++ b/src/ui/templates/admin/attributes.tsx
@@ -12,7 +12,6 @@ import type {
   AttributeOption,
   AttributeWithOptions,
 } from "#shared/db/attributes.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
 import { errorAdminPage } from "#templates/admin/admin-page.tsx";
 import { childEditPage } from "#templates/admin/child-edit-page.tsx";
@@ -31,6 +30,7 @@ import {
   reorderableListPage,
   reorderCountTable,
 } from "#templates/components/reorder-list.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import {
   type ListingPanelProps,
   listingChoicePanel,
@@ -131,21 +131,24 @@ export const adminAttributePage = (
       <h1>{attributeNameFlat(attribute.name)}</h1>
 
       <WritableOnly>
-        <CsrfForm action={`/admin/attributes/${attribute.id}/edit`}>
+        <SaveForm
+          action={`/admin/attributes/${attribute.id}/edit`}
+          submitLabel={t("attributes.update")}
+        >
           <Raw html={attributeNameForm.render({ name: attribute.name })} />
-          <SubmitButton icon="save">{t("attributes.update")}</SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       </WritableOnly>
 
       <h2>{t("attributes.options_heading")}</h2>
       <WritableOnly>
-        <CsrfForm
+        <SaveForm
           action={`/admin/attributes/${attribute.id}/options`}
           id="new-attribute-option"
+          submitIcon="plus"
+          submitLabel={t("attributes.add_option")}
         >
           <Raw html={attributeOptionForm.render()} />
-          <SubmitButton icon="plus">{t("attributes.add_option")}</SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       </WritableOnly>
 
       {reorderCountTable({
@@ -347,7 +350,10 @@ export const ListingAttributesPanel = (
       </p>
     ),
     (availableAttributes) => (
-      <CsrfForm action={`/admin/listing/${listing.id}/attributes`}>
+      <SaveForm
+        action={`/admin/listing/${listing.id}/attributes`}
+        submitLabel={t("common.save")}
+      >
         <FormSections
           sections={availableAttributes.map((attribute) => ({
             children:
@@ -372,8 +378,7 @@ export const ListingAttributesPanel = (
             legend: attribute.name,
           }))}
         />
-        <SubmitButton icon="save">{t("common.save")}</SubmitButton>
-      </CsrfForm>
+      </SaveForm>
     ),
   );
 };

--- a/src/ui/templates/admin/backup.tsx
+++ b/src/ui/templates/admin/backup.tsx
@@ -4,14 +4,14 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { flashDataPage } from "#templates/admin/admin-page.tsx";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
 import { ErrorNote } from "#templates/components/error.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 export type BackupEntry = {
@@ -92,15 +92,13 @@ export const adminBackupPage = flashDataPage<BackupPageState>(
               <h2>{t("backup.create_backup_heading")}</h2>
               <p>{t("backup.create_backup_description")}</p>
             </div>
-            <CsrfForm
+            <SaveForm
               action="/admin/backup/create"
               class="no-bg"
               id="backup-create"
-            >
-              <SubmitButton icon="plus">
-                {t("backup.create_button")}
-              </SubmitButton>
-            </CsrfForm>
+              submitIcon="plus"
+              submitLabel={t("backup.create_button")}
+            />
           </section>
 
           <section>
@@ -142,19 +140,18 @@ export const adminBackupPage = flashDataPage<BackupPageState>(
                 <Raw html={t("backup.restore_warning")} />
               </p>
             </div>
-            <CsrfForm
+            <SaveForm
               action="/admin/backup/restore"
               enctype="multipart/form-data"
               id="backup-restore"
+              submitIcon="rotate-ccw"
+              submitLabel={t("backup.upload_button")}
             >
               <label>
                 {t("backup.backup_file_label")}
                 <input accept=".zip" name="backup_file" required type="file" />
               </label>
-              <SubmitButton icon="rotate-ccw">
-                {t("backup.upload_button")}
-              </SubmitButton>
-            </CsrfForm>
+            </SaveForm>
           </section>
         </>
       )}

--- a/src/ui/templates/admin/builder.tsx
+++ b/src/ui/templates/admin/builder.tsx
@@ -5,15 +5,14 @@
 import { t } from "#i18n";
 import { builderForm } from "#routes/admin/builder.ts";
 import { getDefaultDbProvider } from "#shared/config.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { flashDataPage } from "#templates/admin/admin-page.tsx";
 import { BuiltSitesGuideFooter } from "#templates/admin/built-sites/list-parts.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import { DataTable, namedColumns } from "#templates/components/data-table.tsx";
 /* jscpd:ignore-start */
 import { NewTabUrl } from "#templates/components/new-tab-link.tsx";
 import { ProseSection } from "#templates/components/prose-section.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 export type BuiltSiteDisplay = {
@@ -26,7 +25,12 @@ export type BuiltSiteDisplay = {
 const BuilderForm = (): JSX.Element => (
   <ProseSection
     footer={
-      <CsrfForm action="/admin/builder" id="builder-form">
+      <SaveForm
+        action="/admin/builder"
+        id="builder-form"
+        submitIcon="hammer"
+        submitLabel={t("builder.build_site_button")}
+      >
         <Raw
           html={builderForm.render({ db_provider: getDefaultDbProvider() })}
         />
@@ -37,10 +41,7 @@ const BuilderForm = (): JSX.Element => (
           </label>
           <small>{t("builder.available_for_assignment_help")}</small>
         </fieldset>
-        <SubmitButton icon="hammer">
-          {t("builder.build_site_button")}
-        </SubmitButton>
-      </CsrfForm>
+      </SaveForm>
     }
     title={t("builder.create_new_site")}
   >

--- a/src/ui/templates/admin/catalog-transfer.tsx
+++ b/src/ui/templates/admin/catalog-transfer.tsx
@@ -6,10 +6,10 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import { flashFormPage } from "#templates/admin/admin-page.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import { ProseHeading } from "#templates/components/prose-heading.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 export const adminCatalogImportPage = flashFormPage(
@@ -20,10 +20,11 @@ export const adminCatalogImportPage = flashFormPage(
       <ProseHeading heading={t("catalog_transfer.heading")}>
         <p>{t("catalog_transfer.description")}</p>
       </ProseHeading>
-      <CsrfForm
+      <SaveForm
         action="/admin/catalog/import"
         enctype="multipart/form-data"
         id="catalog-import"
+        submitLabel={t("catalog_transfer.upload_button")}
       >
         <label>
           {t("catalog_transfer.file_label")}
@@ -34,10 +35,7 @@ export const adminCatalogImportPage = flashFormPage(
             type="file"
           />
         </label>
-        <SubmitButton icon="save">
-          {t("catalog_transfer.upload_button")}
-        </SubmitButton>
-      </CsrfForm>
+      </SaveForm>
 
       <GuideFooter
         adminLevel={session.adminLevel}

--- a/src/ui/templates/admin/groups/overview.tsx
+++ b/src/ui/templates/admin/groups/overview.tsx
@@ -9,7 +9,6 @@ import {
 import { settings } from "#shared/db/settings.ts";
 import { buildEmbedSnippets } from "#shared/embed.ts";
 import { isReadOnly } from "#shared/env.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import {
   type Attendee,
@@ -38,7 +37,6 @@ import {
   UnavailablePublicUrlRow,
 } from "#templates/admin/share-rows.tsx";
 import type { TableQuestionData } from "#templates/attendee-table.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import { GroupCapacityMeter } from "#templates/components/capacity.tsx";
 import { DetailTable } from "#templates/components/detail-table.tsx";
 import { LabelledRow } from "#templates/components/labelled-row.tsx";
@@ -50,6 +48,7 @@ import {
   PageBlock,
   PageRegions,
 } from "#templates/components/page-structure.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { TableScroll } from "#templates/components/table-scroll.tsx";
 
 const totalAttendeeCount = sumOf(
@@ -279,7 +278,11 @@ export const GroupOverviewPanel = ({
       </PageBlock>
 
       {!isReadOnly() && ungroupedListings.length > 0 && (
-        <CsrfForm action={`/admin/groups/${group.id}/add-listings`}>
+        <SaveForm
+          action={`/admin/groups/${group.id}/add-listings`}
+          submitIcon="plus"
+          submitLabel={t("groups.detail.add_listings_submit")}
+        >
           <LinkedItemsCheckboxes
             groups={[
               {
@@ -290,10 +293,7 @@ export const GroupOverviewPanel = ({
             heading={({ type }) => t("linked_items.heading_add", { type })}
             name="listing_ids"
           />
-          <SubmitButton icon="plus">
-            {t("groups.detail.add_listings_submit")}
-          </SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       )}
     </PageRegions>
   );

--- a/src/ui/templates/admin/images.tsx
+++ b/src/ui/templates/admin/images.tsx
@@ -25,7 +25,6 @@ import {
   GuideFooter,
   type IconName,
   SaveChangesButton,
-  SubmitButton,
 } from "#templates/components/actions.tsx";
 import {
   type DataColumn,
@@ -35,6 +34,7 @@ import {
   type LinkedItemGroup,
   LinkedItemsCheckboxes,
 } from "#templates/components/linked-items.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 // jscpd:ignore-end
 
 export type ImageItemOption = {
@@ -152,12 +152,16 @@ const imageUploadForm = (
   icon: IconName,
   label: string,
 ): JSX.Element => (
-  <CsrfForm action={action} enctype="multipart/form-data">
+  <SaveForm
+    action={action}
+    enctype="multipart/form-data"
+    submitIcon={icon}
+    submitLabel={label}
+  >
     <Raw
       html={renderFields([...imageFields(), imageUploadField()], imageValue())}
     />
-    <SubmitButton icon={icon}>{label}</SubmitButton>
-  </CsrfForm>
+  </SaveForm>
 );
 
 export const adminImagesPage = (

--- a/src/ui/templates/admin/listing-defaults.tsx
+++ b/src/ui/templates/admin/listing-defaults.tsx
@@ -9,7 +9,6 @@
 /* jscpd:ignore-start */
 import { t } from "#i18n";
 import { VALID_DAY_NAMES } from "#shared/dates.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import {
   listingDefaultInputName as inputName,
   LISTING_DEFAULT_FIELDS,
@@ -22,8 +21,9 @@ import {
 import type { AdminSession } from "#shared/types.ts";
 import { flashAdminPage } from "#templates/admin/admin-page.tsx";
 import { ListingSectionFieldset } from "#templates/admin/money-summary.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import { CheckboxLabel } from "#templates/components/aggregate-sections.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { SelectField } from "#templates/components/select-field.tsx";
 
 /* jscpd:ignore-end */
@@ -198,7 +198,11 @@ export const adminListingDefaultsPage = (
     success,
   )(
     <>
-      <CsrfForm action="/admin/listing-defaults" id="listing-defaults">
+      <SaveForm
+        action="/admin/listing-defaults"
+        id="listing-defaults"
+        submitLabel={t("listing_defaults.save")}
+      >
         <div class="prose">
           <h2>{t("listing_defaults.title")}</h2>
           <p>{t("listing_defaults.intro")}</p>
@@ -206,8 +210,7 @@ export const adminListingDefaultsPage = (
         {fields.map((field) => (
           <DefaultControl defaults={defaults} field={field} />
         ))}
-        <SubmitButton icon="save">{t("listing_defaults.save")}</SubmitButton>
-      </CsrfForm>
+      </SaveForm>
 
       <GuideFooter href="/admin/guide#listings">
         {t("listing_defaults.guide_link")}

--- a/src/ui/templates/admin/listing-qr.tsx
+++ b/src/ui/templates/admin/listing-qr.tsx
@@ -11,13 +11,13 @@
 import { t } from "#i18n";
 import { formatCurrency, toMajorUnits } from "#shared/currency.ts";
 import { formatDateLabel } from "#shared/dates.ts";
-import { CsrfForm, Flash } from "#shared/forms.tsx";
+import { Flash } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { QR_TOKEN_MAX_AGE_S } from "#shared/qr-token.ts";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { AdminListingLink, AdminPage } from "#templates/admin/admin-page.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import { moneyPattern } from "#templates/components/price-input.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 /* jscpd:ignore-end */
 
@@ -184,7 +184,11 @@ export const ListingQrPanel = ({
         </p>
       </div>
       <Flash {...(error !== undefined ? { error } : {})} />
-      <CsrfForm action={formAction}>
+      <SaveForm
+        action={formAction}
+        submitIcon="plus"
+        submitLabel={t("listing_qr.generate_button")}
+      >
         <label>
           {t("listing_qr.customer_name")}
           <input
@@ -207,10 +211,7 @@ export const ListingQrPanel = ({
           />
         </label>
         {isDaily && <DateSelect dates={bookableDates} value={values.date} />}
-        <SubmitButton icon="plus">
-          {t("listing_qr.generate_button")}
-        </SubmitButton>
-      </CsrfForm>
+      </SaveForm>
       {result && (
         <QrResultPanel
           formAction={formAction}

--- a/src/ui/templates/admin/listings/attendees.tsx
+++ b/src/ui/templates/admin/listings/attendees.tsx
@@ -22,9 +22,9 @@ import type {
   AttendeeTableRow,
   TableQuestionData,
 } from "#templates/attendee-table.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import { quantityHeader } from "#templates/components/header-row.tsx";
 import { ProseArticle } from "#templates/components/prose-article.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { colClass } from "#templates/components/table-columns.ts";
 import { TableScroll } from "#templates/components/table-scroll.tsx";
 import { getAddAttendeeFields } from "#templates/fields/add-attendee.ts";
@@ -296,7 +296,11 @@ export const AddAttendeeSection = ({
         })}
       </p>
     )}
-    <CsrfForm action={`/admin/listing/${listing.id}/attendee`}>
+    <SaveForm
+      action={`/admin/listing/${listing.id}/attendee`}
+      submitIcon="plus"
+      submitLabel={t("listings_table.add_attendee")}
+    >
       <Raw
         html={renderFields(
           getAddAttendeeFields(
@@ -308,10 +312,7 @@ export const AddAttendeeSection = ({
           ),
         )}
       />
-      <SubmitButton icon="plus">
-        {t("listings_table.add_attendee")}
-      </SubmitButton>
-    </CsrfForm>
+    </SaveForm>
   </article>
 );
 

--- a/src/ui/templates/admin/listings/roster.tsx
+++ b/src/ui/templates/admin/listings/roster.tsx
@@ -1,7 +1,7 @@
 import { map, pipe } from "#fp";
 import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
-import { attendeeNameMap } from "#shared/db/system-notes.ts";
 import { isReadOnly } from "#shared/env.ts";
+import { idNameMap } from "#shared/id-name-map.ts";
 import { type Attendee, isPaidListing } from "#shared/types.ts";
 import { AttendeeNotesSummary } from "#templates/admin/attendee-notes.tsx";
 import {
@@ -104,10 +104,7 @@ export const ListingRosterPanel = (opts: ListingPanelOptions): JSX.Element => {
         ),
         sharedRowsHtml: renderDetailRows(v.sharedRows),
       })}
-      <AttendeeNotesSummary
-        names={attendeeNameMap(attendees)}
-        notes={systemNotes}
-      />
+      <AttendeeNotesSummary names={idNameMap(attendees)} notes={systemNotes} />
       <AttendeesSection
         activeFilter={v.activeFilter}
         allowedDomain={allowedDomain}

--- a/src/ui/templates/admin/login.tsx
+++ b/src/ui/templates/admin/login.tsx
@@ -5,10 +5,10 @@
 /* jscpd:ignore-start */
 import { t } from "#i18n";
 import { isDemoMode } from "#shared/demo/mode.ts";
-import { CsrfForm, Flash, renderFields } from "#shared/forms.tsx";
+import { Flash, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { flashProps } from "#templates/admin/admin-page.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { getLoginFields } from "#templates/fields/admin.ts";
 import { layoutPage } from "#templates/layout-page.tsx";
 /* jscpd:ignore-end */
@@ -21,10 +21,13 @@ export const adminLoginPage = (error?: string): string =>
     t("login.title"),
     <>
       <Flash {...flashProps(error)} />
-      <CsrfForm action="/admin/login">
+      <SaveForm
+        action="/admin/login"
+        submitIcon="log-in"
+        submitLabel={t("login.submit")}
+      >
         <Raw html={renderFields(getLoginFields())} />
-        <SubmitButton icon="log-in">{t("login.submit")}</SubmitButton>
-      </CsrfForm>
+      </SaveForm>
       {isDemoMode() && (
         <p>
           <a href="/demo/reset">{t("login.reset_database")}</a>

--- a/src/ui/templates/admin/logistics.tsx
+++ b/src/ui/templates/admin/logistics.tsx
@@ -16,7 +16,7 @@
 /* jscpd:ignore-start */
 import { t } from "#i18n";
 import { settings } from "#shared/db/settings.ts";
-import { CsrfForm, entityToFieldValues, renderFields } from "#shared/forms.tsx";
+import { entityToFieldValues, renderFields } from "#shared/forms.tsx";
 import { escapeHtml, Raw } from "#shared/jsx/jsx-runtime.ts";
 import type { AdminLevel, LogisticsAgent } from "#shared/types.ts";
 import {
@@ -26,7 +26,7 @@ import {
 import { defineAdminResourcePages } from "#templates/admin/resource-pages.tsx";
 import { booleanSettingsSection } from "#templates/admin/settings/boolean-settings-section.tsx";
 import { WritableLink, WritableOnly } from "#templates/admin/writable-only.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import {
   CheckboxFieldset,
   CheckboxLabel,
@@ -36,6 +36,7 @@ import {
   type DataColumn,
   dataTable,
 } from "#templates/components/data-table.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { logisticsAgentFields } from "#templates/fields/listing.ts";
 
 /* jscpd:ignore-end */
@@ -72,15 +73,18 @@ const AgentsSection = (agents: LogisticsAgent[]): JSX.Element => (
       dataTable(agentColumns)(agents)
     )}
     <WritableOnly>
-      <CsrfForm action="/admin/logistics">
+      <SaveForm
+        action="/admin/logistics"
+        submitIcon="plus"
+        submitLabel={t("logistics.add_agent")}
+      >
         <SectionFieldset
           className="listing-section"
           legend={t("logistics.add_agent")}
         >
           <Raw html={renderFields(logisticsAgentFields)} />
         </SectionFieldset>
-        <SubmitButton icon="plus">{t("logistics.add_agent")}</SubmitButton>
-      </CsrfForm>
+      </SaveForm>
     </WritableOnly>
   </article>
 );

--- a/src/ui/templates/admin/logout.tsx
+++ b/src/ui/templates/admin/logout.tsx
@@ -3,10 +3,9 @@
  */
 
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdminSession } from "#shared/types.ts";
 import { staffAdminPage } from "#templates/admin/admin-page.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 export const adminLogoutPage = (session: AdminSession): string =>
   staffAdminPage({
@@ -15,11 +14,13 @@ export const adminLogoutPage = (session: AdminSession): string =>
       <section aria-labelledby="logout-confirm-heading">
         <h2 id="logout-confirm-heading">{t("logout.confirm_heading")}</h2>
         <p>{t("logout.confirm_body")}</p>
-        <CsrfForm action="/admin/logout" class="one-button">
-          <SubmitButton class="secondary" icon="log-out">
-            {t("nav.logout")}
-          </SubmitButton>
-        </CsrfForm>
+        <SaveForm
+          action="/admin/logout"
+          class="one-button"
+          submitClass="secondary"
+          submitIcon="log-out"
+          submitLabel={t("nav.logout")}
+        />
       </section>
     ),
     session,

--- a/src/ui/templates/admin/modifiers/links.tsx
+++ b/src/ui/templates/admin/modifiers/links.tsx
@@ -5,13 +5,12 @@
  */
 
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { Modifier } from "#shared/types.ts";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import {
   LinkedItemsCheckboxes,
   toLinkedItemOptions,
 } from "#templates/components/linked-items.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 /** Each linkable scope kind → the form field its checkboxes post under and the
  * term key for its plural type name. Adding a scope kind is one self-contained
@@ -67,7 +66,10 @@ export const ScopeLinksForm = ({
 }): JSX.Element => {
   const { field, term } = SCOPE_LINK_KINDS[links.kind];
   return (
-    <CsrfForm action={`/admin/modifiers/${modifier.id}/links`}>
+    <SaveForm
+      action={`/admin/modifiers/${modifier.id}/links`}
+      submitLabel={t("modifiers.scope.save")}
+    >
       {links.options.length === 0 ? (
         <p>{t("modifiers.scope.none")}</p>
       ) : (
@@ -78,8 +80,7 @@ export const ScopeLinksForm = ({
           selected={links.selected}
         />
       )}
-      <SubmitButton icon="save">{t("modifiers.scope.save")}</SubmitButton>
-    </CsrfForm>
+    </SaveForm>
   );
 };
 
@@ -93,7 +94,10 @@ export const AnswerLinksForm = ({
   modifier: Modifier;
   answerLinks: AnswerLinks;
 }): JSX.Element => (
-  <CsrfForm action={`/admin/modifiers/${modifier.id}/answers`}>
+  <SaveForm
+    action={`/admin/modifiers/${modifier.id}/answers`}
+    submitLabel={t("modifiers.answers.save")}
+  >
     <p>
       <small>{t("modifiers.answers.hint")}</small>
     </p>
@@ -110,6 +114,5 @@ export const AnswerLinksForm = ({
         selected={answerLinks.selected}
       />
     )}
-    <SubmitButton icon="save">{t("modifiers.answers.save")}</SubmitButton>
-  </CsrfForm>
+  </SaveForm>
 );

--- a/src/ui/templates/admin/modifiers/pages.tsx
+++ b/src/ui/templates/admin/modifiers/pages.tsx
@@ -22,9 +22,9 @@ import { MoneyAdjustSection } from "#templates/admin/money-adjust-section.tsx";
 import {
   GuideFooter,
   SaveChangesButton,
-  SubmitButton,
 } from "#templates/components/actions.tsx";
 import { CollectionTable } from "#templates/components/data-table.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { getModifierFields } from "#templates/fields/modifier.ts";
 import {
   ModifierRunningTotalsSection,
@@ -129,11 +129,14 @@ export const adminModifierNewPage = flashFormPage(
   "/admin/modifiers/new",
   () => (
     <>
-      <CsrfForm action="/admin/modifiers">
+      <SaveForm
+        action="/admin/modifiers"
+        submitIcon="plus"
+        submitLabel={t("modifiers.add.submit")}
+      >
         <h1>{t("modifiers.add.heading")}</h1>
         <Raw html={renderModifierFormFields()} />
-        <SubmitButton icon="plus">{t("modifiers.add.submit")}</SubmitButton>
-      </CsrfForm>
+      </SaveForm>
       <ModifiersGuideFooter />
     </>
   ),

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -13,7 +13,7 @@ import type {
   AnswerAggregateRecalculation,
 } from "#shared/db/questions/aggregates.ts";
 import { isReadOnly } from "#shared/env.ts";
-import { CsrfForm, renderFields } from "#shared/forms.tsx";
+import { renderFields } from "#shared/forms.tsx";
 import type { AdminSession, ListingWithCount } from "#shared/types.ts";
 import { errorAdminPage } from "#templates/admin/admin-page.tsx";
 import { childEditPage } from "#templates/admin/child-edit-page.tsx";
@@ -45,6 +45,7 @@ import {
   reorderableListPage,
   reorderCountTable,
 } from "#templates/components/reorder-list.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { SelectField } from "#templates/components/select-field.tsx";
 import { colClass } from "#templates/components/table-columns.ts";
 import { answerAggregateFields } from "#templates/fields/aggregate.ts";
@@ -115,9 +116,10 @@ const QuestionListingAssignment = ({
     return <p>{listingText}</p>;
   }
   return (
-    <CsrfForm
+    <SaveForm
       action={`/admin/questions/${question.id}/listings`}
       id="question-listings"
+      submitLabel={t("questions.save_listings")}
     >
       <LinkedItemsCheckboxes
         groups={[
@@ -140,8 +142,7 @@ const QuestionListingAssignment = ({
         }
         name="listing_ids"
       />
-      <SubmitButton icon="save">{t("questions.save_listings")}</SubmitButton>
-    </CsrfForm>
+    </SaveForm>
   );
 };
 
@@ -208,7 +209,10 @@ export const adminQuestionPage = (
       <h1>{questionTextFlat(question.text)}</h1>
 
       <WritableOnly>
-        <CsrfForm action={`/admin/questions/${question.id}/edit`}>
+        <SaveForm
+          action={`/admin/questions/${question.id}/edit`}
+          submitLabel={t("questions.edit.update")}
+        >
           <Raw html={questionTextForm.field("text").render(question.text)} />
           {question.display_type === "free_text" ? (
             // Free-text questions can't become choice questions (it would orphan
@@ -227,8 +231,7 @@ export const adminQuestionPage = (
               />
             </label>
           )}
-          <SubmitButton icon="save">{t("questions.edit.update")}</SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       </WritableOnly>
 
       {question.display_type === "free_text" ? (
@@ -244,15 +247,14 @@ export const adminQuestionPage = (
         <>
           <h2>{t("questions.edit.answers_heading")}</h2>
           <WritableOnly>
-            <CsrfForm
+            <SaveForm
               action={`/admin/questions/${question.id}/answers`}
               id="add-answer"
+              submitIcon="plus"
+              submitLabel={t("questions.edit.add_answer")}
             >
               <Raw html={answerTextForm.render()} />
-              <SubmitButton icon="plus">
-                {t("questions.edit.add_answer")}
-              </SubmitButton>
-            </CsrfForm>
+            </SaveForm>
           </WritableOnly>
 
           {reorderCountTable({

--- a/src/ui/templates/admin/resource-pages.tsx
+++ b/src/ui/templates/admin/resource-pages.tsx
@@ -40,6 +40,7 @@ import {
   type DataColumn,
   dataTable,
 } from "#templates/components/data-table.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 /** A delete confirmation spec, parameterised by the entity. */
@@ -172,11 +173,14 @@ export const defineAdminResourcePages = <
 
   const newPage = (session: AdminSession, error?: string): string =>
     flashAdminPage(config.labels.addTitle, config.active)(session, error)(
-      <CsrfForm action={config.basePath}>
+      <SaveForm
+        action={config.basePath}
+        submitIcon="plus"
+        submitLabel={config.labels.addSubmit}
+      >
         <h1>{config.labels.addHeading}</h1>
         {config.renderFields(undefined)}
-        <SubmitButton icon="plus">{config.labels.addSubmit}</SubmitButton>
-      </CsrfForm>,
+      </SaveForm>,
     );
 
   const editPage = (

--- a/src/ui/templates/admin/seeds.tsx
+++ b/src/ui/templates/admin/seeds.tsx
@@ -6,22 +6,25 @@
 import { t } from "#i18n";
 import { Raw } from "#jsx/jsx-runtime.ts";
 import { seedsForm } from "#routes/admin/seeds.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import { flashFormPage } from "#templates/admin/admin-page.tsx";
-import { BackButton, SubmitButton } from "#templates/components/actions.tsx";
+import { BackButton } from "#templates/components/actions.tsx";
 import { ProseHeading } from "#templates/components/prose-heading.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 /** Seed data admin page */
 export const adminSeedsPage = flashFormPage("admin.seeds.title", "", () => (
   <>
-    <CsrfForm action="/admin/seeds">
+    <SaveForm
+      action="/admin/seeds"
+      submitIcon="plus"
+      submitLabel={t("admin.seeds.submit")}
+    >
       <ProseHeading heading={t("admin.seeds.heading")}>
         <p>{t("admin.seeds.intro")}</p>
       </ProseHeading>
       <Raw html={seedsForm.render()} />
-      <SubmitButton icon="plus">{t("admin.seeds.submit")}</SubmitButton>
-    </CsrfForm>
+    </SaveForm>
 
     <p>
       <BackButton href="/admin">{t("admin.seeds.back")}</BackButton>

--- a/src/ui/templates/admin/sessions.tsx
+++ b/src/ui/templates/admin/sessions.tsx
@@ -6,11 +6,11 @@
 import { joinStrings, map, pipe } from "#fp";
 import { t } from "#i18n";
 import { formatDatetimeShort } from "#shared/dates.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdminSession, Session } from "#shared/types.ts";
 import { successAdminPage } from "#templates/admin/admin-page.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import { DataTable, textCol } from "#templates/components/data-table.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 /* jscpd:ignore-end */
 
@@ -70,11 +70,15 @@ export const adminSessionsPage = (
         <>
           <br />
 
-          <CsrfForm action="/admin/sessions" class="one-button">
-            <SubmitButton class="danger" icon="log-out">
-              {t("sessions.logout_others", { count: otherSessionCount })}
-            </SubmitButton>
-          </CsrfForm>
+          <SaveForm
+            action="/admin/sessions"
+            class="one-button"
+            submitClass="danger"
+            submitIcon="log-out"
+            submitLabel={t("sessions.logout_others", {
+              count: otherSessionCount,
+            })}
+          />
         </>
       )}
 

--- a/src/ui/templates/admin/settings/custom-domain.tsx
+++ b/src/ui/templates/admin/settings/custom-domain.tsx
@@ -9,6 +9,7 @@ import { DomainPaymentWebhookWarning } from "#templates/admin/settings/domain-pa
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
 import { PageBlock } from "#templates/components/page-structure.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { TextField } from "#templates/components/text-field.tsx";
 /* jscpd:ignore-end */
 
@@ -44,9 +45,11 @@ export const CustomDomainForm = (
       </CsrfForm>
 
       {s.customDomain && (
-        <CsrfForm
+        <SaveForm
           action="/admin/settings/custom-domain/validate"
           id="settings-custom-domain-validate"
+          submitIcon="check"
+          submitLabel={t("settings.advanced.validate_custom_domain")}
         >
           {!s.customDomainLastValidated && (
             <article>
@@ -87,10 +90,7 @@ export const CustomDomainForm = (
               <small>Last validated: {s.customDomainLastValidated}</small>
             </p>
           )}
-          <SubmitButton icon="check">
-            {t("settings.advanced.validate_custom_domain")}
-          </SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       )}
     </PageBlock>
   ) : null;

--- a/src/ui/templates/admin/settings/email.tsx
+++ b/src/ui/templates/admin/settings/email.tsx
@@ -4,10 +4,9 @@
 
 import { t } from "#i18n";
 import { EMAIL_PROVIDER_LABELS, VALID_EMAIL_PROVIDERS } from "#shared/email.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import type { AdvancedSettingsPageState } from "#templates/admin/settings-advanced.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import { MaskedInput } from "#templates/components/masked-input.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { SelectField } from "#templates/components/select-field.tsx";
 import { SettingsSection } from "#templates/components/settings-section.tsx";
 import { TextField } from "#templates/components/text-field.tsx";
@@ -59,11 +58,13 @@ export const EmailNotificationsForm = (
       />
     </SettingsSection>
     {s.emailProvider && (
-      <CsrfForm action="/admin/settings/email/test" id="settings-email-test">
-        <SubmitButton class="secondary" icon="arrow-right">
-          {t("settings.advanced.send_test_email")}
-        </SubmitButton>
-      </CsrfForm>
+      <SaveForm
+        action="/admin/settings/email/test"
+        id="settings-email-test"
+        submitClass="secondary"
+        submitIcon="arrow-right"
+        submitLabel={t("settings.advanced.send_test_email")}
+      />
     )}
   </>
 );

--- a/src/ui/templates/admin/settings/header-image.tsx
+++ b/src/ui/templates/admin/settings/header-image.tsx
@@ -3,12 +3,11 @@
  */
 
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import { formatBytes, MAX_IMAGE_SIZE } from "#shared/limits.ts";
 import { getImageProxyUrl } from "#shared/storage.ts";
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
-import { SubmitButton } from "#templates/components/actions.tsx";
 import { PageBlock } from "#templates/components/page-structure.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { SettingsSection } from "#templates/components/settings-section.tsx";
 
 export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
@@ -21,14 +20,12 @@ export const HeaderImageForm = (s: SettingsPageState): JSX.Element | null =>
             class="listing-image-preview"
             src={getImageProxyUrl(s.headerImageUrl)}
           />
-          <CsrfForm
+          <SaveForm
             action="/admin/settings/header-image/delete"
             id="settings-header-image-delete"
-          >
-            <SubmitButton icon="trash-2">
-              {t("admin.listings.remove_image")}
-            </SubmitButton>
-          </CsrfForm>
+            submitIcon="trash-2"
+            submitLabel={t("admin.listings.remove_image")}
+          />
         </div>
       )}
       <SettingsSection

--- a/src/ui/templates/admin/settings/payment.tsx
+++ b/src/ui/templates/admin/settings/payment.tsx
@@ -14,6 +14,7 @@ import {
 import type { SettingsPageState } from "#templates/admin/settings.tsx";
 import { SubmitButton } from "#templates/components/actions.tsx";
 import { RadioOption } from "#templates/components/radio-option.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import {
   getSquareAccessTokenFields,
   getSquareWebhookFields,
@@ -22,9 +23,10 @@ import {
 } from "#templates/fields/admin.ts";
 
 export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
-  <CsrfForm
+  <SaveForm
     action="/admin/settings/payment-provider"
     id="settings-payment-provider"
+    submitLabel={t("settings.save_payment_provider")}
   >
     <div class="prose">
       <h2>{t("settings.payment_provider")}</h2>
@@ -48,10 +50,7 @@ export const PaymentProviderForm = (s: SettingsPageState): JSX.Element => (
         </RadioOption>
       ))}
     </fieldset>
-    <SubmitButton icon="save">
-      {t("settings.save_payment_provider")}
-    </SubmitButton>
-  </CsrfForm>
+  </SaveForm>
 );
 
 /** Test/live mode notice for providers that use sk_test_/sk_live_ keys
@@ -239,9 +238,10 @@ export const SquareForm = (s: SettingsPageState): JSX.Element | null =>
 
 export const SquareWebhookForm = (s: SettingsPageState): JSX.Element | null =>
   s.paymentProvider === "square" && s.squareTokenConfigured ? (
-    <CsrfForm
+    <SaveForm
       action="/admin/settings/square-webhook"
       id="settings-square-webhook"
+      submitLabel={t("settings.square.update_webhook_key")}
     >
       <div class="prose">
         <h2>{t("settings.square.webhook_heading")}</h2>
@@ -293,10 +293,7 @@ export const SquareWebhookForm = (s: SettingsPageState): JSX.Element | null =>
             : {},
         )}
       />
-      <SubmitButton icon="save">
-        {t("settings.square.update_webhook_key")}
-      </SubmitButton>
-    </CsrfForm>
+    </SaveForm>
   ) : null;
 
 export const SumUpForm = (s: SettingsPageState): JSX.Element | null =>
@@ -322,7 +319,11 @@ export const SumUpForm = (s: SettingsPageState): JSX.Element | null =>
 
 export const BookingFeeForm = (s: SettingsPageState): JSX.Element | null =>
   s.paymentProvider ? (
-    <CsrfForm action="/admin/settings/booking-fee" id="settings-booking-fee">
+    <SaveForm
+      action="/admin/settings/booking-fee"
+      id="settings-booking-fee"
+      submitLabel={t("settings.save_booking_fee")}
+    >
       <div class="prose">
         <h2>{t("settings.booking_fee")}</h2>
         <p>{t("settings.booking_fee_hint")}</p>
@@ -339,6 +340,5 @@ export const BookingFeeForm = (s: SettingsPageState): JSX.Element | null =>
           value={s.bookingFee}
         />
       </label>
-      <SubmitButton icon="save">{t("settings.save_booking_fee")}</SubmitButton>
-    </CsrfForm>
+    </SaveForm>
   ) : null;

--- a/src/ui/templates/admin/site-pages.tsx
+++ b/src/ui/templates/admin/site-pages.tsx
@@ -10,7 +10,6 @@ import {
   sitePageEditForm,
   sitePageForm,
 } from "#routes/admin/site-pages-form.ts";
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type {
   AdminSession,
@@ -30,6 +29,7 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
 import { InlineFormButton } from "#templates/components/inline-form-button.tsx";
 import { ReorderArrows } from "#templates/components/reorder.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 
 /* jscpd:ignore-end */
 
@@ -214,7 +214,12 @@ const ItemPicker = ({
   options: PickerOption[];
 }): JSX.Element | null =>
   options.length === 0 ? null : (
-    <CsrfForm action={`${LIST}/${pageId}/items`} class="inline-add">
+    <SaveForm
+      action={`${LIST}/${pageId}/items`}
+      class="inline-add"
+      submitIcon="plus"
+      submitLabel={t("site.pages.add_item")}
+    >
       <input name="item_type" type="hidden" value={type} />
       <label>
         {label}{" "}
@@ -224,8 +229,7 @@ const ItemPicker = ({
           ))}
         </select>
       </label>{" "}
-      <SubmitButton icon="plus">{t("site.pages.add_item")}</SubmitButton>
-    </CsrfForm>
+    </SaveForm>
   );
 
 /** The Edit tab's panel: the page-fields form (name, editable slug + public

--- a/src/ui/templates/admin/sms.tsx
+++ b/src/ui/templates/admin/sms.tsx
@@ -6,7 +6,6 @@
 /* jscpd:ignore-start */
 import { joinStrings, map, pipe } from "#fp";
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import type {
   AdminSession,
@@ -14,9 +13,10 @@ import type {
   ListingWithCount,
 } from "#shared/types.ts";
 import { flashAdminPage } from "#templates/admin/admin-page.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import { SectionFieldset } from "#templates/components/aggregate-sections.tsx";
 import { DataTable } from "#templates/components/data-table.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 /** A text-message activity-log entry, shown as conversation history. */
@@ -83,7 +83,11 @@ const ComposeForm = ({
       {!configured && <Raw html={t("sms.contact.not_configured")} />}
 
       {attendee.phone && configured && (
-        <CsrfForm action="/admin/sms">
+        <SaveForm
+          action="/admin/sms"
+          submitIcon="check"
+          submitLabel={t("sms.contact.send")}
+        >
           <input name="listing" type="hidden" value={String(listing.id)} />
           <input name="attendee" type="hidden" value={String(attendee.id)} />
           <SectionFieldset
@@ -99,8 +103,7 @@ const ComposeForm = ({
               rows="4"
             />
           </SectionFieldset>
-          <SubmitButton icon="check">{t("sms.contact.send")}</SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       )}
 
       <h3>{t("sms.contact.history_heading")}</h3>

--- a/src/ui/templates/admin/update.tsx
+++ b/src/ui/templates/admin/update.tsx
@@ -4,12 +4,12 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { CsrfForm } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { GITHUB_RELEASES_URL } from "#shared/update.ts";
 import { flashDataPage } from "#templates/admin/admin-page.tsx";
-import { GuideFooter, SubmitButton } from "#templates/components/actions.tsx";
+import { GuideFooter } from "#templates/components/actions.tsx";
 import { ProseSection } from "#templates/components/prose-section.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 /* jscpd:ignore-end */
 
 export type UpdatePageState = {
@@ -37,11 +37,12 @@ const CurrentVersion = ({ state }: { state: UpdatePageState }): JSX.Element => (
 
 /** Check for updates form */
 const CheckForUpdates = (): JSX.Element => (
-  <CsrfForm action="/admin/update/check" id="update-check">
-    <SubmitButton icon="rotate-ccw">
-      {t("update.check_for_updates")}
-    </SubmitButton>
-  </CsrfForm>
+  <SaveForm
+    action="/admin/update/check"
+    id="update-check"
+    submitIcon="rotate-ccw"
+    submitLabel={t("update.check_for_updates")}
+  />
 );
 
 /** Update available section with deploy button */
@@ -53,11 +54,13 @@ const UpdateAvailable = ({
   <ProseSection
     footer={
       state.providerConfigured ? (
-        <CsrfForm action="/admin/update" class="no-bg" id="update-deploy">
-          <SubmitButton icon="rotate-ccw">
-            {t("update.update_now")}
-          </SubmitButton>
-        </CsrfForm>
+        <SaveForm
+          action="/admin/update"
+          class="no-bg"
+          id="update-deploy"
+          submitIcon="rotate-ccw"
+          submitLabel={t("update.update_now")}
+        />
       ) : (
         <p>
           <em>{t("update.cannot_update_automatically")}</em>

--- a/src/ui/templates/admin/users.tsx
+++ b/src/ui/templates/admin/users.tsx
@@ -4,7 +4,7 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { CsrfForm, renderFields } from "#shared/forms.tsx";
+import { renderFields } from "#shared/forms.tsx";
 import type {
   AdminLevel,
   AdminSession,
@@ -21,7 +21,6 @@ import {
   ActionButton,
   DeleteSection,
   GuideFooter,
-  SubmitButton,
 } from "#templates/components/actions.tsx";
 import {
   CheckboxFieldset,
@@ -31,6 +30,7 @@ import { DataTable, textCol } from "#templates/components/data-table.tsx";
 import { DetailTable } from "#templates/components/detail-table.tsx";
 import { LabelledRow } from "#templates/components/labelled-row.tsx";
 import { NewResourceForm } from "#templates/components/new-resource-form.tsx";
+import { SaveForm } from "#templates/components/save-form.tsx";
 import { getInviteUserFields } from "#templates/fields/admin.ts";
 /* jscpd:ignore-end */
 
@@ -272,10 +272,12 @@ export const adminUserAgentsPage: AssignmentEditPage<
           </em>
         </p>
       ) : (
-        <CsrfForm action={`/admin/users/${user.id}/agents`}>
+        <SaveForm
+          action={`/admin/users/${user.id}/agents`}
+          submitLabel={t("users.agents.save")}
+        >
           <AgentSelector agents={agents} selected={selectedIds} />
-          <SubmitButton icon="save">{t("users.agents.save")}</SubmitButton>
-        </CsrfForm>
+        </SaveForm>
       )}
     </>,
   );

--- a/test/fp.test.ts
+++ b/test/fp.test.ts
@@ -11,6 +11,7 @@ import {
   groupToMap,
   lazyRef,
   map,
+  mapById,
   once,
   partition,
   pipe,
@@ -525,6 +526,33 @@ describe("fp", () => {
 
     test("empty input gives an empty map", () => {
       expect(byId([])).toEqual(new Map());
+    });
+  });
+
+  describe("mapById", () => {
+    const toName = mapById((item: { id: number; name: string }) => item.name);
+
+    test("indexes each item's id to the chosen value", () => {
+      const map = toName([
+        { id: 1, name: "a" },
+        { id: 2, name: "b" },
+      ]);
+      expect(map.get(1)).toBe("a");
+      expect(map.get(2)).toBe("b");
+      expect(map.size).toBe(2);
+    });
+
+    test("later items with the same id win", () => {
+      expect(
+        toName([
+          { id: 1, name: "first" },
+          { id: 1, name: "second" },
+        ]).get(1),
+      ).toBe("second");
+    });
+
+    test("empty input gives an empty map", () => {
+      expect(toName([])).toEqual(new Map());
     });
   });
 });

--- a/test/shared/now.test.ts
+++ b/test/shared/now.test.ts
@@ -1,0 +1,25 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+import { expiresIn, nowIso, nowSeconds } from "#shared/now.ts";
+
+describe("expiresIn", () => {
+  test("adds the max age to the current epoch seconds", () => {
+    using _time = new FakeTime(1_700_000_000_000);
+    expect(nowSeconds()).toBe(1_700_000_000);
+    expect(expiresIn(300)).toBe(1_700_000_300);
+    expect(expiresIn(0)).toBe(1_700_000_000);
+  });
+
+  test("a longer max age yields a later expiry", () => {
+    using _time = new FakeTime(1_700_000_000_000);
+    expect(expiresIn(90 * 24 * 60 * 60)).toBe(1_700_000_000 + 7_776_000);
+  });
+});
+
+describe("nowIso", () => {
+  test("returns the current instant as an ISO-8601 string", () => {
+    using _time = new FakeTime(1_700_000_000_000);
+    expect(nowIso()).toBe("2023-11-14T22:13:20.000Z");
+  });
+});

--- a/test/shared/reorder.test.ts
+++ b/test/shared/reorder.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { planReorder } from "#shared/reorder.ts";
+
+describe("planReorder", () => {
+  const keys = ["page:1", "listing:2", "group:3"];
+
+  test("swaps with the correct neighbour", () => {
+    expect(planReorder(keys, "listing:2", "up")).toEqual([
+      "listing:2",
+      "page:1",
+    ]);
+    expect(planReorder(keys, "listing:2", "down")).toEqual([
+      "listing:2",
+      "group:3",
+    ]);
+  });
+
+  test("null at boundaries and for a missing key", () => {
+    expect(planReorder(keys, "page:1", "up")).toBeNull();
+    expect(planReorder(keys, "group:3", "down")).toBeNull();
+    expect(planReorder(keys, "listing:99", "up")).toBeNull();
+  });
+
+  test("works over any key type, e.g. numeric row ids", () => {
+    expect(planReorder([10, 20, 30], 20, "up")).toEqual([20, 10]);
+    expect(planReorder([10, 20, 30], 20, "down")).toEqual([20, 30]);
+    expect(planReorder([10, 20, 30], 10, "up")).toBeNull();
+  });
+
+  test("a move followed by its opposite restores the order (self-inverse)", () => {
+    // Applying planReorder's swap and then the opposite move's swap is the
+    // identity, for every non-boundary position.
+    const applySwap = (
+      order: readonly string[],
+      [a, b]: readonly [string, string],
+    ): string[] => order.map((k) => (k === a ? b : k === b ? a : k));
+    for (const [target, dir, opposite] of [
+      ["listing:2", "down", "up"],
+      ["listing:2", "up", "down"],
+      ["page:1", "down", "up"],
+      ["group:3", "up", "down"],
+    ] as const) {
+      const swap = planReorder(keys, target, dir);
+      expect(swap, `${target} ${dir}`).not.toBeNull();
+      const moved = applySwap(keys, swap!);
+      const back = planReorder(moved, target, opposite);
+      expect(back, `${target} ${opposite} back`).not.toBeNull();
+      expect(applySwap(moved, back!)).toEqual(keys);
+    }
+  });
+});

--- a/test/shared/session-private-key.test.ts
+++ b/test/shared/session-private-key.test.ts
@@ -24,6 +24,10 @@ describeWithEnv("shared > session private key", { db: true }, () => {
     );
   });
 
+  test("SessionKeyError reports its own name, not the generic Error", () => {
+    expect(new SessionKeyError().name).toBe("SessionKeyError");
+  });
+
   test("resolves the current request's key, which decrypts owner-key data", async () => {
     const sealed = await encryptWithOwnerKey("top secret", settings.publicKey);
 

--- a/test/shared/site-pages/core.test.ts
+++ b/test/shared/site-pages/core.test.ts
@@ -9,7 +9,6 @@ import {
   isReservedSlug,
   pageParentMapFromEdges,
   parseTargetKey,
-  planReorder,
   targetKey,
   wouldCreateCycle,
 } from "#shared/site-pages/core.ts";
@@ -216,47 +215,6 @@ describe("site-pages core", () => {
       // Candidates to add under 2: exclude 2 (self), 1 (ancestor), 2-already? ;
       // 3 and 4 are unparented and no cycle → eligible.
       expect(eligibleChildPages(forest, 2).map((p) => p.id)).toEqual([3, 4]);
-    });
-  });
-
-  describe("planReorder", () => {
-    const keys: TargetKey[] = ["page:1", "listing:2", "group:3"];
-    test("swaps with the correct neighbour", () => {
-      expect(planReorder(keys, "listing:2", "up")).toEqual([
-        "listing:2",
-        "page:1",
-      ]);
-      expect(planReorder(keys, "listing:2", "down")).toEqual([
-        "listing:2",
-        "group:3",
-      ]);
-    });
-    test("null at boundaries and for a missing key", () => {
-      expect(planReorder(keys, "page:1", "up")).toBeNull();
-      expect(planReorder(keys, "group:3", "down")).toBeNull();
-      expect(planReorder(keys, "listing:99", "up")).toBeNull();
-    });
-
-    test("a move followed by its opposite restores the order (self-inverse)", () => {
-      // The promised property: applying planReorder's swap and then the
-      // opposite move's swap is the identity, for every non-boundary position.
-      const applySwap = (
-        order: readonly TargetKey[],
-        [a, b]: readonly [TargetKey, TargetKey],
-      ): TargetKey[] => order.map((k) => (k === a ? b : k === b ? a : k));
-      for (const [target, dir, opposite] of [
-        ["listing:2", "down", "up"],
-        ["listing:2", "up", "down"],
-        ["page:1", "down", "up"],
-        ["group:3", "up", "down"],
-      ] as const) {
-        const swap = planReorder(keys, target, dir);
-        expect(swap, `${target} ${dir}`).not.toBeNull();
-        const moved = applySwap(keys, swap!);
-        const back = planReorder(moved, target, opposite);
-        expect(back, `${target} ${opposite} back`).not.toBeNull();
-        expect(applySwap(moved, back!)).toEqual(keys);
-      }
     });
   });
 

--- a/test/shared/site-secrets.test.ts
+++ b/test/shared/site-secrets.test.ts
@@ -259,17 +259,21 @@ describeWithEnv(
   },
 );
 
-describeWithEnv("loadSiteSecretsStatus without an API key", { env: {} }, () => {
-  test("refuses when BUNNY_API_KEY is not configured", async () => {
-    const view = await loadSiteSecretsStatus(buildSite());
-    expect(view.ok).toBe(false);
-    if (!view.ok) expect(view.error).toContain("BUNNY_API_KEY");
-  });
-});
+describeWithEnv(
+  "loadSiteSecretsStatus without an API key",
+  { env: { BUNNY_API_KEY: undefined } },
+  () => {
+    test("refuses when BUNNY_API_KEY is not configured", async () => {
+      const view = await loadSiteSecretsStatus(buildSite());
+      expect(view.ok).toBe(false);
+      if (!view.ok) expect(view.error).toContain("BUNNY_API_KEY");
+    });
+  },
+);
 
 describeWithEnv(
   "loadSiteSecretsStatus (Deno site, no token)",
-  { env: {} },
+  { env: { DENO_DEPLOY_TOKEN: undefined } },
   () => {
     test("refuses when DENO_DEPLOY_TOKEN is not configured", async () => {
       const view = await loadSiteSecretsStatus(

--- a/test/templates/admin/listings/helpers.ts
+++ b/test/templates/admin/listings/helpers.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll } from "@std/testing/bdd";
 import { signCsrfToken } from "#shared/csrf.ts";
-import { attendeeNameMap } from "#shared/db/system-notes.ts";
+import { idNameMap } from "#shared/id-name-map.ts";
 import { detectIframeMode } from "#shared/iframe.ts";
 import { listingLedgerHref } from "#shared/ledger-links.ts";
 import { ListingEditPanel } from "#templates/admin/listings/edit-panel.tsx";
@@ -50,7 +50,7 @@ export const renderListingDetail = (
       // The Overview now takes precomputed stats + note-author names instead of
       // the raw attendee list; derive them from the fixture's attendees so these
       // tests exercise the same rendered output the SQL path produces.
-      noteNames: attendeeNameMap(opts.attendees),
+      noteNames: idNameMap(opts.attendees),
       questionData: opts.questionData,
       stats: overviewStatsFromAttendees(
         opts.listing,


### PR DESCRIPTION
This is a tidy-up pass. Nothing changes for people using the site — it removes copies of the same logic that had been written out by hand in many places, and routes each one through the single shared helper that already existed for it. Less code doing the same job means fewer places for the two copies to drift apart.

Every change keeps the exact same behaviour. The full check suite (typecheck, lint, the whole test run, the zero-duplicate check, and the copy checker) passes.

## What changed

- **Times are read one way.** About a dozen spots worked out "now" by hand (`Date.now()` maths, `new Date().toISOString()`). They now call the shared `nowSeconds()` / `nowIso()` helpers, plus a new `expiresIn()` for the two signed-link builders. A bonus: these can be frozen in tests, so time-based tests are steadier.

- **Error types name themselves.** Eight hand-written error classes now use the shared `namedError()` factory. Five of them never set their own name, so they used to report as a plain "Error" — including the private-key error, which now reports its real name. A test locks that in.

- **Grouping is done by the shared helper.** A private copy of "group rows into lists" was deleted in favour of the shared one, and a slow "rebuild the whole bucket each time" loop in the order page was replaced with a single grouping call.

- **"Does this row exist?" checks share one helper.** The slug-uniqueness and package checks reused a shared `rowExists` helper instead of each writing out the same query-and-compare.

- **Duplicate one-liners removed.** A name-lookup builder and a same-account check that were exact copies of existing helpers are gone; a new small `mapById` helper backs the id→value lookups. A few caught-error and query-string reads now call the helpers that already existed for them.

- **"Move up / move down" is one mechanism.** Six admin lists (questions, answers, attributes, options, attendee statuses) each hand-rolled the same reorder step. They now share one small, well-tested helper, so the fiddly off-by-one lives in exactly one place.

- **Save forms share one component.** Around 38 admin forms that ended in the same "fields, then a save button" shape now use the shared `SaveForm` component, which produces the identical page. Forms that don't fit the shape were left alone.

- **A flaky test was hardened.** One test assumed a setting was absent rather than making sure of it; under the reshuffled test grouping a leftover value from a neighbouring test tripped it. It now sets that state explicitly, matching how the other tests in the area already do it.

## Not in this PR

Two larger consolidations from the same audit are deliberately held back for their own PRs, because they touch money/booking code and deserve to be reviewed on their own:

- Pulling the ledger's transfer-leg definitions into one shared module.
- Merging the two parallel "validate → save → read back" write pipelines behind the resource and CRUD-API factories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent save-form interactions across admin pages, including clearer submit actions for settings, uploads, imports, backups, and account management.
  * Improved admin ordering controls for attributes, questions, answers, and attendee statuses, with safer boundary handling.
  * Added reusable utilities supporting more reliable mapping, expiration times, and reorder behavior.

* **Bug Fixes**
  * Improved attendee and note name display consistency.
  * Strengthened webhook, QR-code, backup, and payment timestamp handling.
  * Improved validation and error reporting for administrative and public workflows.

* **Tests**
  * Added coverage for mapping, expiration, reordering, and session-key error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->