### PR TITLE
Strengthen functional utility mutation coverage

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -64,6 +64,15 @@ src/shared/accounting/manual-entries.ts:209:29  ?? → ||   # guard error messag
 src/shared/checkout-ledger.ts:35:72  ?? → ||   # find(...)?.amount: number|undefined; the only falsy-non-null amount is 0 and 0 ?? 0 === 0 || 0
 src/shared/accounting/queries.ts:162:26  || → &&   # transferActivityBounds: MIN(occurred_at) and MAX(occurred_at) over one table are NULL together (both iff the table is empty), so either-null and both-null coincide
 
+# Collection cache generation values are only compared for equality. Their
+# absolute value and direction do not matter: every invalidation changes the
+# value, so a fetch started before it cannot populate the cache. The unloaded
+# timestamp is never read because `items` is null, and size is an array length.
+src/fp.ts:449:33  0 → 1   # initial time is replaced when items first load; null items short-circuit the TTL check
+src/fp.ts:451:20  0 → 1   # generation starts at an arbitrary value and is only compared with a captured copy
+src/fp.ts:466:17  ++ → --   # either direction changes generation and invalidates every older captured copy
+src/fp.ts:469:49  ?? → ||   # items?.length is undefined or a non-negative integer; 0 and undefined both produce 0
+
 # Parent/child fold moved to fold-tree.ts in Phase 2a (see the fold-tree.ts
 # entries below); the ticket-payment.ts fold-internal equivalents went with it.
 # What stays here are `?? F` vs `|| F` sites whose left operand can never be a

--- a/test/fp/caches.test.ts
+++ b/test/fp/caches.test.ts
@@ -223,6 +223,7 @@ describe("fp caches and resources", () => {
       expect(cache.get("a")).toBe(1);
       setTime(101);
       expect(cache.get("a")).toBe(undefined);
+      expect(cache.size()).toBe(0);
     });
 
     test("clear empties the cache", () => {

--- a/test/fp/collections.test.ts
+++ b/test/fp/collections.test.ts
@@ -2,9 +2,11 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   byId,
+  compact,
   filter,
   flatMap,
   groupToMap,
+  joinStrings,
   map,
   mapBy,
   mapById,
@@ -15,6 +17,18 @@ import {
 } from "#fp";
 
 describe("fp collections", () => {
+  describe("compact", () => {
+    test("removes null and undefined while keeping other falsy values", () => {
+      expect(compact([0, null, "", undefined, false])).toEqual([0, "", false]);
+    });
+  });
+
+  describe("joinStrings", () => {
+    test("joins every string without adding text", () => {
+      expect(joinStrings(["first", "", "second"])).toBe("firstsecond");
+    });
+  });
+
   describe("requiredMapValue", () => {
     test("returns a stored value", () => {
       expect(requiredMapValue(new Map([[4, "four"]]), 4, "missing")).toBe(
@@ -184,6 +198,17 @@ describe("fp collections", () => {
           () => 1,
         )([]),
       ).toEqual(new Map());
+    });
+
+    test("keeps a NaN total", () => {
+      const totals = sumByKey(
+        (item: { amount: number; key: string }) => item.key,
+        (item) => item.amount,
+      )([
+        { amount: Number.NaN, key: "a" },
+        { amount: 2, key: "a" },
+      ]);
+      expect(totals.get("a")).toBe(Number.NaN);
     });
   });
 


### PR DESCRIPTION
## What changed

- Added exact tests for nullish compaction, string joining, `NaN` keyed sums, and removal of expired cache entries.
- Recorded four collection-cache mutants whose behavior is provably identical because cache generations are only compared for equality and sizes are non-negative array lengths.

## Why

A focused mutation run after #1825 found nine survivors in `src/fp.ts`. Five were test gaps and now fail under their mutations. The other four cannot change observable behavior and now have written proofs.

No production code changed.

## Validation

- [x] `deno task precommit` after merging the latest `main`
- [x] `deno task mutation src/fp.ts test/fp/*.test.ts` — 100%: 68 killed, 4 proven equivalents, 0 survivors
- [x] Codex reviewed `468754dc2e` and found no major issues