### PR TITLE
Merge four more genuine duplication clusters (mt18 batch)

### DIFF
--- a/src/shared/merge/attendee-merge.ts
+++ b/src/shared/merge/attendee-merge.ts
@@ -515,6 +515,11 @@ const takeSourceAnswer = (
   return { cleared: 0, kept: 0, taken: 1 };
 };
 
+/** The answer decision's "keep target, change nothing" outcome — reached
+ * either by an explicit "target"/default conflict choice or by there being no
+ * conflict to resolve at all. */
+const KEEP_TARGET_ANSWER = { cleared: 0, kept: 1, taken: 0 } as const;
+
 const applyAnswerDecision = (
   item: AttendeeMergeDiffAnswerItem,
   decision: AttendeeMergeDecisionInput,
@@ -532,7 +537,7 @@ const applyAnswerDecision = (
       return { cleared: 1, kept: 0, taken: 0 };
     }
     // "target" or default — keep target
-    return { cleared: 0, kept: 1, taken: 0 };
+    return KEEP_TARGET_ANSWER;
   }
   if (item.sourceAnswerId !== null && item.targetAnswerId === null) {
     // Source has answer, target doesn't — adopt source answer
@@ -540,7 +545,7 @@ const applyAnswerDecision = (
   }
   // Target has an answer (diff items require at least one side non-null and
   // the conflict/source-only branches are exhausted).
-  return { cleared: 0, kept: 1, taken: 0 };
+  return KEEP_TARGET_ANSWER;
 };
 
 /** Apply all answer decisions — returns final answer map and summary counts */

--- a/src/ui/templates/admin/debug.tsx
+++ b/src/ui/templates/admin/debug.tsx
@@ -177,6 +177,15 @@ const HeadedTable = ({
   </>
 );
 
+/** A `HeadedTable` whose body is one row per item, built by `renderRow`. */
+const rowsTable = <T,>(
+  headers: readonly Child[],
+  items: readonly T[],
+  renderRow: (item: T) => JSX.Element,
+): JSX.Element => (
+  <HeadedTable headers={headers}>{items.map(renderRow)}</HeadedTable>
+);
+
 /** The three config-source rows shared by both wallet sections. */
 const walletConfigRows = (w: {
   dbConfigured: boolean;
@@ -439,15 +448,15 @@ const LimitsSection = ({
     t("debug.section.limits"),
     t("debug.limits_hint"),
   )(
-    <HeadedTable
-      headers={[
+    rowsTable(
+      [
         t("debug.col.setting"),
         t("debug.col.env_var"),
         t("debug.col.default"),
         t("debug.col.current"),
-      ]}
-    >
-      {limits.map((l) => (
+      ],
+      limits,
+      (l) => (
         <tr>
           <td>{l.label}</td>
           <td>
@@ -458,9 +467,22 @@ const LimitsSection = ({
             <LimitValueCell limit={l} />
           </td>
         </tr>
-      ))}
-    </HeadedTable>,
+      ),
+    ),
   );
+
+/** Every pruned table, named as it appears in the schema, paired with the
+ * `DebugPageState["prune"]` field that carries its last-pruned time. */
+const PRUNE_ROWS: readonly [
+  table: string,
+  field: keyof DebugPageState["prune"],
+][] = [
+  ["processed_payments", "payments"],
+  ["sessions", "sessions"],
+  ["strings", "strings"],
+  ["login_attempts", "logins"],
+  ["address_cache", "addresses"],
+];
 
 const PruneSection = ({
   prune,
@@ -474,30 +496,16 @@ const PruneSection = ({
       requests; frequency controlled by <code>PRUNE_INTERVAL_HOURS</code>.
     </>,
   )(
-    <HeadedTable
-      headers={[t("debug.field.table"), t("debug.field.last_pruned_utc")]}
-    >
-      <tr>
-        <td>processed_payments</td>
-        <td>{prune.payments}</td>
-      </tr>
-      <tr>
-        <td>sessions</td>
-        <td>{prune.sessions}</td>
-      </tr>
-      <tr>
-        <td>strings</td>
-        <td>{prune.strings}</td>
-      </tr>
-      <tr>
-        <td>login_attempts</td>
-        <td>{prune.logins}</td>
-      </tr>
-      <tr>
-        <td>address_cache</td>
-        <td>{prune.addresses}</td>
-      </tr>
-    </HeadedTable>,
+    rowsTable(
+      [t("debug.field.table"), t("debug.field.last_pruned_utc")],
+      PRUNE_ROWS,
+      ([table, field]) => (
+        <tr>
+          <td>{table}</td>
+          <td>{prune[field]}</td>
+        </tr>
+      ),
+    ),
   );
 
 /**

--- a/src/ui/templates/admin/guide/operations.tsx
+++ b/src/ui/templates/admin/guide/operations.tsx
@@ -19,6 +19,13 @@ import {
   type GuideSection,
 } from "#templates/admin/guide/components.tsx";
 
+/** The "Default order: `<code>`" line a table-columns FAQ answer opens with. */
+const defaultOrderParagraph = (order: readonly string[]): JSX.Element => (
+  <p>
+    Default order: <code>{buildDefaultTemplate(order)}</code>
+  </p>
+);
+
 export const operationsSections = (): GuideSection[] => [
   {
     entries: [
@@ -132,20 +139,14 @@ export const operationsSections = (): GuideSection[] => [
       custom(
         "listing_table_columns",
         <>
-          <p>
-            Default order:{" "}
-            <code>{buildDefaultTemplate(LISTING_DEFAULT_ORDER)}</code>
-          </p>
+          {defaultOrderParagraph(LISTING_DEFAULT_ORDER)}
           <Raw html={columnReferenceTable(LISTING_TABLE_COLUMNS)} />
         </>,
       ),
       custom(
         "attendee_table_columns",
         <>
-          <p>
-            Default order:{" "}
-            <code>{buildDefaultTemplate(ATTENDEE_DEFAULT_ORDER)}</code>
-          </p>
+          {defaultOrderParagraph(ATTENDEE_DEFAULT_ORDER)}
           <p>
             Columns referencing absent data (e.g. <code>{"{{email}}"}</code>{" "}
             when no attendees have an email) are hidden automatically even when

--- a/src/ui/templates/admin/listings/capacity-rows.tsx
+++ b/src/ui/templates/admin/listings/capacity-rows.tsx
@@ -76,18 +76,28 @@ const AttendeeCountDisplay = (
   );
 };
 
+/** A capacity row's label: the row's own name plus the "(this date)" suffix
+ * daily listings add. */
+const capacityRowLabel = (
+  labelKey: string,
+  dailySuffix: string,
+): JSX.Element => (
+  <>
+    {t(labelKey)}
+    {dailySuffix}
+  </>
+);
+
 type AttendeesSummaryRowProps = Omit<ListingCapacityRowsProps, "groupContext">;
 
 export const AttendeesSummaryRow = (
   props: AttendeesSummaryRowProps,
 ): JSX.Element => (
   <LabelledRow
-    label={
-      <>
-        {t("listings_table.listing_attendees")}
-        {props.dailySuffix}
-      </>
-    }
+    label={capacityRowLabel(
+      "listings_table.listing_attendees",
+      props.dailySuffix,
+    )}
   >
     <AttendeeCountDisplay {...props} />
     {props.isDaily && !props.dateFilter && (
@@ -113,12 +123,7 @@ export const GroupAttendeesRow = ({
   dailySuffix: string;
 }): JSX.Element => (
   <LabelledRow
-    label={
-      <>
-        {t("listings_table.group_attendees")}
-        {dailySuffix}
-      </>
-    }
+    label={capacityRowLabel("listings_table.group_attendees", dailySuffix)}
   >
     <GroupCapacityMeter count={groupAttendeeCount} max={group.max_attendees} />{" "}
     <small>


### PR DESCRIPTION
Continues the jscpd duplication-reduction campaign (mt18 exploration, live gate stays at mt19/0%).

## What changed

- **`attendee-merge.ts`**: the answer-decision "keep target, change nothing" outcome (`{ cleared: 0, kept: 1, taken: 0 }`) was written out twice, reached from two different branches. Named it `KEEP_TARGET_ANSWER`.
- **`capacity-rows.tsx`**: `AttendeesSummaryRow` and `GroupAttendeesRow` each built the same "translated label text plus the daily-listing suffix" `LabelledRow` label, differing only in which translation key and which prop/variable they read. Extracted `capacityRowLabel`.
- **`guide/operations.tsx`**: two table-columns FAQ answers opened with the same "Default order: `<code>...</code>`" paragraph, differing only in which column-order constant they format. Extracted `defaultOrderParagraph`.
- **`debug.tsx`**: the five pruned-table rows were hand-written `<tr>` markup; turned into a small `PRUNE_ROWS` data table (schema over organic structure) rendered by a new `rowsTable` helper. That same helper now also backs `LimitsSection`, which was building the identical `HeadedTable`-plus-`.map` shape — this fixed a live mt19 gate hit introduced by the `PRUNE_ROWS` refactor itself (the two sections' closing `))} </HeadedTable>` boilerplate started matching once the prune rows collapsed to a `.map`).

No behavior changes — same rendered output, same values, written once.

## Test plan

- [x] `deno check` on all touched files
- [x] Targeted test files (attendee-merge decision/apply/diff/labels, admin debug page) pass
- [x] Full `deno task precommit` passes (lint, typecheck, 0% duplication at the live mt19 gate, 100% coverage, full suite)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the admin operations guide’s presentation of default column ordering.

* **Bug Fixes**
  * Preserved existing attendee answer decisions consistently during merge conflict handling.

* **Admin Interface**
  * Standardized debug table rendering while retaining existing limits and pruning information.
  * Improved consistency of capacity-related row labels in listing views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->