### PR TITLE
Only complete a Stripe refund when its status is "succeeded"

### DIFF
--- a/src/shared/stripe-provider.ts
+++ b/src/shared/stripe-provider.ts
@@ -52,7 +52,7 @@ export const stripePaymentProvider: PaymentProvider = {
 
   async refundPayment(paymentReference: string): Promise<boolean> {
     const result = await stripeRefund(paymentReference);
-    return result !== null;
+    return result?.status === "succeeded";
   },
   requiresWebhookSignature: true,
 

--- a/test/lib/server-balance-payment-replay.test.ts
+++ b/test/lib/server-balance-payment-replay.test.ts
@@ -53,9 +53,10 @@ describeWithEnv("server (balance payment replay)", { db: true }, () => {
       ),
     );
     using mockRefund = stub(stripeApi, "refundPayment", () =>
-      Promise.resolve({ id: "re_should_not_happen" } as unknown as Awaited<
-        ReturnType<typeof stripeApi.refundPayment>
-      >),
+      Promise.resolve({
+        id: "re_should_not_happen",
+        status: "succeeded",
+      } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
     );
 
     const first = await handleRequest(

--- a/test/lib/server-balance-webhook.test.ts
+++ b/test/lib/server-balance-webhook.test.ts
@@ -23,7 +23,7 @@ import {
 // Stubs the Stripe refund call to report a refund with the given id.
 const stubRefund = (id: string) =>
   stub(stripeApi, "refundPayment", () =>
-    Promise.resolve({ id } as unknown as Awaited<
+    Promise.resolve({ id, status: "succeeded" } as unknown as Awaited<
       ReturnType<typeof stripeApi.refundPayment>
     >),
   );

--- a/test/lib/server-package-children.test.ts
+++ b/test/lib/server-package-children.test.ts
@@ -310,9 +310,10 @@ describeWithEnv("packages with buyer-choice children", { db: true }, () => {
       "drift-kit-pkg",
     );
     const mockRefund = stub(stripeApi, "refundPayment", () =>
-      Promise.resolve({ id: "re_drift" } as unknown as Awaited<
-        ReturnType<typeof stripeApi.refundPayment>
-      >),
+      Promise.resolve({
+        id: "re_drift",
+        status: "succeeded",
+      } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
     );
     const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
       Promise.resolve(
@@ -373,9 +374,10 @@ describeWithEnv("packages with buyer-choice children", { db: true }, () => {
       unitPrice: 300,
     });
     const mockRefund = stub(stripeApi, "refundPayment", () =>
-      Promise.resolve({ id: "re_grown" } as unknown as Awaited<
-        ReturnType<typeof stripeApi.refundPayment>
-      >),
+      Promise.resolve({
+        id: "re_grown",
+        status: "succeeded",
+      } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
     );
     const mockRetrieve = stub(stripeApi, "retrieveCheckoutSession", () =>
       Promise.resolve({

--- a/test/lib/server-payments-success-refunds.test.ts
+++ b/test/lib/server-payments-success-refunds.test.ts
@@ -102,9 +102,10 @@ describeWithEnv("server (payment flow: ticket success)", { db: true }, () => {
         >),
       );
       const mockRefund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_stale_refund" } as unknown as Awaited<
-          ReturnType<typeof stripeApi.refundPayment>
-        >),
+        Promise.resolve({
+          id: "re_stale_refund",
+          status: "succeeded",
+        } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
       );
       try {
         const response = await handleRequest(
@@ -163,9 +164,10 @@ describeWithEnv("server (payment flow: ticket success)", { db: true }, () => {
         >),
       );
       const mockRefund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_stale_pkg_refund" } as unknown as Awaited<
-          ReturnType<typeof stripeApi.refundPayment>
-        >),
+        Promise.resolve({
+          id: "re_stale_pkg_refund",
+          status: "succeeded",
+        } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
       );
       try {
         const response = await handleRequest(
@@ -212,9 +214,10 @@ describeWithEnv("server (payment flow: ticket success)", { db: true }, () => {
       );
 
       const mockRefund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_inactive_refund" } as unknown as Awaited<
-          ReturnType<typeof stripeApi.refundPayment>
-        >),
+        Promise.resolve({
+          id: "re_inactive_refund",
+          status: "succeeded",
+        } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
       );
 
       try {
@@ -342,9 +345,10 @@ describeWithEnv("server (payment flow: ticket success)", { db: true }, () => {
       );
 
       const mockRefund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_rollback_refund" } as unknown as Awaited<
-          ReturnType<typeof stripeApi.refundPayment>
-        >),
+        Promise.resolve({
+          id: "re_rollback_refund",
+          status: "succeeded",
+        } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
       );
 
       try {

--- a/test/lib/server-reservation/deposit-basics.test.ts
+++ b/test/lib/server-reservation/deposit-basics.test.ts
@@ -138,7 +138,7 @@ describeWithEnv(
         unitPrice: 1000,
       });
       const refund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_1" } as never),
+        Promise.resolve({ id: "re_1", status: "succeeded" } as never),
       );
       // Expected total is 200 (deposit 100 + fee 100); charge a wrong 150.
       const session = stubPaidSession(

--- a/test/lib/server-reservation/edge-cases.test.ts
+++ b/test/lib/server-reservation/edge-cases.test.ts
@@ -91,7 +91,7 @@ describeWithEnv(
       });
       const addOn = await createProgrammeCharge({ stock: 0 });
       const refund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_addon" } as never),
+        Promise.resolve({ id: "re_addon", status: "succeeded" } as never),
       );
       const session = stubPaidSession(
         "cs_addon_sold",

--- a/test/lib/server-reservation/promo-addons.test.ts
+++ b/test/lib/server-reservation/promo-addons.test.ts
@@ -111,7 +111,7 @@ describeWithEnv(
       });
       const addOn = await createProgrammeCharge();
       const refund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve({ id: "re_free_addon" } as never),
+        Promise.resolve({ id: "re_free_addon", status: "succeeded" } as never),
       );
       const session = stubPaidSession(
         "cs_free_addon_bad",

--- a/test/lib/server-webhook-dual-path.test.ts
+++ b/test/lib/server-webhook-dual-path.test.ts
@@ -66,9 +66,10 @@ const paidSession = async (
     type: "checkout.session.completed",
   });
   const mockRefund = stub(stripeApi, "refundPayment", () =>
-    Promise.resolve({ id: `re_${ref}` } as unknown as Awaited<
-      ReturnType<typeof stripeApi.refundPayment>
-    >),
+    Promise.resolve({
+      id: `re_${ref}`,
+      status: "succeeded",
+    } as unknown as Awaited<ReturnType<typeof stripeApi.refundPayment>>),
   );
   return { mockRefund, mockVerify };
 };

--- a/test/lib/server-webhooks/multi-ticket-refunds.test.ts
+++ b/test/lib/server-webhooks/multi-ticket-refunds.test.ts
@@ -1,8 +1,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { afterEach, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
-import { resetStripeClient, stripeApi } from "#shared/stripe.ts";
+import { resetStripeClient } from "#shared/stripe.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -15,6 +14,7 @@ import {
   expectSessionFailed,
   expectWebhookKeptAndRefunded,
   postWebhookAndAssert,
+  stubRefundPayment,
 } from "#test-utils/webhooks.ts";
 
 // jscpd:ignore-end
@@ -68,13 +68,7 @@ describeWithEnv(
         }),
       );
 
-      const mockRefund = stub(stripeApi, "refundPayment", () =>
-        Promise.resolve(
-          true as unknown as Awaited<
-            ReturnType<typeof stripeApi.refundPayment>
-          >,
-        ),
-      );
+      const mockRefund = stubRefundPayment("re_multi_cap");
 
       await postWebhookAndAssert(
         () => {

--- a/test/lib/stripe/provider.test.ts
+++ b/test/lib/stripe/provider.test.ts
@@ -390,6 +390,18 @@ describeStripe("stripe-provider", () => {
       });
     }
 
+    test("returns false when Stripe returns null (no refund created)", async () => {
+      const client = await stripeClient();
+      await withMocks(
+        () =>
+          stub(client.refunds, "create", () => Promise.resolve(null as never)),
+        async () => {
+          const result = await stripePaymentProvider.refundPayment("pi_null");
+          expect(result).toBe(false);
+        },
+      );
+    });
+
     test("returns false when refund fails", async () => {
       const client = await stripeClient();
       await withMocks(

--- a/test/lib/stripe/provider.test.ts
+++ b/test/lib/stripe/provider.test.ts
@@ -367,11 +367,28 @@ describeStripe("stripe-provider", () => {
   });
 
   describe("refundPayment delegation", () => {
-    test("returns true when refund succeeds", async () => {
-      await settings.update.stripe.secretKey("sk_test_mock");
-      const result = await stripePaymentProvider.refundPayment("pi_test_123");
-      expect(result).toBe(true);
-    });
+    for (const [status, completed] of [
+      ["succeeded", true],
+      ["pending", false],
+      ["requires_action", false],
+      ["failed", false],
+      ["canceled", false],
+    ] as const) {
+      test(`returns ${completed} when Stripe reports ${status}`, async () => {
+        const client = await stripeClient();
+        await withMocks(
+          () =>
+            stub(client.refunds, "create", () =>
+              Promise.resolve({ id: `re_${status}`, status } as never),
+            ),
+          async () => {
+            expect(
+              await stripePaymentProvider.refundPayment(`pi_${status}`),
+            ).toBe(completed);
+          },
+        );
+      });
+    }
 
     test("returns false when refund fails", async () => {
       const client = await stripeClient();

--- a/test/lib/webhook-price-signature/helpers.ts
+++ b/test/lib/webhook-price-signature/helpers.ts
@@ -83,7 +83,7 @@ export const redirectRequest = (id: string) =>
 /** Stub the provider refund to succeed (deterministic — no network). */
 export const stubRefundOk = () =>
   stub(stripeApi, "refundPayment", () =>
-    Promise.resolve({ id: "re_ok" } as unknown as Awaited<
+    Promise.resolve({ id: "re_ok", status: "succeeded" } as unknown as Awaited<
       ReturnType<typeof stripeApi.refundPayment>
     >),
   );

--- a/test/test-utils/stripe-mocks.ts
+++ b/test/test-utils/stripe-mocks.ts
@@ -22,13 +22,16 @@ export const stubRetrieveSession = (fields: StripeCheckoutFields): Stub =>
 
 /** Stub `stripeApi.refundPayment` to resolve `result` (default: success). */
 export const stubRefundPayment = (
-  result: { id: string } | null = { id: "re_test" },
+  result: { id: string; status: "succeeded" } | null = {
+    id: "re_test",
+    status: "succeeded",
+  },
 ): Stub =>
   stub(stripeApi, "refundPayment", () => Promise.resolve(result as never));
 
 interface StripeMockOptions {
-  /** The refund result `refundPayment` returns (default: `{ id: "re_test" }`). */
-  refundResult?: { id: string } | null;
+  /** The completed refund that `refundPayment` returns. */
+  refundResult?: { id: string; status: "succeeded" } | null;
   /** The checkout session `retrieveCheckoutSession` returns. */
   session: StripeCheckoutFields;
 }

--- a/test/test-utils/webhooks.ts
+++ b/test/test-utils/webhooks.ts
@@ -131,7 +131,7 @@ export const expectWebhookKeptAndRefunded = async (
 ) => {
   const mockVerify = await stubWebhookVerify(event);
   const mockRefund = stub(stripeApi, "refundPayment", () =>
-    Promise.resolve({ id: refundId } as unknown as Awaited<
+    Promise.resolve({ id: refundId, status: "succeeded" } as unknown as Awaited<
       ReturnType<typeof stripeApi.refundPayment>
     >),
   );
@@ -361,7 +361,7 @@ export const expectAttendeeCreatedWithPiiBlob = async (
  *  `expectWebhookKeptAndRefunded`. */
 export const stubRefundPayment = (refundId = "re_test") =>
   stub(stripeApi, "refundPayment", () =>
-    Promise.resolve({ id: refundId } as unknown as Awaited<
+    Promise.resolve({ id: refundId, status: "succeeded" } as unknown as Awaited<
       ReturnType<typeof stripeApi.refundPayment>
     >),
   );


### PR DESCRIPTION
## What this changes

The Stripe payment provider reported a refund as complete for any non-null refund object. That meant a **pending**, **requires-action**, **failed**, or **canceled** refund was treated as finished, so a customer whose refund had not actually settled could be told it was done.

`refundPayment` in `src/shared/stripe-provider.ts` now returns `true` only when Stripe reports `status === "succeeded"`. Anything else stays unresolved.

## What is included

- **Provider fix** (`src/shared/stripe-provider.ts`): one-line change to check the refund status.
- **Direct status tests** (`test/lib/stripe/provider.test.ts`): a table-driven test covers every Stripe refund status — `succeeded`, `pending`, `requires_action`, `failed`, `canceled` — plus an explicit `null` result case (no refund created, exercises the optional-chaining path) and the existing rejection case.
- **Realistic refund mocks**: existing refund-flow tests previously resolved a bare id (or a boolean) from the stubbed refund call. They now resolve a realistic successful refund object (`{ id, status: "succeeded" }`), matching what the provider now requires. Failure paths that resolve `null` or reject are left as they were.
- **Dedup**: the multi-ticket webhook test now uses the shared `stubRefundPayment` helper instead of inlining the same refund stub.

## What is NOT included

Per the split plan, this PR is limited to Stripe succeeded-status refund correctness and realistic refund mocks. It does **not** include checkout-stage state, the refunding state, checkout expiry handling, or webhook event reconciliation — those belong to later PRs. In particular, a bounded reconciliation path for `pending` refunds (tracking them rather than letting the existing retry loop converge) is explicitly deferred to the staged-runtime work.

## Verification

Biome (`deno task lint:ci`) and the duplication gate (`deno task cpd`) both pass clean. Tests were not run per the session constraints; CI runs the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refunds are now treated as successful only when Stripe returns a refund with `status: "succeeded"`.
  - Refund outcomes reported as pending, failed, canceled, or action-required are no longer considered successful.

- **Tests**
  - Updated refund mocks and fixtures across payment and webhook test coverage to include explicit refund `status` values.
  - Adjusted/strengthened assertions to verify success behavior matches the reported Stripe refund status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->