### PR TITLE
Let the shared write step decide when a save needs a transaction

### DIFF
--- a/src/shared/rest/crud-api.ts
+++ b/src/shared/rest/crud-api.ts
@@ -29,7 +29,7 @@ import type { TxScope } from "#shared/db/client.ts";
 import type { Table } from "#shared/db/table.ts";
 import type { ApiResult } from "#shared/fetch.ts";
 import type { ResponseFn } from "#shared/response-fn.ts";
-import { writeEntity } from "#shared/rest/write-entity.ts";
+import { type JoinWrite, writeEntity } from "#shared/rest/write-entity.ts";
 import type { AdminSession } from "#shared/types.ts";
 /* jscpd:ignore-end */
 
@@ -456,18 +456,22 @@ export const defineCrudApi = <
     const prepared = await prepareSideEffect(inputs);
     if ("error" in prepared) return apiErrorResponse(prepared.error);
     const preparedValue = prepared.value;
+    const joinWrites: JoinWrite[] = [];
+    if (config.sideEffect) {
+      joinWrites.push((tx, rowId) =>
+        config.sideEffect!.persist(tx, rowId, preparedValue),
+      );
+    }
+    if (config.afterWrite) {
+      joinWrites.push((tx, rowId) => config.afterWrite!(tx, rowId, input));
+    }
     const fullRow = await writeEntity<FullRow>({
       afterCommit: config.afterCommit,
       buildStatement: getStatement,
       existingId,
-      joinWrite: async (tx, rowId) => {
-        if (config.sideEffect)
-          await config.sideEffect.persist(tx, rowId, preparedValue);
-        if (config.afterWrite) await config.afterWrite(tx, rowId, input);
-      },
+      joinWrites,
       plainWrite: () => plainWrite() as unknown as Promise<FullRow | null>,
       readBack: lookupAfterWrite,
-      transactional: Boolean(config.sideEffect || config.afterWrite),
     });
     // writeEntity returns null when the just-written row can't be read back —
     // an update whose row was deleted between the entityRoute lookup and the

--- a/src/shared/rest/resource.ts
+++ b/src/shared/rest/resource.ts
@@ -222,11 +222,11 @@ export const defineResource = <
           ? table.insertStatement!(result.input)
           : table.updateStatement!(existingId, result.input),
       existingId,
-      joinWrite: (tx, rowId) =>
-        config.afterWrite!(tx, rowId, result.input, form),
+      joinWrites: config.afterWrite
+        ? [(tx, rowId) => config.afterWrite!(tx, rowId, result.input, form)]
+        : [],
       plainWrite: () => fallback(result.input),
       readBack: (rowId) => table.findByIdPrimary!(rowId),
-      transactional: Boolean(config.afterWrite),
     });
     return { ok: true, row };
   };

--- a/src/shared/rest/write-entity.ts
+++ b/src/shared/rest/write-entity.ts
@@ -16,6 +16,10 @@ import {
   writeRowInTransaction,
 } from "#shared/db/client.ts";
 
+/** One join-table write that must commit atomically with the row it belongs to,
+ *  given the open transaction scope and the written row's id. */
+export type JoinWrite = (tx: TxScope, id: number) => Promise<void>;
+
 /** How to write one row and read it back. `existingId` is null on create (the id
  *  comes from the INSERT) and the row id on update. */
 export interface EntityWrite<Row extends { id: number }> {
@@ -26,9 +30,13 @@ export interface EntityWrite<Row extends { id: number }> {
   /** Build the INSERT/UPDATE statement — only called on the transactional path. */
   buildStatement: () => Promise<SqlStatement>;
   existingId: number | null;
-  /** Join-table writes to run inside the row's own transaction, so a failure
-   *  rolls the row write back rather than leaving partial state. */
-  joinWrite: (tx: TxScope, id: number) => Promise<void>;
+  /** Join-table writes that must commit atomically with the row. Any present ⇒
+   *  the row and every join write share one transaction, so a failed join write
+   *  rolls the row write back rather than leaving partial state; an empty list ⇒
+   *  the plain single-statement path. Run in order, inside that transaction. The
+   *  caller no longer decides "am I transactional?" separately from which hooks
+   *  run — the two can't drift. */
+  joinWrites: readonly JoinWrite[];
   /** The plain insert/update, used when there are no join writes. */
   plainWrite: () => Promise<Row | null>;
   /** Read the just-committed row back — this MUST be pinned to the primary. A
@@ -37,28 +45,29 @@ export interface EntityWrite<Row extends { id: number }> {
    *  (`row.id`) and crash on. Use `table.findByIdPrimary` or a primary-pinned
    *  join lookup. */
   readBack: (id: number) => Promise<Row | null>;
-  /** True when a join-table write must share the row's transaction; false takes
-   *  the plain single-statement path. */
-  transactional: boolean;
 }
 
 /**
- * Write the row (transactionally or plainly), read it back on the primary, then
- * run `afterCommit`. Returns the committed row, or null when the read-back finds
+ * Write the row — transactionally with its join writes when there are any, else
+ * as a plain single statement — read it back on the primary, then run
+ * `afterCommit`. Returns the committed row, or null when the read-back finds
  * nothing (a plain write returning null, or an update whose id no longer exists).
  */
 export const writeEntity = async <Row extends { id: number }>(
   write: EntityWrite<Row>,
 ): Promise<Row | null> => {
-  const row = write.transactional
-    ? await write.readBack(
-        await writeRowInTransaction(
-          await write.buildStatement(),
-          write.existingId,
-          write.joinWrite,
-        ),
-      )
-    : await write.plainWrite();
+  const row =
+    write.joinWrites.length > 0
+      ? await write.readBack(
+          await writeRowInTransaction(
+            await write.buildStatement(),
+            write.existingId,
+            async (tx, id) => {
+              for (const joinWrite of write.joinWrites) await joinWrite(tx, id);
+            },
+          ),
+        )
+      : await write.plainWrite();
   if (row && write.afterCommit) await write.afterCommit(row.id);
   return row;
 };

--- a/test/shared/rest/write-entity.test.ts
+++ b/test/shared/rest/write-entity.test.ts
@@ -16,7 +16,8 @@ const createTable = (): Promise<void> => createIdNameTable("we_items");
 const reject = (what: string) => () =>
   Promise.reject(new Error(`${what} must not run`));
 
-/** Call writeEntity with safe defaults, overriding only what a case exercises. */
+/** Call writeEntity with safe defaults, overriding only what a case exercises.
+ *  Defaults to the plain path (no join writes). */
 const writeWith = (
   table: Table<Row, Input>,
   overrides: Partial<EntityWrite<Row>>,
@@ -24,10 +25,9 @@ const writeWith = (
   writeEntity<Row>({
     buildStatement: () => table.insertStatement!({ name: "row" }),
     existingId: null,
-    joinWrite: () => Promise.resolve(),
+    joinWrites: [],
     plainWrite: () => table.insert({ name: "row" }),
     readBack: (id) => table.findByIdPrimary!(id),
-    transactional: false,
     ...overrides,
   });
 
@@ -48,12 +48,13 @@ describe("writeEntity", () => {
         afterCommitIds.push(id);
         return Promise.resolve();
       },
-      joinWrite: (_tx, id) => {
-        joinIds.push(id);
-        return Promise.resolve();
-      },
+      joinWrites: [
+        (_tx, id) => {
+          joinIds.push(id);
+          return Promise.resolve();
+        },
+      ],
       plainWrite: reject("plainWrite"),
-      transactional: true,
     });
 
     expect(row).toEqual({ id: 1, name: "row" });
@@ -64,7 +65,28 @@ describe("writeEntity", () => {
     expect(await table.findById(1)).toEqual({ id: 1, name: "row" });
   });
 
-  test("transactional path rolls the row back when the join write throws", async () => {
+  test("runs every join write in order, all inside the one transaction", async () => {
+    const table = makeTable();
+    const order: string[] = [];
+
+    await writeWith(table, {
+      joinWrites: [
+        (_tx, id) => {
+          order.push(`first:${id}`);
+          return Promise.resolve();
+        },
+        (_tx, id) => {
+          order.push(`second:${id}`);
+          return Promise.resolve();
+        },
+      ],
+      plainWrite: reject("plainWrite"),
+    });
+
+    expect(order).toEqual(["first:1", "second:1"]);
+  });
+
+  test("transactional path rolls the row back when a join write throws", async () => {
     const table = makeTable();
     let afterCommitRan = false;
 
@@ -74,9 +96,8 @@ describe("writeEntity", () => {
           afterCommitRan = true;
           return Promise.resolve();
         },
-        joinWrite: () => Promise.reject(new Error("join failed")),
+        joinWrites: [() => Promise.reject(new Error("join failed"))],
         plainWrite: reject("plainWrite"),
-        transactional: true,
       }),
     ).rejects.toThrow("join failed");
 
@@ -86,7 +107,7 @@ describe("writeEntity", () => {
     expect(afterCommitRan).toBe(false);
   });
 
-  test("plain path: uses plainWrite, skips the statement/join hooks, still runs afterCommit", async () => {
+  test("plain path (no join writes): uses plainWrite, skips the statement, still runs afterCommit", async () => {
     const table = makeTable();
     let buildStatementRan = false;
     const afterCommitIds: number[] = [];
@@ -100,9 +121,7 @@ describe("writeEntity", () => {
         buildStatementRan = true;
         return table.insertStatement!({ name: "row" });
       },
-      joinWrite: reject("joinWrite"),
       readBack: reject("readBack"),
-      transactional: false,
     });
 
     expect(row).toEqual({ id: 1, name: "row" });
@@ -121,7 +140,6 @@ describe("writeEntity", () => {
       },
       plainWrite: () => Promise.resolve(null),
       readBack: () => Promise.resolve(null),
-      transactional: false,
     });
 
     expect(row).toBeNull();
@@ -133,7 +151,6 @@ describe("writeEntity", () => {
     const row = await writeWith(table, {
       plainWrite: () => table.insert({ name: "Dave" }),
       readBack: reject("readBack"),
-      transactional: false,
     });
     expect(row).toEqual({ id: 1, name: "Dave" });
   });

--- a/test/shared/rest/write-entity.test.ts
+++ b/test/shared/rest/write-entity.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import type { TxScope } from "#shared/db/client.ts";
 import type { Table } from "#shared/db/table.ts";
 import { type EntityWrite, writeEntity } from "#shared/rest/write-entity.ts";
 import { createTestDb, resetDb } from "#test-utils/db.ts";
@@ -68,14 +69,17 @@ describe("writeEntity", () => {
   test("runs every join write in order, all inside the one transaction", async () => {
     const table = makeTable();
     const order: string[] = [];
+    const scopes: TxScope[] = [];
 
     await writeWith(table, {
       joinWrites: [
-        (_tx, id) => {
+        (tx, id) => {
+          scopes.push(tx);
           order.push(`first:${id}`);
           return Promise.resolve();
         },
-        (_tx, id) => {
+        (tx, id) => {
+          scopes.push(tx);
           order.push(`second:${id}`);
           return Promise.resolve();
         },
@@ -84,6 +88,9 @@ describe("writeEntity", () => {
     });
 
     expect(order).toEqual(["first:1", "second:1"]);
+    // Both join writes share the one transaction scope — not two separate ones.
+    expect(scopes).toHaveLength(2);
+    expect(scopes[0]).toBe(scopes[1]);
   });
 
   test("transactional path rolls the row back when a join write throws", async () => {


### PR DESCRIPTION
A small follow-on to the shared write-step work (#1805).

Both admin save paths (the web forms and the JSON API) each decided two things by hand: whether the save needs to run as one all-or-nothing transaction, and — when it does — which linked-row writes ride along inside it. Those two decisions have to agree: if a path says "not a transaction" but still has a linked-row write, or vice versa, the linked rows can save without the main row (or not roll back with it). Keeping the decision in two places is a chance for them to drift apart.

This moves that decision into the one shared save step: it now takes the list of linked-row writes and works out for itself whether a transaction is needed (any in the list ⇒ yes; none ⇒ a plain single save). Each save path just hands over its list — the web form has at most one, the API has up to two — and the "needs a transaction exactly when there are linked writes" rule lives in one place and can't drift.

Behaviour is unchanged. The full check suite passes — every admin resource and the whole JSON API — and the shared step keeps its 100% mutation score, now also covering that the linked writes run in order.

## What changed

- `src/shared/rest/write-entity.ts` now takes an ordered `joinWrites` list and derives "run in a transaction" from whether the list is non-empty, running the writes in order inside that transaction. The old separate "is this transactional?" flag is gone.
- `defineResource` and `defineCrudApi` each just build their list and hand it over. Everything that's genuinely different between the two — validating the API's linked-row data up front, and the form-vs-JSON edges — stays where it belongs, per path.

## Notes for reviewers

- This is deliberately a small, invariant-centralising change, not a bigger merge: the parsing, validation timing, and response shaping of the two paths are legitimately different and are left alone.
- I explored a separate wrapper that also owned the up-front validation, but for the web-form path (which has no such validation and so can never fail there) it would have added an unreachable, untestable error branch. Folding the decision into the existing write step avoids that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced create/update flows to persist related (join) writes together with the primary record.
  * Related writes are now executed in a defined order within a single transaction when present.
  * Refined handling of optional after-write hooks while preserving existing read-back and post-commit behavior.
* **Tests**
  * Updated transactional behavior tests to use the new multiple-join-writes approach.
  * Added assertions for multiple join writes running in order and validated standard (non-transactional) write behavior and post-commit actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->