### PR TITLE
Unify the session/form/entity guard type shapes

### DIFF
--- a/src/features/admin/confirmation.ts
+++ b/src/features/admin/confirmation.ts
@@ -7,6 +7,7 @@ import { asString } from "#fp";
 import type { AuthSession } from "#routes/auth.ts";
 import {
   AUTH_FORM,
+  type Guard,
   OWNER_FORM,
   requireOwnerOr,
   requireSessionOr,
@@ -21,6 +22,7 @@ import {
 } from "#routes/response.ts";
 import {
   type AuthedBase,
+  type AuthedHandleStep,
   type AuthedRoute,
   authedHandlerWithStep,
 } from "#shared/app-forms.ts";
@@ -29,13 +31,7 @@ import type { FormParams } from "#shared/form-data.ts";
 /* jscpd:ignore-end */
 
 /** Form guard: require auth + CSRF, call handler with session and form */
-export type FormGuard<TSession> = (
-  request: Request,
-  handler: (
-    session: TSession,
-    form: FormParams,
-  ) => Response | Promise<Response>,
-) => Promise<Response>;
+export type FormGuard<TSession> = Guard<[TSession, FormParams]>;
 
 /** Verify identifier matches for confirmation (case-insensitive, trimmed) */
 export const verifyIdentifier = (expected: string, provided: string): boolean =>
@@ -96,12 +92,7 @@ type VerifiedFormRouteConfig<TParams, TContext> = AuthedBase<
   /** Where to redirect on identifier mismatch */
   mismatchRedirect: (context: TContext, params: TParams) => string;
   /** Run after identifier verifies */
-  onConfirm: (args: {
-    context: TContext;
-    form: FormParams;
-    params: TParams;
-    session: AuthSession;
-  }) => Response | Promise<Response>;
+  onConfirm: AuthedHandleStep<TParams, TContext>;
 };
 
 /**

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -430,11 +430,16 @@ export const requireSiteOr = requireRolesOr(SITE_ADMIN_LEVELS);
  * outside {@link DELIVERY_ADMIN_LEVELS}. */
 export const requireDeliveryOr = requireRolesOr(DELIVERY_ADMIN_LEVELS);
 
-/** Session guard: require auth and call handler with session */
-export type SessionGuard<TSession> = (
+/** A gate a route runs before its handler: it authenticates/loads whatever
+ * the handler needs, then calls it with that data — or answers the request
+ * itself (a redirect, a 403) without ever calling it. */
+export type Guard<TArgs extends unknown[]> = (
   request: Request,
-  handler: (session: TSession) => Response | Promise<Response>,
+  handler: (...args: TArgs) => Response | Promise<Response>,
 ) => Promise<Response>;
+
+/** Session guard: require auth and call handler with session */
+export type SessionGuard<TSession> = Guard<[TSession]>;
 
 /** Factory for authenticated GET routes whose builder returns the full
  * Response — for pages that may 404, redirect, or set headers. Applies any

--- a/src/features/entity.ts
+++ b/src/features/entity.ts
@@ -4,6 +4,7 @@
 
 import {
   type AuthSession,
+  type Guard,
   OWNER_FORM,
   requireSessionOr,
 } from "#routes/auth.ts";
@@ -81,10 +82,7 @@ export type AttendeeListingRouteParams = {
 
 /** An auth gate a `:id` route runs before touching its entity: it yields the
  * gate's context (a session, a parsed form, …) to the inner handler. */
-type EntityGate<C> = (
-  request: Request,
-  handler: (ctx: C) => Response | Promise<Response>,
-) => Promise<Response>;
+type EntityGate<C> = Guard<[C]>;
 
 /**
  * Gated `:id` route factory — the one shape behind every "auth, load the


### PR DESCRIPTION
Continues the jscpd duplication-reduction campaign (mt18 exploration, live gate stays at mt19/0%).

## What changed

- **`auth.ts`, `entity.ts`, `confirmation.ts`**: each declared its own `(request: Request, handler: (...) => Response | Promise<Response>) => Promise<Response>` guard type — `SessionGuard<TSession>` (handler gets a session), `FormGuard<TSession>` (handler gets a session and a form), `EntityGate<C>` (handler gets a generic context). Same shape, three names, three separate declarations. Named the shared shape `Guard<TArgs extends unknown[]>` in `auth.ts` (where `SessionGuard` already lived) and built the other two as specializations: `SessionGuard<TSession> = Guard<[TSession]>`, `FormGuard<TSession> = Guard<[TSession, FormParams]>`, `EntityGate<C> = Guard<[C]>`.
- **`confirmation.ts`**: its `onConfirm` field's inline handler signature was byte-for-byte `app-forms.ts`'s own named `AuthedHandleStep<TParams, TContext>` type. Reused that type instead of repeating it — this also resolved a live mt19 gate hit the first version of this fix introduced (the inline signature's closing brace plus the next type's opening doc-comment coincidentally matched `app-forms.ts` at 19 tokens once `AuthedHandlerArgs` was reused directly).

Pure type-level refactor — no runtime behavior changes anywhere. Verified with a full `deno check src test` (every file in the project, not just the touched ones) since `Guard`/`SessionGuard` are widely referenced auth types.

## Test plan

- [x] `deno check` on all touched files, and a full `deno check src test` across the whole project
- [x] Full `deno task precommit` passes (lint, typecheck, 0% duplication at the live mt19 gate, 100% coverage, full suite)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ14XzMXHj7P9CUJzMWn3z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized authentication, session, form, and entity route guards under a shared guard interface.
  * Updated route configuration contracts to provide more consistent handler signatures.
  * Improved type consistency across verified form routes and entity-gated routes.
* **Bug Fixes**
  * No runtime behavior changes; updates improve compile-time validation and API consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->