### PR TITLE
Use a small MIME list for attachments

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -58,7 +58,6 @@
     "intl-messageformat": "npm:intl-messageformat@^10",
     "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
     "@std/http": "jsr:@std/http@^1.1.1",
-    "@std/media-types": "jsr:@std/media-types@^1.1.0",
     "@sentry/core": "npm:@sentry/core@^10.60.0",
     "@sentry/deno": "npm:@sentry/deno@^10.60.0",
     "stripe": "npm:stripe@^22.0.1",

--- a/deno.lock
+++ b/deno.lock
@@ -1714,7 +1714,6 @@
       "jsr:@std/collections@^1.2.0",
       "jsr:@std/expect@^1.0.18",
       "jsr:@std/http@^1.1.1",
-      "jsr:@std/media-types@^1.1.0",
       "jsr:@std/path@^1.1.4",
       "jsr:@std/testing@^1.0.17",
       "npm:@botpoison/browser@~0.1.30",

--- a/src/features/attachments.ts
+++ b/src/features/attachments.ts
@@ -6,11 +6,10 @@
  * Each download increments the attendee's attachment_downloads counter.
  */
 
-import { typeByExtension } from "@std/media-types";
-import { extname } from "@std/path";
 import { notFoundResponse } from "#routes/response.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
 import { defineRoutes } from "#routes/router.ts";
+import { getAttachmentMediaType } from "#shared/attachment-media-type.ts";
 import { verifyAttachmentUrl } from "#shared/attachment-url.ts";
 import { hasActiveBookingLine } from "#shared/db/attendees/queries.ts";
 import { incrementAttachmentDownloads } from "#shared/db/attendees/update.ts";
@@ -21,11 +20,6 @@ import {
   isStorageEnabled,
   sanitizeBasename,
 } from "#shared/storage.ts";
-
-/** Get MIME type from a filename's extension, defaulting to octet-stream */
-export const getMimeType = (filename: string): string =>
-  typeByExtension(extname(filename).slice(1).toLowerCase()) ??
-  "application/octet-stream";
 
 /** Return a 403 forbidden response */
 const forbiddenResponse = (): Response =>
@@ -105,7 +99,7 @@ const handleAttachmentDownload: TypedRouteHandler<
   await incrementAttachmentDownloads(attendeeId, id);
 
   // Serve with Content-Disposition for proper download filename
-  const contentType = getMimeType(listing.attachment_name);
+  const contentType = getAttachmentMediaType(listing.attachment_name);
   const disposition = buildContentDisposition(listing.attachment_name);
   return new Response(data.buffer as BodyInit, {
     headers: {

--- a/src/shared/attachment-media-type.ts
+++ b/src/shared/attachment-media-type.ts
@@ -1,0 +1,33 @@
+import { extname } from "@std/path";
+
+/** Common attachment types. Every other file stays safely downloadable. */
+const MEDIA_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  ".csv": "text/csv",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".mov": "video/quicktime",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".ppt": "application/vnd.ms-powerpoint",
+  ".pptx":
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ".txt": "text/plain",
+  ".wav": "audio/wav",
+  ".webm": "video/webm",
+  ".webp": "image/webp",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".zip": "application/zip",
+};
+
+/** Return a useful content type for a common attachment, else generic bytes. */
+export const getAttachmentMediaType = (filename: string): string => {
+  const mediaType = MEDIA_TYPE_BY_EXTENSION[extname(filename).toLowerCase()];
+  return mediaType === undefined ? "application/octet-stream" : mediaType;
+};

--- a/test/lib/attachment-route.test.ts
+++ b/test/lib/attachment-route.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
-import { getMimeType } from "#routes/attachments.ts";
 import { signAttachmentUrl } from "#shared/attachment-url.ts";
 import { encryptBytes } from "#shared/crypto/encryption.ts";
 import { getAttendeeRaw } from "#shared/db/attendees/queries.ts";
@@ -17,37 +16,6 @@ import {
   withFetchMock,
   withStorageDisabled,
 } from "#test-utils/mocks.ts";
-
-describe("getMimeType", () => {
-  test("returns application/pdf for .pdf", () => {
-    expect(getMimeType("file.pdf")).toBe("application/pdf");
-  });
-
-  test("returns image/jpeg for .jpg", () => {
-    expect(getMimeType("photo.jpg")).toBe("image/jpeg");
-  });
-
-  test("returns text/plain for .txt", () => {
-    expect(getMimeType("readme.txt")).toBe("text/plain");
-  });
-
-  test("returns video/mp4 for .mp4", () => {
-    expect(getMimeType("video.mp4")).toBe("video/mp4");
-  });
-
-  test("returns application/octet-stream for unknown extension", () => {
-    expect(getMimeType("file.unknownext")).toBe("application/octet-stream");
-  });
-
-  test("returns application/octet-stream for no extension", () => {
-    expect(getMimeType("noextension")).toBe("application/octet-stream");
-  });
-
-  test("handles uppercase extensions", () => {
-    expect(getMimeType("FILE.PDF")).toBe("application/pdf");
-    expect(getMimeType("PHOTO.JPG")).toBe("image/jpeg");
-  });
-});
 
 describeWithEnv(
   "GET /attachment/:id",

--- a/test/shared/attachment-media-type.test.ts
+++ b/test/shared/attachment-media-type.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { getAttachmentMediaType } from "#shared/attachment-media-type.ts";
+
+describe("attachment media types", () => {
+  test("labels common downloadable file types", () => {
+    const examples = [
+      ["data.csv", "text/csv"],
+      ["letter.doc", "application/msword"],
+      [
+        "letter.docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ],
+      ["animation.gif", "image/gif"],
+      ["photo.jpeg", "image/jpeg"],
+      ["photo.jpg", "image/jpeg"],
+      ["film.mov", "video/quicktime"],
+      ["song.mp3", "audio/mpeg"],
+      ["film.mp4", "video/mp4"],
+      ["guide.pdf", "application/pdf"],
+      ["image.png", "image/png"],
+      ["slides.ppt", "application/vnd.ms-powerpoint"],
+      [
+        "slides.pptx",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      ],
+      ["notes.txt", "text/plain"],
+      ["sound.wav", "audio/wav"],
+      ["film.webm", "video/webm"],
+      ["image.webp", "image/webp"],
+      ["sheet.xls", "application/vnd.ms-excel"],
+      [
+        "sheet.xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ],
+      ["files.zip", "application/zip"],
+    ] as const;
+
+    for (const [filename, mediaType] of examples) {
+      expect(getAttachmentMediaType(filename)).toBe(mediaType);
+    }
+  });
+
+  test("matches extensions without case sensitivity", () => {
+    expect(getAttachmentMediaType("GUIDE.PDF")).toBe("application/pdf");
+  });
+
+  test("uses generic bytes for an unknown extension", () => {
+    expect(getAttachmentMediaType("archive.uncommon")).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  test("uses generic bytes when there is no extension", () => {
+    expect(getAttachmentMediaType("README")).toBe("application/octet-stream");
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the full `@std/media-types` database with a small list covering 20 common document, image, audio, video, and archive extensions.
- Keeps every other attachment downloadable as `application/octet-stream`. Attachment responses still force downloads with `Content-Disposition: attachment`.
- Moves MIME selection into a pure shared helper and adds direct coverage for every supported extension, uppercase names, unknown extensions, and names without extensions.

## Bundle impact

- Self-contained edge bundle: 5,155,539 to 5,009,457 bytes.
- Estimated CDN-enabled edge bundle: 2,851,647 to 2,705,565 bytes.
- Net reduction: 146,082 bytes.

## Testing

- `deno task precommit`
- `deno task bundle:report`
- Exhaustive mutation testing: 89 of 89 mutants detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment content-type detection for common file formats.
  * Added case-insensitive handling of file extensions.
  * Unknown or extensionless attachments now use a safe default content type.

* **Tests**
  * Added coverage for common, mixed-case, unknown, and missing file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->