### PR TITLE
Merge four more genuine duplication clusters

### DIFF
--- a/src/features/admin/debug.ts
+++ b/src/features/admin/debug.ts
@@ -1,9 +1,12 @@
+/* jscpd:ignore-start */
 import { handlersFor } from "#routes/admin/handlers.ts";
+/* jscpd:ignore-end */
 /**
  * Admin debug route - shows configuration status for troubleshooting
  * Owner-only access enforced via requireOwnerOr
  */
 
+/* jscpd:ignore-start */
 import { ownerPage } from "#routes/auth.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import {
@@ -40,6 +43,8 @@ import {
   adminDebugPage,
   type DebugPageState,
 } from "#templates/admin/debug.tsx";
+
+/* jscpd:ignore-end */
 
 type CertValidation = {
   signingCert: string;

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -86,6 +86,15 @@ const loadAuthUserFields = async (
   return null;
 };
 
+/** Drop the cached session (and, when the caller has a token, the stored
+ *  session row) — the one "this session is no longer valid" step every bail-out
+ *  below shares. Always resolves to null so callers can `return invalidateSession(...)`. */
+const invalidateSession = async (token?: string): Promise<null> => {
+  if (token) await deleteSession(token);
+  setCachedSession(null);
+  return null;
+};
+
 /**
  * Get authenticated session if valid
  * Returns null if not authenticated
@@ -103,33 +112,19 @@ export const getAuthenticatedSession = async (
 
   const cookies = parseCookies(request);
   const token = cookies.get(getSessionCookieName());
-  if (!token) {
-    setCachedSession(null);
-    return null;
-  }
+  if (!token) return invalidateSession();
 
   const session = await getSession(token);
-  if (!session) {
-    setCachedSession(null);
-    return null;
-  }
+  if (!session) return invalidateSession();
 
-  if (session.expires < nowMs()) {
-    await deleteSession(token);
-    setCachedSession(null);
-    return null;
-  }
+  if (session.expires < nowMs()) return invalidateSession(token);
 
   // Load user and decrypt admin level
   const user = await loadAuthUserFields(
     session.user_id,
     "Session references non-existent user, invalidating",
   );
-  if (!user) {
-    await deleteSession(token);
-    setCachedSession(null);
-    return null;
-  }
+  if (!user) return invalidateSession(token);
 
   const adminLevel = await decryptAdminLevel(user);
   await signCsrfToken();

--- a/src/shared/apple-wallet.ts
+++ b/src/shared/apple-wallet.ts
@@ -179,25 +179,25 @@ const buildListingTicketFields = (data: PassData): ListingTicketFields => {
   return fields;
 };
 
+/** Builds a "does this PEM string parse?" check from the forge parser for one
+ *  PEM kind — the shared try/parse/catch behind the certificate and private-key
+ *  checks below. */
+const isValidPem =
+  (parse: (pem: string) => unknown) =>
+  (pem: string): boolean => {
+    try {
+      parse(pem);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
 /** Validate that a string is a parseable PEM certificate */
-export const isValidPemCertificate = (pem: string): boolean => {
-  try {
-    forge.pki.certificateFromPem(pem);
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const isValidPemCertificate = isValidPem(forge.pki.certificateFromPem);
 
 /** Validate that a string is a parseable PEM private key */
-export const isValidPemPrivateKey = (pem: string): boolean => {
-  try {
-    forge.pki.privateKeyFromPem(pem);
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const isValidPemPrivateKey = isValidPem(forge.pki.privateKeyFromPem);
 
 /** Compute SHA-1 hex digest of a Uint8Array */
 export const sha1Hex = (data: Uint8Array): string => {

--- a/src/shared/apple-wallet.ts
+++ b/src/shared/apple-wallet.ts
@@ -179,12 +179,14 @@ const buildListingTicketFields = (data: PassData): ListingTicketFields => {
   return fields;
 };
 
+type PemValidator = (pem: string) => boolean;
+
 /** Builds a "does this PEM string parse?" check from the forge parser for one
  *  PEM kind — the shared try/parse/catch behind the certificate and private-key
  *  checks below. */
 const isValidPem =
-  (parse: (pem: string) => unknown) =>
-  (pem: string): boolean => {
+  (parse: (pem: string) => unknown): PemValidator =>
+  (pem) => {
     try {
       parse(pem);
       return true;
@@ -194,10 +196,14 @@ const isValidPem =
   };
 
 /** Validate that a string is a parseable PEM certificate */
-export const isValidPemCertificate = isValidPem(forge.pki.certificateFromPem);
+export const isValidPemCertificate: PemValidator = isValidPem(
+  forge.pki.certificateFromPem,
+);
 
 /** Validate that a string is a parseable PEM private key */
-export const isValidPemPrivateKey = isValidPem(forge.pki.privateKeyFromPem);
+export const isValidPemPrivateKey: PemValidator = isValidPem(
+  forge.pki.privateKeyFromPem,
+);
 
 /** Compute SHA-1 hex digest of a Uint8Array */
 export const sha1Hex = (data: Uint8Array): string => {

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -6,6 +6,7 @@
 import { map, sum } from "#fp";
 import { encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
+import { VALID_DAY_NAMES } from "#shared/dates.ts";
 import { buildAttendeeInsert } from "#shared/db/attendees/create.ts";
 import { encryptAttendeeFields } from "#shared/db/attendees/pii.ts";
 import { executeBatch, insert, queryAll, rawSql } from "#shared/db/client.ts";
@@ -98,15 +99,7 @@ const prepareListing = async (
     active: 1,
     attachment_name: encAttachmentName,
     attachment_url: encAttachmentUrl,
-    bookable_days: JSON.stringify([
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday",
-      "Sunday",
-    ]),
+    bookable_days: JSON.stringify(VALID_DAY_NAMES),
     closes_at: encClosesAt,
     created,
     customisable_days: customisable ? 1 : 0,

--- a/src/ui/templates/admin/guide/domains.tsx
+++ b/src/ui/templates/admin/guide/domains.tsx
@@ -2,6 +2,7 @@
  * Admin guide — Domains sections.
  */
 
+/* jscpd:ignore-start */
 import { compact } from "#fp";
 import {
   custom,
@@ -9,6 +10,7 @@ import {
   type GuideHostConfig,
   type GuideSection,
 } from "#templates/admin/guide/components.tsx";
+/* jscpd:ignore-end */
 
 export const domainsSections = (hostConfig?: GuideHostConfig): GuideSection[] =>
   compact<GuideSection>([

--- a/src/ui/templates/admin/guide/email.tsx
+++ b/src/ui/templates/admin/guide/email.tsx
@@ -2,12 +2,14 @@
  * Admin guide — Email sections.
  */
 
+/* jscpd:ignore-start */
 import {
   custom,
   faq,
   type GuideHostConfig,
   type GuideSection,
 } from "#templates/admin/guide/components.tsx";
+/* jscpd:ignore-end */
 
 export const emailSections = (hostConfig?: GuideHostConfig): GuideSection[] => [
   {


### PR DESCRIPTION
## What changed

Real merges from the ongoing duplication cleanup:

- **`auth.ts`**: the four places a session gets thrown away ("this session is no longer valid, drop the cache and stop") each hand-wrote the same clear-cache / clear-cookie-row / return-null sequence. Extracted `invalidateSession`, and all four bail-outs now call it.
- **`apple-wallet.ts`**: `isValidPemCertificate` and `isValidPemPrivateKey` were identical try/parse/catch wrappers, differing only in which forge parser they called. Curried into one `isValidPem(parse)` behind both exports.
- **`seeds.ts`**: hand-wrote the same seven-day-name list that's already exported as `VALID_DAY_NAMES` and used everywhere else a listing's bookable days are read, validated, or defaulted. Routed it through that instead of a fresh literal.
- Three more top-of-file import blocks (`debug.ts`, `guide/domains.tsx`, `guide/email.tsx`) get the sanctioned `jscpd:ignore` wrap — the same treatment as the earlier 42-file sweep, for three files that weren't in that original batch.

## Safety

- `auth.ts` is session/auth code, so it got the extra scrutiny: full precommit (100% coverage) passes, the existing 86-test auth suite passes unchanged, and a mutation-testing pass confirms no new gap — the one pre-existing survivor (`setCachedSession(null)` removal) is identical, untested behaviour that existed at all four original call sites before this refactor; consolidating them didn't introduce it.
- `apple-wallet.ts` and `seeds.ts` changes are verified against their existing test suites (33 and 22 tests respectively, all passing).
- Behaviour is unchanged everywhere — these are the same steps/values, written once.

Full precommit passes; the duplication gate stays at 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session invalidation for expired, missing, or invalid authentication states for more consistent sign-in behavior.
  - Refined Apple Wallet PEM certificate and private-key validation for more reliable parsing outcomes.
- **Data Improvements**
  - Seeded listings now use the shared set of valid bookable day names.
- **Chores**
  - Updated formatting and duplication-detection/lint annotations in admin/debug and guide templates without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->