### PR TITLE
Reuse VALID_DAY_NAMES in the catalog-transfer schema, keep it dependency-free

### DIFF
--- a/src/features/admin/catalog-transfer/schema.ts
+++ b/src/features/admin/catalog-transfer/schema.ts
@@ -18,6 +18,7 @@
  */
 
 import * as v from "valibot";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   isContactField,
   ListingTypeSchema,
@@ -119,15 +120,7 @@ const FieldsSchema = v.pipe(
 );
 /** A bookable weekday name — validated so a typo ("Funday") is a field error
  * rather than a day that never matches an availability check. */
-const BookableDaySchema = v.picklist([
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-  "Sunday",
-]);
+const BookableDaySchema = v.picklist(VALID_DAY_NAMES);
 /** A minor-unit price — a non-negative integer. */
 const PriceSchema = intAtLeast(0);
 /** A required, trimmed, non-empty name reference. */

--- a/src/features/admin/settings-listing-defaults.ts
+++ b/src/features/admin/settings-listing-defaults.ts
@@ -11,7 +11,7 @@ import { t } from "#i18n";
 import { settingsHandler } from "#routes/admin/settings-helpers.ts";
 import { ownerPage } from "#routes/auth.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { invalidateListingsCache } from "#shared/db/listings/records.ts";
 import { settings } from "#shared/db/settings.ts";
 import { isDemoMode } from "#shared/demo/mode.ts";

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -3,6 +3,7 @@
  */
 
 import { filter, once } from "#fp";
+import { DAY_NAMES } from "#shared/day-names.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   formatDatetimeInTz,
@@ -16,23 +17,6 @@ import {
   type Listing,
   normalizeDurationDays,
 } from "#shared/types.ts";
-
-/** Day name lookup from Date.getUTCDay() index (Sunday=0) */
-export const DAY_NAMES = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-] as const;
-
-/** Valid day names for bookable_days (Monday-first for display) */
-export const VALID_DAY_NAMES: readonly string[] = [
-  ...DAY_NAMES.slice(1),
-  DAY_NAMES[0]!,
-];
 
 /** Month names for display */
 const MONTH_NAMES = [

--- a/src/shared/day-names.ts
+++ b/src/shared/day-names.ts
@@ -1,0 +1,19 @@
+/**
+ * Weekday name data — deliberately dependency-free so early-loaded, self-
+ * contained modules (like the catalog transfer schema) can read the day
+ * names without pulling in the timezone/settings-loading graph.
+ */
+
+/** Day name lookup from Date.getUTCDay() index (Sunday=0) */
+export const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/** Valid day names for bookable_days (Monday-first for display) */
+export const VALID_DAY_NAMES = [...DAY_NAMES.slice(1), DAY_NAMES[0]!];

--- a/src/shared/db/listings/table.ts
+++ b/src/shared/db/listings/table.ts
@@ -3,7 +3,7 @@
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   defineIdTable,
   encryptedNameSchema,

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -6,7 +6,7 @@
 import { map, sum } from "#fp";
 import { encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { buildAttendeeInsert } from "#shared/db/attendees/create.ts";
 import { encryptAttendeeFields } from "#shared/db/attendees/pii.ts";
 import { executeBatch, insert, queryAll, rawSql } from "#shared/db/client.ts";

--- a/src/ui/templates/admin/listing-defaults.tsx
+++ b/src/ui/templates/admin/listing-defaults.tsx
@@ -8,7 +8,7 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   listingDefaultInputName as inputName,
   LISTING_DEFAULT_FIELDS,

--- a/src/ui/templates/admin/listings/form-sections.tsx
+++ b/src/ui/templates/admin/listings/form-sections.tsx
@@ -2,7 +2,7 @@
 import { map, mapNotNullish, pipe } from "#fp";
 import { t } from "#i18n";
 import { isBuilderEnabled } from "#routes/admin/builder.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { settings } from "#shared/db/settings.ts";
 import { type Field, type FieldValues, renderFields } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";

--- a/src/ui/templates/fields/listing.ts
+++ b/src/ui/templates/fields/listing.ts
@@ -5,7 +5,7 @@
 
 import { t } from "#i18n";
 import { formatCurrency, getDecimalPlaces } from "#shared/currency.ts";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { settings } from "#shared/db/settings.ts";
 import type { Field } from "#shared/forms.tsx";
 import { formatBytes, MAX_ATTACHMENT_SIZE } from "#shared/limits.ts";

--- a/src/ui/templates/fields/validators.ts
+++ b/src/ui/templates/fields/validators.ts
@@ -10,7 +10,7 @@
 /* jscpd:ignore-start */
 import * as v from "valibot";
 import { t } from "#i18n";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { isUpdateTier } from "#shared/db/built-sites.ts";
 import type { Field } from "#shared/forms.tsx";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";

--- a/test/lib/booking-model-fixtures.ts
+++ b/test/lib/booking-model-fixtures.ts
@@ -2,7 +2,7 @@ import {
   buildTicketListing,
   type TicketListing,
 } from "#shared/booking/model.ts";
-import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/dates.ts";
+import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { testListingWithCount } from "#test-utils/factories.ts";

--- a/test/lib/server-parents-gate/helpers.ts
+++ b/test/lib/server-parents-gate/helpers.ts
@@ -12,7 +12,7 @@
 
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { DAY_NAMES } from "#shared/dates.ts";
+import { DAY_NAMES } from "#shared/day-names.ts";
 import { listingChildren } from "#shared/db/listing-parents.ts";
 import type { Listing } from "#shared/types.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";

--- a/test/lib/server-parents-gate/render-dates.test.ts
+++ b/test/lib/server-parents-gate/render-dates.test.ts
@@ -1,7 +1,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { DAY_NAMES } from "#shared/dates.ts";
+import { DAY_NAMES } from "#shared/day-names.ts";
 import { listingChildren } from "#shared/db/listing-parents.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";

--- a/test/shared/dates.test.ts
+++ b/test/shared/dates.test.ts
@@ -6,7 +6,6 @@ import {
   bookedRangeLabel,
   bookedSpanDays,
   calendarGridDates,
-  DAY_NAMES,
   daysAgo,
   formatDateLabel,
   formatDateRangeLabel,
@@ -23,9 +22,9 @@ import {
   normalizeDatetime,
   parseIsoDateParam,
   shiftMonth,
-  VALID_DAY_NAMES,
   widestDatedEntry,
 } from "#shared/dates.ts";
+import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import { testHoliday, testListing } from "#test-utils/factories.ts";
 import { testWithSetting, useSetting } from "#test-utils/settings.ts";

--- a/test/shared/dates/pinned-values.test.ts
+++ b/test/shared/dates/pinned-values.test.ts
@@ -13,13 +13,12 @@ import {
   bookedRangeLabel,
   bookedSpanDays,
   calendarGridDates,
-  DAY_NAMES,
   formatDateLabel,
   getBookableStartDates,
   startOfHour,
-  VALID_DAY_NAMES,
   widestDatedEntry,
 } from "#shared/dates.ts";
+import { DAY_NAMES, VALID_DAY_NAMES } from "#shared/day-names.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { useSetting } from "#test-utils/settings.ts";
 

--- a/test/ui/templates/fields/validators.test.ts
+++ b/test/ui/templates/fields/validators.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { VALID_DAY_NAMES } from "#shared/dates.ts";
+import { VALID_DAY_NAMES } from "#shared/day-names.ts";
 import {
   splitCsv,
   validateAddress,


### PR DESCRIPTION
Small follow-up to #1813/#1816. #1813 already routed `seeds.ts` through the existing `VALID_DAY_NAMES` constant, but `catalog-transfer/schema.ts`'s `BookableDaySchema` still hand-rolled its own `Monday`–`Sunday` picklist array — the jscpd mt18 exploration still flags it against `seeds.ts`.

## What changed

- Reusing `VALID_DAY_NAMES` naively (via `dates.ts`) would pull the catalog-transfer schema — a deliberately self-contained, early-loaded module (its own doc comment says so, to stay off the Temporal/timezone/settings-loading graph) — into that heavier import graph.
- So `DAY_NAMES`/`VALID_DAY_NAMES` move to a new dependency-free `shared/day-names.ts`, and every consumer (`dates.ts` itself, `seeds.ts`, the listing form fields, the admin listing-defaults page, `catalog-transfer/schema.ts`) imports from there directly.
- `VALID_DAY_NAMES` keeps its literal element type — no `readonly string[]` annotation — so `BookableDaySchema`'s `v.picklist()` still infers the real weekday union (`"Monday" | "Tuesday" | ...`) instead of widening to plain `string` at the type level.

No behavior changes — same validation, same values, written once.

## Test plan

- [x] `deno check` on all touched files
- [x] Full `deno task precommit` passes (lint, typecheck, 0% duplication at the live mt19 gate, 100% coverage, full suite)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized weekday names and display ordering in a shared source.
  * Preserved existing date formatting, booking-day defaults, validation, and listing behavior.
  * Updated administrative listing settings and forms to use the shared weekday definitions.
* **Tests**
  * Updated date, booking, and validation test coverage to reference the centralized weekday definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->