### PR TITLE
Keep Stripe selected when webhook cleanup fails

### DIFF
--- a/src/features/admin/settings-stripe.ts
+++ b/src/features/admin/settings-stripe.ts
@@ -31,13 +31,14 @@ export const stripeRoutes = defineProviderCredentialsRoute<undefined>({
     if (!result.success) {
       return `Failed to set up Stripe webhook: ${result.error}`;
     }
-    await settings.update.stripe.credentials({
+    await settings.update.stripe.activate({
       secretKey: value,
       webhookEndpointId: result.endpointId,
       webhookSecret: result.secret,
     });
     // Cleanup can now fail without leaving saved credentials that name a
-    // deleted endpoint. The error still propagates so stale state is visible.
+    // deleted endpoint or leaving Stripe unselected. The error still propagates
+    // so stale state is visible.
     await cleanupOldWebhookEndpoints(
       value,
       webhookUrl,

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -456,13 +456,14 @@ const settingsBase = {
     },
     // --- Stripe writes ---
     stripe: {
-      credentials: async (config: {
+      activate: async (config: {
         secretKey: string;
         webhookSecret: string;
         webhookEndpointId: string;
       }): Promise<void> => {
         // The API key and webhook pair belong to one Stripe account. Save all
-        // three together so a failed write leaves the prior account usable.
+        // three and select Stripe together so a failed write leaves the prior
+        // provider usable, while later endpoint cleanup can fail safely.
         await writeRawBatch([
           [CONFIG_KEYS.STRIPE_SECRET_KEY, await encrypt(config.secretKey)],
           [
@@ -470,10 +471,13 @@ const settingsBase = {
             await encrypt(config.webhookSecret),
           ],
           [CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID, config.webhookEndpointId],
+          [CONFIG_KEYS.PAYMENT_PROVIDER, "stripe"],
         ]);
         data.stripe_secret_key = config.secretKey;
         data.stripe_webhook_secret = config.webhookSecret;
         data.stripe_webhook_endpoint_id = config.webhookEndpointId;
+        data.payment_provider = "stripe";
+        data.payment_provider_setting = "stripe";
       },
       secretKey: encryptedUpdate(CONFIG_KEYS.STRIPE_SECRET_KEY),
     },

--- a/test/lib/server-debug.test.ts
+++ b/test/lib/server-debug.test.ts
@@ -23,7 +23,7 @@ import { describeWithEnv } from "#test-utils/db.ts";
 import { nonRsaCertificatePem } from "#test-utils/der.ts";
 import { withEnv } from "#test-utils/env.ts";
 import { adminGet } from "#test-utils/session.ts";
-import { setStripeCredentials } from "#test-utils/settings.ts";
+import { activateStripe } from "#test-utils/settings.ts";
 
 /** Build a complete DebugPageState, overriding only the fields a test cares about. */
 const makeDebugState = (
@@ -287,7 +287,7 @@ describeWithEnv("server (admin debug)", { db: true }, () => {
   describe("GET /admin/debug with Stripe configured", () => {
     test("shows stripe as provider with key and webhook status", async () => {
       await settings.update.paymentProvider("stripe");
-      await setStripeCredentials("whsec_fake", "we_fake", "sk_test_fake");
+      await activateStripe("whsec_fake", "we_fake", "sk_test_fake");
       await assertAdminHtml("/admin/debug", "stripe", "Configured");
     });
 

--- a/test/lib/server-settings/stripe.test.ts
+++ b/test/lib/server-settings/stripe.test.ts
@@ -18,8 +18,8 @@ import {
 import { mockFormRequest, withMocks } from "#test-utils/mocks.ts";
 import { adminFormPost, adminGet, testCookie } from "#test-utils/session.ts";
 import {
+  activateStripe,
   describeAdminSettings,
-  setStripeCredentials,
   withSuccessfulStripeWebhook,
 } from "#test-utils/settings.ts";
 
@@ -301,7 +301,8 @@ describeAdminSettings(() => {
     });
 
     test("surfaces cleanup failure after saving all new credentials", async () => {
-      await setStripeCredentials("whsec_old", "we_old", "sk_test_old_key");
+      await activateStripe("whsec_old", "we_old", "sk_test_old_key");
+      await settings.update.paymentProvider("square");
 
       await withMocks(
         () => ({
@@ -325,6 +326,7 @@ describeAdminSettings(() => {
           expect(settings.stripe.secretKey).toBe("sk_test_new_key");
           expect(settings.stripe.webhookEndpointId).toBe("we_new");
           expect(settings.stripe.webhookSecret).toBe("whsec_new");
+          expect(settings.paymentProvider).toBe("stripe");
         },
       );
     });

--- a/test/lib/stripe/connection.test.ts
+++ b/test/lib/stripe/connection.test.ts
@@ -16,7 +16,7 @@ import {
 import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { withMocks } from "#test-utils/mocks.ts";
-import { setStripeCredentials } from "#test-utils/settings.ts";
+import { activateStripe } from "#test-utils/settings.ts";
 import {
   lineFor,
   noWebhooks,
@@ -130,7 +130,7 @@ describeStripe("stripe", () => {
 
     test("returns full success when API key valid and webhooks exist", async () => {
       const client = await stripeClient();
-      await setStripeCredentials("whsec_test", "we_test_valid");
+      await activateStripe("whsec_test", "we_test_valid");
 
       await withBalanceAndList(
         client,
@@ -201,7 +201,7 @@ describeStripe("stripe", () => {
       expect(signature).toMatch(/^t=\d+,v1=[a-f0-9]+$/);
 
       // Signature should be verifiable with the same secret (stored in DB)
-      await setStripeCredentials(secret, "we_test_construction");
+      await activateStripe(secret, "we_test_construction");
       const result = await verifyWebhookSignature(payload, signature);
       expect(result.valid).toBe(true);
     });

--- a/test/lib/stripe/core.test.ts
+++ b/test/lib/stripe/core.test.ts
@@ -18,7 +18,7 @@ import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { createTestDb, resetDb } from "#test-utils/db.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { withMocks } from "#test-utils/mocks.ts";
-import { setStripeCredentials } from "#test-utils/settings.ts";
+import { activateStripe } from "#test-utils/settings.ts";
 import {
   type CreatedSessionParams,
   lineFor,
@@ -309,7 +309,7 @@ describeStripe("stripe", () => {
 
     beforeEach(async () => {
       // Set webhook secret in database (encrypted)
-      await setStripeCredentials(TEST_SECRET);
+      await activateStripe(TEST_SECRET);
     });
 
     test("returns error when webhook secret not configured", async () => {

--- a/test/lib/stripe/provider.test.ts
+++ b/test/lib/stripe/provider.test.ts
@@ -15,7 +15,7 @@ import { checkoutIntent, checkoutItem } from "#test-utils/checkout.ts";
 import { withEnv } from "#test-utils/env.ts";
 import { testListing } from "#test-utils/factories.ts";
 import { withMocks } from "#test-utils/mocks.ts";
-import { setStripeCredentials } from "#test-utils/settings.ts";
+import { activateStripe } from "#test-utils/settings.ts";
 import { lineFor, stripeClient } from "./fixtures.ts";
 import { describeStripe } from "./harness.ts";
 
@@ -288,7 +288,7 @@ describeStripe("stripe-provider", () => {
   describe("verifyWebhookSignature delegation", () => {
     test("delegates to stripe.ts verifyWebhookSignature", async () => {
       const TEST_SECRET = "whsec_provider_verify_test";
-      await setStripeCredentials(TEST_SECRET, "we_provider_test");
+      await activateStripe(TEST_SECRET, "we_provider_test");
 
       const listing: StripeWebhookEvent = {
         data: { object: { id: "cs_test" } },
@@ -315,7 +315,7 @@ describeStripe("stripe-provider", () => {
 
     test("returns error for invalid signature", async () => {
       const TEST_SECRET = "whsec_provider_invalid_test";
-      await setStripeCredentials(TEST_SECRET, "we_provider_inv");
+      await activateStripe(TEST_SECRET, "we_provider_inv");
 
       const timestamp = Math.floor(Date.now() / 1000);
       const body = '{"test": true}';

--- a/test/lib/stripe/webhook-setup.test.ts
+++ b/test/lib/stripe/webhook-setup.test.ts
@@ -9,7 +9,7 @@ import {
 } from "#shared/stripe.ts";
 import { withEnv } from "#test-utils/env.ts";
 import { withFetchMock } from "#test-utils/mocks.ts";
-import { setStripeCredentials } from "#test-utils/settings.ts";
+import { activateStripe } from "#test-utils/settings.ts";
 import { describeStripe } from "./harness.ts";
 import {
   newWebhookApiCalls,
@@ -128,7 +128,7 @@ describeStripe("Stripe webhook setup", () => {
     test("keeps the recorded endpoint live when the cap retry fails", async () => {
       const webhookUrl = "https://example.com/payment/webhook";
       const calls = newWebhookApiCalls();
-      await setStripeCredentials("whsec_recorded", "we_recorded");
+      await activateStripe("whsec_recorded", "we_recorded");
 
       const result = await setupWithWebhookApi(
         webhookUrl,

--- a/test/lib/stripe/webhook.test.ts
+++ b/test/lib/stripe/webhook.test.ts
@@ -6,7 +6,7 @@ import {
   constructTestWebhookEvent,
   verifyWebhookSignature,
 } from "#shared/stripe.ts";
-import { setStripeCredentials } from "#test-utils/settings.ts";
+import { activateStripe } from "#test-utils/settings.ts";
 import { signedHeader } from "./fixtures.ts";
 import { describeStripe } from "./harness.ts";
 
@@ -15,7 +15,7 @@ describeStripe("stripe", () => {
     const TEST_SECRET = "whsec_test_secret_key_for_timestamp_test";
 
     test("handles timestamp value that needs parseInt", async () => {
-      await setStripeCredentials(TEST_SECRET, "we_test_ts");
+      await activateStripe(TEST_SECRET, "we_test_ts");
 
       // Create listing with proper signature
       const listing: StripeWebhookEvent = {
@@ -34,7 +34,7 @@ describeStripe("stripe", () => {
     });
 
     test("parses timestamp with parseInt when t key has value", async () => {
-      await setStripeCredentials(TEST_SECRET, "we_test_parse");
+      await activateStripe(TEST_SECRET, "we_test_parse");
 
       // A valid number-string timestamp, exercising Number.parseInt
       const payload = '{"id": "evt_parse", "type": "test"}';
@@ -46,7 +46,7 @@ describeStripe("stripe", () => {
     });
 
     test("treats t key without equals as zero timestamp via parseInt fallback", async () => {
-      await setStripeCredentials(TEST_SECRET, "we_test_nullish");
+      await activateStripe(TEST_SECRET, "we_test_nullish");
 
       // Header "t,v1=abc123" - split("=") on "t" gives ["t"], so value is undefined
       // value ?? "0" gives "0", parseInt("0", 10) gives 0
@@ -62,7 +62,7 @@ describeStripe("stripe", () => {
     });
 
     test("secureCompare handles strings of different lengths", async () => {
-      await setStripeCredentials(TEST_SECRET, "we_test_len");
+      await activateStripe(TEST_SECRET, "we_test_len");
 
       // Provide a signature that has different length than expected
       const timestamp = Math.floor(Date.now() / 1000);
@@ -82,7 +82,7 @@ describeStripe("stripe", () => {
     const TEST_SECRET = "whsec_test_secret_key_for_detail_tests";
 
     beforeEach(async () => {
-      await setStripeCredentials(TEST_SECRET, "we_test_details");
+      await activateStripe(TEST_SECRET, "we_test_details");
     });
 
     test("logs 'missing timestamp' when header has signature but no timestamp", async () => {

--- a/test/shared/db/stripe-settings.test.ts
+++ b/test/shared/db/stripe-settings.test.ts
@@ -6,11 +6,12 @@ import { describeWithEnv } from "#test-utils/db.ts";
 
 describeWithEnv("db > Stripe settings", { db: true }, () => {
   test("keeps all prior credentials when the endpoint ID write fails", async () => {
-    await settings.update.stripe.credentials({
+    await settings.update.stripe.activate({
       secretKey: "sk_test_old",
       webhookEndpointId: "we_old",
       webhookSecret: "whsec_old",
     });
+    await settings.update.paymentProvider("square");
     await getDb().execute(`
       CREATE TRIGGER fail_stripe_endpoint_id
       BEFORE INSERT ON settings
@@ -22,7 +23,7 @@ describeWithEnv("db > Stripe settings", { db: true }, () => {
 
     try {
       await expect(
-        settings.update.stripe.credentials({
+        settings.update.stripe.activate({
           secretKey: "sk_test_new",
           webhookEndpointId: "we_new",
           webhookSecret: "whsec_new",
@@ -37,9 +38,11 @@ describeWithEnv("db > Stripe settings", { db: true }, () => {
       CONFIG_KEYS.STRIPE_SECRET_KEY,
       CONFIG_KEYS.STRIPE_WEBHOOK_ENDPOINT_ID,
       CONFIG_KEYS.STRIPE_WEBHOOK_SECRET,
+      CONFIG_KEYS.PAYMENT_PROVIDER,
     ]);
     expect(settings.stripe.secretKey).toBe("sk_test_old");
     expect(settings.stripe.webhookEndpointId).toBe("we_old");
     expect(settings.stripe.webhookSecret).toBe("whsec_old");
+    expect(settings.paymentProvider).toBe("square");
   });
 });

--- a/test/test-utils/settings.ts
+++ b/test/test-utils/settings.ts
@@ -71,13 +71,13 @@ export const setupStripe = async (key = "sk_test_mock"): Promise<void> => {
   await s.update.paymentProvider("stripe");
 };
 
-/** Store one internally consistent Stripe API key and webhook pair. */
-export const setStripeCredentials = (
+/** Store one internally consistent Stripe API key and webhook pair, and select Stripe. */
+export const activateStripe = (
   webhookSecret: string,
   webhookEndpointId = "we_test_endpoint",
   secretKey = "sk_test_mock",
 ): Promise<void> =>
-  settings.update.stripe.credentials({
+  settings.update.stripe.activate({
     secretKey,
     webhookEndpointId,
     webhookSecret,


### PR DESCRIPTION
## Summary

- save the Stripe key, webhook pair, and selected payment provider in one atomic batch
- run old endpoint cleanup only after that durable activation
- keep the previous provider and credentials when the atomic save fails
- rename the shared Stripe test setup to match its activation behavior

This follows up on the final review thread from #1830, which merged while the fix was being verified.

## Testing

- `deno task precommit`
- 263 focused Stripe, settings, and debug tests
- strict lint and zero-duplication checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Stripe activation so payment-provider status stays synchronized with saved credentials.
  - Preserved the active Stripe provider when webhook cleanup fails.
  - Prevented inconsistent provider and webhook configuration after failed updates.

- **Tests**
  - Expanded coverage for Stripe activation, webhook handling, credential persistence, and cleanup failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->