### PR TITLE
Gate note ledger links by owner role

### DIFF
--- a/src/features/admin/attendee-page.ts
+++ b/src/features/admin/attendee-page.ts
@@ -49,6 +49,7 @@ import { settings } from "#shared/db/settings.ts";
 import { getNotesForAttendee } from "#shared/db/system-notes.ts";
 import { isReadOnly } from "#shared/env.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
+import { isOwnerRole } from "#shared/types.ts";
 import {
   AttendeeAnswersTable,
   AttendeeBookingsTable,
@@ -185,7 +186,7 @@ const overviewTab: TabDef<LoadedAttendee> = {
         return ContactHistory({
           attendee,
           contactRecords,
-          isOwner: ctx.session.adminLevel === "owner",
+      isOwner: isOwnerRole(ctx.session.adminLevel),
           previousBookings,
         });
       },

--- a/src/features/admin/attendee-page.ts
+++ b/src/features/admin/attendee-page.ts
@@ -196,9 +196,10 @@ const overviewTab: TabDef<LoadedAttendee> = {
 
 /** The tabbed attendee page. */
 export const attendeePage: EntityPage<LoadedAttendee> = defineEntityPage({
-  banner: async ({ attendee }) =>
+  banner: async ({ attendee }, ctx) =>
     attendeeBanner({
       attendee,
+      isOwner: ctx.session.adminLevel === "owner",
       notes: await getNotesForAttendee(
         attendee.id,
         await requireRequestPrivateKey(),

--- a/src/features/admin/attendee-page.ts
+++ b/src/features/admin/attendee-page.ts
@@ -186,7 +186,7 @@ const overviewTab: TabDef<LoadedAttendee> = {
         return ContactHistory({
           attendee,
           contactRecords,
-      isOwner: isOwnerRole(ctx.session.adminLevel),
+          isOwner: isOwnerRole(ctx.session.adminLevel),
           previousBookings,
         });
       },

--- a/src/features/admin/listing-page-data.ts
+++ b/src/features/admin/listing-page-data.ts
@@ -46,6 +46,7 @@ import { listingLedgerHref } from "#shared/ledger-links.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import {
   type Attendee,
+  isOwnerRole,
   isPaidListing,
   type ListingWithCount,
 } from "#shared/types.ts";
@@ -221,6 +222,7 @@ export const loadListingOverviewPanel = async (
     isChild,
     isHiddenPackageMember,
     ...(canViewLedger ? { ledgerHref: listingLedgerHref(listing.id) } : {}),
+    isOwner: canViewLedger,
     listing,
     noteNames,
     ...(questionData !== undefined ? { questionData } : {}),
@@ -281,6 +283,7 @@ export const loadListingRosterPanel = async (
     ),
     dateFilter,
     groupContext,
+    isOwner: isOwnerRole(ctx.session.adminLevel),
     listing,
     paymentReferenceAttendeeIds,
     phonePrefix: settings.phonePrefix,

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -7,6 +7,7 @@
  *     `javascript:`/`data:` URLs can't smuggle script execution past step 1.
  */
 
+import { assert } from "@std/assert";
 import { Lexer, Marked, type Token, type Tokens } from "marked";
 import { once } from "#fp";
 import { escapeHtml } from "#templates/layout.tsx";
@@ -192,6 +193,10 @@ const leafTokens = (token: Token): Token[] => {
 const rewriteToken = (token: Token, matcher: LinkMatcher): string => {
   if (token.type === "link") {
     if (!linkMatches(matcher, token.href)) return token.raw;
+    // `Token` is `MarkedToken | Tokens.Generic`; Generic has `tokens?`
+    // optional and `type: string`, so narrowing on `type === "link"` still
+    // leaves `tokens` as `Token[] | undefined`. The assert narrows it.
+    assert(token.tokens, "Markdown link has no parsed text");
     return rewriteChildren(token.text, token.tokens, matcher);
   }
   if (isTableToken(token)) return rewriteTable(token, matcher);

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -7,7 +7,6 @@
  *     `javascript:`/`data:` URLs can't smuggle script execution past step 1.
  */
 
-import { assert } from "@std/assert";
 import { Lexer, Marked, type Token, type Tokens } from "marked";
 import { once } from "#fp";
 import { escapeHtml } from "#templates/layout.tsx";
@@ -95,8 +94,10 @@ const linkMatches = (matcher: LinkMatcher, href: string): boolean =>
  * text. Used to strip links the viewer isn't allowed to open (e.g. owner-only
  * admin pages) before rendering — a rendered link is a promise that it works,
  * so a viewer who can't follow it gets the words without the link. */
-export const withoutLinksTo = (markdown: string, matcher: LinkMatcher): string =>
-  rewriteTokens(Lexer.lex(markdown), matcher);
+export const withoutLinksTo = (
+  markdown: string,
+  matcher: LinkMatcher,
+): string => rewriteTokens(Lexer.lex(markdown), matcher);
 
 /** Replace child token source in order while preserving every byte between
  * children (markers, whitespace, table pipes, list bullets, and safe markdown). */
@@ -191,7 +192,6 @@ const leafTokens = (token: Token): Token[] => {
 const rewriteToken = (token: Token, matcher: LinkMatcher): string => {
   if (token.type === "link") {
     if (!linkMatches(matcher, token.href)) return token.raw;
-    assert(token.tokens, "Markdown link has no parsed text");
     return rewriteChildren(token.text, token.tokens, matcher);
   }
   if (isTableToken(token)) return rewriteTable(token, matcher);
@@ -204,5 +204,7 @@ const rewriteToken = (token: Token, matcher: LinkMatcher): string => {
   return token.raw;
 };
 
-const rewriteTokens = (tokens: readonly Token[], matcher: LinkMatcher): string =>
-  tokens.map((token) => rewriteToken(token, matcher)).join("");
+const rewriteTokens = (
+  tokens: readonly Token[],
+  matcher: LinkMatcher,
+): string => tokens.map((token) => rewriteToken(token, matcher)).join("");

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -7,6 +7,7 @@
  *     `javascript:`/`data:` URLs can't smuggle script execution past step 1.
  */
 
+import { assert } from "@std/assert";
 import { Lexer, Marked, type Token, type Tokens } from "marked";
 import { once } from "#fp";
 import { escapeHtml } from "#templates/layout.tsx";
@@ -79,3 +80,116 @@ export const isSimpleMarkdown = (text: string): boolean => {
     (PLAIN_INLINE_TYPES as readonly string[]).includes(tok.type),
   );
 };
+
+/** Replace each markdown link whose target starts with `prefix` with its plain
+ * text. Used to strip links the viewer isn't allowed to open (e.g. owner-only
+ * admin pages) before rendering — a rendered link is a promise that it works,
+ * so a viewer who can't follow it gets the words without the link. */
+export const withoutLinksTo = (markdown: string, prefix: string): string =>
+  rewriteTokens(Lexer.lex(markdown), prefix);
+
+/** Replace child token source in order while preserving every byte between
+ * children (markers, whitespace, table pipes, list bullets, and safe markdown). */
+type LocatedSourcePart<Part> = {
+  index: number;
+  part: Part;
+  source: string;
+};
+
+const locateSourceParts = <Part>(
+  raw: string,
+  parts: readonly Part[],
+  sourceOf: (part: Part) => string,
+): LocatedSourcePart<Part>[] => {
+  let cursor = 0;
+  return parts.map((part) => {
+    const source = sourceOf(part);
+    const index = raw.indexOf(source, cursor);
+    if (index >= 0) cursor = index + source.length;
+    return { index, part, source };
+  });
+};
+
+const rewriteSourceParts = <Part>(
+  raw: string,
+  parts: readonly LocatedSourcePart<Part>[],
+  rewrite: (part: Part) => string,
+): string => {
+  let cursor = 0;
+  return (
+    parts.reduce((result, { index, part, source }) => {
+      const before = raw.slice(cursor, index);
+      cursor = index + source.length;
+      return result + before + rewrite(part);
+    }, "") + raw.slice(cursor)
+  );
+};
+
+const rewriteChildren = (
+  raw: string,
+  children: readonly Token[],
+  prefix: string,
+  flattenMissing = true,
+): string => {
+  const parts = locateSourceParts(raw, children, (child) => child.raw);
+  if (flattenMissing && parts.some(({ index }) => index < 0)) {
+    return rewriteChildren(raw, children.flatMap(leafTokens), prefix, false);
+  }
+  return rewriteSourceParts(
+    raw,
+    parts.filter(({ index }) => index >= 0),
+    (child) => rewriteToken(child, prefix),
+  );
+};
+
+const rewriteTable = (token: Tokens.Table, prefix: string): string => {
+  const cells = [...token.header, ...token.rows.flat()];
+  const parts = locateSourceParts(token.raw, cells, (cell) => cell.text);
+  assert(
+    parts.every(({ index }) => index >= 0),
+    "Markdown table cell not found",
+  );
+  return rewriteSourceParts(token.raw, parts, (cell) =>
+    rewriteChildren(cell.text, cell.tokens, prefix),
+  );
+};
+
+const isTableToken = (token: Token): token is Tokens.Table =>
+  token.type === "table" && "header" in token && "rows" in token;
+
+const childTokens = (token: Token): readonly Token[] => {
+  if (isTableToken(token)) {
+    return [...token.header, ...token.rows.flat()].flatMap(
+      (cell) => cell.tokens,
+    );
+  }
+  return "tokens" in token && Array.isArray(token.tokens) ? token.tokens : [];
+};
+
+/** Deepest parsed tokens in source order. Links stay whole so their complete
+ * spelling is replaced; code tokens stay whole so link-looking code advances
+ * the source cursor without being changed. */
+const leafTokens = (token: Token): Token[] => {
+  if (token.type === "link") return [token];
+  const children = childTokens(token);
+  return children.length > 0 ? children.flatMap(leafTokens) : [token];
+};
+
+const rewriteToken = (token: Token, prefix: string): string => {
+  if (token.type === "link") {
+    if (!token.href.startsWith(prefix)) return token.raw;
+    assert(token.tokens, "Markdown link has no parsed text");
+    return rewriteChildren(token.text, token.tokens, prefix);
+  }
+  if (isTableToken(token)) return rewriteTable(token, prefix);
+  if (token.type === "list") {
+    return rewriteChildren(token.raw, token.items, prefix);
+  }
+  if ("tokens" in token && Array.isArray(token.tokens)) {
+    return rewriteChildren(token.raw, token.tokens, prefix);
+  }
+  return token.raw;
+};
+
+const rewriteTokens = (tokens: readonly Token[], prefix: string): string =>
+  tokens.map((token) => rewriteToken(token, prefix)).join("");

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -81,12 +81,22 @@ export const isSimpleMarkdown = (text: string): boolean => {
   );
 };
 
-/** Replace each markdown link whose target starts with `prefix` with its plain
+/** A link target to strip: either a URL prefix (the common case) or a predicate
+ * for patterns that can't be expressed as a single prefix (e.g. an owner-only
+ * tab whose URL also starts with a shared base the viewer CAN open). */
+type LinkMatcher = string | ((href: string) => boolean);
+
+/** True when `href` should be demoted to plain text. A string matcher is a
+ * prefix check; a function matcher is called directly. */
+const linkMatches = (matcher: LinkMatcher, href: string): boolean =>
+  typeof matcher === "string" ? href.startsWith(matcher) : matcher(href);
+
+/** Replace each markdown link whose target matches `matcher` with its plain
  * text. Used to strip links the viewer isn't allowed to open (e.g. owner-only
  * admin pages) before rendering — a rendered link is a promise that it works,
  * so a viewer who can't follow it gets the words without the link. */
-export const withoutLinksTo = (markdown: string, prefix: string): string =>
-  rewriteTokens(Lexer.lex(markdown), prefix);
+export const withoutLinksTo = (markdown: string, matcher: LinkMatcher): string =>
+  rewriteTokens(Lexer.lex(markdown), matcher);
 
 /** Replace child token source in order while preserving every byte between
  * children (markers, whitespace, table pipes, list bullets, and safe markdown). */
@@ -128,29 +138,32 @@ const rewriteSourceParts = <Part>(
 const rewriteChildren = (
   raw: string,
   children: readonly Token[],
-  prefix: string,
+  matcher: LinkMatcher,
   flattenMissing = true,
 ): string => {
   const parts = locateSourceParts(raw, children, (child) => child.raw);
   if (flattenMissing && parts.some(({ index }) => index < 0)) {
-    return rewriteChildren(raw, children.flatMap(leafTokens), prefix, false);
+    return rewriteChildren(raw, children.flatMap(leafTokens), matcher, false);
   }
   return rewriteSourceParts(
     raw,
     parts.filter(({ index }) => index >= 0),
-    (child) => rewriteToken(child, prefix),
+    (child) => rewriteToken(child, matcher),
   );
 };
 
-const rewriteTable = (token: Tokens.Table, prefix: string): string => {
+const rewriteTable = (token: Tokens.Table, matcher: LinkMatcher): string => {
   const cells = [...token.header, ...token.rows.flat()];
   const parts = locateSourceParts(token.raw, cells, (cell) => cell.text);
-  assert(
-    parts.every(({ index }) => index >= 0),
-    "Markdown table cell not found",
-  );
-  return rewriteSourceParts(token.raw, parts, (cell) =>
-    rewriteChildren(cell.text, cell.tokens, prefix),
+  // Marked normalizes escaped pipes (`\|` → `|`) in cell.text, so a cell whose
+  // source has an escaped pipe won't be found in token.raw. Skip those cells
+  // (their raw source is preserved by rewriteSourceParts' gap handling) rather
+  // than crashing — the table still renders, and any link in a matched cell is
+  // still demoted.
+  return rewriteSourceParts(
+    token.raw,
+    parts.filter(({ index }) => index >= 0),
+    (cell) => rewriteChildren(cell.text, cell.tokens, matcher),
   );
 };
 
@@ -175,21 +188,21 @@ const leafTokens = (token: Token): Token[] => {
   return children.length > 0 ? children.flatMap(leafTokens) : [token];
 };
 
-const rewriteToken = (token: Token, prefix: string): string => {
+const rewriteToken = (token: Token, matcher: LinkMatcher): string => {
   if (token.type === "link") {
-    if (!token.href.startsWith(prefix)) return token.raw;
+    if (!linkMatches(matcher, token.href)) return token.raw;
     assert(token.tokens, "Markdown link has no parsed text");
-    return rewriteChildren(token.text, token.tokens, prefix);
+    return rewriteChildren(token.text, token.tokens, matcher);
   }
-  if (isTableToken(token)) return rewriteTable(token, prefix);
+  if (isTableToken(token)) return rewriteTable(token, matcher);
   if (token.type === "list") {
-    return rewriteChildren(token.raw, token.items, prefix);
+    return rewriteChildren(token.raw, token.items, matcher);
   }
   if ("tokens" in token && Array.isArray(token.tokens)) {
-    return rewriteChildren(token.raw, token.tokens, prefix);
+    return rewriteChildren(token.raw, token.tokens, matcher);
   }
   return token.raw;
 };
 
-const rewriteTokens = (tokens: readonly Token[], prefix: string): string =>
-  tokens.map((token) => rewriteToken(token, prefix)).join("");
+const rewriteTokens = (tokens: readonly Token[], matcher: LinkMatcher): string =>
+  tokens.map((token) => rewriteToken(token, matcher)).join("");

--- a/src/ui/templates/admin/attendee-notes.tsx
+++ b/src/ui/templates/admin/attendee-notes.tsx
@@ -20,7 +20,7 @@ import {
 import { CsrfForm, Flash, hiddenInputs, renderField } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
-import { renderMarkdown } from "#shared/markdown.ts";
+import { renderMarkdown, withoutLinksTo } from "#shared/markdown.ts";
 import type { AdminSession } from "#shared/types.ts";
 import { AdminPage } from "#templates/admin/admin-page.tsx";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
@@ -48,9 +48,20 @@ const deleteNoteUrl = (note: SystemNote, returnUrl: string): string =>
     returnUrl,
   )}`;
 
-/** Render a note's body as (safe) markdown — links and emphasis, HTML escaped. */
-const NoteBody = ({ note }: { note: SystemNote }): JSX.Element => (
-  <Raw html={renderMarkdown(note.note)} />
+/** One note plus whether the viewer is an owner (the only role allowed to
+ * open the ledger pages a note may link to). */
+type NoteViewProps = { note: SystemNote; isOwner: boolean };
+
+/** Render a note's body as (safe) markdown — links and emphasis, HTML escaped.
+ * The ledger pages are owner-only, so for any other admin a stored ledger link
+ * (the refund notes carry one) is demoted to its plain text — a rendered link
+ * is a promise that it works. */
+const NoteBody = ({ note, isOwner }: NoteViewProps): JSX.Element => (
+  <Raw
+    html={renderMarkdown(
+      isOwner ? note.note : withoutLinksTo(note.note, "/admin/ledger"),
+    )}
+  />
 );
 
 /**
@@ -78,7 +89,7 @@ const NoteActions = ({
  * booking can't be missed), a neutral box for an `owner` note. The "×" opens the
  * delete confirmation, returning to the attendee page.
  */
-const NoteBox = ({ note }: { note: SystemNote }): JSX.Element => {
+const NoteBox = ({ note, isOwner }: NoteViewProps): JSX.Element => {
   const isSystem = note.type === "system";
   return (
     <div
@@ -98,7 +109,7 @@ const NoteBox = ({ note }: { note: SystemNote }): JSX.Element => {
       {isSystem && (
         <span class="system-note-tag">{t("notes.system_label")}</span>
       )}
-      <NoteBody note={note} />
+      <NoteBody isOwner={isOwner} note={note} />
       <p class="muted small">{formatDatetimeShort(note.created)}</p>
     </div>
   );
@@ -112,13 +123,15 @@ const NoteBox = ({ note }: { note: SystemNote }): JSX.Element => {
  */
 export const AttendeeNotesSection = ({
   notes,
+  isOwner,
 }: {
   notes: SystemNote[];
+  isOwner: boolean;
 }): JSX.Element | null =>
   notes.length === 0 ? null : (
     <section class="attendee-notes">
       {notes.map((note) => (
-        <NoteBox note={note} />
+        <NoteBox isOwner={isOwner} note={note} />
       ))}
     </section>
   );
@@ -151,9 +164,11 @@ export const AddNoteLink = ({
 export const AttendeeNotesSummary = ({
   notes,
   names,
+  isOwner,
 }: {
   notes: SystemNote[];
   names: Map<number, string>;
+  isOwner: boolean;
 }): JSX.Element | null => {
   if (notes.length === 0) return null;
   const grouped = groupNotesByAttendee(notes);
@@ -169,7 +184,7 @@ export const AttendeeNotesSummary = ({
           </strong>
           {attendeeNotes.map((note) => (
             <div class="system-note">
-              <NoteBody note={note} />
+              <NoteBody isOwner={isOwner} note={note} />
             </div>
           ))}
         </div>
@@ -252,7 +267,7 @@ export const adminDeleteNotePage = ({
             : "system-note"
         }
       >
-        <NoteBody note={note} />
+        <NoteBody isOwner={session.adminLevel === "owner"} note={note} />
       </div>
     ),
     returnUrl,

--- a/src/ui/templates/admin/attendee-notes.tsx
+++ b/src/ui/templates/admin/attendee-notes.tsx
@@ -21,7 +21,7 @@ import { CsrfForm, Flash, hiddenInputs, renderField } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { renderMarkdown, withoutLinksTo } from "#shared/markdown.ts";
-import { isOwnerRole, type AdminSession } from "#shared/types.ts";
+import { type AdminSession, isOwnerRole } from "#shared/types.ts";
 import { AdminPage } from "#templates/admin/admin-page.tsx";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
 import { WritableOnly } from "#templates/admin/writable-only.tsx";

--- a/src/ui/templates/admin/attendee-notes.tsx
+++ b/src/ui/templates/admin/attendee-notes.tsx
@@ -21,7 +21,7 @@ import { CsrfForm, Flash, hiddenInputs, renderField } from "#shared/forms.tsx";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { renderMarkdown, withoutLinksTo } from "#shared/markdown.ts";
-import type { AdminSession } from "#shared/types.ts";
+import { isOwnerRole, type AdminSession } from "#shared/types.ts";
 import { AdminPage } from "#templates/admin/admin-page.tsx";
 import { ConfirmPage } from "#templates/admin/confirm-page.tsx";
 import { WritableOnly } from "#templates/admin/writable-only.tsx";
@@ -52,6 +52,19 @@ const deleteNoteUrl = (note: SystemNote, returnUrl: string): string =>
  * open the ledger pages a note may link to). */
 type NoteViewProps = { note: SystemNote; isOwner: boolean };
 
+/** A collection of notes plus whether the viewer is an owner. Shared by the
+ * note section, the summary, and the attendee banner so the `{ notes, isOwner }`
+ * pair has one declared shape. */
+export type NotesViewProps = { notes: SystemNote[]; isOwner: boolean };
+
+/** True when a link target is an owner-only page — the standalone ledger routes
+ * (`/admin/ledger…`) and the attendee page's ledger tab
+ * (`/admin/attendees/:id/ledger`). A non-owner's note renders the words without
+ * the link, since a rendered link is a promise that it works. */
+const isOwnerOnlyLink = (href: string): boolean =>
+  href.startsWith("/admin/ledger") ||
+  (href.startsWith("/admin/attendees/") && href.includes("/ledger"));
+
 /** Render a note's body as (safe) markdown — links and emphasis, HTML escaped.
  * The ledger pages are owner-only, so for any other admin a stored ledger link
  * (the refund notes carry one) is demoted to its plain text — a rendered link
@@ -59,7 +72,7 @@ type NoteViewProps = { note: SystemNote; isOwner: boolean };
 const NoteBody = ({ note, isOwner }: NoteViewProps): JSX.Element => (
   <Raw
     html={renderMarkdown(
-      isOwner ? note.note : withoutLinksTo(note.note, "/admin/ledger"),
+      isOwner ? note.note : withoutLinksTo(note.note, isOwnerOnlyLink),
     )}
   />
 );
@@ -124,10 +137,7 @@ const NoteBox = ({ note, isOwner }: NoteViewProps): JSX.Element => {
 export const AttendeeNotesSection = ({
   notes,
   isOwner,
-}: {
-  notes: SystemNote[];
-  isOwner: boolean;
-}): JSX.Element | null =>
+}: NotesViewProps): JSX.Element | null =>
   notes.length === 0 ? null : (
     <section class="attendee-notes">
       {notes.map((note) => (
@@ -165,11 +175,7 @@ export const AttendeeNotesSummary = ({
   notes,
   names,
   isOwner,
-}: {
-  notes: SystemNote[];
-  names: Map<number, string>;
-  isOwner: boolean;
-}): JSX.Element | null => {
+}: NotesViewProps & { names: Map<number, string> }): JSX.Element | null => {
   if (notes.length === 0) return null;
   const grouped = groupNotesByAttendee(notes);
   return (
@@ -267,7 +273,7 @@ export const adminDeleteNotePage = ({
             : "system-note"
         }
       >
-        <NoteBody isOwner={session.adminLevel === "owner"} note={note} />
+        <NoteBody isOwner={isOwnerRole(session.adminLevel)} note={note} />
       </div>
     ),
     returnUrl,

--- a/src/ui/templates/admin/attendee-page.tsx
+++ b/src/ui/templates/admin/attendee-page.tsx
@@ -323,10 +323,14 @@ export const attendeeBanner = ({
   attendee,
   statuses,
   notes,
+  isOwner,
 }: {
   attendee: Attendee;
   statuses: AttendeeStatus[];
   notes: SystemNote[];
+  /** Only owners may open the ledger pages, so a note's ledger link renders as
+   * plain text for everyone else. */
+  isOwner: boolean;
 }): JSX.Element | null => {
   const showStatus = statuses.length > 1;
   if (!showStatus && notes.length === 0) return null;
@@ -342,7 +346,7 @@ export const attendeeBanner = ({
           </h2>
         </div>
       )}
-      <AttendeeNotesSection notes={notes} />
+      <AttendeeNotesSection isOwner={isOwner} notes={notes} />
     </PageBlock>
   );
 };

--- a/src/ui/templates/admin/attendee-page.tsx
+++ b/src/ui/templates/admin/attendee-page.tsx
@@ -326,7 +326,10 @@ export const attendeeBanner = ({
   statuses,
   notes,
   isOwner,
-}: { attendee: Attendee; statuses: AttendeeStatus[] } & NotesViewProps): JSX.Element | null => {
+}: {
+  attendee: Attendee;
+  statuses: AttendeeStatus[];
+} & NotesViewProps): JSX.Element | null => {
   const showStatus = statuses.length > 1;
   if (!showStatus && notes.length === 0) return null;
   const status = statuses.find((s) => s.id === attendee.status_id);

--- a/src/ui/templates/admin/attendee-page.tsx
+++ b/src/ui/templates/admin/attendee-page.tsx
@@ -14,11 +14,13 @@ import { formatCurrency } from "#shared/currency.ts";
 import { formatDatetimeShort } from "#shared/dates.ts";
 import type { AttendeeStatus } from "#shared/db/attendee-statuses.ts";
 import type { ContactRecord } from "#shared/db/contact-preferences.ts";
-import type { SystemNote } from "#shared/db/system-notes.ts";
 import { Raw } from "#shared/jsx/jsx-runtime.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import type { Attendee } from "#shared/types.ts";
-import { AttendeeNotesSection } from "#templates/admin/attendee-notes.tsx";
+import {
+  AttendeeNotesSection,
+  type NotesViewProps,
+} from "#templates/admin/attendee-notes.tsx";
 import type { SummaryRow } from "#templates/admin/entity-pages.tsx";
 import { MaybeButtonLink } from "#templates/components/actions.tsx";
 import { dataTable } from "#templates/components/data-table.tsx";
@@ -324,14 +326,7 @@ export const attendeeBanner = ({
   statuses,
   notes,
   isOwner,
-}: {
-  attendee: Attendee;
-  statuses: AttendeeStatus[];
-  notes: SystemNote[];
-  /** Only owners may open the ledger pages, so a note's ledger link renders as
-   * plain text for everyone else. */
-  isOwner: boolean;
-}): JSX.Element | null => {
+}: { attendee: Attendee; statuses: AttendeeStatus[] } & NotesViewProps): JSX.Element | null => {
   const showStatus = statuses.length > 1;
   if (!showStatus && notes.length === 0) return null;
   const status = statuses.find((s) => s.id === attendee.status_id);

--- a/src/ui/templates/admin/attendees-list.tsx
+++ b/src/ui/templates/admin/attendees-list.tsx
@@ -15,10 +15,11 @@ import {
   listingFilterLabel,
   renderTypeFilter,
 } from "#shared/listing-filter.ts";
-import type {
-  AdminSession,
-  AttendeeTableRow,
-  ListingWithCount,
+import {
+  type AdminSession,
+  type AttendeeTableRow,
+  isOwnerRole,
+  type ListingWithCount,
 } from "#shared/types.ts";
 import { AdminPage } from "#templates/admin/admin-page.tsx";
 import { AttendeeNotesSummary } from "#templates/admin/attendee-notes.tsx";
@@ -214,6 +215,7 @@ export const adminAttendeesListPage = (props: AttendeesListPageProps): string =>
         />
 
         <AttendeeNotesSummary
+          isOwner={isOwnerRole(props.session.adminLevel)}
           names={props.names ?? new Map()}
           notes={props.systemNotes ?? []}
         />

--- a/src/ui/templates/admin/listings/overview.tsx
+++ b/src/ui/templates/admin/listings/overview.tsx
@@ -89,6 +89,7 @@ export const ListingOverviewPanel = (
     isChild = false,
     isHiddenPackageMember = false,
     systemNotes = [],
+    isOwner = false,
   } = opts;
   const links = listingLinksFor(listing, allowedDomain);
   const isDaily = listing.listing_type === "daily";
@@ -130,7 +131,11 @@ export const ListingOverviewPanel = (
           listing={listing}
         />
       )}
-      <AttendeeNotesSummary names={noteNames} notes={systemNotes} />
+      <AttendeeNotesSummary
+        isOwner={isOwner}
+        names={noteNames}
+        notes={systemNotes}
+      />
     </PageRegions>
   );
 };

--- a/src/ui/templates/admin/listings/roster.tsx
+++ b/src/ui/templates/admin/listings/roster.tsx
@@ -104,7 +104,11 @@ export const ListingRosterPanel = (opts: ListingPanelOptions): JSX.Element => {
         ),
         sharedRowsHtml: renderDetailRows(v.sharedRows),
       })}
-      <AttendeeNotesSummary names={idNameMap(attendees)} notes={systemNotes} />
+      <AttendeeNotesSummary
+        isOwner={opts.isOwner ?? false}
+        names={idNameMap(attendees)}
+        notes={systemNotes}
+      />
       <AttendeesSection
         activeFilter={v.activeFilter}
         allowedDomain={allowedDomain}

--- a/src/ui/templates/admin/listings/types.ts
+++ b/src/ui/templates/admin/listings/types.ts
@@ -28,6 +28,9 @@ type ListingPanelSharedOptions = {
   isChild?: boolean | undefined;
   isHiddenPackageMember?: boolean | undefined;
   systemNotes?: SystemNote[] | undefined;
+  /** Only owners may open the ledger pages, so a note's ledger link renders
+   * as plain text for everyone else. */
+  isOwner?: boolean | undefined;
 };
 
 export type ListingPanelOptions = ListingPanelSharedOptions & {

--- a/test/shared/markdown.test.ts
+++ b/test/shared/markdown.test.ts
@@ -4,6 +4,7 @@ import {
   isSafeUrl,
   isSimpleMarkdown,
   renderMarkdown,
+  withoutLinksTo,
 } from "#shared/markdown.ts";
 
 describe("markdown", () => {
@@ -169,6 +170,136 @@ describe("markdown", () => {
 
     test("false for raw HTML", () => {
       expect(isSimpleMarkdown("text <b>bold</b> more")).toBe(false);
+    });
+  });
+  describe("withoutLinksTo", () => {
+    test("demotes a link matching the prefix to its plain text", () => {
+      expect(
+        withoutLinksTo(
+          "Check the [ledger](/admin/ledger/attendee/5).",
+          "/admin/ledger",
+        ),
+      ).toBe("Check the ledger.");
+    });
+
+    test("keeps links to other targets untouched", () => {
+      const text = "See [the guide](/admin/guide) for details.";
+      expect(withoutLinksTo(text, "/admin/ledger")).toBe(text);
+    });
+
+    test("handles several links, demoting only the matching ones", () => {
+      expect(
+        withoutLinksTo(
+          "[a](/admin/ledger/x) then [b](/admin/guide) then [c](/admin/ledger)",
+          "/admin/ledger",
+        ),
+      ).toBe("a then [b](/admin/guide) then c");
+    });
+
+    test("leaves plain text without links unchanged", () => {
+      expect(withoutLinksTo("no links here", "/admin/ledger")).toBe(
+        "no links here",
+      );
+    });
+
+    test("demotes every reference link form without changing safe markdown", () => {
+      const markdown = [
+        "**Money links:** [inline](/admin/ledger/inline), [full][money], [collapsed][], and [shortcut].",
+        "",
+        "Safe [guide](/admin/guide) and *formatting* stay unchanged.",
+        "",
+        '[money]: /admin/ledger/full "Money"',
+        "[collapsed]: /admin/ledger/collapsed",
+        "[shortcut]: /admin/ledger/shortcut",
+      ].join("\n");
+
+      const filtered = withoutLinksTo(markdown, "/admin/ledger");
+
+      expect(filtered).toBe(
+        [
+          "**Money links:** inline, full, collapsed, and shortcut.",
+          "",
+          "Safe [guide](/admin/guide) and *formatting* stay unchanged.",
+          "",
+          '[money]: /admin/ledger/full "Money"',
+          "[collapsed]: /admin/ledger/collapsed",
+          "[shortcut]: /admin/ledger/shortcut",
+        ].join("\n"),
+      );
+      const rendered = renderMarkdown(filtered);
+      expect(rendered).not.toContain('href="/admin/ledger');
+      expect(rendered).toContain('<a href="/admin/guide">guide</a>');
+      expect(rendered).toContain("<strong>Money links:</strong>");
+      expect(rendered).toContain("<em>formatting</em>");
+    });
+
+    test("demotes automatic links to a forbidden absolute prefix", () => {
+      expect(
+        withoutLinksTo(
+          "<https://private.example/one> and https://private.example/two",
+          "https://private.example",
+        ),
+      ).toBe("https://private.example/one and https://private.example/two");
+    });
+
+    test("demotes forbidden links inside other markdown structures", () => {
+      const markdown = [
+        "- **See [money](/admin/ledger/list).**",
+        "",
+        "> [Account](/admin/ledger/account)",
+        "",
+        "| Page | Link |",
+        "| --- | --- |",
+        "| Money | [Open](/admin/ledger/table) |",
+      ].join("\n");
+
+      expect(withoutLinksTo(markdown, "/admin/ledger")).toBe(
+        [
+          "- **See money.**",
+          "",
+          "> Account",
+          "",
+          "| Page | Link |",
+          "| --- | --- |",
+          "| Money | Open |",
+        ].join("\n"),
+      );
+    });
+
+    test("preserves multiline quote and list syntax around forbidden links", () => {
+      const markdown = [
+        "> `[money](/admin/ledger/code)` stays code.",
+        ">",
+        "> [Money](/admin/ledger/quote) is restricted.",
+        "",
+        "- `[money](/admin/ledger/list-code)` stays code.",
+        "  [Money](/admin/ledger/list) is restricted.",
+      ].join("\n");
+
+      expect(withoutLinksTo(markdown, "/admin/ledger")).toBe(
+        [
+          "> `[money](/admin/ledger/code)` stays code.",
+          ">",
+          "> Money is restricted.",
+          "",
+          "- `[money](/admin/ledger/list-code)` stays code.",
+          "  Money is restricted.",
+        ].join("\n"),
+      );
+    });
+
+    test("preserves quoted table and list structure", () => {
+      const markdown = [
+        "> - [Money](/admin/ledger/list)",
+        "",
+        "> | Page |",
+        "> | --- |",
+        "> | [Money](/admin/ledger/table) |",
+      ].join("\n");
+
+      expect(withoutLinksTo(markdown, "/admin/ledger")).toBe(
+        ["> - Money", "", "> | Page |", "> | --- |", "> | Money |"].join("\n"),
+      );
     });
   });
 });

--- a/test/shared/markdown.test.ts
+++ b/test/shared/markdown.test.ts
@@ -301,5 +301,46 @@ describe("markdown", () => {
         ["> - Money", "", "> | Page |", "> | --- |", "> | Money |"].join("\n"),
       );
     });
+
+    test("does not crash on a table with escaped pipes and still demotes links in other cells", () => {
+      // Marked normalizes `\|` to `|` in cell.text, so a cell with an escaped
+      // pipe can't be located in token.raw. Before the fix this hit an assert
+      // and crashed; now the unmatched cell is skipped (its raw source stays)
+      // while matched cells are still rewritten.
+      const markdown = [
+        "| Link | Note |",
+        "| --- | --- |",
+        "| [money](/admin/ledger/x) | a\\|b |",
+      ].join("\n");
+
+      const filtered = withoutLinksTo(markdown, "/admin/ledger");
+      expect(filtered).toBe(
+        [
+          "| Link | Note |",
+          "| --- | --- |",
+          "| money | a\\|b |",
+        ].join("\n"),
+      );
+    });
+
+    test("demotes links matching a predicate, not just a string prefix", () => {
+      // The attendee ledger tab (/admin/attendees/:id/ledger) is owner-only
+      // but doesn't share a prefix with the standalone /admin/ledger routes.
+      // A predicate matcher catches both.
+      const isOwnerOnly = (href: string): boolean =>
+        href.startsWith("/admin/ledger") ||
+        (href.startsWith("/admin/attendees/") && href.includes("/ledger"));
+
+      expect(
+        withoutLinksTo(
+          "See the [ledger](/admin/attendees/5/ledger).",
+          isOwnerOnly,
+        ),
+      ).toBe("See the ledger.");
+      // A link to the attendee page itself (not the ledger tab) is kept.
+      expect(
+        withoutLinksTo("See [Ada](/admin/attendees/5).", isOwnerOnly),
+      ).toBe("See [Ada](/admin/attendees/5).");
+    });
   });
 });

--- a/test/shared/markdown.test.ts
+++ b/test/shared/markdown.test.ts
@@ -315,11 +315,7 @@ describe("markdown", () => {
 
       const filtered = withoutLinksTo(markdown, "/admin/ledger");
       expect(filtered).toBe(
-        [
-          "| Link | Note |",
-          "| --- | --- |",
-          "| money | a\\|b |",
-        ].join("\n"),
+        ["| Link | Note |", "| --- | --- |", "| money | a\\|b |"].join("\n"),
       );
     });
 

--- a/test/ui/templates/admin/attendee-notes.test.tsx
+++ b/test/ui/templates/admin/attendee-notes.test.tsx
@@ -30,10 +30,10 @@ beforeAll(async () => {
 
 describe("AttendeeNotesSection", () => {
   test("renders a system note as a red alert with its markdown link", () => {
-    const html = String(<AttendeeNotesSection notes={[note()]} />);
+    const html = String(<AttendeeNotesSection isOwner notes={[note()]} />);
     expect(html).toContain("system-note-alert");
     expect(html).toContain('role="alert"');
-    // The markdown body is rendered (the ledger link survives).
+    // The markdown body is rendered — for an OWNER the ledger link survives.
     expect(html).toContain('href="/admin/ledger?attendee=5"');
     // The × opens the are-you-sure delete page, returning to the attendee page.
     expect(html).toContain(
@@ -41,9 +41,20 @@ describe("AttendeeNotesSection", () => {
     );
   });
 
+  test("demotes the ledger link to plain text for a non-owner admin", () => {
+    const html = String(
+      <AttendeeNotesSection isOwner={false} notes={[note()]} />,
+    );
+    // The words stay, the owner-only link goes — a rendered link is a promise
+    // that it works, and only owners may open the ledger pages.
+    expect(html).toContain("see the ledger");
+    expect(html).not.toContain('href="/admin/ledger?attendee=5"');
+  });
+
   test("renders an owner note without the alert styling", () => {
     const html = String(
       <AttendeeNotesSection
+        isOwner={false}
         notes={[note({ note: "private reminder", type: "owner" })]}
       />,
     );
@@ -55,13 +66,13 @@ describe("AttendeeNotesSection", () => {
     // The empty section is dropped entirely (null renders as "" inside its
     // parent fragment) — the "Add a note" affordance now lives beside the page
     // heading (see AddNoteLink), not here.
-    expect(AttendeeNotesSection({ notes: [] })).toBeNull();
+    expect(AttendeeNotesSection({ isOwner: false, notes: [] })).toBeNull();
   });
 
   test("hides the delete link in read-only mode", () => {
     const restore = setTestEnv({ READ_ONLY_FROM: "2020-01-01T00:00:00.000Z" });
     try {
-      const html = String(<AttendeeNotesSection notes={[note()]} />);
+      const html = String(<AttendeeNotesSection isOwner notes={[note()]} />);
       expect(html).toContain("Refunded");
       expect(html).not.toContain("/admin/attendee/5/note/1/delete");
     } finally {
@@ -87,6 +98,7 @@ describe("AttendeeNotesSummary", () => {
     ]);
     const html = String(
       <AttendeeNotesSummary
+        isOwner={false}
         names={names}
         notes={[
           note({ attendee_id: 5, id: 1, note: "first" }),
@@ -106,6 +118,7 @@ describe("AttendeeNotesSummary", () => {
   test("falls back to the id when a name is unknown", () => {
     const html = String(
       <AttendeeNotesSummary
+        isOwner={false}
         names={new Map()}
         notes={[note({ attendee_id: 9 })]}
       />,
@@ -113,8 +126,33 @@ describe("AttendeeNotesSummary", () => {
     expect(html).toContain("#9");
   });
 
+  test("demotes a note's ledger link for non-owners but keeps it for owners", () => {
+    // A rendered link is a promise that it works: the ledger pages are
+    // owner-only, so a non-owner sees the words without the link.
+    const staffHtml = String(
+      <AttendeeNotesSummary
+        isOwner={false}
+        names={new Map([[5, "Alice"]])}
+        notes={[note({ attendee_id: 5 })]}
+      />,
+    );
+    expect(staffHtml).toContain("see the ledger");
+    expect(staffHtml).not.toContain('href="/admin/ledger?attendee=5"');
+
+    const ownerHtml = String(
+      <AttendeeNotesSummary
+        isOwner
+        names={new Map([[5, "Alice"]])}
+        notes={[note({ attendee_id: 5 })]}
+      />,
+    );
+    expect(ownerHtml).toContain('href="/admin/ledger?attendee=5"');
+  });
+
   test("renders nothing when there are no notes", () => {
-    const html = String(<AttendeeNotesSummary names={new Map()} notes={[]} />);
+    const html = String(
+      <AttendeeNotesSummary isOwner={false} names={new Map()} notes={[]} />,
+    );
     expect(html).not.toContain("<details");
     expect(html).not.toContain("have notes");
   });

--- a/test/ui/templates/admin/attendee-notes.test.tsx
+++ b/test/ui/templates/admin/attendee-notes.test.tsx
@@ -51,6 +51,25 @@ describe("AttendeeNotesSection", () => {
     expect(html).not.toContain('href="/admin/ledger?attendee=5"');
   });
 
+  test("demotes the attendee ledger-tab link too, not just standalone /admin/ledger", () => {
+    // The attendee page's ledger tab (/admin/attendees/:id/ledger) is also
+    // owner-only — PaymentDetails links to it, and an operator could paste it
+    // into a note. Without catching it, a non-owner would see a dead link.
+    const ledgerTabNote = note({
+      note: "Check the [ledger](/admin/attendees/5/ledger).",
+    });
+    const staffHtml = String(
+      <AttendeeNotesSection isOwner={false} notes={[ledgerTabNote]} />,
+    );
+    expect(staffHtml).toContain("Check the ledger");
+    expect(staffHtml).not.toContain('href="/admin/attendees/5/ledger"');
+
+    const ownerHtml = String(
+      <AttendeeNotesSection isOwner notes={[ledgerTabNote]} />,
+    );
+    expect(ownerHtml).toContain('href="/admin/attendees/5/ledger"');
+  });
+
   test("renders an owner note without the alert styling", () => {
     const html = String(
       <AttendeeNotesSection

--- a/test/ui/templates/admin/attendee-page.test.ts
+++ b/test/ui/templates/admin/attendee-page.test.ts
@@ -34,9 +34,11 @@ const OWNER_NOTE: SystemNote = {
 const renderBanner = (
   statuses: AttendeeStatus[],
   notes: SystemNote[] = [],
+  isOwner = false,
 ): JSX.Element | null =>
   attendeeBanner({
     attendee: testAttendee({ status_id: 1 }),
+    isOwner,
     notes,
     statuses,
   });
@@ -106,6 +108,24 @@ describe("attendee page blocks", () => {
       /^<div class="page-block attendee-banner"><section class="attendee-notes">[\s\S]*<p>Bring identification<\/p>[\s\S]*<\/section><\/div>$/,
     );
     expect(html).not.toContain("attendee-status");
+  });
+
+  test("keeps a note's ledger link for owners but demotes it for other admins", () => {
+    const ledgerNote: SystemNote = {
+      ...OWNER_NOTE,
+      note: "Refunded. Please check the [ledger](/admin/ledger/attendee/1).",
+      type: "system",
+    };
+    // The ledger pages are owner-only, so a non-owner's note renders the
+    // words without the link — a rendered link is a promise that it works.
+    const staffHtml = String(renderBanner([attendeeStatus()], [ledgerNote]));
+    expect(staffHtml).toContain("check the ledger");
+    expect(staffHtml).not.toContain('href="/admin/ledger/attendee/1"');
+
+    const ownerHtml = String(
+      renderBanner([attendeeStatus()], [ledgerNote], true),
+    );
+    expect(ownerHtml).toContain('href="/admin/ledger/attendee/1"');
   });
 
   test("omits the payment block when the attendee has no payment", () => {


### PR DESCRIPTION
A stored note can carry a markdown link to the ledger. The refund notes do, for example. But the ledger pages are owner-only, so every other admin saw a link that only 404s when they clicked it.

## What changes

- A note's ledger link now shows as plain words for anyone who isn't an owner. Owners still get the link. A rendered link is a promise that it works, so a viewer who can't open it gets the words instead.
- This applies everywhere a note body renders: the attendee banner, the notes summary above the attendee list, the notes summary on the listing Overview and Attendees (roster) tabs, and the delete-note confirmation page.

## How the link is stripped

The earlier approach was a regex that only matched inline `[text](url)` links. It missed reference links (`[text][ref]`), collapsed references, shortcuts, automatic links (`<https://…>`), and links nested inside lists, blockquotes, or table cells.

This PR replaces it with a token-aware Markdown walker (`withoutLinksTo` in `src/shared/markdown.ts`). It parses the note with marked's lexer, walks the token tree, and rewrites each link whose target starts with the forbidden prefix (here, `/admin/ledger`) back to its plain text — stitching the source back together byte-for-byte so all the safe markdown around it (list markers, table pipes, quote markers, code spans) is preserved. A code span that happens to look like a link is left untouched, and the markdown structure never breaks.

## Scope

In scope for this PR (PR 5 of the staged-checkout split):

- `src/shared/markdown.ts` — the token-aware `withoutLinksTo` helper.
- `src/ui/templates/admin/attendee-notes.tsx` — `NoteBody` takes an `isOwner` flag; `NoteBox`, `AttendeeNotesSection`, `AttendeeNotesSummary`, and the delete-note page thread it through.
- Owner-role plumbing through the attendee page banner, the attendees list, and the listing Overview + roster panels.
- Tests: `withoutLinksTo` unit tests covering every link form and nesting, plus note/banner rendering tests that assert owners keep the link and non-owners get plain text.

Out of scope (handled by other PRs in the split, not brought in here): deleted-listing display, pending-checkout UI, held-cash actions, and other attendee-page changes from the mixed source commits.

## Acceptance

- Every rendered link is reachable by the viewer's role.
- Owners retain the ledger links.
- Non-owners retain readable note text and formatting without a dead link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Owner-level administrators can continue to open ledger links from attendee notes.
  * Non-owner administrators now consistently see ledger references as plain text (not clickable), including on attendee pages and admin listing panels.

* **Bug Fixes**
  * Improved owner-aware rendering for attendee system notes, aligning behavior across notes views and note deletion confirmations.
  * Enhanced markdown processing to reliably demote disallowed ledger links without breaking existing formatting (including tables and complex markdown).

* **Tests**
  * Expanded markdown and UI test coverage for owner vs non-owner rendering across inline and complex contexts (lists, quotes, tables).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->