### PR TITLE
Reuse VALID_DAY_NAMES and curry small duplicated checks

### DIFF
--- a/src/features/admin/catalog-transfer/schema.ts
+++ b/src/features/admin/catalog-transfer/schema.ts
@@ -18,7 +18,7 @@
  */
 
 import * as v from "valibot";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   isContactField,
   ListingTypeSchema,

--- a/src/features/admin/catalog-transfer/schema.ts
+++ b/src/features/admin/catalog-transfer/schema.ts
@@ -18,6 +18,7 @@
  */
 
 import * as v from "valibot";
+import { VALID_DAY_NAMES } from "#shared/dates.ts";
 import {
   isContactField,
   ListingTypeSchema,
@@ -119,15 +120,7 @@ const FieldsSchema = v.pipe(
 );
 /** A bookable weekday name — validated so a typo ("Funday") is a field error
  * rather than a day that never matches an availability check. */
-const BookableDaySchema = v.picklist([
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-  "Sunday",
-]);
+const BookableDaySchema = v.picklist(VALID_DAY_NAMES);
 /** A minor-unit price — a non-negative integer. */
 const PriceSchema = intAtLeast(0);
 /** A required, trimmed, non-empty name reference. */

--- a/src/features/admin/settings-listing-defaults.ts
+++ b/src/features/admin/settings-listing-defaults.ts
@@ -11,7 +11,7 @@ import { t } from "#i18n";
 import { settingsHandler } from "#routes/admin/settings-helpers.ts";
 import { ownerPage } from "#routes/auth.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { invalidateListingsCache } from "#shared/db/listings/records.ts";
 import { settings } from "#shared/db/settings.ts";
 import { isDemoMode } from "#shared/demo/mode.ts";

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -95,6 +95,14 @@ const loadAuthUserFields = async (
  * Validates that wrapped_data_key can be unwrapped with current DB_ENCRYPTION_KEY.
  * If unwrapping fails (e.g., after key rotation), the session is invalidated.
  */
+/** Drop a session's stored row and its request-scoped cache, then answer
+ * "not authenticated" — used everywhere a session token turns out unusable. */
+const invalidateSession = async (token: string): Promise<null> => {
+  await deleteSession(token);
+  setCachedSession(null);
+  return null;
+};
+
 export const getAuthenticatedSession = async (
   request: Request,
 ): Promise<AuthSession | null> => {
@@ -115,9 +123,7 @@ export const getAuthenticatedSession = async (
   }
 
   if (session.expires < nowMs()) {
-    await deleteSession(token);
-    setCachedSession(null);
-    return null;
+    return invalidateSession(token);
   }
 
   // Load user and decrypt admin level
@@ -126,9 +132,7 @@ export const getAuthenticatedSession = async (
     "Session references non-existent user, invalidating",
   );
   if (!user) {
-    await deleteSession(token);
-    setCachedSession(null);
-    return null;
+    return invalidateSession(token);
   }
 
   const adminLevel = await decryptAdminLevel(user);

--- a/src/shared/apple-wallet.ts
+++ b/src/shared/apple-wallet.ts
@@ -179,11 +179,14 @@ const buildListingTicketFields = (data: PassData): ListingTicketFields => {
   return fields;
 };
 
+/** Checks whether a string is a parseable PEM value. */
+type PemValidator = (pem: string) => boolean;
+
 /** Build a check for whether a string is a parseable PEM value — true when
  * `parse` reads it without throwing. */
 const isValidPem =
-  (parse: (pem: string) => unknown) =>
-  (pem: string): boolean => {
+  (parse: (pem: string) => unknown): PemValidator =>
+  (pem) => {
     try {
       parse(pem);
       return true;
@@ -193,10 +196,14 @@ const isValidPem =
   };
 
 /** Validate that a string is a parseable PEM certificate */
-export const isValidPemCertificate = isValidPem(forge.pki.certificateFromPem);
+export const isValidPemCertificate: PemValidator = isValidPem(
+  forge.pki.certificateFromPem,
+);
 
 /** Validate that a string is a parseable PEM private key */
-export const isValidPemPrivateKey = isValidPem(forge.pki.privateKeyFromPem);
+export const isValidPemPrivateKey: PemValidator = isValidPem(
+  forge.pki.privateKeyFromPem,
+);
 
 /** Compute SHA-1 hex digest of a Uint8Array */
 export const sha1Hex = (data: Uint8Array): string => {

--- a/src/shared/apple-wallet.ts
+++ b/src/shared/apple-wallet.ts
@@ -179,25 +179,24 @@ const buildListingTicketFields = (data: PassData): ListingTicketFields => {
   return fields;
 };
 
+/** Build a check for whether a string is a parseable PEM value — true when
+ * `parse` reads it without throwing. */
+const isValidPem =
+  (parse: (pem: string) => unknown) =>
+  (pem: string): boolean => {
+    try {
+      parse(pem);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
 /** Validate that a string is a parseable PEM certificate */
-export const isValidPemCertificate = (pem: string): boolean => {
-  try {
-    forge.pki.certificateFromPem(pem);
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const isValidPemCertificate = isValidPem(forge.pki.certificateFromPem);
 
 /** Validate that a string is a parseable PEM private key */
-export const isValidPemPrivateKey = (pem: string): boolean => {
-  try {
-    forge.pki.privateKeyFromPem(pem);
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const isValidPemPrivateKey = isValidPem(forge.pki.privateKeyFromPem);
 
 /** Compute SHA-1 hex digest of a Uint8Array */
 export const sha1Hex = (data: Uint8Array): string => {

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -3,6 +3,7 @@
  */
 
 import { filter, once } from "#fp";
+import { DAY_NAMES } from "#shared/day-names.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   formatDatetimeInTz,
@@ -16,23 +17,6 @@ import {
   type Listing,
   normalizeDurationDays,
 } from "#shared/types.ts";
-
-/** Day name lookup from Date.getUTCDay() index (Sunday=0) */
-export const DAY_NAMES = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-] as const;
-
-/** Valid day names for bookable_days (Monday-first for display) */
-export const VALID_DAY_NAMES: readonly string[] = [
-  ...DAY_NAMES.slice(1),
-  DAY_NAMES[0]!,
-];
 
 /** Month names for display */
 const MONTH_NAMES = [

--- a/src/shared/day-names.ts
+++ b/src/shared/day-names.ts
@@ -1,0 +1,22 @@
+/**
+ * Weekday name data — deliberately dependency-free so early-loaded, self-
+ * contained modules (like the catalog transfer schema) can read the day
+ * names without pulling in the timezone/settings-loading graph.
+ */
+
+/** Day name lookup from Date.getUTCDay() index (Sunday=0) */
+export const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/** Valid day names for bookable_days (Monday-first for display) */
+export const VALID_DAY_NAMES: readonly string[] = [
+  ...DAY_NAMES.slice(1),
+  DAY_NAMES[0]!,
+];

--- a/src/shared/day-names.ts
+++ b/src/shared/day-names.ts
@@ -16,7 +16,4 @@ export const DAY_NAMES = [
 ] as const;
 
 /** Valid day names for bookable_days (Monday-first for display) */
-export const VALID_DAY_NAMES: readonly string[] = [
-  ...DAY_NAMES.slice(1),
-  DAY_NAMES[0]!,
-];
+export const VALID_DAY_NAMES = [...DAY_NAMES.slice(1), DAY_NAMES[0]!];

--- a/src/shared/db/listings/table.ts
+++ b/src/shared/db/listings/table.ts
@@ -3,7 +3,7 @@
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   defineIdTable,
   encryptedNameSchema,

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -6,6 +6,7 @@
 import { map, sum } from "#fp";
 import { encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
+import { VALID_DAY_NAMES } from "#shared/dates.ts";
 import { buildAttendeeInsert } from "#shared/db/attendees/create.ts";
 import { encryptAttendeeFields } from "#shared/db/attendees/pii.ts";
 import { executeBatch, insert, queryAll, rawSql } from "#shared/db/client.ts";
@@ -98,15 +99,7 @@ const prepareListing = async (
     active: 1,
     attachment_name: encAttachmentName,
     attachment_url: encAttachmentUrl,
-    bookable_days: JSON.stringify([
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday",
-      "Sunday",
-    ]),
+    bookable_days: JSON.stringify(VALID_DAY_NAMES),
     closes_at: encClosesAt,
     created,
     customisable_days: customisable ? 1 : 0,

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -6,7 +6,7 @@
 import { map, sum } from "#fp";
 import { encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { buildAttendeeInsert } from "#shared/db/attendees/create.ts";
 import { encryptAttendeeFields } from "#shared/db/attendees/pii.ts";
 import { executeBatch, insert, queryAll, rawSql } from "#shared/db/client.ts";

--- a/src/ui/templates/admin/listing-defaults.tsx
+++ b/src/ui/templates/admin/listing-defaults.tsx
@@ -8,7 +8,7 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   listingDefaultInputName as inputName,
   LISTING_DEFAULT_FIELDS,

--- a/src/ui/templates/admin/listings/form-sections.tsx
+++ b/src/ui/templates/admin/listings/form-sections.tsx
@@ -2,7 +2,7 @@
 import { map, mapNotNullish, pipe } from "#fp";
 import { t } from "#i18n";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { settings } from "#shared/db/settings.ts";
 import { type Field, type FieldValues, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";

--- a/src/ui/templates/fields/listing.ts
+++ b/src/ui/templates/fields/listing.ts
@@ -5,7 +5,7 @@
 
 import { t } from "#i18n";
 import { formatCurrency, getDecimalPlaces } from "#shared/currency.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { settings } from "#shared/db/settings.ts";
 import type { Field } from "#shared/forms.tsx";
 import { formatBytes, MAX_ATTACHMENT_SIZE } from "#shared/limits.ts";

--- a/src/ui/templates/fields/validators.ts
+++ b/src/ui/templates/fields/validators.ts
@@ -10,7 +10,7 @@
 /* jscpd:ignore-start */
 import * as v from "valibot";
 import { t } from "#i18n";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { isUpdateTier } from "#shared/db/built-sites.ts";
 import type { Field } from "#shared/forms.tsx";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";

--- a/test/lib/booking-model-fixtures.ts
+++ b/test/lib/booking-model-fixtures.ts
@@ -2,7 +2,7 @@ import {
   buildTicketListing,
   type TicketListing,
 } from "#shared/booking/model.ts";
-import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/dates.ts";
+import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { testListingWithCount } from "#test-utils/factories.ts";

--- a/test/lib/server-parents-gate/helpers.ts
+++ b/test/lib/server-parents-gate/helpers.ts
@@ -12,7 +12,7 @@
 
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { DAY_NAMES } from "#shared/dates.ts";
+import { DAY_NAMES } from "#shared/day-names.ts";
 import { listingChildren } from "#shared/db/listing-parents.ts";
 import type { Listing } from "#shared/types.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";

--- a/test/lib/server-parents-gate/render-dates.test.ts
+++ b/test/lib/server-parents-gate/render-dates.test.ts
@@ -1,7 +1,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { DAY_NAMES } from "#shared/dates.ts";
+import { DAY_NAMES } from "#shared/day-names.ts";
 import { listingChildren } from "#shared/db/listing-parents.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";

--- a/test/shared/dates.test.ts
+++ b/test/shared/dates.test.ts
@@ -6,7 +6,6 @@ import {
   bookedRangeLabel,
   bookedSpanDays,
   calendarGridDates,
-  DAY_NAMES,
   daysAgo,
   formatDateLabel,
   formatDateRangeLabel,
@@ -23,9 +22,9 @@ import {
   normalizeDatetime,
   parseIsoDateParam,
   shiftMonth,
-  VALID_DAY_NAMES,
   widestDatedEntry,
 } from "#shared/dates.ts";
+import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import { testHoliday, testListing } from "#test-utils/factories.ts";
 import { testWithSetting, useSetting } from "#test-utils/settings.ts";

--- a/test/shared/dates/pinned-values.test.ts
+++ b/test/shared/dates/pinned-values.test.ts
@@ -13,13 +13,12 @@ import {
   bookedRangeLabel,
   bookedSpanDays,
   calendarGridDates,
-  DAY_NAMES,
   formatDateLabel,
   getBookableStartDates,
   startOfHour,
-  VALID_DAY_NAMES,
   widestDatedEntry,
 } from "#shared/dates.ts";
+import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { useSetting } from "#test-utils/settings.ts";
 

--- a/test/ui/templates/fields/validators.test.ts
+++ b/test/ui/templates/fields/validators.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   splitCsv,
   validateAddress,


### PR DESCRIPTION
Continues the jscpd duplication-reduction campaign (mt18 exploration, live gate stays at mt19/0%).

## What changed

- **`catalog-transfer/schema.ts`** and **`seeds.ts`** both hand-rolled the same `Monday`–`Sunday` array as a `bookable_days` default/validator instead of reusing the existing `VALID_DAY_NAMES` constant from `shared/dates.ts`.
- **`apple-wallet.ts`**'s `isValidPemCertificate` and `isValidPemPrivateKey` were identical try/catch wrappers that only differed in which `forge.pki` parse function they called. Curried into one `isValidPem(parse)` factory; both exports are now one-liners built from it.
- **`auth.ts`**'s `getAuthenticatedSession` repeated the same "delete the session row, clear the cached session, answer not-authenticated" three-line sequence in two places. Extracted it into `invalidateSession(token)`.

No behavior changes — same validation, same error messages, same auth flow.

## Test plan

- [x] `deno check` on all touched files
- [x] Targeted test files for auth sessions, Apple Wallet, catalog transfer, and seeds all pass
- [x] Full `deno task precommit` passes (lint, typecheck, 100% coverage, full suite)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized weekday names for listing booking availability, validation, admin defaults, and seeded data.
  * Improved reliability when removing unusable/expired user sessions.
  * Preserved accurate Apple Wallet PEM validation for certificates and private keys.

* **Refactor**
  * Centralized weekday name definitions and reused them across the app.
  * Reworked Apple Wallet PEM checks into shared, reusable validation logic.

* **Tests**
  * Updated tests/fixtures to use the centralized weekday name source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->