### PR TITLE
Curry two repeated config blocks into small factories

### DIFF
--- a/scripts/build-static-assets.ts
+++ b/scripts/build-static-assets.ts
@@ -86,120 +86,82 @@ export interface StaticBundle {
   options: esbuild.BuildOptions;
 }
 
+/** A browser bundle built the standard way (bundled, minified, IIFE, deno
+ *  loader plugins). `extra` overrides that default per bundle — the order
+ *  widget needs ESM, the iframe-resizer child needs a licence banner. */
+const browserBundle = (
+  label: string,
+  entryPoint: string,
+  outfile: string,
+  extra: esbuild.BuildOptions = {},
+): StaticBundle => ({
+  label,
+  options: {
+    bundle: true,
+    entryPoints: [entryPoint],
+    format: "iife",
+    minify: true,
+    outfile,
+    platform: "browser",
+    plugins: denoLoaderPlugins(),
+    ...extra,
+  },
+});
+
 export const STATIC_JS_BUNDLES: StaticBundle[] = [
-  {
-    label: "Scanner",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/scanner.js"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.scanner,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    label: "Admin",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/admin.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.admin,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    label: "Logistics map",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/logistics-map.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.logisticsMap,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    label: "Markdown editor",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/markdown-editor.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.markdownEditor,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    label: "Embed",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/embed.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.embed,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    label: "Contact",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/contact.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.contact,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    // ESM (not IIFE): the order widget is loaded as `<script type="module">`,
-    // and that module form is what makes the cross-origin CORS gate bite — a
-    // classic-script include would bypass it. The `export {}` in order.ts also
-    // forces module-only parsing.
-    label: "Order",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/order.ts"],
+  browserBundle(
+    "Scanner",
+    "./src/ui/client/scanner.js",
+    STATIC_ASSET_OUTFILES.scanner,
+  ),
+  browserBundle(
+    "Admin",
+    "./src/ui/client/admin.ts",
+    STATIC_ASSET_OUTFILES.admin,
+  ),
+  browserBundle(
+    "Logistics map",
+    "./src/ui/client/logistics-map.ts",
+    STATIC_ASSET_OUTFILES.logisticsMap,
+  ),
+  browserBundle(
+    "Markdown editor",
+    "./src/ui/client/markdown-editor.ts",
+    STATIC_ASSET_OUTFILES.markdownEditor,
+  ),
+  browserBundle(
+    "Embed",
+    "./src/ui/client/embed.ts",
+    STATIC_ASSET_OUTFILES.embed,
+  ),
+  browserBundle(
+    "Contact",
+    "./src/ui/client/contact.ts",
+    STATIC_ASSET_OUTFILES.contact,
+  ),
+  // ESM (not IIFE): the order widget is loaded as `<script type="module">`,
+  // and that module form is what makes the cross-origin CORS gate bite — a
+  // classic-script include would bypass it. The `export {}` in order.ts also
+  // forces module-only parsing.
+  browserBundle(
+    "Order",
+    "./src/ui/client/order.ts",
+    STATIC_ASSET_OUTFILES.order,
+    {
       format: "esm",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.order,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
     },
-  },
-  {
-    label: "iframe-resizer-parent",
-    options: {
-      bundle: true,
-      entryPoints: ["./src/ui/client/iframe-resizer-parent.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.iframeResizerParent,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
-  {
-    label: "iframe-resizer-child",
-    options: {
-      banner: { js: "window.iframeResizer={license:'GPLv3'};" },
-      bundle: true,
-      entryPoints: ["./src/ui/client/iframe-resizer-child.ts"],
-      format: "iife",
-      minify: true,
-      outfile: STATIC_ASSET_OUTFILES.iframeResizerChild,
-      platform: "browser",
-      plugins: denoLoaderPlugins(),
-    },
-  },
+  ),
+  browserBundle(
+    "iframe-resizer-parent",
+    "./src/ui/client/iframe-resizer-parent.ts",
+    STATIC_ASSET_OUTFILES.iframeResizerParent,
+  ),
+  browserBundle(
+    "iframe-resizer-child",
+    "./src/ui/client/iframe-resizer-child.ts",
+    STATIC_ASSET_OUTFILES.iframeResizerChild,
+    { banner: { js: "window.iframeResizer={license:'GPLv3'};" } },
+  ),
 ];
 
 export const buildStaticAssets = async (

--- a/src/shared/admin-api-example.ts
+++ b/src/shared/admin-api-example.ts
@@ -214,43 +214,78 @@ export const PUBLIC_API_ENDPOINTS: EndpointDoc[] = [
   },
 ];
 
+/** The five standard admin-CRUD doc entries for a resource. Descriptions are
+ *  passed in (they carry per-resource wording — "an listing", the holiday
+ *  "owner only" notes), so this shares only the method/path/request/response
+ *  shape every resource repeats. `desc` is [list, get, create, update, delete]. */
+const crudDocs = (c: {
+  singular: string;
+  plural: string;
+  idParam: string;
+  example: unknown;
+  listResponse: unknown;
+  createBody: unknown;
+  updateBody: unknown;
+  deleteBody: unknown;
+  desc: [string, string, string, string, string];
+}): EndpointDoc[] => {
+  const base = `/api/admin/${c.plural}`;
+  const byId = `${base}/:${c.idParam}`;
+  const one = json({ [c.singular]: c.example });
+  const [list, get, create, update, del] = c.desc;
+  return [
+    {
+      description: list,
+      method: "GET",
+      path: base,
+      response: json(c.listResponse),
+    },
+    { description: get, method: "GET", path: byId, response: one },
+    {
+      description: create,
+      method: "POST",
+      path: base,
+      request: json(c.createBody),
+      response: one,
+    },
+    {
+      description: update,
+      method: "PUT",
+      path: byId,
+      request: json(c.updateBody),
+      response: one,
+    },
+    {
+      description: del,
+      method: "DELETE",
+      path: byId,
+      request: json(c.deleteBody),
+      response: json({ status: "ok" }),
+    },
+  ];
+};
+
 export const ADMIN_API_ENDPOINTS: EndpointDoc[] = [
-  {
-    description: "List all listings with attendee counts",
-    method: "GET",
-    path: "/api/admin/listings",
-    response: json({
+  ...crudDocs({
+    createBody: ADMIN_API_CREATE_BODY,
+    deleteBody: ADMIN_API_DELETE_BODY,
+    desc: [
+      "List all listings with attendee counts",
+      "Get a single listing by ID",
+      "Create a new listing",
+      "Update an listing (all fields optional)",
+      "Delete an listing (requires name confirmation)",
+    ],
+    example: ADMIN_API_EXAMPLE_ADMIN_LISTING,
+    idParam: "listingId",
+    listResponse: {
       admin_level: "owner",
       listings: [ADMIN_API_EXAMPLE_ADMIN_LISTING],
-    }),
-  },
-  {
-    description: "Get a single listing by ID",
-    method: "GET",
-    path: "/api/admin/listings/:listingId",
-    response: json({ listing: ADMIN_API_EXAMPLE_ADMIN_LISTING }),
-  },
-  {
-    description: "Create a new listing",
-    method: "POST",
-    path: "/api/admin/listings",
-    request: json(ADMIN_API_CREATE_BODY),
-    response: json({ listing: ADMIN_API_EXAMPLE_ADMIN_LISTING }),
-  },
-  {
-    description: "Update an listing (all fields optional)",
-    method: "PUT",
-    path: "/api/admin/listings/:listingId",
-    request: json(ADMIN_API_UPDATE_BODY),
-    response: json({ listing: ADMIN_API_EXAMPLE_ADMIN_LISTING }),
-  },
-  {
-    description: "Delete an listing (requires name confirmation)",
-    method: "DELETE",
-    path: "/api/admin/listings/:listingId",
-    request: json(ADMIN_API_DELETE_BODY),
-    response: json({ status: "ok" }),
-  },
+    },
+    plural: "listings",
+    singular: "listing",
+    updateBody: ADMIN_API_UPDATE_BODY,
+  }),
   {
     description: "Deactivate an listing",
     method: "POST",
@@ -263,72 +298,38 @@ export const ADMIN_API_ENDPOINTS: EndpointDoc[] = [
     path: "/api/admin/listings/:listingId/reactivate",
     response: json({ listing: ADMIN_API_EXAMPLE_ADMIN_LISTING }),
   },
-  // Groups (any admin)
-  {
-    description: "List all groups",
-    method: "GET",
-    path: "/api/admin/groups",
-    response: json({ groups: [ADMIN_API_EXAMPLE_GROUP] }),
-  },
-  {
-    description: "Get a single group by ID",
-    method: "GET",
-    path: "/api/admin/groups/:groupId",
-    response: json({ group: ADMIN_API_EXAMPLE_GROUP }),
-  },
-  {
-    description: "Create a new group",
-    method: "POST",
-    path: "/api/admin/groups",
-    request: json(ADMIN_API_GROUP_CREATE_BODY),
-    response: json({ group: ADMIN_API_EXAMPLE_GROUP }),
-  },
-  {
-    description: "Update a group (all fields optional)",
-    method: "PUT",
-    path: "/api/admin/groups/:groupId",
-    request: json(ADMIN_API_GROUP_UPDATE_BODY),
-    response: json({ group: ADMIN_API_EXAMPLE_GROUP }),
-  },
-  {
-    description: "Delete a group (requires name confirmation)",
-    method: "DELETE",
-    path: "/api/admin/groups/:groupId",
-    request: json(ADMIN_API_GROUP_DELETE_BODY),
-    response: json({ status: "ok" }),
-  },
-  // Holidays (owner only)
-  {
-    description: "List all holidays (owner only)",
-    method: "GET",
-    path: "/api/admin/holidays",
-    response: json({ holidays: [ADMIN_API_EXAMPLE_HOLIDAY] }),
-  },
-  {
-    description: "Get a single holiday by ID (owner only)",
-    method: "GET",
-    path: "/api/admin/holidays/:holidayId",
-    response: json({ holiday: ADMIN_API_EXAMPLE_HOLIDAY }),
-  },
-  {
-    description: "Create a holiday (owner only)",
-    method: "POST",
-    path: "/api/admin/holidays",
-    request: json(ADMIN_API_HOLIDAY_CREATE_BODY),
-    response: json({ holiday: ADMIN_API_EXAMPLE_HOLIDAY }),
-  },
-  {
-    description: "Update a holiday (owner only, all fields optional)",
-    method: "PUT",
-    path: "/api/admin/holidays/:holidayId",
-    request: json(ADMIN_API_HOLIDAY_UPDATE_BODY),
-    response: json({ holiday: ADMIN_API_EXAMPLE_HOLIDAY }),
-  },
-  {
-    description: "Delete a holiday (owner only, requires name confirmation)",
-    method: "DELETE",
-    path: "/api/admin/holidays/:holidayId",
-    request: json(ADMIN_API_HOLIDAY_DELETE_BODY),
-    response: json({ status: "ok" }),
-  },
+  ...crudDocs({
+    createBody: ADMIN_API_GROUP_CREATE_BODY,
+    deleteBody: ADMIN_API_GROUP_DELETE_BODY,
+    desc: [
+      "List all groups",
+      "Get a single group by ID",
+      "Create a new group",
+      "Update a group (all fields optional)",
+      "Delete a group (requires name confirmation)",
+    ],
+    example: ADMIN_API_EXAMPLE_GROUP,
+    idParam: "groupId",
+    listResponse: { groups: [ADMIN_API_EXAMPLE_GROUP] },
+    plural: "groups",
+    singular: "group",
+    updateBody: ADMIN_API_GROUP_UPDATE_BODY,
+  }),
+  ...crudDocs({
+    createBody: ADMIN_API_HOLIDAY_CREATE_BODY,
+    deleteBody: ADMIN_API_HOLIDAY_DELETE_BODY,
+    desc: [
+      "List all holidays (owner only)",
+      "Get a single holiday by ID (owner only)",
+      "Create a holiday (owner only)",
+      "Update a holiday (owner only, all fields optional)",
+      "Delete a holiday (owner only, requires name confirmation)",
+    ],
+    example: ADMIN_API_EXAMPLE_HOLIDAY,
+    idParam: "holidayId",
+    listResponse: { holidays: [ADMIN_API_EXAMPLE_HOLIDAY] },
+    plural: "holidays",
+    singular: "holiday",
+    updateBody: ADMIN_API_HOLIDAY_UPDATE_BODY,
+  }),
 ];


### PR DESCRIPTION
First of a few small clean-up PRs that fold repeated blocks into a single factory each. This one takes two spots where the same shape was written out over and over.

Nothing changes for anyone using the site. This is internal tidying, and the outputs are identical — the API docs page shows exactly the same text (proven by a snapshot comparison), and the built browser files are built the same way.

## What changed

- **The browser-file build list** (`scripts/build-static-assets.ts`) listed nine bundles, each spelling out the same build settings (bundled, minified, browser, same plugins) and differing only in the name, the source file, and the output file. They now go through one small `browserBundle(name, source, output)` helper. The two that differ — the order widget (loaded as a module, so ESM not IIFE) and the iframe-resizer helper (needs a licence banner) — pass those extras in.

- **The admin API examples** (`src/shared/admin-api-example.ts`) documented the same five actions (list, get, create, update, delete) three times over, once each for listings, groups and holidays. Those now come from one `crudDocs()` generator; the wording that genuinely differs per section (like the holidays' "owner only" notes) is still passed in. The docs page renders byte-for-byte the same, and the test that checks every admin route has a documented example still passes.

## Notes for reviewers

- No behaviour change: a snapshot of the rendered endpoint docs is identical before and after, and the static-asset build produces the same bundles.
- This is part of tightening the duplicate-code check one more notch; both files are now clone-free at the stricter setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_