### PR TITLE
Unify listing/modifier recalculate routes, collapse migration verify checks

### DIFF
--- a/src/features/admin/aggregate-recalculation.ts
+++ b/src/features/admin/aggregate-recalculation.ts
@@ -1,9 +1,15 @@
+/* jscpd:ignore-start */
+import { AUTH_FORM, requireSessionOr, withAuth } from "#routes/auth.ts";
 import { htmlResponse, redirect } from "#routes/response.ts";
+import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { Field } from "#shared/forms.tsx";
 import { type ValidationResult, validateForm } from "#shared/forms.tsx";
 import { RECALCULATE_FIELD_NAME } from "#shared/recalculate-fields.ts";
 import { failure } from "#shared/result.ts";
+import type { AdminSession } from "#shared/types.ts";
+
+/* jscpd:ignore-end */
 
 type AggregateParseResult<T> =
   | { input: T | null; ok: true }
@@ -79,3 +85,58 @@ export const createRecalculatePageRenderer =
       page(entity, await snapshot(entity), session, error, success),
       error ? 400 : 200,
     );
+
+/**
+ * Build the GET + POST route handlers for one entity's aggregate-recalculation
+ * page — identical for listings and modifiers: GET loads the entity and renders
+ * the page with the current flash; POST runs {@link runRecalculatePost} against
+ * it. Each caller supplies its own id-keyed loader (404 when the id is missing
+ * or unknown), field set, reset step, and the bits that vary by entity kind
+ * (the logged line, the success redirect).
+ */
+export const createRecalculateHandlers = <T, F extends string, ID>(config: {
+  withEntity: (
+    id: ID,
+  ) => (
+    handler: (entity: T) => Response | Promise<Response>,
+  ) => Promise<Response>;
+  render: (
+    entity: T,
+    session: AdminSession,
+    error?: string,
+    success?: string,
+  ) => Promise<Response>;
+  fields: readonly F[];
+  entityId: (entity: T) => number;
+  reset: (entityId: number, selected: F[]) => Promise<unknown>;
+  log: (entity: T) => Promise<unknown>;
+  successPath: (entity: T) => string;
+  successMessage: string;
+  chooseMessage: string;
+}): {
+  get: (request: Request, id: ID) => Promise<Response>;
+  post: (request: Request, id: ID) => Promise<Response>;
+} => ({
+  get: (request, id) =>
+    requireSessionOr(request, (session) =>
+      config.withEntity(id)((entity) => {
+        const flash = getFlash();
+        return config.render(entity, session, flash.error, flash.success);
+      }),
+    ),
+  post: (request, id) =>
+    withAuth(request, AUTH_FORM, (session, form) =>
+      config.withEntity(id)((entity) =>
+        runRecalculatePost({
+          fields: config.fields,
+          form,
+          log: () => config.log(entity),
+          renderChoose: () =>
+            config.render(entity, session, config.chooseMessage),
+          reset: (selected) => config.reset(config.entityId(entity), selected),
+          successMessage: config.successMessage,
+          successPath: config.successPath(entity),
+        }),
+      ),
+    ),
+});

--- a/src/features/admin/listings-recalculate.ts
+++ b/src/features/admin/listings-recalculate.ts
@@ -8,10 +8,9 @@
 /* jscpd:ignore-start */
 import { t } from "#i18n";
 import {
+  createRecalculateHandlers,
   createRecalculatePageRenderer,
-  runRecalculatePost,
 } from "#routes/admin/aggregate-recalculation.ts";
-import { AUTH_FORM, requireSessionOr, withAuth } from "#routes/auth.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import {
@@ -20,7 +19,6 @@ import {
   resetListingAggregateFields,
 } from "#shared/db/listings/aggregates.ts";
 import { getListingWithCount } from "#shared/db/listings/records.ts";
-import { getFlash } from "#shared/flash-context.ts";
 import { adminListingRecalculatePage } from "#templates/admin/listings/aggregates.tsx";
 import { withEntityFromParam } from "./entity-handlers.ts";
 
@@ -31,40 +29,26 @@ const renderListingRecalculatePage = createRecalculatePageRenderer(
   adminListingRecalculatePage,
 );
 
+const listingRecalculateHandlers = createRecalculateHandlers({
+  chooseMessage: t("listings_table.recalculate_choose"),
+  entityId: (listing) => listing.id,
+  fields: LISTING_AGGREGATE_FIELDS,
+  log: (listing) =>
+    logActivity(`Listing '${listing.name}' totals recalculated`, listing),
+  render: renderListingRecalculatePage,
+  reset: resetListingAggregateFields,
+  successMessage: t("listings_table.recalculate_success"),
+  successPath: (listing) => `/admin/listing/${listing.id}/edit`,
+  withEntity: (id: string | number | undefined) => (handler) =>
+    withEntityFromParam(id, getListingWithCount, handler),
+});
+
 export const handleListingRecalculateGet: TypedRouteHandler<
   "GET /admin/listings/recalculate/:listingId"
 > = (request, { listingId }) =>
-  requireSessionOr(request, (session) =>
-    withEntityFromParam(listingId, getListingWithCount, (listing) => {
-      const flash = getFlash();
-      return renderListingRecalculatePage(
-        listing,
-        session,
-        flash.error,
-        flash.success,
-      );
-    }),
-  );
+  listingRecalculateHandlers.get(request, listingId);
 
 export const handleListingRecalculatePost: TypedRouteHandler<
   "POST /admin/listings/recalculate/:listingId"
 > = (request, { listingId }) =>
-  withAuth(request, AUTH_FORM, (session, form) =>
-    withEntityFromParam(listingId, getListingWithCount, (listing) =>
-      runRecalculatePost({
-        fields: LISTING_AGGREGATE_FIELDS,
-        form,
-        log: () =>
-          logActivity(`Listing '${listing.name}' totals recalculated`, listing),
-        renderChoose: () =>
-          renderListingRecalculatePage(
-            listing,
-            session,
-            t("listings_table.recalculate_choose"),
-          ),
-        reset: (selected) => resetListingAggregateFields(listing.id, selected),
-        successMessage: t("listings_table.recalculate_success"),
-        successPath: `/admin/listing/${listing.id}/edit`,
-      }),
-    ),
-  );
+  listingRecalculateHandlers.post(request, listingId);

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -7,9 +7,9 @@ import { handlersFor } from "#routes/admin/handlers.ts";
 import { once } from "#fp";
 import { t } from "#i18n";
 import {
+  createRecalculateHandlers,
   createRecalculatePageRenderer,
   parseEditableAggregateForm,
-  runRecalculatePost,
 } from "#routes/admin/aggregate-recalculation.ts";
 import { loadAccountLedger } from "#routes/admin/ledger/statements.ts";
 import { createCrudHandlers } from "#routes/admin/owner-crud.ts";
@@ -55,7 +55,6 @@ import {
   updateModifierAggregateValues,
 } from "#shared/db/modifiers.ts";
 import { getAllQuestionsWithAnswers } from "#shared/db/questions/queries.ts";
-import { getFlash } from "#shared/flash-context.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import {
   type CalcKind,
@@ -449,44 +448,28 @@ const renderModifierRecalculatePage = createRecalculatePageRenderer(
   adminModifierRecalculatePage,
 );
 
+const modifierRecalculateHandlers = createRecalculateHandlers({
+  chooseMessage: t("modifiers.recalculate.choose"),
+  entityId: (modifier) => modifier.id,
+  fields: MODIFIER_AGGREGATE_FIELDS,
+  log: (modifier) =>
+    logActivity(`Modifier '${modifier.name}' totals recalculated`),
+  render: renderModifierRecalculatePage,
+  reset: resetModifierAggregateFields,
+  successMessage: t("modifiers.recalculate.success"),
+  successPath: (modifier) => `/admin/modifiers/${modifier.id}/edit`,
+  withEntity: withModifier,
+});
+
 const handleModifierRecalculateGet: TypedRouteHandler<
   "GET /admin/modifiers/recalculate/:modifierId"
 > = (request, { modifierId }) =>
-  requireSessionOr(request, (session) =>
-    withModifier(modifierId)((modifier) => {
-      const flash = getFlash();
-      return renderModifierRecalculatePage(
-        modifier,
-        session,
-        flash.error,
-        flash.success,
-      );
-    }),
-  );
+  modifierRecalculateHandlers.get(request, modifierId);
 
 const handleModifierRecalculatePost: TypedRouteHandler<
   "POST /admin/modifiers/recalculate/:modifierId"
 > = (request, { modifierId }) =>
-  withAuth(request, AUTH_FORM, (session, form) =>
-    withModifier(modifierId)((modifier) =>
-      runRecalculatePost({
-        fields: MODIFIER_AGGREGATE_FIELDS,
-        form,
-        log: () =>
-          logActivity(`Modifier '${modifier.name}' totals recalculated`),
-        renderChoose: () =>
-          renderModifierRecalculatePage(
-            modifier,
-            session,
-            t("modifiers.recalculate.choose"),
-          ),
-        reset: (selected) =>
-          resetModifierAggregateFields(modifier.id, selected),
-        successMessage: t("modifiers.recalculate.success"),
-        successPath: `/admin/modifiers/${modifier.id}/edit`,
-      }),
-    ),
-  );
+  modifierRecalculateHandlers.post(request, modifierId);
 
 /** Selected ids from a checkbox group, positive integers only. */
 const selectedIds = (form: FormParams, field: string): number[] =>

--- a/src/shared/db/migrations/verify.ts
+++ b/src/shared/db/migrations/verify.ts
@@ -35,16 +35,17 @@ const assertMembership =
     expected: "present" | "absent",
   ) =>
   (live: LiveSchema, names: readonly string[] | undefined): void => {
-    for (const name of names ?? []) {
+    const violates = (name: string): boolean => {
       const isPresent = liveSet(live).has(name);
-      if (expected === "present" ? !isPresent : isPresent) {
-        throw new Error(
-          expected === "present"
-            ? `Migration verification failed: missing ${noun} ${name}`
-            : `Migration verification failed: legacy ${noun} ${name} still present`,
-        );
-      }
-    }
+      return expected === "present" ? !isPresent : isPresent;
+    };
+    const failing = (names ?? []).find(violates);
+    if (failing === undefined) return;
+    throw new Error(
+      expected === "present"
+        ? `Migration verification failed: missing ${noun} ${failing}`
+        : `Migration verification failed: legacy ${noun} ${failing} still present`,
+    );
   };
 
 const assertRequiredIndexes = assertMembership(

--- a/src/shared/db/migrations/verify.ts
+++ b/src/shared/db/migrations/verify.ts
@@ -24,39 +24,44 @@ const assertRequiredTables = (
   }
 };
 
-const assertRequiredIndexes = (
-  live: LiveSchema,
-  req: SchemaRequirement,
-): void => {
-  for (const index of req.indexes ?? []) {
-    if (!live.indexes.has(index)) {
-      throw new Error(`Migration verification failed: missing index ${index}`);
+/** Build a check that every named object in a live set matches `expected`:
+ *  "present" throws "missing <noun> <name>" for the first one absent;
+ *  "absent" throws "legacy <noun> <name> still present" for the first
+ *  survivor a migration was supposed to have dropped. */
+const assertMembership =
+  (
+    liveSet: (live: LiveSchema) => { has(name: string): boolean },
+    noun: string,
+    expected: "present" | "absent",
+  ) =>
+  (live: LiveSchema, names: readonly string[] | undefined): void => {
+    for (const name of names ?? []) {
+      const isPresent = liveSet(live).has(name);
+      if (expected === "present" ? !isPresent : isPresent) {
+        throw new Error(
+          expected === "present"
+            ? `Migration verification failed: missing ${noun} ${name}`
+            : `Migration verification failed: legacy ${noun} ${name} still present`,
+        );
+      }
     }
-  }
-};
+  };
 
-const assertRequiredTriggers = (
-  live: LiveSchema,
-  req: SchemaRequirement,
-): void => {
-  for (const trigger of req.triggers ?? []) {
-    if (!live.triggers.has(trigger)) {
-      throw new Error(
-        `Migration verification failed: missing trigger ${trigger}`,
-      );
-    }
-  }
-};
-
-const assertAbsentTables = (live: LiveSchema, req: SchemaRequirement): void => {
-  for (const name of req.absentTables ?? []) {
-    if (live.tables.has(name)) {
-      throw new Error(
-        `Migration verification failed: legacy table ${name} still present`,
-      );
-    }
-  }
-};
+const assertRequiredIndexes = assertMembership(
+  (live) => live.indexes,
+  "index",
+  "present",
+);
+const assertRequiredTriggers = assertMembership(
+  (live) => live.triggers,
+  "trigger",
+  "present",
+);
+const assertAbsentTables = assertMembership(
+  (live) => live.tables,
+  "table",
+  "absent",
+);
 
 /**
  * Build a verify() that checks only the objects a migration owns, from a single
@@ -66,9 +71,9 @@ export const verifyRequirement =
   (req: SchemaRequirement) => async (): Promise<void> => {
     const live = await snapshotLiveSchema();
     assertRequiredTables(live, req);
-    assertRequiredIndexes(live, req);
-    assertRequiredTriggers(live, req);
-    assertAbsentTables(live, req);
+    assertRequiredIndexes(live, req.indexes);
+    assertRequiredTriggers(live, req.triggers);
+    assertAbsentTables(live, req.absentTables);
   };
 
 /** Build a migration whose verify() is derived from the objects it owns. */


### PR DESCRIPTION
## What changed

Two more genuine merges from the ongoing duplication cleanup:

- **`createRecalculateHandlers`** (`aggregate-recalculation.ts`): the listings and modifiers "recalculate totals" admin routes hand-wrote the exact same GET (load the entity, render with the current flash) and POST (run the shared recalculate-and-redirect flow) handlers. Both now build their pair from one small config object — a loader, the allowed fields, the reset step, the log line, and the success redirect — passed to a new factory alongside the existing `createRecalculatePageRenderer`.
- **`assertMembership`** (`shared/db/migrations/verify.ts`): three near-identical "for each named object a migration requires/drops, check it against the live schema snapshot and throw a specific message" loops (required indexes, required triggers, absent tables) collapsed into one curried check taking a `"present" | "absent"` direction.

## Notes

- Building the recalculate-handler factory introduced a fresh import-block match against `owner-crud.ts` (caught by the live duplication gate, not just the lower exploratory threshold) — wrapped in the sanctioned `jscpd:ignore` marker, same as every other import block in the codebase.
- Collapsing `verify.ts`'s two near-identical helpers (`assertPresent`/`assertAbsent`) into one is itself a case of "the merge surfaces the next merge" — the first pass left them duplicating each other, caught immediately by a recount.

## Safety

- Full precommit passes (100% coverage).
- The listings/modifiers recalculate route tests (39 tests covering GET/POST, the "choose a field" empty-selection case, activity logging, and 404s) pass unchanged.
- Behaviour is unchanged everywhere — same steps, same messages, written once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined admin aggregate recalculation workflows for listings and modifiers using shared request handlers.
  * Centralized authentication, entity loading, messaging/flash handling, logging, reset behavior, and success redirects across recalculation pages.
  * Improved migration verification by introducing a reusable membership assertion to better distinguish missing versus legacy live-set objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->