### PR TITLE
Merge three more duplication clusters

### DIFF
--- a/src/features/admin/attendee-page-data.ts
+++ b/src/features/admin/attendee-page-data.ts
@@ -28,8 +28,7 @@ import { getAttendeeOrderSummary } from "#shared/db/attendees/balance.ts";
 import { checkLinesCapacity } from "#shared/db/attendees/capacity.ts";
 import { hasActiveBookingLine } from "#shared/db/attendees/queries.ts";
 import {
-  getContactRecord,
-  getRepairFallbackRecord,
+  getContactRecordOrRepair,
   hashEmail,
   hashPhone,
   toContactHashParam,
@@ -51,7 +50,6 @@ import {
   getAttendeeTextAnswers,
   loadAttendeeQuestionData,
 } from "#shared/db/questions/attendee-answers/reads.ts";
-import { ErrorCode, logError } from "#shared/logger.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { Attendee, ListingWithCount } from "#shared/types.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
@@ -588,7 +586,13 @@ export const EMPTY_CONTACT_RECORDS: ContactRecordsByChannel = {
 };
 
 /** Load and decrypt one channel's contact record (null when no value on file).
- * Notes are owner-encrypted, so this needs the session private key. */
+ * Notes are owner-encrypted, so this needs the session private key. A corrupt/
+ * undecryptable stats_blob for one contact must not take down the whole
+ * attendee page: `getContactRecordOrRepair` surfaces it for repair and keeps
+ * the channel with its surviving counts and (crucially) its /admin/history
+ * link, so the operator can still open the editor and overwrite the bad row —
+ * dropping the channel here would hide the only path to fix it. */
+const loadChannelRecordOrRepair = getContactRecordOrRepair("contact history");
 const loadChannelRecord = async (
   value: string,
   hashOf: (value: string) => Promise<string>,
@@ -596,26 +600,10 @@ const loadChannelRecord = async (
 ): Promise<ContactChannelData | null> => {
   if (!value.trim()) return null;
   const hash = await hashOf(value);
-  try {
-    return {
-      hashParam: toContactHashParam(hash),
-      record: await getContactRecord(hash, privateKey),
-    };
-  } catch (error) {
-    // A corrupt/undecryptable stats_blob for one contact must not take down
-    // the whole attendee page. Surface it for repair and keep the channel
-    // with its surviving counts and (crucially) its /admin/history link, so the
-    // operator can still open the editor and overwrite the bad row — dropping
-    // the channel here would hide the only path to fix it.
-    logError({
-      code: ErrorCode.DECRYPT_FAILED,
-      detail: `contact history ${toContactHashParam(hash)}: ${error}`,
-    });
-    return {
-      hashParam: toContactHashParam(hash),
-      record: await getRepairFallbackRecord(hash),
-    };
-  }
+  return {
+    hashParam: toContactHashParam(hash),
+    record: await loadChannelRecordOrRepair(hash, privateKey),
+  };
 };
 
 /** Read the attendee's per-channel contact history for the read-only panel.

--- a/src/features/admin/contact-history.ts
+++ b/src/features/admin/contact-history.ts
@@ -17,37 +17,21 @@ import { htmlResponse, redirect } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import {
   type ContactRecord,
-  type ContactRecordLoader,
   fromContactHashParam,
-  getContactRecord,
-  getRepairFallbackRecord,
+  getContactRecordOrRepair,
   saveContactRecord,
-  toContactHashParam,
 } from "#shared/db/contact-preferences.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
-import { ErrorCode, logError } from "#shared/logger.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import { contactHistoryPage } from "#templates/admin/contact-history.tsx";
 
 /* jscpd:ignore-end */
 
-/** Load the record for the editor, tolerating a corrupt stats blob. This editor
- * is the repair path, so a decryption failure must not lock the operator out:
- * keep the plaintext counts (read separately) and blank the unreadable note, so
- * the rendered form lets a save overwrite the bad ciphertext without losing the
- * real booking history. */
-const loadForRepair: ContactRecordLoader = async (hash, privateKey) => {
-  try {
-    return await getContactRecord(hash, privateKey);
-  } catch (error) {
-    logError({
-      code: ErrorCode.DECRYPT_FAILED,
-      detail: `contact history editor ${toContactHashParam(hash)}: ${error}`,
-    });
-    return getRepairFallbackRecord(hash);
-  }
-};
+/** Load the record for the editor, tolerating a corrupt stats blob — this
+ * editor is the repair path, so a decryption failure must not lock the
+ * operator out. */
+const loadForRepair = getContactRecordOrRepair("contact history editor");
 
 /** Read one editable counter as a non-negative integer (blank/garbage → 0). */
 const nonNegativeInt = (form: FormParams, field: string): number =>

--- a/src/features/public/qr-book.ts
+++ b/src/features/public/qr-book.ts
@@ -21,7 +21,7 @@ import {
   listingChildren,
 } from "#shared/db/listing-parents.ts";
 import { getListingWithCountBySlug } from "#shared/db/listings/records.ts";
-import type { CheckoutIntent } from "#shared/payments.ts";
+import { type CheckoutIntent, checkoutItem } from "#shared/payments.ts";
 import { listingSupportsDirectCheckout } from "#shared/qr.ts";
 import { type QrBookPayload, verifyQrBookToken } from "#shared/qr-token.ts";
 import type { ListingWithCount } from "#shared/types.ts";
@@ -100,15 +100,7 @@ const buildCheckoutIntent = (
   address: "",
   date: capacityDateFor(listing.listing_type, payload.d),
   email: "",
-  items: [
-    {
-      listingId: listing.id,
-      name: listing.name,
-      quantity: payload.q,
-      slug: listing.slug,
-      unitPrice: payload.v,
-    },
-  ],
+  items: [checkoutItem(listing, payload.q, payload.v)],
   name: payload.n,
   phone: "",
   special_instructions: "",

--- a/src/shared/booking.ts
+++ b/src/shared/booking.ts
@@ -17,7 +17,7 @@ import {
 import type { LedgerPoster } from "#shared/db/attendees/create.ts";
 import { nowIso } from "#shared/now.ts";
 import { singleListingAnswerIds } from "#shared/payment-helpers.ts";
-import { getActivePaymentProvider } from "#shared/payments.ts";
+import { checkoutItem, getActivePaymentProvider } from "#shared/payments.ts";
 import type { Attendee, ContactInfo, ListingWithCount } from "#shared/types.ts";
 import { logAndNotifyRegistration } from "#shared/webhook.ts";
 
@@ -97,15 +97,7 @@ export const processBooking = async (
       {
         ...contact,
         date,
-        items: [
-          {
-            listingId: listing.id,
-            name: listing.name,
-            quantity,
-            slug: listing.slug,
-            unitPrice,
-          },
-        ],
+        items: [checkoutItem(listing, quantity, unitPrice)],
         listingAnswerIds: singleListingAnswerIds(listing.id, answerIds),
       },
       baseUrl,

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -61,6 +61,14 @@ const isLeapYear = (year: number): boolean =>
 const daysInMonth = (year: number, month: number): number =>
   month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month]!;
 
+/** Parse a date/timestamp string to epoch milliseconds, or null when it
+ *  doesn't parse — the safe wrapper around `Date.parse`, whose own failure
+ *  mode (`NaN`) is easy to let leak into arithmetic by accident. */
+export const parseDateMs = (value: string): number | null => {
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : ms;
+};
+
 /**
  * Add N months to an ISO timestamp, clamping to the last day of the target month.
  * e.g. 2026-01-31 + 1mo → 2026-02-28

--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -12,6 +12,7 @@
 
 import { unzipSync, zipSync } from "fflate";
 import { chunk, compact } from "#fp";
+import { parseDateMs } from "#shared/dates.ts";
 import { executeBatch, queryAll } from "#shared/db/client.ts";
 import { MIGRATION_IDS } from "#shared/db/migrations/registry.ts";
 import {
@@ -300,8 +301,7 @@ const BACKUP_LEAF = new RegExp(`^backup-${BACKUP_TIMESTAMP}\\.zip$`);
 export const parseBackupTime = (filename: string): number | null => {
   const m = filename.match(BACKUP_TIME_TAIL);
   if (!m) return null;
-  const ms = Date.parse(`${m[1]}T${m[2]}:${m[3]}:${m[4]}.${m[5]}Z`);
-  return Number.isNaN(ms) ? null : ms;
+  return parseDateMs(`${m[1]}T${m[2]}:${m[3]}:${m[4]}.${m[5]}Z`);
 };
 
 /** True when a bare leaf name is exactly "backup-{timestamp}.zip". Anchored, so

--- a/src/shared/db/contact-preferences.ts
+++ b/src/shared/db/contact-preferences.ts
@@ -24,6 +24,7 @@ import {
 } from "#shared/db/client.ts";
 import { queryColumnSet } from "#shared/db/query.ts";
 import { settings } from "#shared/db/settings.ts";
+import { ErrorCode, logError } from "#shared/logger.ts";
 import { nowIso, nowMs } from "#shared/now.ts";
 import { normalizePhone } from "#shared/phone.ts";
 import { guardFor } from "#shared/validation/guard.ts";
@@ -263,6 +264,26 @@ export const getRepairFallbackRecord = async (
   ...EMPTY_STATS,
   ...(await getContactCountFields(hash)),
 });
+
+/** {@link getContactRecord}, but a corrupt/undecryptable note must not take
+ *  down the caller: log it for repair and fall back to
+ *  {@link getRepairFallbackRecord} instead of throwing, so the real booking
+ *  counts and the record's repair link stay visible. `context` names the
+ *  caller in the logged detail (e.g. "contact history", "contact history
+ *  editor"). */
+export const getContactRecordOrRepair: (
+  context: string,
+) => ContactRecordLoader = (context) => async (hash, privateKey) => {
+  try {
+    return await getContactRecord(hash, privateKey);
+  } catch (error) {
+    logError({
+      code: ErrorCode.DECRYPT_FAILED,
+      detail: `${context} ${toContactHashParam(hash)}: ${error}`,
+    });
+    return getRepairFallbackRecord(hash);
+  }
+};
 
 export const getContactCounts = async (
   hashes: string[],

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -12,6 +12,7 @@ import type {
 } from "#shared/checkout-pricing.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
+import { parseDateMs } from "#shared/dates.ts";
 import type { ErrorCodeType, LogCategory } from "#shared/logger.ts";
 import { logDebug, logError } from "#shared/logger.ts";
 import { namedError } from "#shared/named-error.ts";
@@ -50,8 +51,8 @@ export const toCanonicalIso = (
   value: string | undefined,
 ): string | undefined => {
   if (value === undefined) return;
-  const ms = Date.parse(value);
-  return Number.isNaN(ms) ? undefined : new Date(ms).toISOString();
+  const ms = parseDateMs(value);
+  return ms === null ? undefined : new Date(ms).toISOString();
 };
 
 /** Shared shape for a provider credential check in connection-test results. */

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -38,6 +38,21 @@ export type CheckoutItem = {
   packageGroupId?: number | undefined;
 };
 
+/** Build a standalone-line {@link CheckoutItem} for one listing — the shared
+ * shape every single-listing checkout (direct-to-provider QR booking, the
+ * plain public booking form) builds its one-item `items` array from. */
+export const checkoutItem = (
+  listing: Pick<CheckoutItem, "name" | "slug"> & { id: number },
+  quantity: number,
+  unitPrice: number,
+): CheckoutItem => ({
+  listingId: listing.id,
+  name: listing.name,
+  quantity,
+  slug: listing.slug,
+  unitPrice,
+});
+
 /**
  * A modifier resolved for a specific checkout — the input the pricing pipeline
  * applies. Eligibility (scope, stock, codes) is decided upstream; by the time a

--- a/src/shared/site-assignment.ts
+++ b/src/shared/site-assignment.ts
@@ -10,7 +10,7 @@ import { builderApi, resolveHostingProvider } from "#shared/builder.ts";
 import { getEffectiveDomain } from "#shared/config.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import { generateSecureToken } from "#shared/crypto/utils.ts";
-import { addMonthsIso } from "#shared/dates.ts";
+import { addMonthsIso, parseDateMs } from "#shared/dates.ts";
 import {
   assignBuiltSite,
   type BuiltSite,
@@ -181,11 +181,7 @@ export const generateRenewalToken = async (): Promise<RenewalTokenData> => {
 /** Parse a site's stored read-only deadline as milliseconds, or null when empty/invalid. */
 export const parseReadOnlyFromMs = (
   site: Pick<BuiltSite, "readOnlyFrom">,
-): number | null => {
-  if (!site.readOnlyFrom) return null;
-  const ms = Date.parse(site.readOnlyFrom);
-  return Number.isNaN(ms) ? null : ms;
-};
+): number | null => (site.readOnlyFrom ? parseDateMs(site.readOnlyFrom) : null);
 
 /** Stack-forward base: max(now, existing deadline). Falls back to now when missing. */
 export const renewalDeadlineBaseMs = (


### PR DESCRIPTION
## What changed

Real merges from the ongoing duplication cleanup:

- **`parseDateMs`** (`dates.ts`): the "parse a date string to epoch milliseconds, or null when it doesn't parse" step was hand-written three times — a backup file's embedded timestamp, a site's stored read-only deadline, and a payment session's canonical-ISO normalization. All three now share one safe-parse helper instead of repeating `Date.parse` + a `Number.isNaN` check.
- **`getContactRecordOrRepair`** (`contact-preferences.ts`): the attendee page's per-channel contact panel and the `/admin/history` record editor both hand-wrote the same "load the record; if the note won't decrypt, log it and fall back to the repairable (counts-only) view" try/catch. Extracted the whole load-or-repair step into one loader both callers use.
- **`checkoutItem`** (`payments.ts`): a single-listing checkout — the QR direct-to-provider path and the plain public booking form — both built the same one-item `CheckoutItem` object by hand. One small builder now backs both.

## Safety

- `payments.ts` (carries the new `checkoutItem` builder) gets a mutation-testing pass: 21/21 mutants killed, 100%.
- Full precommit passes (100% coverage), including the existing qr-book and ticket-payment test suites (78 tests) run directly.
- The contact-record consolidation keeps the same behaviour for both callers — the attendee panel still returns its `{hashParam, record}` wrapper, the editor still returns the bare record — only the shared load-and-log-and-fall-back step moved to one place, at 100% coverage.
- Behaviour is unchanged everywhere — these are the same values/steps, written once.

Full precommit passes; the duplication gate stays at 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when contact-history records cannot be decrypted, allowing read-only views and editing workflows to continue with repair data.
  - Standardized date parsing to handle invalid timestamps safely across backups, payments, and site renewal deadlines.
  - Preserved consistent checkout item details across QR-book and paid-booking checkout flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->