### PR TITLE
Add one shared builder for signed paid booking rows

### DIFF
--- a/src/features/api/payment-processing/create.ts
+++ b/src/features/api/payment-processing/create.ts
@@ -258,19 +258,24 @@ export const createAttendeeForSession = async (
   // 1:1 by index with validatedItems. `paidByIntentItem.get(...)` is always
   // defined for a priced item (every intent item produces a priced line), so
   // the raw value flows straight through — a genuine `0` (a free line that
-  // was still signed) stays `0`, and a line that carries no price stays
-  // unpriced, the distinction `orderBookings` preserves onto the rows.
+  // was still signed) stays `0`. The conditional spread is for
+  // `exactOptionalPropertyTypes`: an explicit `undefined` cannot be assigned
+  // to an optional `number`, so `pricePaid` is omitted when absent (the DB
+  // layer then coerces it to `0` at insert, matching the prior `?? 0`).
   const paidByIntentItem = paidByItem(pricedOrder);
   const bookings = orderBookings({
     allocations: intent.allocations,
     date: intent.date,
     dayCount: intent.dayCount,
-    lines: validatedItems.map(({ item, listing }, index) => ({
-      ...bookingSlot(item),
-      listing,
-      pricePaid: paidByIntentItem.get(pricingIntent.items[index]!),
-      quantity: item.q,
-    })),
+    lines: validatedItems.map(({ item, listing }, index) => {
+      const pricePaid = paidByIntentItem.get(pricingIntent.items[index]!);
+      return {
+        ...bookingSlot(item),
+        listing,
+        ...(pricePaid !== undefined ? { pricePaid } : {}),
+        quantity: item.q,
+      };
+    }),
   });
   const fullTotal = pricedOrder.fullSubtotal;
   const depositTotal = orderLineTotal(pricedOrder);

--- a/src/features/api/payment-processing/create.ts
+++ b/src/features/api/payment-processing/create.ts
@@ -16,12 +16,8 @@ import type {
   BookingIntent,
   PaymentResult,
 } from "#routes/api/webhook-types.ts";
-import { bookingDateFields } from "#routes/public/ticket-payment.ts";
-import {
-  soleParentPackageIds,
-  stampChildRowPackages,
-} from "#shared/booking/page-packages.ts";
 import { lineGroupId } from "#shared/booking/signed-metadata.ts";
+import { orderBookings } from "#shared/booking-lines.ts";
 import { capacityErrorFormatter } from "#shared/capacity-error.ts";
 import { bookingBatchPlan } from "#shared/checkout-complete.ts";
 import type {
@@ -31,13 +27,11 @@ import type {
 import { formatCurrency } from "#shared/currency.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import { getPublicStatusId } from "#shared/db/attendee-statuses.ts";
-import type { ListingBooking } from "#shared/db/attendee-types.ts";
 import {
   type createAttendeeAtomic,
   createBookingAtomic,
 } from "#shared/db/attendees/api.ts";
 import { ensureAllBookings } from "#shared/db/attendees/create.ts";
-import { expandChildAllocations } from "#shared/db/attendees/order-parents.ts";
 import {
   decryptSessionTokens,
   type ProcessedPayment,
@@ -261,33 +255,23 @@ export const createAttendeeForSession = async (
   // Per-LINE paid amounts: a listing booked through two paths is two lines
   // with their own prices, and each becomes its own booking row. The priced
   // order's lines reference the pricing intent's item objects, which pair
-  // 1:1 by index with validatedItems.
+  // 1:1 by index with validatedItems. `paidByIntentItem.get(...)` is always
+  // defined for a priced item (every intent item produces a priced line), so
+  // the raw value flows straight through — a genuine `0` (a free line that
+  // was still signed) stays `0`, and a line that carries no price stays
+  // unpriced, the distinction `orderBookings` preserves onto the rows.
   const paidByIntentItem = paidByItem(pricedOrder);
-  const rawBookings: ListingBooking[] = validatedItems.map(
-    ({ item, listing }, index) => ({
+  const bookings = orderBookings({
+    allocations: intent.allocations,
+    date: intent.date,
+    dayCount: intent.dayCount,
+    lines: validatedItems.map(({ item, listing }, index) => ({
       ...bookingSlot(item),
-      pricePaid: paidByIntentItem.get(pricingIntent.items[index]!) ?? 0,
+      listing,
+      pricePaid: paidByIntentItem.get(pricingIntent.items[index]!),
       quantity: item.q,
-      ...bookingDateFields(listing, intent.date, intent.dayCount),
-    }),
-  );
-  // Expand summed child bookings into per-parent rows when allocations were
-  // carried through the signed metadata (paid-path provenance): each
-  // allocation becomes its own listing_attendees row with the correct
-  // parentListingId and proportional pricePaid, mirroring the free-path
-  // behaviour in createFreeReservation. Each child row is then stamped with
-  // its parent's package when the parent books through exactly one path.
-  const bookings = stampChildRowPackages(
-    intent.allocations && intent.allocations.length > 0
-      ? expandChildAllocations(rawBookings, intent.allocations)
-      : rawBookings,
-    soleParentPackageIds(
-      intent.items.map((item) => ({
-        listingId: item.e,
-        packageGroupId: lineGroupId(item),
-      })),
-    ),
-  );
+    })),
+  });
   const fullTotal = pricedOrder.fullSubtotal;
   const depositTotal = orderLineTotal(pricedOrder);
   const remainingBalance =

--- a/src/features/api/payment-processing/store-refund.ts
+++ b/src/features/api/payment-processing/store-refund.ts
@@ -28,7 +28,7 @@ import type {
   PaymentFailureResult,
   PaymentResult,
 } from "#routes/api/webhook-types.ts";
-import { bookingDateFields } from "#routes/public/ticket-payment.ts";
+import { bookingDateFields } from "#shared/booking-date-fields.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import { createAttendeeAtomic } from "#shared/db/attendees/api.ts";
 import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";

--- a/src/features/public/ticket-payment.ts
+++ b/src/features/public/ticket-payment.ts
@@ -35,7 +35,7 @@ import {
   stampChildRowPackages,
 } from "#shared/booking/page-packages.ts";
 import type { BookingTree } from "#shared/booking/tree.ts";
-import { capacityDateFor } from "#shared/capacity-rules.ts";
+import { bookingDateFields } from "#shared/booking-date-fields.ts";
 import { bookingBatchPlan } from "#shared/checkout-complete.ts";
 import type { PricedOrder } from "#shared/checkout-pricing.ts";
 import { getBookableStartDates, isBookingRangeValid } from "#shared/dates.ts";
@@ -97,7 +97,6 @@ import {
   type Group,
   type Holiday,
   type ListingWithCount,
-  normalizeDurationDays,
 } from "#shared/types.ts";
 import { parsePositiveInt } from "#shared/validation/number.ts";
 /* jscpd:ignore-start */
@@ -200,27 +199,6 @@ export const checkAvailability = (
     ),
     date,
   );
-
-/**
- * Shared booking-date fields (date + durationDays), keeping the payment and
- * webhook flows aligned. Span: customisable listings use the chosen `dayCount`;
- * daily listings use their fixed `duration_days`; standard listings span 1 day.
- */
-export const bookingDateFields = (
-  listing: Pick<
-    TicketListing["listing"],
-    "listing_type" | "duration_days" | "customisable_days"
-  >,
-  date: string | null,
-  dayCount = 1,
-): { date: string | null; durationDays: number } => ({
-  date: capacityDateFor(listing.listing_type, date),
-  durationDays: listing.customisable_days
-    ? normalizeDurationDays(dayCount)
-    : listing.listing_type === "daily"
-      ? normalizeDurationDays(listing.duration_days)
-      : 1,
-});
 
 /** Load one group's package pricing and shape it into the {@link PagePackage}
  * the booking flow carries — the group's display fields plus its member

--- a/src/shared/booking-date-fields.ts
+++ b/src/shared/booking-date-fields.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared booking date and duration rules — the single definition of how a
+ * booking row's `date` and `durationDays` are derived from a listing's type
+ * and the buyer's chosen span. Both the payment flows (paid webhook,
+ * store-and-refund placeholder) and the public availability/free-booking
+ * paths route through here so a listing's range policy can never drift between
+ * them.
+ *
+ * This module is pure: callers pass the listing facts and the chosen date/day
+ * count, it returns the two fields. No database, no settings.
+ */
+
+import { capacityDateFor } from "#shared/capacity-rules.ts";
+import type { ListingWithCount } from "#shared/types.ts";
+import { normalizeDurationDays } from "#shared/types.ts";
+
+/** The listing facts the row builder reads to derive a booking's date and
+ *  duration. Narrower than the full listing so the helper stays pure over the
+ *  fields it actually consumes. */
+export type BookingDateSource = Pick<
+  ListingWithCount,
+  "listing_type" | "duration_days" | "customisable_days"
+>;
+
+/**
+ * Shared booking-date fields (date + durationDays).
+ *
+ * Span rules, one declaration:
+ *  - A `customisable_days` listing spans the chosen `dayCount`.
+ *  - A non-customisable `daily` listing spans its fixed `duration_days`.
+ *  - A `standard` listing spans one dateless day (no range column).
+ *
+ * `dayCount` defaults to `1`, and {@link normalizeDurationDays} clamps
+ * non-finite input back to `1`, so a genuinely optional `dayCount` (a legacy
+ * signed session without `day_count`, modelled as `undefined` on
+ * `BookingIntent`) flows through that default unchanged — missing day count
+ * still means one day. `capacityDateFor` drops the date for date-less
+ * (standard) listings whose own cap is a running total, never a per-date
+ * count.
+ */
+export const bookingDateFields = (
+  listing: BookingDateSource,
+  date: string | null,
+  dayCount = 1,
+): { date: string | null; durationDays: number } => ({
+  date: capacityDateFor(listing.listing_type, date),
+  durationDays: listing.customisable_days
+    ? normalizeDurationDays(dayCount)
+    : listing.listing_type === "daily"
+      ? normalizeDurationDays(listing.duration_days)
+      : 1,
+});

--- a/src/shared/booking-lines.ts
+++ b/src/shared/booking-lines.ts
@@ -64,11 +64,15 @@ export type OrderBookingsInput = {
    *  when no selected listing is customisable — modelled as optional to
    *  mirror the genuinely optional `BookingIntent.dayCount` (a legacy session
    *  without `day_count` still means one day via {@link bookingDateFields}'s
-   *  default). */
-  dayCount?: number;
+   *  default). Typed `number | undefined` (not bare `?: number`) so an
+   *  intent's `dayCount` can be passed through directly under
+   *  `exactOptionalPropertyTypes`. */
+  dayCount?: number | undefined;
   /** Per-(child, parent) allocations from the fold, carried through the signed
-   *  metadata. Absent or empty for legacy/no-parent orders. */
-  allocations?: ChildAllocation[];
+   *  metadata. Absent or empty for legacy/no-parent orders. Typed
+   *  `ChildAllocation[] | undefined` so an intent's `allocations` can be
+   *  passed through directly under `exactOptionalPropertyTypes`. */
+  allocations?: ChildAllocation[] | undefined;
 };
 
 /**

--- a/src/shared/booking-lines.ts
+++ b/src/shared/booking-lines.ts
@@ -1,0 +1,105 @@
+/**
+ * The canonical signed paid booking rows — one representation of what a
+ * completed, correctly-priced order writes to `listing_attendees`, shared by
+ * ordinary payment completion. The later staged-checkout runtime will reach
+ * the same rows through the same builder, which is why the builder is pure
+ * over its inputs (the only impurity is the single order-token UUID the
+ * expansion mints, mirroring the in-memory token main's rows already share).
+ *
+ * Behaviour kept identical to main's paid webhook path:
+ *  - one row per signed line, carrying listing, quantity, date, duration,
+ *    package path, and paid price, in input order;
+ *  - child allocations expand into one row per (child, parent), preserving
+ *    total quantity and exact total paid price (the last split row absorbs
+ *    the rounding residue) and sharing one order token;
+ *  - a folded child is stamped with its parent's package ONLY when that parent
+ *    books through exactly one path — mixed and standalone parent paths do
+ *    not falsely stamp children;
+ *  - a genuine `pricePaid: 0` (a free line that was still signed) is kept
+ *    distinct from an omitted price, so the ledger never confuses "free"
+ *    with "unpriced".
+ */
+
+import {
+  soleParentPackageIds,
+  stampChildRowPackages,
+} from "#shared/booking/page-packages.ts";
+import {
+  type BookingDateSource,
+  bookingDateFields,
+} from "#shared/booking-date-fields.ts";
+import type {
+  ChildAllocation,
+  ListingBooking,
+} from "#shared/db/attendee-types.ts";
+import { expandChildAllocations } from "#shared/db/attendees/order-parents.ts";
+
+/** One signed paid line: the booking slot (listing id + package path), the
+ *  quantity, the listing's date/duration facts, and the line's charged
+ *  amount — everything {@link orderBookings} needs to build one canonical
+ *  {@link ListingBooking} row before child-allocation expansion.
+ *
+ *  The slot's `packageGroupId` is `0` for a standalone line and the package's
+ *  group id for a line booked through a package — the same `packageGroupId 0`
+ *  contract the existing writers expect. `pricePaid` carries the distinction
+ *  the ledger depends on: a genuine `0` stays `0`; an `undefined` line
+ *  carries no price and is written to no row's `pricePaid`. */
+export type SignedPaidLine = {
+  listingId: number;
+  packageGroupId: number;
+  quantity: number;
+  /** The listing facts that derive the row's `date`/`durationDays`. */
+  listing: BookingDateSource;
+  /** The line's charged amount in minor units, or `undefined` when the line
+   *  carries no price. */
+  pricePaid?: number;
+};
+
+/** Input to {@link orderBookings}: the signed paid lines plus the order's
+ *  shared date, day count, and per-(child, parent) allocations. */
+export type OrderBookingsInput = {
+  lines: SignedPaidLine[];
+  date: string | null;
+  /** Visitor-chosen day count for "customisable days" listings. Absent or 1
+   *  when no selected listing is customisable — modelled as optional to
+   *  mirror the genuinely optional `BookingIntent.dayCount` (a legacy session
+   *  without `day_count` still means one day via {@link bookingDateFields}'s
+   *  default). */
+  dayCount?: number;
+  /** Per-(child, parent) allocations from the fold, carried through the signed
+   *  metadata. Absent or empty for legacy/no-parent orders. */
+  allocations?: ChildAllocation[];
+};
+
+/**
+ * Build the canonical signed paid booking rows from a validated, priced order.
+ *
+ * Each line becomes one row carrying its listing, quantity, date, duration,
+ * package path, and paid price; child lines expand into per-parent rows when
+ * allocations are present; each folded child is stamped with its parent's
+ * package only when that parent books through exactly one path (see
+ * {@link soleParentPackageIds}). Preserves input order, exact total paid price
+ * (the last split row absorbs the rounding residue), the `pricePaid: 0`
+ * versus omitted distinction, and one shared order token across every
+ * expanded row.
+ */
+export const orderBookings = (input: OrderBookingsInput): ListingBooking[] => {
+  const { lines, date, dayCount, allocations } = input;
+  const rawBookings: ListingBooking[] = lines.map((line) => ({
+    listingId: line.listingId,
+    packageGroupId: line.packageGroupId,
+    quantity: line.quantity,
+    ...bookingDateFields(line.listing, date, dayCount),
+    ...(line.pricePaid !== undefined ? { pricePaid: line.pricePaid } : {}),
+  }));
+  return stampChildRowPackages(
+    allocations && allocations.length > 0
+      ? expandChildAllocations(rawBookings, allocations)
+      : rawBookings,
+    // soleParentPackageIds reads each line's package path; a SignedPaidLine
+    // already carries packageGroupId (0 = standalone, dropped; N = a sole
+    // package, kept), so the lines can be passed directly — matching main's
+    // per-line package-group derivation.
+    soleParentPackageIds(lines),
+  );
+};

--- a/src/shared/db/attendees/order-parents.ts
+++ b/src/shared/db/attendees/order-parents.ts
@@ -108,15 +108,23 @@ const splitPricePaid = (
 };
 
 /** Expand one booking into its rows: one per `(child, parent)` allocation
- * (carrying that parent), plus — for any units the allocations don't cover — a
- * single parent-less remainder row. A booking with no allocation stays one
- * standalone row. `pricePaid` is split across the rows by {@link splitPricePaid}. */
-const expandBooking = (
-  booking: ListingBooking,
+ *  (carrying that parent), plus — for any units the allocations don't cover — a
+ *  single parent-less remainder row. A booking with no allocation stays one
+ *  standalone row. `pricePaid` is split across the rows by {@link splitPricePaid}.
+ *
+ *  Generic over `T extends ListingBooking` so a caller that carries extra
+ *  required row fields through the booking keeps them on every expanded row —
+ *  the spread copies all of `booking`'s own properties and only overrides the
+ *  `ListingBooking`-compatible members (parent, quantity, price, token). The
+ *  cast is the standard workaround for TypeScript's inability to prove a
+ *  generic object spread is assignable back to its parameter; the spread
+ *  structurally preserves `T`, so the assertion is sound. */
+const expandBooking = <T extends ListingBooking>(
+  booking: T,
   childAllocs: readonly { parentId: number; qty: number }[] | undefined,
   orderToken: string,
-): ListingBooking[] => {
-  if (!childAllocs) return [{ ...booking, orderToken }];
+): T[] => {
+  if (!childAllocs) return [{ ...booking, orderToken }] as T[];
   const totalQty = booking.quantity ?? 1;
   const allocatedQty = childAllocs.reduce((sum, a) => sum + a.qty, 0);
   const remainderQty = totalQty - allocatedQty;
@@ -135,7 +143,7 @@ const expandBooking = (
     quantity: row.qty,
     ...(row.parentId !== undefined ? { parentListingId: row.parentId } : {}),
     ...(prices[i] !== undefined ? { pricePaid: prices[i] } : {}),
-  }));
+  })) as T[];
 };
 
 /**
@@ -152,12 +160,14 @@ const expandBooking = (
  * the latter recomputes parentListingId as "first in-order parent" (lossy for
  * multi-parent), this function uses the allocation list to record the exact
  * parent for each unit. Used by both the free path and the paid webhook path,
- * which thread the allocation through the round-trip.
+ * which thread the allocation through the round-trip. Generic over
+ * `T extends ListingBooking` so any required row fields a caller carries on
+ * each booking survive the expansion.
  */
-export const expandChildAllocations = (
-  bookings: ListingBooking[],
+export const expandChildAllocations = <T extends ListingBooking>(
+  bookings: T[],
   allocations: ChildAllocation[],
-): ListingBooking[] => {
+): T[] => {
   const orderToken = crypto.randomUUID();
   const allocByChild = new Map<number, { parentId: number; qty: number }[]>();
   for (const alloc of allocations) {

--- a/test/features/public/ticket-payment.test.ts
+++ b/test/features/public/ticket-payment.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { parseQuantityValue } from "#routes/public/ticket-form.ts";
 import {
-  bookingDateFields,
   computeSharedDates,
   createFreeReservation,
   foldSelectedChildren,
@@ -561,53 +560,6 @@ describeWithEnv("routes > public > ticket-payment", { db: true }, () => {
       // Nothing persisted — no attendee, and no orphaned ledger legs.
       expect((await getAttendeesRaw(listing.id)).length).toBe(0);
       expect((await allTransfers()).length).toBe(0);
-    });
-  });
-
-  describe("bookingDateFields", () => {
-    test("standard non-customisable booking spans a single dateless day", () => {
-      const listing = testListingWithCount({ listing_type: "standard" });
-      expect(bookingDateFields(listing, null, 3)).toEqual({
-        date: null,
-        durationDays: 1,
-      });
-    });
-
-    test("daily non-customisable booking uses the listing's fixed duration", () => {
-      const listing = testListingWithCount({
-        duration_days: 4,
-        listing_type: "daily",
-      });
-      expect(bookingDateFields(listing, "2026-07-01", 2)).toEqual({
-        date: "2026-07-01",
-        durationDays: 4,
-      });
-    });
-
-    test("customisable daily booking spans the chosen day count", () => {
-      const listing = testListingWithCount({
-        customisable_days: true,
-        day_prices: { 1: 1000, 3: 2500 },
-        duration_days: 5,
-        listing_type: "daily",
-      });
-      expect(bookingDateFields(listing, "2026-07-01", 3)).toEqual({
-        date: "2026-07-01",
-        durationDays: 3,
-      });
-    });
-
-    test("customisable standard booking carries the day count but no date", () => {
-      const listing = testListingWithCount({
-        customisable_days: true,
-        day_prices: { 2: 1800 },
-        duration_days: 3,
-        listing_type: "standard",
-      });
-      expect(bookingDateFields(listing, null, 2)).toEqual({
-        date: null,
-        durationDays: 2,
-      });
     });
   });
 

--- a/test/shared/booking-date-fields.test.ts
+++ b/test/shared/booking-date-fields.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { bookingDateFields } from "#shared/booking-date-fields.ts";
+import { testListingWithCount } from "#test-utils/factories.ts";
+
+describe("bookingDateFields", () => {
+  test("standard non-customisable booking spans a single dateless day", () => {
+    const listing = testListingWithCount({ listing_type: "standard" });
+    expect(bookingDateFields(listing, null, 3)).toEqual({
+      date: null,
+      durationDays: 1,
+    });
+  });
+
+  test("daily non-customisable booking uses the listing's fixed duration", () => {
+    const listing = testListingWithCount({
+      duration_days: 4,
+      listing_type: "daily",
+    });
+    expect(bookingDateFields(listing, "2026-07-01", 2)).toEqual({
+      date: "2026-07-01",
+      durationDays: 4,
+    });
+  });
+
+  test("customisable daily booking spans the chosen day count", () => {
+    const listing = testListingWithCount({
+      customisable_days: true,
+      day_prices: { 1: 1000, 3: 2500 },
+      duration_days: 5,
+      listing_type: "daily",
+    });
+    expect(bookingDateFields(listing, "2026-07-01", 3)).toEqual({
+      date: "2026-07-01",
+      durationDays: 3,
+    });
+  });
+
+  test("customisable standard booking carries the day count but no date", () => {
+    const listing = testListingWithCount({
+      customisable_days: true,
+      day_prices: { 2: 1800 },
+      duration_days: 3,
+      listing_type: "standard",
+    });
+    expect(bookingDateFields(listing, null, 2)).toEqual({
+      date: null,
+      durationDays: 2,
+    });
+  });
+
+  test("a customisable listing with a missing day count spans one day", () => {
+    // A legacy signed session without day_count reaches the builder with no
+    // day count; the default must mean one day (not the listing's maximum),
+    // so a row never silently books the whole configurable span.
+    const listing = testListingWithCount({
+      customisable_days: true,
+      day_prices: { 1: 1000, 3: 2500 },
+      duration_days: 5,
+      listing_type: "daily",
+    });
+    expect(bookingDateFields(listing, "2026-07-01")).toEqual({
+      date: "2026-07-01",
+      durationDays: 1,
+    });
+  });
+
+  test("a non-finite day count clamps back to one day", () => {
+    // normalizeDurationDays guards the column writer and the per-day expansion
+    // from NaN/Infinity; bookingDateFields routes the chosen count through it.
+    const listing = testListingWithCount({
+      customisable_days: true,
+      day_prices: { 1: 1000 },
+      duration_days: 5,
+      listing_type: "daily",
+    });
+    expect(bookingDateFields(listing, "2026-07-01", Number.NaN)).toEqual({
+      date: "2026-07-01",
+      durationDays: 1,
+    });
+  });
+});

--- a/test/shared/booking-lines.test.ts
+++ b/test/shared/booking-lines.test.ts
@@ -166,11 +166,14 @@ describe("orderBookings > allocations", () => {
 describe("orderBookings > package stamping", () => {
   /** The package stamped onto child 20's folded row for the given parent
    *  lines (child folded under parent 10 once), so each stamping case reads
-   *  only the parent paths it varies. Returns the row's `packageGroupId`
-   *  verbatim (no `?? 0` fallback): the builder always sets it, so an
-   *  unexpected `undefined` is a real bug the assertion should surface, not
-   *  one to coerce away. */
-  const childPackageFor = (parentLines: SignedPaidLine[]): number | undefined =>
+   *  only the parent paths it varies. Returns the row's `packageGroupId` as a
+   *  `number` (not `number | undefined`): the builder always sets it — every
+   *  row leaves `orderBookings` with a concrete `packageGroupId` (set on the
+   *  raw line, preserved by `expandChildAllocations`'s spread, kept or
+   *  stamped by `stampChildRowPackages`) — so the invariant is asserted here
+   *  with `!` rather than modelled as a state the application says is
+   *  impossible (per the repo's "Trust application invariants" rule). */
+  const childPackageFor = (parentLines: SignedPaidLine[]): number =>
     orderBookings({
       allocations: [alloc(20, 10, 1)],
       date: null,
@@ -178,7 +181,7 @@ describe("orderBookings > package stamping", () => {
         ...parentLines,
         line({ listingId: 20, packageGroupId: 0, quantity: 1 }),
       ],
-    }).find((r) => r.listingId === 20)!.packageGroupId;
+    }).find((r) => r.listingId === 20)!.packageGroupId!;
 
   test("a folded child is stamped with its parent's sole package", () => {
     expect(

--- a/test/shared/booking-lines.test.ts
+++ b/test/shared/booking-lines.test.ts
@@ -1,0 +1,200 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { orderBookings, type SignedPaidLine } from "#shared/booking-lines.ts";
+import type { ChildAllocation } from "#shared/db/attendee-types.ts";
+import { testListingWithCount } from "#test-utils/factories.ts";
+
+/** A standard dateless listing — the default source for date/duration facts. */
+const standardListing = () =>
+  testListingWithCount({ listing_type: "standard" });
+
+/** A bare signed paid line; overrides pick out the case under test. */
+const line = (overrides: Partial<SignedPaidLine>): SignedPaidLine => ({
+  listing: standardListing(),
+  listingId: 1,
+  packageGroupId: 0,
+  quantity: 1,
+  ...overrides,
+});
+
+/** A per-(child, parent) allocation entry. */
+const alloc = (
+  childId: number,
+  parentId: number,
+  qty: number,
+): ChildAllocation => ({ childId, parentId, qty });
+
+describe("orderBookings > standalone and tagged package rows", () => {
+  test("a standalone line books one dateless row with no parent and no token", () => {
+    const result = orderBookings({
+      date: null,
+      lines: [line({ listingId: 7, packageGroupId: 0, quantity: 2 })],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      date: null,
+      durationDays: 1,
+      listingId: 7,
+      packageGroupId: 0,
+      quantity: 2,
+    });
+    // No allocations → the row is plain: no order token, no parent.
+    expect(result[0]!.orderToken).toBeUndefined();
+    expect(result[0]!.parentListingId).toBeUndefined();
+  });
+
+  test("a tagged package line keeps its package path", () => {
+    const result = orderBookings({
+      date: null,
+      lines: [line({ listingId: 7, packageGroupId: 5, quantity: 1 })],
+    });
+    expect(result[0]).toEqual({
+      date: null,
+      durationDays: 1,
+      listingId: 7,
+      packageGroupId: 5,
+      quantity: 1,
+    });
+  });
+});
+
+describe("orderBookings > pricePaid: 0 versus omitted", () => {
+  test("a genuine 0 pricePaid is written to the row", () => {
+    const result = orderBookings({
+      date: null,
+      lines: [line({ pricePaid: 0 })],
+    });
+    expect(result[0]!.pricePaid).toBe(0);
+  });
+
+  test("an omitted pricePaid stays off the row entirely", () => {
+    const result = orderBookings({
+      date: null,
+      lines: [line({})],
+    });
+    expect("pricePaid" in result[0]!).toBe(false);
+    expect(result[0]!.pricePaid).toBeUndefined();
+  });
+});
+
+describe("orderBookings > allocations", () => {
+  test("empty allocations leave the rows plain — no order token, no parent", () => {
+    const result = orderBookings({
+      allocations: [],
+      date: null,
+      lines: [line({ listingId: 7 }), line({ listingId: 8 })],
+    });
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.orderToken === undefined)).toBe(true);
+    expect(result.every((r) => r.parentListingId === undefined)).toBe(true);
+  });
+
+  test("multiple allocations expand into one row per (child, parent), sharing one order token", () => {
+    // Child 20 chosen under two parents in one order: one signed line but two
+    // per-parent rows, plus each parent's own row — every row carries the
+    // same order token.
+    const result = orderBookings({
+      allocations: [alloc(20, 10, 1), alloc(20, 30, 1)],
+      date: null,
+      lines: [
+        line({ listingId: 10, quantity: 1 }),
+        line({ listingId: 30, quantity: 1 }),
+        line({ listingId: 20, quantity: 2 }),
+      ],
+    });
+    expect(result).toHaveLength(4);
+    const token = result[0]!.orderToken;
+    expect(token).toBeTruthy();
+    expect(result.every((r) => r.orderToken === token)).toBe(true);
+    const childRows = result.filter((r) => r.listingId === 20);
+    expect(childRows).toHaveLength(2);
+    expect(childRows.some((r) => r.parentListingId === 10)).toBe(true);
+    expect(childRows.some((r) => r.parentListingId === 30)).toBe(true);
+    expect(childRows.every((r) => r.quantity === 1)).toBe(true);
+  });
+
+  test("a parent-less remainder row keeps the shared order token", () => {
+    // Child 20 has qty 3 but only 1 unit allocated under a parent — the other
+    // 2 were bought standalone, so the expansion keeps them as one parent-less
+    // remainder row that still shares the order's token.
+    const result = orderBookings({
+      allocations: [alloc(20, 10, 1)],
+      date: null,
+      lines: [
+        line({ listingId: 10, quantity: 1 }),
+        line({ listingId: 20, quantity: 3 }),
+      ],
+    });
+    const remainder = result.find(
+      (r) => r.listingId === 20 && r.parentListingId === undefined,
+    );
+    expect(remainder).toBeDefined();
+    expect(remainder!.quantity).toBe(2);
+    expect(remainder!.orderToken).toBeTruthy();
+  });
+
+  test("exact paid price is conserved across the split rows", () => {
+    // 100 across three single-unit allocations would lose a penny to rounding
+    // under a naive per-row split; the last row must absorb the residue so
+    // the order's total never drifts. orderBookings must hand the line's
+    // pricePaid to the expansion unchanged.
+    const result = orderBookings({
+      allocations: [alloc(20, 10, 1), alloc(20, 30, 1), alloc(20, 40, 1)],
+      date: null,
+      lines: [
+        line({ listingId: 10, quantity: 1 }),
+        line({ listingId: 20, pricePaid: 100, quantity: 3 }),
+      ],
+    });
+    const childPrices = result
+      .filter((r) => r.listingId === 20)
+      .map((r) => r.pricePaid ?? 0);
+    expect(childPrices.reduce((total, p) => total + p, 0)).toBe(100);
+    // The residual penny lands on one row, not lost to rounding.
+    expect(Math.max(...childPrices)).toBe(34);
+  });
+});
+
+describe("orderBookings > package stamping", () => {
+  /** The package stamped onto child 20's folded row for the given parent
+   *  lines (child folded under parent 10 once), so each stamping case reads
+   *  only the parent paths it varies. */
+  const childPackageFor = (parentLines: SignedPaidLine[]): number =>
+    orderBookings({
+      allocations: [alloc(20, 10, 1)],
+      date: null,
+      lines: [
+        ...parentLines,
+        line({ listingId: 20, packageGroupId: 0, quantity: 1 }),
+      ],
+    }).find((r) => r.listingId === 20)!.packageGroupId ?? 0;
+
+  test("a folded child is stamped with its parent's sole package", () => {
+    expect(
+      childPackageFor([
+        line({ listingId: 10, packageGroupId: 7, quantity: 1 }),
+      ]),
+    ).toBe(7);
+  });
+
+  test("a mixed-parent path does not stamp the child", () => {
+    // The parent (10) books through BOTH a package (7) and standalone (0), so
+    // it has no single package path — its folded child must stay unstamped.
+    expect(
+      childPackageFor([
+        line({ listingId: 10, packageGroupId: 7, quantity: 1 }),
+        line({ listingId: 10, packageGroupId: 0, quantity: 1 }),
+      ]),
+    ).toBe(0);
+  });
+
+  test("a standalone-only parent does not stamp its child", () => {
+    // The parent (10) books only standalone (packageGroupId 0), so there is
+    // no package path to inherit — the child stays at 0.
+    expect(
+      childPackageFor([
+        line({ listingId: 10, packageGroupId: 0, quantity: 1 }),
+      ]),
+    ).toBe(0);
+  });
+});

--- a/test/shared/booking-lines.test.ts
+++ b/test/shared/booking-lines.test.ts
@@ -85,8 +85,12 @@ describe("orderBookings > allocations", () => {
       lines: [line({ listingId: 7 }), line({ listingId: 8 })],
     });
     expect(result).toHaveLength(2);
-    expect(result.every((r) => r.orderToken === undefined)).toBe(true);
-    expect(result.every((r) => r.parentListingId === undefined)).toBe(true);
+    // Per-row: a mutation that silently drops one row's token keeps the
+    // aggregate green, so assert each row directly.
+    for (const row of result) {
+      expect(row.orderToken).toBeUndefined();
+      expect(row.parentListingId).toBeUndefined();
+    }
   });
 
   test("multiple allocations expand into one row per (child, parent), sharing one order token", () => {
@@ -105,12 +109,16 @@ describe("orderBookings > allocations", () => {
     expect(result).toHaveLength(4);
     const token = result[0]!.orderToken;
     expect(token).toBeTruthy();
-    expect(result.every((r) => r.orderToken === token)).toBe(true);
+    for (const row of result) {
+      expect(row.orderToken).toBe(token);
+    }
     const childRows = result.filter((r) => r.listingId === 20);
     expect(childRows).toHaveLength(2);
     expect(childRows.some((r) => r.parentListingId === 10)).toBe(true);
     expect(childRows.some((r) => r.parentListingId === 30)).toBe(true);
-    expect(childRows.every((r) => r.quantity === 1)).toBe(true);
+    for (const row of childRows) {
+      expect(row.quantity).toBe(1);
+    }
   });
 
   test("a parent-less remainder row keeps the shared order token", () => {
@@ -158,8 +166,11 @@ describe("orderBookings > allocations", () => {
 describe("orderBookings > package stamping", () => {
   /** The package stamped onto child 20's folded row for the given parent
    *  lines (child folded under parent 10 once), so each stamping case reads
-   *  only the parent paths it varies. */
-  const childPackageFor = (parentLines: SignedPaidLine[]): number =>
+   *  only the parent paths it varies. Returns the row's `packageGroupId`
+   *  verbatim (no `?? 0` fallback): the builder always sets it, so an
+   *  unexpected `undefined` is a real bug the assertion should surface, not
+   *  one to coerce away. */
+  const childPackageFor = (parentLines: SignedPaidLine[]): number | undefined =>
     orderBookings({
       allocations: [alloc(20, 10, 1)],
       date: null,
@@ -167,7 +178,7 @@ describe("orderBookings > package stamping", () => {
         ...parentLines,
         line({ listingId: 20, packageGroupId: 0, quantity: 1 }),
       ],
-    }).find((r) => r.listingId === 20)!.packageGroupId ?? 0;
+    }).find((r) => r.listingId === 20)!.packageGroupId;
 
   test("a folded child is stamped with its parent's sole package", () => {
     expect(


### PR DESCRIPTION
This pull request is the next staged-checkout foundation step. It creates one pure, canonical representation of the signed paid booking rows that both ordinary payment completion and the later staged runtime can use, and lifts the shared booking date/duration rules into their own helper alongside it — the row builder depends directly on those rules, so splitting them would only add ordering without isolating meaningful risk.

## What changes

- **`src/shared/booking-date-fields.ts` (new):** the single definition of how a booking row's `date` and `durationDays` are derived from a listing's type and the buyer's chosen span. A `customisable_days` listing uses the chosen `dayCount`; a non-customisable `daily` listing uses its fixed `duration_days`; a `standard` listing spans one dateless day. A missing `dayCount` (a legacy signed session without `day_count`) still means one day.
- **`src/shared/booking-lines.ts` (new):** `orderBookings` — an explicitly typed builder for the signed paid `listing_attendees` rows. It builds one row per signed line carrying its listing, quantity, date, duration, package path, and paid price; expands child lines into one row per `(child, parent)` when allocations are present; and stamps a folded child with its parent's package only when that parent books through exactly one path.
- **`src/features/api/payment-processing/create.ts`:** the paid webhook's row construction/allocation/package-stamping block is replaced by one `orderBookings` call. Payment finalization and error behaviour are unchanged. The DB layer still coerces an undefined `pricePaid` to `0`, so removing the old `?? 0` makes no observable difference; it just lets a genuine `0` (a free line that was still signed) stay distinct from an omitted price on the in-memory rows.
- **`src/features/api/payment-processing/store-refund.ts`:** only the `bookingDateFields` import moves to the shared helper.
- **`src/features/public/ticket-payment.ts`:** uses the shared `bookingDateFields` for its existing availability and free-booking callers. Current `ResponseHandler` and modular capacity behaviour are preserved.
- **`src/shared/db/attendees/order-parents.ts`:** `expandChildAllocations` and `expandBooking` are made generic over `T extends ListingBooking` so any required row fields a caller carries on each booking survive the expansion.

## Behaviour contract

- Listing, quantity, date, duration, package path, allocation, input order, and paid price are all preserved.
- A `pricePaid` of `0` is kept distinct from an omitted price.
- Standard non-customisable rows are dateless with duration `1`; daily/customisable combinations keep the current date/day rules; a missing legacy `day_count` means one day.
- Child allocations preserve total quantity and exact total paid price; the last split row absorbs the rounding residue; every expanded row shares one order token.
- A folded child is stamped with a parent package only when that parent has one unambiguous package path. Mixed and standalone parent paths do not falsely stamp children.
- The current main in-memory standalone package contract is kept, including `packageGroupId 0` where existing writers expect it.

## Tests

- `test/shared/booking-lines.test.ts` (new): focused pure tests for standalone and tagged package rows, `pricePaid` 0 versus omitted, empty and multiple allocations, parentless remainder, exact price conservation, shared order token, sole-parent stamping, and mixed-parent non-stamping.
- `test/shared/booking-date-fields.test.ts` (new): the standard/daily/customisable cases moved out of `test/features/public/ticket-payment.test.ts`, plus a missing-`dayCount` case and a non-finite-clamp case.

## Scope excluded

No `checkout_stages`, migrations, activation, rollback fences, refund lifecycle, cleanup, expiry, backup split, admin locks, staged callbacks, webhook reconciliation, or wholesale copies of the old reference branch. Newer work on main from PRs #1821–#1826 and #1828 is preserved. Build on the current main commit `31417124`; #1827 (Stripe webhook setup) was still open at push time, so no main re-merge was needed.

## Verification

Biome (`lint:ci`) and CPD (`src` + `test` configs) both run clean. Full typecheck and the test suite are left to CI and the commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared helpers to consistently compute booking dates/durations and to generate signed paid booking rows, including parent/child allocation expansion and package stamping.
* **Bug Fixes**
  * Ensures booking date/duration behavior is identical across payment and refund flows.
  * Preserves explicitly provided `pricePaid: 0` while omitting `pricePaid` when not present to allow correct downstream defaults.
* **Tests**
  * Added/updated test coverage for booking date/duration logic and signed paid booking row expansion (allocations, price conservation, and package assignment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->