### PR TITLE
Share three repeated build-script helpers

### DIFF
--- a/scripts/coverage-output.ts
+++ b/scripts/coverage-output.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { rethrowUnlessNotFound } from "./not-found.ts";
 import { projectRoot } from "./project-root.ts";
 
 export const COVERAGE_OUTPUT_DIR = join(projectRoot, "coverage");
@@ -9,7 +10,6 @@ export const removeOldCoverageOutput = async (
   try {
     await Deno.remove(coverageDir, { recursive: true });
   } catch (error) {
-    if (error instanceof Deno.errors.NotFound) return;
-    throw error;
+    rethrowUnlessNotFound(error);
   }
 };

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -7,7 +7,12 @@
 
 import { relative } from "@std/path";
 import { errorMessage } from "#shared/error-message.ts";
-import { processExists, stopProcess, stopProcessNow } from "../process.ts";
+import {
+  INHERIT_STDIO,
+  processExists,
+  stopProcess,
+  stopProcessNow,
+} from "../process.ts";
 import { projectRoot } from "../project-root.ts";
 import {
   envWith,
@@ -206,9 +211,7 @@ export const runMutationInSnapshot: MutationCommandRunner = async (
         args: childArgs(root, record.workRoot, args),
         cwd: record.workRoot,
         env: childEnv(id, record.root, record.workRoot),
-        stderr: "inherit",
-        stdin: "inherit",
-        stdout: "inherit",
+        ...INHERIT_STDIO,
       }).spawn();
       child = spawned;
       record = markRunning(record, spawned.pid);

--- a/scripts/precommit/git.ts
+++ b/scripts/precommit/git.ts
@@ -1,3 +1,5 @@
+import { INHERIT_STDIO } from "../process.ts";
+
 export interface CommandResult {
   code: number;
   stderr: string;
@@ -49,11 +51,7 @@ export const runCommand: RunCommand = async (cmd, options = {}) => {
 
 /** Run a command wired to the parent's stdio (for interactive steps). */
 export const runInteractiveCommand: RunCommand = async (cmd) => {
-  const status = await buildCommand(cmd, {
-    stderr: "inherit",
-    stdin: "inherit",
-    stdout: "inherit",
-  }).spawn().status;
+  const status = await buildCommand(cmd, { ...INHERIT_STDIO }).spawn().status;
 
   return {
     code: status.code,
@@ -79,6 +77,14 @@ export const commandValue = async (
   const value = result.stdout.trim();
   return value || undefined;
 };
+
+/** The commit a ref resolves to, verified to exist — or undefined when it
+ *  doesn't (an unfetched `origin/main`, a missing `HEAD`). */
+export const verifyRef = (
+  run: RunCommand,
+  ref: string,
+): Promise<string | undefined> =>
+  commandValue(run, ["rev-parse", "--verify", ref]);
 
 /** True when `run` executes inside a git work tree. */
 export const isInsideWorkTree = async (run: RunCommand): Promise<boolean> =>

--- a/scripts/precommit/merge-warning.ts
+++ b/scripts/precommit/merge-warning.ts
@@ -2,6 +2,7 @@ import {
   commandValue,
   type RunCommand,
   runGit,
+  verifyRef,
   withinWorkTree,
 } from "./git.ts";
 
@@ -26,12 +27,8 @@ export const getMergeConflictWarning = (
 ): Promise<string | undefined> =>
   withinWorkTree(run, async () => {
     const originUrl = await getOriginUrl(run);
-    const head = await commandValue(run, ["rev-parse", "--verify", "HEAD"]);
-    const originMain = await commandValue(run, [
-      "rev-parse",
-      "--verify",
-      "origin/main",
-    ]);
+    const head = await verifyRef(run, "HEAD");
+    const originMain = await verifyRef(run, "origin/main");
     const mergeBase = await commandValue(run, [
       "merge-base",
       "HEAD",

--- a/scripts/precommit/push.ts
+++ b/scripts/precommit/push.ts
@@ -2,6 +2,7 @@ import {
   commandValue,
   type RunCommand,
   runGit,
+  verifyRef,
   withinWorkTree,
 } from "./git.ts";
 import { getOriginUrl } from "./merge-warning.ts";
@@ -43,11 +44,7 @@ const getUnpushedCommitCount = async (
     return commandNumber(run, ["rev-list", "--count", `${upstream}..HEAD`]);
   }
 
-  const originMain = await commandValue(run, [
-    "rev-parse",
-    "--verify",
-    "origin/main",
-  ]);
+  const originMain = await verifyRef(run, "origin/main");
   if (originMain) {
     return commandNumber(run, ["rev-list", "--count", "origin/main..HEAD"]);
   }

--- a/scripts/process.ts
+++ b/scripts/process.ts
@@ -1,5 +1,13 @@
 import nodeProcess from "node:process";
 
+/** Wire a child process's three stdio streams straight to the parent's — for
+ *  interactive or inherited runs where the child shares the same terminal. */
+export const INHERIT_STDIO = {
+  stderr: "inherit",
+  stdin: "inherit",
+  stdout: "inherit",
+} as const;
+
 const beforeTimeout = async (
   status: Promise<unknown>,
   timeoutMs: number,

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -190,8 +190,10 @@ const removeStaleInstallLock = async (
     await Deno.remove(lockPath);
     return true;
   } catch (error) {
-    if (error instanceof Deno.errors.NotFound) return true;
-    throw error;
+    // NotFound: another runner already cleared the stale lock — it's gone
+    // either way, which is exactly what this returns true for.
+    rethrowUnlessNotFound(error);
+    return true;
   }
 };
 


### PR DESCRIPTION
## What changed

Three small repeats in the build and test scripts now go through one shared helper each:

- **Removing a path that might not be there** — both the coverage-output cleanup and the stripe-mock stale-lock cleanup route their "delete it; 'already gone' is fine; anything else is a real error" catch through the existing `rethrowUnlessNotFound` helper. (The stripe-mock one already imported that helper but hand-wrote the check anyway — now it uses it.)
- **Wiring a child process to the terminal** — `INHERIT_STDIO` in `process.ts` holds the "send the child's input/output/errors to the parent's" option triple. The interactive git command and the mutation-run child spawn both use it instead of repeating the three lines.
- **Checking a git ref exists** — `verifyRef(run, ref)` resolves a git ref and confirms it's really there. The unpushed-commit count and the merge-conflict warning both use it instead of writing out the same `rev-parse --verify` call.

## Why

The copy-paste detector flags these as its sensitivity is lowered a step at a time. Each is a real merge: the same step written once, so a change to how a script deletes a path, wires a child's output, or checks a ref happens in a single place.

## Notes

- Behaviour is unchanged — these are the same steps, just shared.
- Full precommit passes.
- The remaining flagged pairs in `scripts/` are coincidental — small sibling functions that happen to share a signature or a common idiom (an entry-point `main`, two record-updaters) rather than real shared logic. Those need a deeper unification and are left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-commit checks for missing or unavailable Git references, preserving expected fallback behavior.
  * Improved handling of temporary coverage and installation files when they have already been removed.
  * Unexpected errors during cleanup are now reported instead of being silently ignored.
* **Developer Experience**
  * Interactive command output is handled more consistently across automated development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->