### PR TITLE
Keep database upgrades within edge request limits

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,30 @@ everything still outstanding is captured below.
 
 ---
 
+## Split the database migration runtime
+
+*Origin: CodeRabbit review on PR #1845 (`src/shared/db/migrations.ts`).*
+
+`src/shared/db/migrations.ts` already exceeded 700 lines before PR #1845 and now
+also owns request-sized batches and lease-scoped completion. Split it without
+changing behavior. A useful starting boundary is:
+
+- Move lease acquisition, ownership checks, and release into a focused lock
+  module.
+- Move migration marker and schema marker statement builders into a recording
+  module.
+- Move retry and pending-migration execution into a runner module.
+- Leave `initDb` and database-state routing in `migrations.ts` as thin
+  orchestration.
+
+Keep the existing request round-trip count, lazy migration loading, partial
+progress behavior, and lock failure tests unchanged. This is intentionally
+separate from PR #1845 because moving the whole migration subsystem while
+changing its locking and batching would make the safety fix much harder to
+review and roll back.
+
+---
+
 ## Booking unification — phases 3 & 4
 
 *Origin: `booking-unification.md`, `booking-unification-phase2.md`.*

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -527,8 +527,10 @@ export const executeBatch = async (
 };
 
 /** The slice of an open write transaction handed to a {@link withTransaction}
- *  callback: run statements with `execute`; commit/rollback are managed for you. */
+ *  callback: run statements singly or as one batch; commit/rollback are managed
+ *  for you. */
 export type TxScope = {
+  batch: (statements: InStatement[]) => Promise<ResultSet[]>;
   execute: (stmt: InStatement) => Promise<ResultSet>;
 };
 
@@ -550,6 +552,15 @@ const runWriteTransactionOnce = async <T>(
   const writtenSql: string[] = [];
   let statementCount = 0;
   const scope: TxScope = {
+    batch: (statements) => {
+      const sqls = statements.map((statement) =>
+        typeof statement === "string" ? statement : statement.sql,
+      );
+      writtenSql.push(...sqls);
+      statementCount += 1;
+      enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
+      return tx.batch(statements);
+    },
     execute: (stmt) => {
       const sql = typeof stmt === "string" ? stmt : stmt.sql;
       writtenSql.push(sql);

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -24,8 +24,7 @@ import { beginTransaction, wrapExecute } from "#shared/db/libsql-call.ts";
 import {
   countDatabaseRoundTrip,
   enforceTransactionRoundTripGuard,
-  trackQueries,
-  trackQuery,
+  trackSql,
 } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
 import { namedError } from "#shared/named-error.ts";
@@ -243,7 +242,7 @@ const retryOnDatabaseLock = <T>(run: () => Promise<T>): Promise<T> =>
 type StatementRunner<T> = (sql: string, args?: InValue[]) => Promise<T>;
 
 const executeTrackedStatement: StatementRunner<ResultSet> = (sql, args) =>
-  trackQuery(sql, () =>
+  trackSql(sql, () =>
     retryOnDatabaseLock(() =>
       args ? getDb().execute({ args, sql }) : getDb().execute(sql),
     ),
@@ -462,7 +461,7 @@ const runBatch = async (
   // Batch writes serialize against the single SQLite writer like any other write,
   // so a contended batch waits and retries (then surfaces DatabaseBusyError)
   // rather than throwing raw SQLITE_BUSY — matching execute() and withTransaction.
-  const results = await trackQueries(sqls, () =>
+  const results = await trackSql(sqls, () =>
     retryOnDatabaseLock(() => getDb().batch(statements, mode)),
   );
   for (const stmt of statements) {
@@ -550,7 +549,7 @@ const runWriteTransactionOnce = async <T>(
       writtenSql.push(...sqls);
       statementCount += 1;
       enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
-      return trackQueries(sqls, () => tx.batch(statements));
+      return trackSql(sqls, () => tx.batch(statements));
     },
     execute: (stmt) => {
       const sql = typeof stmt === "string" ? stmt : stmt.sql;
@@ -562,7 +561,7 @@ const runWriteTransactionOnce = async <T>(
       enforceTransactionRoundTripGuard(statementCount, sql);
       // Track transactional statements too, so reads inside the callback still
       // show in the debug footer and count toward the N+1 guard.
-      return trackQuery(sql, () => tx.execute(stmt));
+      return trackSql(sql, () => tx.execute(stmt));
     },
   };
   try {

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -22,11 +22,9 @@ import {
 } from "#shared/cache-registry.ts";
 import { beginTransaction, wrapExecute } from "#shared/db/libsql-call.ts";
 import {
-  addQueryLogEntry,
   countDatabaseRoundTrip,
   enforceTransactionRoundTripGuard,
-  isQueryLogEnabled,
-  logCompletedSql,
+  trackQueries,
   trackQuery,
 } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
@@ -460,21 +458,14 @@ const runBatch = async (
   mode: TransactionMode,
   invalidate: boolean,
 ): Promise<ResultSet[]> => {
-  const start = performance.now();
+  const sqls = statements.map(({ sql }) => sql);
   // Batch writes serialize against the single SQLite writer like any other write,
   // so a contended batch waits and retries (then surfaces DatabaseBusyError)
   // rather than throwing raw SQLITE_BUSY — matching execute() and withTransaction.
-  const results = await retryOnDatabaseLock(() =>
-    getDb().batch(statements, mode),
+  const results = await trackQueries(sqls, () =>
+    retryOnDatabaseLock(() => getDb().batch(statements, mode)),
   );
-  if (isQueryLogEnabled()) {
-    const elapsed = performance.now() - start;
-    // Every statement shares the one round-trip window [start, start+elapsed],
-    // so the footer's wall-clock union counts that time once (not N times).
-    for (const stmt of statements) addQueryLogEntry(stmt.sql, elapsed, start);
-  }
   for (const stmt of statements) {
-    void logCompletedSql(stmt.sql);
     if (invalidate) invalidateForSql(stmt.sql);
   }
   return results;
@@ -559,7 +550,7 @@ const runWriteTransactionOnce = async <T>(
       writtenSql.push(...sqls);
       statementCount += 1;
       enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
-      return tx.batch(statements);
+      return trackQueries(sqls, () => tx.batch(statements));
     },
     execute: (stmt) => {
       const sql = typeof stmt === "string" ? stmt : stmt.sql;

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -38,7 +38,10 @@ import { repairLegacyRenames } from "./migrations/rename-utils.ts";
 import { SCHEMA, SCHEMA_HASH } from "./migrations/schema/index.ts";
 import { TRIGGERS } from "./migrations/schema/triggers.ts";
 import {
+  DB_SCHEMA_HASH_KEY,
+  LATEST_DB_UPDATE_KEY,
   LATEST_UPDATE,
+  MIGRATION_LOCK_KEY,
   SCHEMA_MIGRATIONS_TABLE,
 } from "./migrations/schema/version.ts";
 import {
@@ -111,8 +114,7 @@ type DbProbe = {
   appliedMigrations: number | null;
 };
 
-const SCHEMA_MARKERS_SQL =
-  "SELECT key, value FROM settings WHERE key IN ('latest_db_update', 'db_schema_hash')";
+const SCHEMA_MARKERS_SQL = `SELECT key, value FROM settings WHERE key IN ('${LATEST_DB_UPDATE_KEY}', '${DB_SCHEMA_HASH_KEY}')`;
 
 /** Turn a probe's key/value rows into a lookup map. */
 const rowsToMap = (rows: readonly Record<string, unknown>[]) =>
@@ -120,11 +122,11 @@ const rowsToMap = (rows: readonly Record<string, unknown>[]) =>
 
 /** Read the schema state from the marker rows a probe returned. */
 const markerState = (values: Map<string, string>): DbState => {
-  if (!values.has("latest_db_update") && !values.has("db_schema_hash")) {
+  if (!values.has(LATEST_DB_UPDATE_KEY) && !values.has(DB_SCHEMA_HASH_KEY)) {
     return "uninitialized_settings";
   }
-  return values.get("latest_db_update") === LATEST_UPDATE &&
-    values.get("db_schema_hash") === SCHEMA_HASH
+  return values.get(LATEST_DB_UPDATE_KEY) === LATEST_UPDATE &&
+    values.get(DB_SCHEMA_HASH_KEY) === SCHEMA_HASH
     ? "up_to_date"
     : "needs_migration";
 };
@@ -209,11 +211,11 @@ const ensureDefaultAttendeeStatus = async (): Promise<void> => {
 const schemaMarkerStatements = (): SqlStatement[] => [
   {
     args: [LATEST_UPDATE],
-    sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('latest_db_update', ?)",
+    sql: `INSERT OR REPLACE INTO settings (key, value) VALUES ('${LATEST_DB_UPDATE_KEY}', ?)`,
   },
   {
     args: [SCHEMA_HASH],
-    sql: "INSERT OR REPLACE INTO settings (key, value) VALUES ('db_schema_hash', ?)",
+    sql: `INSERT OR REPLACE INTO settings (key, value) VALUES ('${DB_SCHEMA_HASH_KEY}', ?)`,
   },
 ];
 
@@ -323,8 +325,6 @@ const getAppliedMigrationIds = async (): Promise<Set<string>> => {
   return stringColumnSet(result.rows, "id");
 };
 
-const MIGRATION_LOCK_KEY = "migration_lock";
-
 /** Build the INSERT that records a migration as applied. */
 const migrationMarkerStatement = (
   migration: Migration,
@@ -369,8 +369,8 @@ const ownedMigrationMarkerStatements = (
 const ownedSchemaMarkerStatements = (lockToken: string): SqlStatement[] =>
   (
     [
-      ["latest_db_update", LATEST_UPDATE],
-      ["db_schema_hash", SCHEMA_HASH],
+      [LATEST_DB_UPDATE_KEY, LATEST_UPDATE],
+      [DB_SCHEMA_HASH_KEY, SCHEMA_HASH],
     ] as const
   ).map(([key, value]) =>
     whileMigrationLockOwned(
@@ -520,6 +520,12 @@ export const applyMigrationWithRetry = async (
   }
 };
 
+const combinedFailures = (
+  message: string,
+  first: unknown,
+  second: unknown,
+): AggregateError => new AggregateError([first, second], message);
+
 const runPendingMigrations = async (
   pending: Migration[],
   lockToken: string,
@@ -538,10 +544,18 @@ const runPendingMigrations = async (
     // Keep successful progress when a later migration fails. The success path
     // writes these markers with the schema markers and lock release below.
     if (completed.length > 0) {
-      await executeWhileMigrationLockOwned(
-        ownedMigrationMarkerStatements(completed, lockToken),
-        lockToken,
-      );
+      try {
+        await executeWhileMigrationLockOwned(
+          ownedMigrationMarkerStatements(completed, lockToken),
+          lockToken,
+        );
+      } catch (markerError) {
+        throw combinedFailures(
+          "Database migration failed and completed progress could not be recorded.",
+          error,
+          markerError,
+        );
+      }
     }
     throw error;
   }
@@ -752,11 +766,12 @@ const releaseAfterMigrationFailure = async (
   try {
     await releaseMigrationLock(lockToken);
   } catch (releaseError) {
-    throw new AggregateError(
-      [failure, releaseError],
+    throw combinedFailures(
       `Database migration failed and its lock could not be released: ${errorMessage(
         failure,
       )}; ${errorMessage(releaseError)}`,
+      failure,
+      releaseError,
     );
   }
   throw failure;

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -21,6 +21,7 @@ import {
   type SqlStatement,
 } from "#shared/db/client.ts";
 import { stringColumnSet } from "#shared/db/query.ts";
+import { isDatabaseRoundTripLimited } from "#shared/db/query-log.ts";
 import { getEnv } from "#shared/env.ts";
 import { errorMessage } from "#shared/error-message.ts";
 import { logDebug } from "#shared/logger.ts";
@@ -331,27 +332,22 @@ const migrationMarkerStatement = (
   sql: `INSERT OR REPLACE INTO ${SCHEMA_MIGRATIONS_TABLE} (id, description, applied_at) VALUES (?, ?, ?)`,
 });
 
-const markMigrationApplied = async (migration: Migration): Promise<void> => {
-  await ensureMigrationTrackingTable();
-  await getDb().execute(migrationMarkerStatement(migration, nowIso()));
+const migrationMarkerStatements = (migrations: Migration[]): SqlStatement[] => {
+  const appliedAt = nowIso();
+  return migrations.map((migration) =>
+    migrationMarkerStatement(migration, appliedAt),
+  );
 };
 
 /**
- * Record several migrations as applied in one batch transaction — used by the
- * fresh-install and baseline paths, which mark every migration with no work in
- * between, so one round-trip replaces one per migration. Both callers only pass
- * a non-empty list (baseline returns early when nothing is missing).
+ * Record several completed migrations in one batch transaction, so one
+ * round-trip replaces one write per migration. Callers only pass a non-empty
+ * list.
  */
 const markMigrationsApplied = async (
   migrations: Migration[],
 ): Promise<void> => {
-  const appliedAt = nowIso();
-  await getDb().batch(
-    migrations.map((migration) =>
-      migrationMarkerStatement(migration, appliedAt),
-    ),
-    "write",
-  );
+  await getDb().batch(migrationMarkerStatements(migrations), "write");
 };
 
 const writeSchemaMarkers = async (): Promise<void> => {
@@ -466,10 +462,24 @@ export const applyMigrationWithRetry = async (
 };
 
 const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
-  for (const migration of pending) {
-    logDebug("Migration", `Running ${migration.id}: ${migration.description}`);
-    await applyMigrationWithRetry(migration);
-    await markMigrationApplied(migration);
+  const completed: Migration[] = [];
+  let succeeded = false;
+  try {
+    for (const migration of pending) {
+      logDebug(
+        "Migration",
+        `Running ${migration.id}: ${migration.description}`,
+      );
+      await applyMigrationWithRetry(migration);
+      completed.push(migration);
+    }
+    succeeded = true;
+  } finally {
+    // Keep successful progress when a later migration fails. The success path
+    // writes these markers with the schema markers and lock release below.
+    if (!succeeded && completed.length > 0) {
+      await markMigrationsApplied(completed);
+    }
   }
 };
 
@@ -495,6 +505,25 @@ const restoreStaleSchemaMarkers = async (): Promise<void> => {
 };
 
 const MIGRATION_LOCK_KEY = "migration_lock";
+// A batch of four leaves room for the lock, probes, schema checks, and the
+// largest migrations while staying below Bunny's 50-subrequest request cap.
+const MIGRATIONS_PER_REQUEST = 4;
+
+/** Record one migration batch, optionally seal the finished schema, and release
+ * its lock atomically. */
+const recordMigrationBatch = async (
+  migrations: Migration[],
+  finished: boolean,
+): Promise<void> => {
+  await executeBatch([
+    ...migrationMarkerStatements(migrations),
+    ...(finished ? schemaMarkerStatements() : []),
+    {
+      args: [MIGRATION_LOCK_KEY],
+      sql: "DELETE FROM settings WHERE key = ?",
+    },
+  ]);
+};
 
 /**
  * A migration lock older than this is treated as abandoned and stolen.
@@ -623,6 +652,7 @@ const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
     );
   }
 
+  let lockReleased = false;
   try {
     // Re-check after acquiring lock (another process may have finished)
     const recheck = await probeDbState();
@@ -647,19 +677,36 @@ const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
     // run out-of-band instead — the upgrade GitHub Action backs each site up
     // first, and /admin/update + the per-site update button refuse to run
     // without a backup from the last hour (see hasRecentBackup).
-    await runPendingMigrations(pending);
+    const batch = isDatabaseRoundTripLimited()
+      ? pending.slice(0, MIGRATIONS_PER_REQUEST)
+      : pending;
+    const finished = batch.length === pending.length;
+    await runPendingMigrations(batch);
 
-    logDebug("Migration", "Updating version marker...");
-    await writeSchemaMarkers();
+    logDebug(
+      "Migration",
+      finished
+        ? "Updating version marker..."
+        : `Recorded ${batch.length} migrations; continuing on the next request...`,
+    );
+    await recordMigrationBatch(batch, finished);
+    lockReleased = true;
+    if (!finished) {
+      throw new MigrationInProgressError(
+        "Database update is continuing on the next request.",
+      );
+    }
   } finally {
     // If the isolate is evicted mid-migration this finally will not run, so
     // stale locks are still reclaimed by MIGRATION_LOCK_TTL_MS.
-    await releaseMigrationLock().catch((error) =>
-      logDebug(
-        "Migration",
-        `Failed to release migration lock: ${errorMessage(error)}`,
-      ),
-    );
+    if (!lockReleased) {
+      await releaseMigrationLock().catch((error) =>
+        logDebug(
+          "Migration",
+          `Failed to release migration lock: ${errorMessage(error)}`,
+        ),
+      );
+    }
   }
 };
 

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -16,6 +16,7 @@ import { lazyRef, once } from "#fp";
 import { resetAllCaches } from "#shared/cache-registry.ts";
 import {
   executeBatch,
+  executeBatchWithResults,
   getDb,
   inPlaceholders,
   type SqlStatement,
@@ -49,7 +50,6 @@ import {
   fullSchemaCreateStatements,
   noArgStatements,
   recreateTable,
-  runMigration,
   syncCurrentSchema as syncCurrentSchemaBase,
   syncIndexes,
   syncTriggers,
@@ -323,6 +323,8 @@ const getAppliedMigrationIds = async (): Promise<Set<string>> => {
   return stringColumnSet(result.rows, "id");
 };
 
+const MIGRATION_LOCK_KEY = "migration_lock";
+
 /** Build the INSERT that records a migration as applied. */
 const migrationMarkerStatement = (
   migration: Migration,
@@ -332,11 +334,68 @@ const migrationMarkerStatement = (
   sql: `INSERT OR REPLACE INTO ${SCHEMA_MIGRATIONS_TABLE} (id, description, applied_at) VALUES (?, ?, ?)`,
 });
 
-const migrationMarkerStatements = (migrations: Migration[]): SqlStatement[] => {
-  const appliedAt = nowIso();
-  return migrations.map((migration) =>
-    migrationMarkerStatement(migration, appliedAt),
+const buildMigrationMarkerStatements =
+  (build: (migration: Migration, appliedAt: string) => SqlStatement) =>
+  (migrations: Migration[]): SqlStatement[] => {
+    const appliedAt = nowIso();
+    return migrations.map((migration) => build(migration, appliedAt));
+  };
+
+const migrationMarkerStatements = buildMigrationMarkerStatements(
+  migrationMarkerStatement,
+);
+
+const whileMigrationLockOwned = (
+  sql: string,
+  args: SqlStatement["args"],
+  lockToken: string,
+): SqlStatement => ({
+  args: [...args, MIGRATION_LOCK_KEY, lockToken],
+  sql: `${sql} WHERE EXISTS (SELECT 1 FROM settings WHERE key = ? AND value = ?)`,
+});
+
+const ownedMigrationMarkerStatements = (
+  migrations: Migration[],
+  lockToken: string,
+): SqlStatement[] =>
+  buildMigrationMarkerStatements((migration, appliedAt) =>
+    whileMigrationLockOwned(
+      `INSERT OR REPLACE INTO ${SCHEMA_MIGRATIONS_TABLE} (id, description, applied_at) SELECT ?, ?, ?`,
+      [migration.id, migration.description, appliedAt],
+      lockToken,
+    ),
+  )(migrations);
+
+const ownedSchemaMarkerStatements = (lockToken: string): SqlStatement[] =>
+  (
+    [
+      ["latest_db_update", LATEST_UPDATE],
+      ["db_schema_hash", SCHEMA_HASH],
+    ] as const
+  ).map(([key, value]) =>
+    whileMigrationLockOwned(
+      "INSERT OR REPLACE INTO settings (key, value) SELECT ?, ?",
+      [key, value],
+      lockToken,
+    ),
   );
+
+const executeWhileMigrationLockOwned = async (
+  statements: SqlStatement[],
+  lockToken: string,
+): Promise<void> => {
+  const [ownership] = await executeBatchWithResults([
+    {
+      args: [MIGRATION_LOCK_KEY, lockToken],
+      sql: "UPDATE settings SET value = value WHERE key = ? AND value = ?",
+    },
+    ...statements,
+  ]);
+  if (ownership!.rowsAffected !== 1) {
+    throw new MigrationInProgressError(
+      "Database migration lock ownership was lost before completion.",
+    );
+  }
 };
 
 /**
@@ -461,9 +520,11 @@ export const applyMigrationWithRetry = async (
   }
 };
 
-const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
+const runPendingMigrations = async (
+  pending: Migration[],
+  lockToken: string,
+): Promise<void> => {
   const completed: Migration[] = [];
-  let succeeded = false;
   try {
     for (const migration of pending) {
       logDebug(
@@ -473,13 +534,16 @@ const runPendingMigrations = async (pending: Migration[]): Promise<void> => {
       await applyMigrationWithRetry(migration);
       completed.push(migration);
     }
-    succeeded = true;
-  } finally {
+  } catch (error) {
     // Keep successful progress when a later migration fails. The success path
     // writes these markers with the schema markers and lock release below.
-    if (!succeeded && completed.length > 0) {
-      await markMigrationsApplied(completed);
+    if (completed.length > 0) {
+      await executeWhileMigrationLockOwned(
+        ownedMigrationMarkerStatements(completed, lockToken),
+        lockToken,
+      );
     }
+    throw error;
   }
 };
 
@@ -504,7 +568,6 @@ const restoreStaleSchemaMarkers = async (): Promise<void> => {
   await writeSchemaMarkers();
 };
 
-const MIGRATION_LOCK_KEY = "migration_lock";
 // A batch of four leaves room for the lock, probes, schema checks, and the
 // largest migrations while staying below Bunny's 50-subrequest request cap.
 const MIGRATIONS_PER_REQUEST = 4;
@@ -514,15 +577,19 @@ const MIGRATIONS_PER_REQUEST = 4;
 const recordMigrationBatch = async (
   migrations: Migration[],
   finished: boolean,
+  lockToken: string,
 ): Promise<void> => {
-  await executeBatch([
-    ...migrationMarkerStatements(migrations),
-    ...(finished ? schemaMarkerStatements() : []),
-    {
-      args: [MIGRATION_LOCK_KEY],
-      sql: "DELETE FROM settings WHERE key = ?",
-    },
-  ]);
+  await executeWhileMigrationLockOwned(
+    [
+      ...ownedMigrationMarkerStatements(migrations, lockToken),
+      ...(finished ? ownedSchemaMarkerStatements(lockToken) : []),
+      {
+        args: [MIGRATION_LOCK_KEY, lockToken],
+        sql: "DELETE FROM settings WHERE key = ? AND value = ?",
+      },
+    ],
+    lockToken,
+  );
 };
 
 /**
@@ -535,22 +602,23 @@ export const MIGRATION_LOCK_TTL_MS = 2 * 60 * 1000;
 
 /**
  * Acquire an advisory migration lock via the settings table.
- * Returns true if acquired, false if another process holds a fresh lock.
- * Stored values are ISO-8601 UTC timestamps, which sort lexicographically,
- * so a single atomic UPSERT both takes a free lock and steals an expired
- * one: DO UPDATE only fires when the held lock predates the cutoff, and a
- * fresh lock leaves rowsAffected at 0. Race-free across concurrent isolates
- * without a separate read.
+ * Returns this request's timestamp-prefixed lease token when acquired, or null
+ * when another process holds a fresh lock. The ISO-8601 prefix sorts
+ * lexicographically, so one atomic UPSERT both takes a free lock and steals an
+ * expired one: DO UPDATE only fires when the held lock predates the cutoff, and
+ * a fresh lock leaves rowsAffected at 0. The random suffix lets completion and
+ * cleanup prove they still own this exact lease.
  */
 const acquireMigrationLock = async (
   allowMissingSettings: boolean,
-): Promise<boolean> => {
+): Promise<string | null> => {
   const now = new Date();
   const cutoff = new Date(now.getTime() - MIGRATION_LOCK_TTL_MS).toISOString();
   const stamp = now.toISOString();
+  const lockToken = `${stamp}|${crypto.randomUUID()}`;
   const result = await getDb()
     .execute({
-      args: [MIGRATION_LOCK_KEY, stamp, stamp, cutoff],
+      args: [MIGRATION_LOCK_KEY, lockToken, lockToken, cutoff],
       sql:
         "INSERT INTO settings (key, value) VALUES (?, ?) " +
         "ON CONFLICT(key) DO UPDATE SET value = ? WHERE settings.value < ?",
@@ -561,15 +629,15 @@ const acquireMigrationLock = async (
       }
       throw error;
     });
-  return result === null || result.rowsAffected === 1;
+  return result === null || result.rowsAffected === 1 ? lockToken : null;
 };
 
-/** Release the migration lock */
-const releaseMigrationLock = async (): Promise<void> => {
-  await runMigration(
-    `DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'`,
-  );
-};
+/** Release only the migration lock lease acquired by this request. */
+const releaseMigrationLock = (lockToken: string): Promise<unknown> =>
+  getDb().execute({
+    args: [MIGRATION_LOCK_KEY, lockToken],
+    sql: "DELETE FROM settings WHERE key = ? AND value = ?",
+  });
 
 type InitDbOptions = {
   /** Only setup/restore/bootstrap callers should create a missing settings table. */
@@ -636,13 +704,71 @@ const finishIfUpToDate = async (probe: DbProbe): Promise<boolean> => {
   return true;
 };
 
+type LockedMigrationResult = "continue" | "release" | "released";
+
+const runAcquiredMigrations = async (
+  lockToken: string,
+): Promise<LockedMigrationResult> => {
+  // Re-check after acquiring lock because another process may have finished.
+  const recheck = await probeDbState();
+  if (await finishIfUpToDate(recheck)) return "release";
+
+  if (
+    recheck.state === "missing_settings" ||
+    recheck.state === "uninitialized_settings"
+  ) {
+    await initializeFreshSchema();
+    return "release";
+  }
+
+  const pending = await missingMigrations();
+  if (pending.length === 0) {
+    await restoreStaleSchemaMarkers();
+    return "release";
+  }
+
+  // Backups run out-of-band because the edge request budget cannot fit a full
+  // dump alongside migrations. Update routes require a recent backup instead.
+  const batch = isDatabaseRoundTripLimited()
+    ? pending.slice(0, MIGRATIONS_PER_REQUEST)
+    : pending;
+  const finished = batch.length === pending.length;
+  await runPendingMigrations(batch, lockToken);
+
+  logDebug(
+    "Migration",
+    finished
+      ? "Updating version marker..."
+      : `Recorded ${batch.length} migrations; continuing on the next request...`,
+  );
+  await recordMigrationBatch(batch, finished, lockToken);
+  return finished ? "released" : "continue";
+};
+
+const releaseAfterMigrationFailure = async (
+  lockToken: string,
+  failure: unknown,
+): Promise<never> => {
+  try {
+    await releaseMigrationLock(lockToken);
+  } catch (releaseError) {
+    throw new AggregateError(
+      [failure, releaseError],
+      `Database migration failed and its lock could not be released: ${errorMessage(
+        failure,
+      )}; ${errorMessage(releaseError)}`,
+    );
+  }
+  throw failure;
+};
+
 const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
   const probe = await probeDbState();
   if (await finishIfUpToDate(probe)) return;
   requireAllowedInitialDbState(probe.state, allowMissingSettings);
 
-  const acquired = await acquireMigrationLock(allowMissingSettings);
-  if (!acquired) {
+  const lockToken = await acquireMigrationLock(allowMissingSettings);
+  if (lockToken === null) {
     void sendNtfyError(`E_DB_MIGRATION_LOCK ${getEnv("DB_URL") ?? "unknown"}`);
     throw new MigrationInProgressError(
       "Database migration is already in progress (migration_lock held). " +
@@ -652,61 +778,17 @@ const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
     );
   }
 
-  let lockReleased = false;
+  let result: LockedMigrationResult;
   try {
-    // Re-check after acquiring lock (another process may have finished)
-    const recheck = await probeDbState();
-    if (await finishIfUpToDate(recheck)) return;
-
-    if (
-      recheck.state === "missing_settings" ||
-      recheck.state === "uninitialized_settings"
-    ) {
-      await initializeFreshSchema();
-      return;
-    }
-
-    const pending = await missingMigrations();
-    if (pending.length === 0) {
-      await restoreStaleSchemaMarkers();
-      return;
-    }
-
-    // Backups are no longer taken inline here: the Bunny edge subrequest budget
-    // can't fit a full dump of a 31-table schema alongside the migration. They
-    // run out-of-band instead — the upgrade GitHub Action backs each site up
-    // first, and /admin/update + the per-site update button refuse to run
-    // without a backup from the last hour (see hasRecentBackup).
-    const batch = isDatabaseRoundTripLimited()
-      ? pending.slice(0, MIGRATIONS_PER_REQUEST)
-      : pending;
-    const finished = batch.length === pending.length;
-    await runPendingMigrations(batch);
-
-    logDebug(
-      "Migration",
-      finished
-        ? "Updating version marker..."
-        : `Recorded ${batch.length} migrations; continuing on the next request...`,
+    result = await runAcquiredMigrations(lockToken);
+  } catch (error) {
+    return await releaseAfterMigrationFailure(lockToken, error);
+  }
+  if (result === "release") await releaseMigrationLock(lockToken);
+  if (result === "continue") {
+    throw new MigrationInProgressError(
+      "Database update is continuing on the next request.",
     );
-    await recordMigrationBatch(batch, finished);
-    lockReleased = true;
-    if (!finished) {
-      throw new MigrationInProgressError(
-        "Database update is continuing on the next request.",
-      );
-    }
-  } finally {
-    // If the isolate is evicted mid-migration this finally will not run, so
-    // stale locks are still reclaimed by MIGRATION_LOCK_TTL_MS.
-    if (!lockReleased) {
-      await releaseMigrationLock().catch((error) =>
-        logDebug(
-          "Migration",
-          `Failed to release migration lock: ${errorMessage(error)}`,
-        ),
-      );
-    }
   }
 };
 

--- a/src/shared/db/migrations/schema-sync.ts
+++ b/src/shared/db/migrations/schema-sync.ts
@@ -248,10 +248,10 @@ const canCreateTrigger = (
  * leaving a live table missing (say) a UNIQUE index until the migration is
  * retried — a window in which duplicate rows could land and then permanently
  * break the index re-creation. An interactive transaction (rather than a batch)
- * is what makes this possible: a compound `CREATE TRIGGER … BEGIN … END`
- * carries internal semicolons that some batch transports mis-split, so triggers
- * cannot ride in a batch — but each is sent through its own `tx.execute()` here
- * and still commits atomically with the rebuild.
+ * is what makes this possible. The ordered statements run as one structured
+ * batch inside that transaction. Each trigger body remains one statement, so
+ * its internal semicolons are not treated as batch separators, and one network
+ * call replaces one call per rebuild/index/trigger statement.
  *
  * The new table is created WITHOUT foreign keys (only column definitions), so
  * any FKs the original table had are removed after recreation.
@@ -296,7 +296,7 @@ export const recreateTable = async (tableName: string): Promise<void> => {
     ).map((trg) => trg.sql),
   ];
   await withTransaction(async (tx) => {
-    for (const sql of statements) await tx.execute(sql);
+    await tx.batch(statements.map(writeStatement));
   });
 };
 

--- a/src/shared/db/migrations/schema/version.ts
+++ b/src/shared/db/migrations/schema/version.ts
@@ -4,3 +4,6 @@ export const LATEST_UPDATE =
   "Unify admin feature visibility, enforce attendee status integrity, and add checkout stage storage.";
 
 export const SCHEMA_MIGRATIONS_TABLE = "schema_migrations";
+export const LATEST_DB_UPDATE_KEY = "latest_db_update";
+export const DB_SCHEMA_HASH_KEY = "db_schema_hash";
+export const MIGRATION_LOCK_KEY = "migration_lock";

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -70,6 +70,10 @@ const getState = (): QueryLogState => queryLogScope.current() ?? fallbackState;
 export const runWithQueryLogContext = <T>(fn: () => T): T =>
   queryLogScope.run(freshState(), fn);
 
+/** Whether database calls are currently subject to Bunny's per-request cap. */
+export const isDatabaseRoundTripLimited = (): boolean =>
+  queryLogScope.current() !== undefined;
+
 /** Enable query logging and clear previous entries */
 export const enableQueryLog = (): void => {
   const state = getState();

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -278,14 +278,13 @@ export const enforceTransactionRoundTripGuard = (
  * Run an async DB operation, enforcing the N+1 read guard and logging it when
  * footer tracking is active.
  */
-export const trackQueries = async <T>(
-  sqls: string[],
+export const trackSql = async <T>(
+  sql: string | string[],
   fn: () => Promise<T>,
 ): Promise<T> => {
   const store = queryLogScope.current();
-  if (store) {
-    for (const sql of sqls) enforceN1Guard(store, sql);
-  }
+  if (store && typeof sql === "string") enforceN1Guard(store, sql);
+  const sqls = typeof sql === "string" ? [sql] : sql;
   const state = store ?? fallbackState;
   const start = performance.now();
   const result = await fn();
@@ -298,6 +297,3 @@ export const trackQueries = async <T>(
   for (const sql of sqls) void logCompletedSql(sql);
   return result;
 };
-
-export const trackQuery = <T>(sql: string, fn: () => Promise<T>): Promise<T> =>
-  trackQueries([sql], fn);

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -82,9 +82,6 @@ export const enableQueryLog = (): void => {
   state.startTime = performance.now();
 };
 
-/** Whether query logging is currently active */
-export const isQueryLogEnabled = (): boolean => getState().enabled;
-
 /** Allow the admin debug footer to render the captured queries (staff-only). */
 export const enableFooterDebug = (): void => {
   getState().footerVisible = true;
@@ -95,16 +92,6 @@ export const isFooterDebugEnabled = (): boolean => getState().footerVisible;
 
 /** Return the start time recorded by enableQueryLog() */
 export const getQueryLogStartTime = (): number => getState().startTime;
-
-/** Record a query (no-op when logging is disabled) */
-export const addQueryLogEntry = (
-  sql: string,
-  durationMs: number,
-  startedAtMs: number,
-): void => {
-  const state = getState();
-  if (state.enabled) state.entries.push({ durationMs, sql, startedAtMs });
-};
 
 /** Return a snapshot of all logged queries */
 export const getQueryLog = (): QueryLogEntry[] => [...getState().entries];
@@ -291,22 +278,26 @@ export const enforceTransactionRoundTripGuard = (
  * Run an async DB operation, enforcing the N+1 read guard and logging it when
  * footer tracking is active.
  */
-export const trackQuery = async <T>(
-  sql: string,
+export const trackQueries = async <T>(
+  sqls: string[],
   fn: () => Promise<T>,
 ): Promise<T> => {
   const store = queryLogScope.current();
-  if (store) enforceN1Guard(store, sql);
+  if (store) {
+    for (const sql of sqls) enforceN1Guard(store, sql);
+  }
   const state = store ?? fallbackState;
   const start = performance.now();
   const result = await fn();
+  const durationMs = performance.now() - start;
   if (state.enabled) {
-    state.entries.push({
-      durationMs: performance.now() - start,
-      sql,
-      startedAtMs: start,
-    });
+    state.entries.push(
+      ...sqls.map((sql) => ({ durationMs, sql, startedAtMs: start })),
+    );
   }
-  void logCompletedSql(sql);
+  for (const sql of sqls) void logCompletedSql(sql);
   return result;
 };
+
+export const trackQuery = <T>(sql: string, fn: () => Promise<T>): Promise<T> =>
+  trackQueries([sql], fn);

--- a/test/lib/db/migration-restore/helpers.ts
+++ b/test/lib/db/migration-restore/helpers.ts
@@ -338,6 +338,32 @@ export const ownsSchemaObjects = (req: SchemaRequirement): boolean =>
       Object.values(req.columns ?? {}).some((cols) => cols.length > 0),
   );
 
+const columnsRemovedByMigration: Partial<Record<string, string[]>> = {
+  "2026-07-05_first_class_images": [
+    "ALTER TABLE listings ADD COLUMN image_url TEXT NOT NULL DEFAULT ''",
+  ],
+};
+
+/** Wind the live schema back to just before these migrations ran. */
+export const restoreSchemaBeforeMigrations = async (
+  migrations: Migration[],
+): Promise<void> => {
+  for (const migration of [...migrations].reverse()) {
+    if (
+      migration.requires &&
+      !migration.requires.absentTables &&
+      ownsSchemaObjects(migration.requires)
+    ) {
+      await dropOwnedObjects(migration.requires);
+    }
+  }
+  for (const migration of migrations) {
+    for (const statement of columnsRemovedByMigration[migration.id] ?? []) {
+      await getDb().execute(statement);
+    }
+  }
+};
+
 // Additive migrations own concrete objects and can be reconstructed by
 // re-running up(). The baseline reconcile (no `requires`), migrations that
 // remove legacy tables, and data-only migrations are covered separately.
@@ -459,15 +485,7 @@ export const defineChainSuite = (shard: number, shardCount: number): void => {
           const pending = MIGRATIONS.slice(
             MIGRATIONS.indexOf(baseMigration) + 1,
           );
-          for (const migration of [...pending].reverse()) {
-            if (
-              migration.requires &&
-              !migration.requires.absentTables &&
-              ownsSchemaObjects(migration.requires)
-            ) {
-              await dropOwnedObjects(migration.requires);
-            }
-          }
+          await restoreSchemaBeforeMigrations(pending);
 
           await markAppliedThrough(baseMigration.id);
           await markSchemaMarkersStale();

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -1,8 +1,14 @@
-import type { InStatement } from "@libsql/client";
+import type { InStatement, TransactionMode } from "@libsql/client";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { executeBatch, getDb } from "#shared/db/client.ts";
+import { executeBatch, getDb, inPlaceholders } from "#shared/db/client.ts";
+import {
+  DB_SCHEMA_HASH_KEY,
+  LATEST_DB_UPDATE_KEY,
+  MIGRATION_LOCK_KEY,
+  SCHEMA_MIGRATIONS_TABLE,
+} from "#shared/db/migrations/schema/version.ts";
 import {
   fullSchemaCreateStatements,
   verifyCurrentAppSchema,
@@ -34,6 +40,8 @@ import { invalidateTestDbCache } from "#test-utils/test-state.ts";
 import { withVirtualBackoff } from "#test-utils/virtual-time.ts";
 import { markCurrentSchemaMigrationPending } from "./migration-test-helpers.ts";
 
+type BatchStatement = Parameters<ReturnType<typeof getDb>["batch"]>[0][number];
+
 describeWithEnv("db > migration runtime", { db: true }, () => {
   const TEST_DB_URL = "libsql://abc-tickets-spencer.lite.bunnydb.net";
 
@@ -42,9 +50,9 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
   const setStaleSchemaAndLock = async (heldSince: Date): Promise<void> => {
     await getDb().batch(
       [
-        "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
+        `UPDATE settings SET value = 'stale' WHERE key = '${DB_SCHEMA_HASH_KEY}'`,
         {
-          args: ["migration_lock", heldSince.toISOString()],
+          args: [MIGRATION_LOCK_KEY, heldSince.toISOString()],
           sql: "INSERT INTO settings (key, value) VALUES (?, ?)",
         },
       ],
@@ -57,10 +65,10 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
   const restoreLockSettings = (): Promise<unknown> =>
     getDb().batch(
       [
-        "DELETE FROM settings WHERE key = 'migration_lock'",
+        `DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'`,
         {
           args: [SCHEMA_HASH],
-          sql: "UPDATE settings SET value = ? WHERE key = 'db_schema_hash'",
+          sql: `UPDATE settings SET value = ? WHERE key = '${DB_SCHEMA_HASH_KEY}'`,
         },
       ],
       "write",
@@ -70,29 +78,47 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
     await restoreLockSettings();
   };
 
-  const markMigrationPending = async (migrationId: string): Promise<void> => {
+  const markMigrationsPending = async (
+    migrationIds: string[],
+  ): Promise<void> => {
     await executeBatch([
       {
-        args: [migrationId],
-        sql: "DELETE FROM schema_migrations WHERE id = ?",
+        args: migrationIds,
+        sql: `DELETE FROM ${SCHEMA_MIGRATIONS_TABLE} WHERE id IN (${inPlaceholders(migrationIds)})`,
       },
       {
         args: [],
-        sql: "UPDATE settings SET value = 'stale' WHERE key IN ('latest_db_update', 'db_schema_hash')",
+        sql: `UPDATE settings SET value = 'stale' WHERE key IN ('${LATEST_DB_UPDATE_KEY}', '${DB_SCHEMA_HASH_KEY}')`,
       },
     ]);
     invalidateInitDbCache();
   };
 
+  const statementSql = (statement: BatchStatement | InStatement): string =>
+    Array.isArray(statement)
+      ? statement[0]
+      : typeof statement === "string"
+        ? statement
+        : statement.sql;
+
   const stubLockReleaseFailure = () => {
     const client = getDb();
     const execute = client.execute.bind(client);
-    return stub(client, "execute", (statement: InStatement) => {
-      const sql = typeof statement === "string" ? statement : statement.sql;
-      return sql === "DELETE FROM settings WHERE key = ? AND value = ?"
+    return stub(client, "execute", (statement: InStatement) =>
+      statementSql(statement) ===
+      "DELETE FROM settings WHERE key = ? AND value = ?"
         ? Promise.reject(new Error("lock release failed"))
-        : execute(statement);
-    });
+        : execute(statement),
+    );
+  };
+
+  const expectMigrationFailureWith = async (second: string): Promise<void> => {
+    const error = await initDb().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors.map(String)).toEqual([
+      "Error: migration work failed",
+      `Error: ${second}`,
+    ]);
   };
 
   describe("migration behaviour", () => {
@@ -100,14 +126,14 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
       using tmpDir = tempDir();
       using _env = withEnv({ LOCAL_STORAGE_PATH: tmpDir.path });
       await getDb().execute(
-        "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
+        `UPDATE settings SET value = 'stale' WHERE key = '${DB_SCHEMA_HASH_KEY}'`,
       );
       await markCurrentSchemaMigrationPending();
       await initDb();
 
       // The migration completed...
       const result = await getDb().execute(
-        "SELECT value FROM settings WHERE key = 'db_schema_hash'",
+        `SELECT value FROM settings WHERE key = '${DB_SCHEMA_HASH_KEY}'`,
       );
       expect(result.rows[0]?.value).toBe(SCHEMA_HASH);
 
@@ -169,12 +195,12 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
         await initDb();
 
         const result = await getDb().execute(
-          "SELECT value FROM settings WHERE key = 'db_schema_hash'",
+          `SELECT value FROM settings WHERE key = '${DB_SCHEMA_HASH_KEY}'`,
         );
         expect(result.rows[0]?.value).toBe(SCHEMA_HASH);
       } finally {
         await getDb().execute(
-          "DELETE FROM settings WHERE key = 'migration_lock'",
+          `DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'`,
         );
       }
     });
@@ -197,37 +223,37 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
       const migration = migrations.at(-1)!;
       const originalVerify = migration.verify;
       const successorLock = `${new Date().toISOString()}|successor`;
-      await markMigrationPending(migration.id);
+      await markMigrationsPending([migration.id]);
       migration.verify = async () => {
         await originalVerify();
         await getDb().execute({
           args: [successorLock],
-          sql: "UPDATE settings SET value = ? WHERE key = 'migration_lock'",
+          sql: `UPDATE settings SET value = ? WHERE key = '${MIGRATION_LOCK_KEY}'`,
         });
       };
 
       try {
         await expect(initDb()).rejects.toThrow("lock ownership was lost");
         const lock = await getDb().execute(
-          "SELECT value FROM settings WHERE key = 'migration_lock'",
+          `SELECT value FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'`,
         );
         expect(lock.rows[0]?.value).toBe(successorLock);
         const marker = await getDb().execute({
           args: [migration.id],
-          sql: "SELECT id FROM schema_migrations WHERE id = ?",
+          sql: `SELECT id FROM ${SCHEMA_MIGRATIONS_TABLE} WHERE id = ?`,
         });
         expect(marker.rows).toHaveLength(0);
       } finally {
         migration.verify = originalVerify;
         await getDb().execute(
-          "DELETE FROM settings WHERE key = 'migration_lock'",
+          `DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'`,
         );
       }
     });
 
     test("surfaces a lock release failure after otherwise successful work", async () => {
       await getDb().execute(
-        "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
+        `UPDATE settings SET value = 'stale' WHERE key = '${DB_SCHEMA_HASH_KEY}'`,
       );
       invalidateInitDbCache();
       const executeStub = stubLockReleaseFailure();
@@ -244,20 +270,47 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
       const migrations = await loadMigrations();
       const migration = migrations.at(-1)!;
       const originalUp = migration.up;
-      await markMigrationPending(migration.id);
+      await markMigrationsPending([migration.id]);
       migration.up = () => Promise.reject(new Error("migration work failed"));
       const executeStub = stubLockReleaseFailure();
 
       try {
-        const error = await initDb().catch((caught: unknown) => caught);
-        expect(error).toBeInstanceOf(AggregateError);
-        expect((error as AggregateError).errors.map(String)).toEqual([
-          "Error: migration work failed",
-          "Error: lock release failed",
-        ]);
+        await expectMigrationFailureWith("lock release failed");
       } finally {
         executeStub.restore();
         migration.up = originalUp;
+        await restoreLockSettings();
+      }
+    });
+
+    test("reports migration and progress marker failures together", async () => {
+      const migrations = await loadMigrations();
+      const [completedMigration, failingMigration] = migrations.slice(-2);
+      const originalUp = failingMigration!.up;
+      await markMigrationsPending([
+        completedMigration!.id,
+        failingMigration!.id,
+      ]);
+      failingMigration!.up = () =>
+        Promise.reject(new Error("migration work failed"));
+      const client = getDb();
+      const batch = client.batch.bind(client);
+      const batchStub = stub(
+        client,
+        "batch",
+        (statements: BatchStatement[], mode?: TransactionMode) =>
+          statements.some((statement) =>
+            statementSql(statement).includes("SET value = value"),
+          )
+            ? Promise.reject(new Error("progress marker failed"))
+            : batch(statements, mode),
+      );
+
+      try {
+        await expectMigrationFailureWith("progress marker failed");
+      } finally {
+        batchStub.restore();
+        failingMigration!.up = originalUp;
         await restoreLockSettings();
       }
     });

--- a/test/lib/db/migration-runtime.test.ts
+++ b/test/lib/db/migration-runtime.test.ts
@@ -1,6 +1,8 @@
+import type { InStatement } from "@libsql/client";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { getDb } from "#shared/db/client.ts";
+import { stub } from "@std/testing/mock";
+import { executeBatch, getDb } from "#shared/db/client.ts";
 import {
   fullSchemaCreateStatements,
   verifyCurrentAppSchema,
@@ -9,6 +11,7 @@ import {
   applyMigrationWithRetry,
   initDb,
   invalidateInitDbCache,
+  loadMigrations,
   MIGRATION_LOCK_TTL_MS,
   type Migration,
   MigrationInProgressError,
@@ -65,6 +68,31 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
 
   const restoreLockTest = async () => {
     await restoreLockSettings();
+  };
+
+  const markMigrationPending = async (migrationId: string): Promise<void> => {
+    await executeBatch([
+      {
+        args: [migrationId],
+        sql: "DELETE FROM schema_migrations WHERE id = ?",
+      },
+      {
+        args: [],
+        sql: "UPDATE settings SET value = 'stale' WHERE key IN ('latest_db_update', 'db_schema_hash')",
+      },
+    ]);
+    invalidateInitDbCache();
+  };
+
+  const stubLockReleaseFailure = () => {
+    const client = getDb();
+    const execute = client.execute.bind(client);
+    return stub(client, "execute", (statement: InStatement) => {
+      const sql = typeof statement === "string" ? statement : statement.sql;
+      return sql === "DELETE FROM settings WHERE key = ? AND value = ?"
+        ? Promise.reject(new Error("lock release failed"))
+        : execute(statement);
+    });
   };
 
   describe("migration behaviour", () => {
@@ -160,6 +188,76 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
 
         await expect(initDb()).rejects.toThrow("migration_lock held");
       } finally {
+        await restoreLockSettings();
+      }
+    });
+
+    test("does not record completion or delete a successor lock after losing ownership", async () => {
+      const migrations = await loadMigrations();
+      const migration = migrations.at(-1)!;
+      const originalVerify = migration.verify;
+      const successorLock = `${new Date().toISOString()}|successor`;
+      await markMigrationPending(migration.id);
+      migration.verify = async () => {
+        await originalVerify();
+        await getDb().execute({
+          args: [successorLock],
+          sql: "UPDATE settings SET value = ? WHERE key = 'migration_lock'",
+        });
+      };
+
+      try {
+        await expect(initDb()).rejects.toThrow("lock ownership was lost");
+        const lock = await getDb().execute(
+          "SELECT value FROM settings WHERE key = 'migration_lock'",
+        );
+        expect(lock.rows[0]?.value).toBe(successorLock);
+        const marker = await getDb().execute({
+          args: [migration.id],
+          sql: "SELECT id FROM schema_migrations WHERE id = ?",
+        });
+        expect(marker.rows).toHaveLength(0);
+      } finally {
+        migration.verify = originalVerify;
+        await getDb().execute(
+          "DELETE FROM settings WHERE key = 'migration_lock'",
+        );
+      }
+    });
+
+    test("surfaces a lock release failure after otherwise successful work", async () => {
+      await getDb().execute(
+        "UPDATE settings SET value = 'stale' WHERE key = 'db_schema_hash'",
+      );
+      invalidateInitDbCache();
+      const executeStub = stubLockReleaseFailure();
+
+      try {
+        await expect(initDb()).rejects.toThrow("lock release failed");
+      } finally {
+        executeStub.restore();
+        await restoreLockSettings();
+      }
+    });
+
+    test("reports migration and lock release failures together", async () => {
+      const migrations = await loadMigrations();
+      const migration = migrations.at(-1)!;
+      const originalUp = migration.up;
+      await markMigrationPending(migration.id);
+      migration.up = () => Promise.reject(new Error("migration work failed"));
+      const executeStub = stubLockReleaseFailure();
+
+      try {
+        const error = await initDb().catch((caught: unknown) => caught);
+        expect(error).toBeInstanceOf(AggregateError);
+        expect((error as AggregateError).errors.map(String)).toEqual([
+          "Error: migration work failed",
+          "Error: lock release failed",
+        ]);
+      } finally {
+        executeStub.restore();
+        migration.up = originalUp;
         await restoreLockSettings();
       }
     });

--- a/test/lib/serve-app.test.ts
+++ b/test/lib/serve-app.test.ts
@@ -14,7 +14,7 @@ import { stub } from "@std/testing/mock";
 import {
   N_PLUS_ONE_THRESHOLD,
   runWithQueryLogContext,
-  trackQuery,
+  trackSql,
 } from "#shared/db/query-log.ts";
 import { setSuppressDebugLogs } from "#shared/log-settings.ts";
 import { devServerPort, serveHandler } from "#src/serve-app.ts";
@@ -86,7 +86,7 @@ describeWithEnv("serve-app", { db: true }, () => {
       try {
         await runWithQueryLogContext(async () => {
           for (let i = 0; i < N_PLUS_ONE_THRESHOLD + 1; i++) {
-            await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+            await trackSql("SELECT 1", () => Promise.resolve("ok"));
           }
         });
         // Let the fire-and-forget dynamic import + logError settle.

--- a/test/lib/stripe-mock/install.test.ts
+++ b/test/lib/stripe-mock/install.test.ts
@@ -209,7 +209,7 @@ describe("stripe-mock install", () => {
           await expectStripeMockFails({
             delayMs: 10,
             installLockRetryMs: 5,
-            installLockTimeoutMs: 500,
+            installLockTimeoutMs: 5_000,
             maxAttempts: 3,
             paths,
           });
@@ -245,7 +245,7 @@ describe("stripe-mock install", () => {
                 delayMs: 10,
                 installLockRetryMs: 5,
                 installLockStaleMs: 500,
-                installLockTimeoutMs: 500,
+                installLockTimeoutMs: 5_000,
                 maxAttempts: 3,
                 paths,
               });

--- a/test/shared/db/client/batch.test.ts
+++ b/test/shared/db/client/batch.test.ts
@@ -2,7 +2,12 @@ import type { TransactionMode } from "@libsql/client";
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { returnsNext, stub } from "@std/testing/mock";
-import { getDb, queryBatch, queryBatchPrimary } from "#shared/db/client.ts";
+import {
+  getDb,
+  queryBatch,
+  queryBatchPrimary,
+  withTransaction,
+} from "#shared/db/client.ts";
 import {
   enableQueryLog,
   getQueryLog,
@@ -42,6 +47,20 @@ describeWithEnv("db > client batch", { db: true }, () => {
     // "read" mode lets Turso serve the batch from a replica; anything else
     // would needlessly pin read-only batches to the primary.
     expect(await captureBatchModes(queryBatch)).toEqual(["read"]);
+  });
+
+  test("transaction batches commit string statements together", async () => {
+    await withTransaction(async (tx) => {
+      await tx.batch([
+        "CREATE TABLE transaction_batch_test (value TEXT NOT NULL)",
+        "INSERT INTO transaction_batch_test (value) VALUES ('saved')",
+      ]);
+    });
+
+    const result = await getDb().execute(
+      "SELECT value FROM transaction_batch_test",
+    );
+    expect(result.rows.map(({ value }) => String(value))).toEqual(["saved"]);
   });
 
   test("queryBatchPrimary runs its statements in write mode", async () => {

--- a/test/shared/db/client/batch.test.ts
+++ b/test/shared/db/client/batch.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   enableQueryLog,
   getQueryLog,
+  N_PLUS_ONE_THRESHOLD,
   runWithQueryLogContext,
 } from "#shared/db/query-log.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -47,6 +48,16 @@ describeWithEnv("db > client batch", { db: true }, () => {
     // "read" mode lets Turso serve the batch from a replica; anything else
     // would needlessly pin read-only batches to the primary.
     expect(await captureBatchModes(queryBatch)).toEqual(["read"]);
+  });
+
+  test("queryBatch does not count repeated statements as separate N+1 reads", async () => {
+    await runWithQueryLogContext(async () => {
+      const statements = Array.from(
+        { length: N_PLUS_ONE_THRESHOLD + 1 },
+        () => ({ args: [], sql: "SELECT 1" }),
+      );
+      expect(await queryBatch(statements)).toHaveLength(statements.length);
+    });
   });
 
   test("transaction batches commit string statements together", async () => {

--- a/test/shared/db/client/batch.test.ts
+++ b/test/shared/db/client/batch.test.ts
@@ -63,6 +63,26 @@ describeWithEnv("db > client batch", { db: true }, () => {
     expect(result.rows.map(({ value }) => String(value))).toEqual(["saved"]);
   });
 
+  test("transaction batches track every statement in one shared window", async () => {
+    await runWithQueryLogContext(async () => {
+      enableQueryLog();
+      await withTransaction(async (tx) => {
+        await tx.batch([
+          "CREATE TABLE tracked_transaction_batch (value TEXT NOT NULL)",
+          "INSERT INTO tracked_transaction_batch (value) VALUES ('saved')",
+        ]);
+      });
+
+      const entries = getQueryLog();
+      expect(entries.map(({ sql }) => sql)).toEqual([
+        "CREATE TABLE tracked_transaction_batch (value TEXT NOT NULL)",
+        "INSERT INTO tracked_transaction_batch (value) VALUES ('saved')",
+      ]);
+      expect(entries[1]!.startedAtMs).toBe(entries[0]!.startedAtMs);
+      expect(entries[1]!.durationMs).toBe(entries[0]!.durationMs);
+    });
+  });
+
   test("queryBatchPrimary runs its statements in write mode", async () => {
     // "write" mode is the read-your-writes guarantee: Turso always serves it
     // from the primary, so a just-committed row is visible.

--- a/test/shared/db/link-table.test.ts
+++ b/test/shared/db/link-table.test.ts
@@ -101,6 +101,7 @@ describeWithEnv("db link-table", { db: true }, () => {
     await withTransaction(async (tx) => {
       await byUser.addIdsTx(
         {
+          ...tx,
           execute: (stmt) => {
             statements += 1;
             return tx.execute(stmt);

--- a/test/shared/db/migration-round-trip-budget.test.ts
+++ b/test/shared/db/migration-round-trip-budget.test.ts
@@ -16,6 +16,7 @@ import { describeWithEnv } from "#test-utils/db.ts";
 const LISTINGS_TAG_MIGRATION_ID = "2026-07-03_attendee_listings_tag";
 const LISTINGS_TAG_REVISION =
   "Rewrite the {{listing}} attendee column-order tag to {{listings}} for the grouped Listings column.";
+const FREE_TEXT_MIGRATION_ID = "2026-06-20_free_text_questions";
 
 const MIGRATIONS = await loadMigrations();
 
@@ -30,6 +31,35 @@ const migrationsAfterListingsTag = (): Migration[] => {
 };
 
 describeWithEnv("migration request round-trip budget", { db: true }, () => {
+  test("records the free-text migration within one guarded request", async () => {
+    const migration = MIGRATIONS.find(
+      ({ id }) => id === FREE_TEXT_MIGRATION_ID,
+    );
+    if (!migration) {
+      throw new Error(`Missing migration ${FREE_TEXT_MIGRATION_ID}`);
+    }
+    await restoreSchemaBeforeMigrations([migration]);
+    await executeBatch([
+      {
+        args: [migration.id],
+        sql: "DELETE FROM schema_migrations WHERE id = ?",
+      },
+      {
+        args: [],
+        sql: "UPDATE settings SET value = 'stale' WHERE key IN ('latest_db_update', 'db_schema_hash')",
+      },
+    ]);
+    invalidateInitDbCache();
+
+    await runWithQueryLogContext(() => initDb());
+
+    const marker = await getDb().execute({
+      args: [migration.id],
+      sql: "SELECT id FROM schema_migrations WHERE id = ?",
+    });
+    expect(marker.rows.map((row) => String(row.id))).toEqual([migration.id]);
+  });
+
   test("upgrades the listings-tag revision within guarded edge requests", async () => {
     const pending = migrationsAfterListingsTag();
     const pendingIds = pending.map((migration) => migration.id);

--- a/test/shared/db/migration-round-trip-budget.test.ts
+++ b/test/shared/db/migration-round-trip-budget.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { executeBatch, getDb, inPlaceholders } from "#shared/db/client.ts";
+import { MIGRATION_IDS } from "#shared/db/migrations/registry.ts";
+import {
+  initDb,
+  invalidateInitDbCache,
+  LATEST_UPDATE,
+  MigrationInProgressError,
+} from "#shared/db/migrations.ts";
+import { runWithQueryLogContext } from "#shared/db/query-log.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+
+const LISTINGS_TAG_MIGRATION_ID = "2026-07-03_attendee_listings_tag";
+const LISTINGS_TAG_REVISION =
+  "Rewrite the {{listing}} attendee column-order tag to {{listings}} for the grouped Listings column.";
+
+const migrationsAfterListingsTag = (): string[] => {
+  const appliedIndex = MIGRATION_IDS.indexOf(LISTINGS_TAG_MIGRATION_ID);
+  if (appliedIndex < 0) {
+    throw new Error(`Missing migration ${LISTINGS_TAG_MIGRATION_ID}`);
+  }
+  return MIGRATION_IDS.slice(appliedIndex + 1);
+};
+
+describeWithEnv("migration request round-trip budget", { db: true }, () => {
+  test("upgrades the listings-tag revision within guarded edge requests", async () => {
+    const pendingIds = migrationsAfterListingsTag();
+    await executeBatch([
+      {
+        args: [LISTINGS_TAG_REVISION],
+        sql: "UPDATE settings SET value = ? WHERE key = 'latest_db_update'",
+      },
+      {
+        args: pendingIds,
+        sql: `DELETE FROM schema_migrations WHERE id IN (${inPlaceholders(pendingIds)})`,
+      },
+    ]);
+    invalidateInitDbCache();
+
+    let continuations = 0;
+    let finished = false;
+    for (let attempt = 0; attempt < pendingIds.length; attempt += 1) {
+      try {
+        await runWithQueryLogContext(() => initDb());
+        finished = true;
+        break;
+      } catch (error) {
+        expect(error).toBeInstanceOf(MigrationInProgressError);
+        continuations += 1;
+      }
+    }
+    expect(finished).toBe(true);
+    expect(continuations).toBe(3);
+
+    const result = await getDb().execute({
+      args: pendingIds,
+      sql: `SELECT id FROM schema_migrations WHERE id IN (${inPlaceholders(pendingIds)}) ORDER BY id`,
+    });
+    expect(result.rows.map((row) => String(row.id))).toEqual(
+      [...pendingIds].sort(),
+    );
+    const marker = await getDb().execute(
+      "SELECT value FROM settings WHERE key = 'latest_db_update'",
+    );
+    expect(marker.rows[0]?.value).toBe(LATEST_UPDATE);
+  });
+});

--- a/test/shared/db/migration-round-trip-budget.test.ts
+++ b/test/shared/db/migration-round-trip-budget.test.ts
@@ -2,6 +2,11 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { executeBatch, getDb, inPlaceholders } from "#shared/db/client.ts";
 import {
+  DB_SCHEMA_HASH_KEY,
+  LATEST_DB_UPDATE_KEY,
+  SCHEMA_MIGRATIONS_TABLE,
+} from "#shared/db/migrations/schema/version.ts";
+import {
   initDb,
   invalidateInitDbCache,
   LATEST_UPDATE,
@@ -42,20 +47,34 @@ describeWithEnv("migration request round-trip budget", { db: true }, () => {
     await executeBatch([
       {
         args: [migration.id],
-        sql: "DELETE FROM schema_migrations WHERE id = ?",
+        sql: `DELETE FROM ${SCHEMA_MIGRATIONS_TABLE} WHERE id = ?`,
       },
       {
-        args: [],
-        sql: "UPDATE settings SET value = 'stale' WHERE key IN ('latest_db_update', 'db_schema_hash')",
+        args: [LATEST_DB_UPDATE_KEY, DB_SCHEMA_HASH_KEY],
+        sql: "UPDATE settings SET value = 'stale' WHERE key IN (?, ?)",
       },
     ]);
     invalidateInitDbCache();
+
+    const staleMarkers = await getDb().execute({
+      args: [LATEST_DB_UPDATE_KEY, DB_SCHEMA_HASH_KEY],
+      sql: "SELECT key, value FROM settings WHERE key IN (?, ?) ORDER BY key",
+    });
+    expect(
+      staleMarkers.rows.map(({ key, value }) => ({
+        key: String(key),
+        value: String(value),
+      })),
+    ).toEqual([
+      { key: DB_SCHEMA_HASH_KEY, value: "stale" },
+      { key: LATEST_DB_UPDATE_KEY, value: "stale" },
+    ]);
 
     await runWithQueryLogContext(() => initDb());
 
     const marker = await getDb().execute({
       args: [migration.id],
-      sql: "SELECT id FROM schema_migrations WHERE id = ?",
+      sql: `SELECT id FROM ${SCHEMA_MIGRATIONS_TABLE} WHERE id = ?`,
     });
     expect(marker.rows.map((row) => String(row.id))).toEqual([migration.id]);
   });
@@ -67,11 +86,11 @@ describeWithEnv("migration request round-trip budget", { db: true }, () => {
     await executeBatch([
       {
         args: [LISTINGS_TAG_REVISION],
-        sql: "UPDATE settings SET value = ? WHERE key = 'latest_db_update'",
+        sql: `UPDATE settings SET value = ? WHERE key = '${LATEST_DB_UPDATE_KEY}'`,
       },
       {
         args: pendingIds,
-        sql: `DELETE FROM schema_migrations WHERE id IN (${inPlaceholders(pendingIds)})`,
+        sql: `DELETE FROM ${SCHEMA_MIGRATIONS_TABLE} WHERE id IN (${inPlaceholders(pendingIds)})`,
       },
     ]);
     invalidateInitDbCache();
@@ -104,13 +123,13 @@ describeWithEnv("migration request round-trip budget", { db: true }, () => {
 
     const result = await getDb().execute({
       args: pendingIds,
-      sql: `SELECT id FROM schema_migrations WHERE id IN (${inPlaceholders(pendingIds)}) ORDER BY id`,
+      sql: `SELECT id FROM ${SCHEMA_MIGRATIONS_TABLE} WHERE id IN (${inPlaceholders(pendingIds)}) ORDER BY id`,
     });
     expect(result.rows.map((row) => String(row.id))).toEqual(
       [...pendingIds].sort(),
     );
     const marker = await getDb().execute(
-      "SELECT value FROM settings WHERE key = 'latest_db_update'",
+      `SELECT value FROM settings WHERE key = '${LATEST_DB_UPDATE_KEY}'`,
     );
     expect(marker.rows[0]?.value).toBe(LATEST_UPDATE);
   });

--- a/test/shared/db/migration-round-trip-budget.test.ts
+++ b/test/shared/db/migration-round-trip-budget.test.ts
@@ -1,31 +1,39 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { executeBatch, getDb, inPlaceholders } from "#shared/db/client.ts";
-import { MIGRATION_IDS } from "#shared/db/migrations/registry.ts";
 import {
   initDb,
   invalidateInitDbCache,
   LATEST_UPDATE,
+  loadMigrations,
+  type Migration,
   MigrationInProgressError,
 } from "#shared/db/migrations.ts";
 import { runWithQueryLogContext } from "#shared/db/query-log.ts";
+import { restoreSchemaBeforeMigrations } from "#test/lib/db/migration-restore/helpers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 
 const LISTINGS_TAG_MIGRATION_ID = "2026-07-03_attendee_listings_tag";
 const LISTINGS_TAG_REVISION =
   "Rewrite the {{listing}} attendee column-order tag to {{listings}} for the grouped Listings column.";
 
-const migrationsAfterListingsTag = (): string[] => {
-  const appliedIndex = MIGRATION_IDS.indexOf(LISTINGS_TAG_MIGRATION_ID);
+const MIGRATIONS = await loadMigrations();
+
+const migrationsAfterListingsTag = (): Migration[] => {
+  const appliedIndex = MIGRATIONS.findIndex(
+    (migration) => migration.id === LISTINGS_TAG_MIGRATION_ID,
+  );
   if (appliedIndex < 0) {
     throw new Error(`Missing migration ${LISTINGS_TAG_MIGRATION_ID}`);
   }
-  return MIGRATION_IDS.slice(appliedIndex + 1);
+  return MIGRATIONS.slice(appliedIndex + 1);
 };
 
 describeWithEnv("migration request round-trip budget", { db: true }, () => {
   test("upgrades the listings-tag revision within guarded edge requests", async () => {
-    const pendingIds = migrationsAfterListingsTag();
+    const pending = migrationsAfterListingsTag();
+    const pendingIds = pending.map((migration) => migration.id);
+    await restoreSchemaBeforeMigrations(pending);
     await executeBatch([
       {
         args: [LISTINGS_TAG_REVISION],
@@ -37,6 +45,17 @@ describeWithEnv("migration request round-trip budget", { db: true }, () => {
       },
     ]);
     invalidateInitDbCache();
+
+    const oldListingColumns = await getDb().execute(
+      "SELECT name FROM pragma_table_info('listings')",
+    );
+    expect(oldListingColumns.rows.map((row) => String(row.name))).toContain(
+      "image_url",
+    );
+    const oldImagesTable = await getDb().execute(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'images'",
+    );
+    expect(oldImagesTable.rows).toHaveLength(0);
 
     let continuations = 0;
     let finished = false;

--- a/test/shared/db/query-log.test.ts
+++ b/test/shared/db/query-log.test.ts
@@ -14,7 +14,7 @@ import {
   setN1GuardNotifyOnly,
   sqlWallClockMs,
   TRANSACTION_ROUNDTRIP_THRESHOLD,
-  trackQuery,
+  trackSql,
 } from "#shared/db/query-log.ts";
 // Importing logger eagerly also preloads it, so the dynamic
 // `import("#shared/logger.ts")` in the N+1 guard and the SQL system-log
@@ -28,7 +28,7 @@ describe("query-log", () => {
     test("clears log on enable", async () => {
       await runWithQueryLogContext(async () => {
         enableQueryLog();
-        await trackQuery("SELECT old", () => Promise.resolve());
+        await trackSql("SELECT old", () => Promise.resolve());
         expect(getQueryLog()).toHaveLength(1);
 
         enableQueryLog();
@@ -41,9 +41,9 @@ describe("query-log", () => {
     test("returned array is independent of internal state", async () => {
       await runWithQueryLogContext(async () => {
         enableQueryLog();
-        await trackQuery("SELECT 1", () => Promise.resolve());
+        await trackSql("SELECT 1", () => Promise.resolve());
         const snapshot = getQueryLog();
-        await trackQuery("SELECT 2", () => Promise.resolve());
+        await trackSql("SELECT 2", () => Promise.resolve());
         expect(snapshot).toHaveLength(1);
         expect(getQueryLog()).toHaveLength(2);
       });
@@ -154,12 +154,12 @@ describe("query-log", () => {
     });
   });
 
-  describe("trackQuery recording", () => {
+  describe("trackSql recording", () => {
     test("records duration and start time when logging is enabled", async () => {
       await runWithQueryLogContext(async () => {
         enableQueryLog();
         const before = performance.now();
-        await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+        await trackSql("SELECT 1", () => Promise.resolve("ok"));
         const after = performance.now();
         const [logged] = getQueryLog();
         expect(logged!.sql).toBe("SELECT 1");
@@ -177,7 +177,7 @@ describe("query-log", () => {
         enableQueryLog();
         const nowStub = stub(performance, "now", returnsNext([1000, 1005]));
         try {
-          await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+          await trackSql("SELECT 1", () => Promise.resolve("ok"));
         } finally {
           nowStub.restore();
         }
@@ -208,7 +208,7 @@ describe("query-log", () => {
 
     test("mirrors a completed statement, omitting bound values", async () => {
       const logs = await captureSqlLogs(() =>
-        trackQuery("SELECT name FROM users WHERE id = ?", () =>
+        trackSql("SELECT name FROM users WHERE id = ?", () =>
           Promise.resolve("ok"),
         ),
       );
@@ -221,7 +221,7 @@ describe("query-log", () => {
 
     test("collapses whitespace so a multi-line statement logs on one line", async () => {
       const logs = await captureSqlLogs(() =>
-        trackQuery("SELECT\n  id\nFROM   users", () => Promise.resolve("ok")),
+        trackSql("SELECT\n  id\nFROM   users", () => Promise.resolve("ok")),
       );
       expect(
         logs.some((line) => line.includes("[SQL] SELECT id FROM users")),
@@ -236,7 +236,7 @@ describe("query-log", () => {
     const readSelectOne = async (count: number): Promise<unknown> => {
       let last: unknown;
       for (let i = 0; i < count; i++) {
-        last = await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+        last = await trackSql("SELECT 1", () => Promise.resolve("ok"));
       }
       return last;
     };
@@ -250,10 +250,10 @@ describe("query-log", () => {
     test("throws when the same read crosses the threshold", async () => {
       await runWithQueryLogContext(async () => {
         for (let i = 0; i < N_PLUS_ONE_THRESHOLD; i++) {
-          await trackQuery("SELECT 1", () => Promise.resolve("ok"));
+          await trackSql("SELECT 1", () => Promise.resolve("ok"));
         }
         await expect(
-          trackQuery("SELECT 1", () => Promise.resolve("ok")),
+          trackSql("SELECT 1", () => Promise.resolve("ok")),
         ).rejects.toThrow(/N\+1 query detected/);
       });
     });
@@ -262,7 +262,7 @@ describe("query-log", () => {
       await runWithQueryLogContext(async () => {
         let last: unknown;
         for (let i = 0; i < N_PLUS_ONE_THRESHOLD * 2; i++) {
-          last = await trackQuery("INSERT INTO t (id) VALUES (?)", () =>
+          last = await trackSql("INSERT INTO t (id) VALUES (?)", () =>
             Promise.resolve("ok"),
           );
         }
@@ -274,8 +274,8 @@ describe("query-log", () => {
       await runWithQueryLogContext(async () => {
         let last: unknown;
         for (let i = 0; i < N_PLUS_ONE_THRESHOLD; i++) {
-          await trackQuery("SELECT a", () => Promise.resolve("a"));
-          last = await trackQuery("SELECT b", () => Promise.resolve("b"));
+          await trackSql("SELECT a", () => Promise.resolve("a"));
+          last = await trackSql("SELECT b", () => Promise.resolve("b"));
         }
         expect(last).toBe("b");
       });

--- a/test/shared/db/query-log.test.ts
+++ b/test/shared/db/query-log.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { returnsNext, stub } from "@std/testing/mock";
 import {
-  addQueryLogEntry,
   countDatabaseRoundTrip,
   enableFooterDebug,
   enableQueryLog,
@@ -10,7 +9,6 @@ import {
   getQueryLog,
   getQueryLogStartTime,
   isFooterDebugEnabled,
-  isQueryLogEnabled,
   N_PLUS_ONE_THRESHOLD,
   runWithQueryLogContext,
   setN1GuardNotifyOnly,
@@ -26,57 +24,11 @@ import { setSuppressDebugLogs } from "#shared/log-settings.ts";
 import { BUNNY_SUBREQUEST_LIMIT } from "#shared/subrequest-budget.ts";
 
 describe("query-log", () => {
-  describe("enableQueryLog", () => {
-    test("starts disabled", async () => {
-      await runWithQueryLogContext(async () => {
-        expect(isQueryLogEnabled()).toBe(false);
-      });
-    });
-
-    test("enableQueryLog enables tracking", async () => {
-      await runWithQueryLogContext(async () => {
-        enableQueryLog();
-        expect(isQueryLogEnabled()).toBe(true);
-      });
-    });
-  });
-
-  describe("addQueryLogEntry", () => {
-    test("records entries when enabled", async () => {
-      await runWithQueryLogContext(async () => {
-        enableQueryLog();
-        addQueryLogEntry("SELECT 1", 1.5, 100);
-        addQueryLogEntry("SELECT 2", 2.3, 200);
-        const log = getQueryLog();
-        expect(log).toHaveLength(2);
-        expect(log[0]!.sql).toBe("SELECT 1");
-        expect(log[0]!.durationMs).toBe(1.5);
-        expect(log[1]!.sql).toBe("SELECT 2");
-        expect(log[1]!.durationMs).toBe(2.3);
-      });
-    });
-
-    test("records the query start time for wall-clock math", async () => {
-      await runWithQueryLogContext(async () => {
-        enableQueryLog();
-        addQueryLogEntry("SELECT 1", 1.5, 100);
-        expect(getQueryLog()[0]!.startedAtMs).toBe(100);
-      });
-    });
-
-    test("ignores entries when disabled", async () => {
-      await runWithQueryLogContext(async () => {
-        addQueryLogEntry("SELECT 1", 1.0, 0);
-        expect(getQueryLog()).toHaveLength(0);
-      });
-    });
-  });
-
   describe("enableQueryLog resets previous entries", () => {
     test("clears log on enable", async () => {
       await runWithQueryLogContext(async () => {
         enableQueryLog();
-        addQueryLogEntry("SELECT old", 1.0, 0);
+        await trackQuery("SELECT old", () => Promise.resolve());
         expect(getQueryLog()).toHaveLength(1);
 
         enableQueryLog();
@@ -89,9 +41,9 @@ describe("query-log", () => {
     test("returned array is independent of internal state", async () => {
       await runWithQueryLogContext(async () => {
         enableQueryLog();
-        addQueryLogEntry("SELECT 1", 1.0, 0);
+        await trackQuery("SELECT 1", () => Promise.resolve());
         const snapshot = getQueryLog();
-        addQueryLogEntry("SELECT 2", 2.0, 1);
+        await trackQuery("SELECT 2", () => Promise.resolve());
         expect(snapshot).toHaveLength(1);
         expect(getQueryLog()).toHaveLength(2);
       });


### PR DESCRIPTION
## Summary

- Run at most four pending migrations in each edge request.
- Batch migration history, schema markers, and lock release into fewer database calls.
- Batch each atomic table rebuild inside its transaction, so one heavy migration can finish within the edge request limit.
- Give each migration request its own lease, so an expired request cannot record progress or delete a newer request’s lock.
- Continue unfinished upgrades safely on the next request.
- Test upgrades from the free-text-question and listings-tag schemas under the real database round-trip guard.

## Why

Sites with several pending migrations could exceed Bunny’s 50-subrequest request limit while starting. Splitting the work keeps each request within that limit while preserving completed migration progress. Batching table rebuild statements also prevents one heavy migration from exhausting the whole request before its progress can be saved. Lease-scoped completion keeps overlapping or stalled requests from changing each other’s migration state.

## Risks

- A POST that arrives while the new script is upgrading the database can receive the continuation page without being processed. We always move requests to the latest script and do not replay POST bodies across versions, so the user must submit that request again. This is an accepted deployment risk.

## Testing

- `deno task precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migration reliability under limited round-trip budgets by batching migration marker recording.
  - Reworked migration locking to use request-scoped lease tokens, improving safety when lock ownership expires or marker/lock updates fail.
  - Strengthened migration schema restoration and ensured partial progress is preserved with correct completion marker behavior.

- **Tests**
  - Added a migration “round-trip budget” test covering guarded/continuation upgrade edge cases.
  - Expanded migration runtime tests for lock TTL/ownership loss and aggregated error reporting.

- **Documentation**
  - Added query-log scope helper and updated batching guidance for database transactions and rebuild-style table recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->