### PR TITLE
Keep cached pages fresh after database changes

### DIFF
--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -64,7 +64,6 @@ export type WriteInfo = {
 export type CacheInvalidation = "manual" | "write";
 
 type Invalidator = (cause: CacheInvalidation) => void;
-type Reset = () => void;
 type Registration = {
   invalidate: Invalidator;
   /** If set, an UPDATE only fires when it assigns at least one of these columns.
@@ -75,13 +74,13 @@ type Registration = {
 const invalidatorsByTable = new Map<string, Set<Registration>>();
 
 /** Full-clear hooks for caches that no table registration covers (e.g. the
- * per-token session cache, which is invalidated entry-by-entry on writes). */
-const resetHooks = new Set<Reset>();
+ * permanent setup-complete shortcut). */
+const resetHooks = new Set<Invalidator>();
 
-/** Register an extra full-clear to run when every cache is reset. Only needed
- * by caches without a table registration; `resetAllCaches` already fires every
- * table-registered invalidator. */
-export const registerCacheReset = (reset: Reset): Unregister => {
+/** Register an extra full-clear to run with a write cause when every cache is
+ * reset. Only needed by caches without a table registration;
+ * `resetAllCaches` already fires every table-registered invalidator. */
+export const registerCacheReset = (reset: Invalidator): Unregister => {
   resetHooks.add(reset);
   return () => resetHooks.delete(reset);
 };
@@ -101,7 +100,7 @@ export const resetAllCaches = (): void => {
   for (const registration of unique(registrations)) {
     registration.invalidate("write");
   }
-  for (const reset of resetHooks) reset();
+  for (const reset of resetHooks) reset("write");
 };
 
 const setsIntersect = (

--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -60,7 +60,11 @@ export type WriteInfo = {
   columns: ReadonlySet<string>;
 };
 
-type Invalidator = () => void;
+/** Why cached data was cleared. Only a committed write needs primary refills. */
+export type CacheInvalidation = "manual" | "write";
+
+type Invalidator = (cause: CacheInvalidation) => void;
+type Reset = () => void;
 type Registration = {
   invalidate: Invalidator;
   /** If set, an UPDATE only fires when it assigns at least one of these columns.
@@ -72,12 +76,12 @@ const invalidatorsByTable = new Map<string, Set<Registration>>();
 
 /** Full-clear hooks for caches that no table registration covers (e.g. the
  * per-token session cache, which is invalidated entry-by-entry on writes). */
-const resetHooks = new Set<Invalidator>();
+const resetHooks = new Set<Reset>();
 
 /** Register an extra full-clear to run when every cache is reset. Only needed
  * by caches without a table registration; `resetAllCaches` already fires every
  * table-registered invalidator. */
-export const registerCacheReset = (reset: Invalidator): Unregister => {
+export const registerCacheReset = (reset: Reset): Unregister => {
   resetHooks.add(reset);
   return () => resetHooks.delete(reset);
 };
@@ -95,7 +99,7 @@ export const resetAllCaches = (): void => {
     ...set,
   ]);
   for (const registration of unique(registrations)) {
-    registration.invalidate();
+    registration.invalidate("write");
   }
   for (const reset of resetHooks) reset();
 };
@@ -149,7 +153,7 @@ export const invalidateCachesForWrite = (
     ) {
       continue;
     }
-    reg.invalidate();
+    reg.invalidate("write");
   }
 };
 
@@ -172,7 +176,7 @@ export type DependsOnEntry =
 export const registerDependencies = (
   ownTable: string,
   deps: readonly DependsOnEntry[],
-  invalidate: () => void,
+  invalidate: Invalidator,
 ): Unregister => {
   const unregisters = [
     registerTableInvalidation([ownTable], invalidate),

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -21,6 +21,7 @@ import {
   type WriteVerb,
 } from "#shared/cache-registry.ts";
 import { beginTransaction, wrapExecute } from "#shared/db/libsql-call.ts";
+import { mustReadFromPrimary } from "#shared/db/primary-reads.ts";
 import {
   countDatabaseRoundTrip,
   enforceTransactionRoundTripGuard,
@@ -281,9 +282,18 @@ const firstRowOrNull = <T>(result: ResultSet): T | null => {
   return rows.length === 0 ? null : rows[0]!;
 };
 
+/** Run a read on the primary when its cache refill requires read-your-writes. */
+const executeRead = async (...[sql, args]: SqlArgs): Promise<ResultSet> => {
+  if (!mustReadFromPrimary() || primaryReadMode() === "read") {
+    return execute(sql, args);
+  }
+  const [result] = await queryBatchPrimary([{ args: args ?? [], sql }]);
+  return result!;
+};
+
 /** Query single row, returning null if not found */
 export const queryOne = async <T>(...[sql, args]: SqlArgs): Promise<T | null> =>
-  firstRowOrNull<T>(await execute(sql, args));
+  firstRowOrNull<T>(await executeRead(sql, args));
 
 /**
  * Query a single row on the primary (read-your-writes), returning null if not
@@ -304,7 +314,7 @@ export const queryOnePrimary = async <T>(
 
 /** Query all rows, returning a typed array */
 export const queryAll = async <T>(...[sql, args]: SqlArgs): Promise<T[]> =>
-  resultRows<T>(await execute(sql, args));
+  resultRows<T>(await executeRead(sql, args));
 
 /**
  * True when the query returns at least one row. `sql` should be an existence
@@ -482,14 +492,25 @@ export const executeBatchWithoutCacheInvalidation = async (
   await runBatch(statements, "write", false);
 };
 
-/** Create a batch executor for a given transaction mode */
+/** A read/write batch with a fixed mode, or one chosen when it runs. */
+type BatchExecutor = (statements: SqlStatement[]) => Promise<ResultSet[]>;
+
+/** Create a batch executor for a fixed or per-call transaction mode. */
 const batchFor =
-  (mode: TransactionMode) =>
-  (statements: SqlStatement[]): Promise<ResultSet[]> =>
-    runBatch(statements, mode, true);
+  (mode: TransactionMode | (() => TransactionMode)): BatchExecutor =>
+  (statements) =>
+    runBatch(statements, typeof mode === "function" ? mode() : mode, true);
+
+/** Local SQLite has no replica and write mode would only take a needless lock. */
+const primaryReadMode = (): TransactionMode => {
+  const url = getEnv("DB_URL");
+  return url === ":memory:" || url?.startsWith("file:") ? "read" : "write";
+};
 
 /** Execute multiple read queries in a single round-trip using Turso batch API. */
-export const queryBatch = batchFor("read");
+export const queryBatch = batchFor(() =>
+  mustReadFromPrimary() ? primaryReadMode() : "read",
+);
 
 /**
  * Run read queries pinned to the primary in a single round-trip.

--- a/src/shared/db/common-schema.ts
+++ b/src/shared/db/common-schema.ts
@@ -45,8 +45,7 @@ export const cachedEntityTable = <Row, Input, Cached = Row>(
 ): { cache: KeyedCache<Cached>; table: Table<Row, Input> } => {
   const cache = createKeyedCache(config);
   registerCache(() => ({ entries: cache.size(), name }));
-  const invalidate = (): void => cache.invalidate();
-  registerDependencies(table.name, dependsOn, invalidate);
+  registerDependencies(table.name, dependsOn, cache.invalidate);
   return { cache, table };
 };
 

--- a/src/shared/db/keyed-cache.ts
+++ b/src/shared/db/keyed-cache.ts
@@ -9,18 +9,23 @@
  * dictionaries. Each entry carries its own expiry (`ttlMs`); a whole-list load
  * stamps every entry, a single-record load stamps only what it fetched.
  *
- * Staleness is bounded and never authoritative: writes invalidate immediately
- * within the isolate, and security gating (capacity, session validity) is
- * enforced against the database, not this cache — so a stale entry can only
- * show slightly out-of-date display data for up to the TTL across isolates.
+ * Writes invalidate immediately within the isolate. Refills use the primary
+ * during the replica catch-up window, so a stale replica result cannot replace
+ * the cleared data. Security gating (capacity, session validity) is enforced
+ * against the database, not this cache.
  *
  * A generation counter (bumped by `invalidate`) drops any fetch that was in
  * flight when an invalidation landed, so a write can never be overwritten by a
  * read that started before it.
  */
 
+/* jscpd:ignore-start -- imports */
 import { lazyRef, ttlCache, unique } from "#fp";
+import type { CacheInvalidation } from "#shared/cache-registry.ts";
+import { createPrimaryCacheRefill } from "#shared/db/primary-reads.ts";
 import { nowMs } from "#shared/now.ts";
+
+/* jscpd:ignore-end */
 
 /** Reads over a keyed entity cache. */
 export type KeyedCache<T> = {
@@ -28,7 +33,7 @@ export type KeyedCache<T> = {
   getById: (id: number) => Promise<T | null>;
   getByKey: (key: string) => Promise<T | null>;
   getByKeys: (keys: string[]) => Promise<(T | null)[]>;
-  invalidate: () => void;
+  invalidate: (cause?: CacheInvalidation) => void;
   size: () => number;
 };
 
@@ -73,6 +78,7 @@ export const createKeyedCache = <T>(
     loadedAt: number;
   } | null>(() => null);
   let generation = 0;
+  const primaryRefill = createPrimaryCacheRefill(now);
 
   // Index a freshly-loaded row into both dictionaries — unless an invalidation
   // raced the fetch (generation moved), in which case the row may predate a
@@ -87,7 +93,7 @@ export const createKeyedCache = <T>(
 
   const loadFull = async (): Promise<T[]> => {
     const gen = generation;
-    const ordered = await fetchAll();
+    const ordered = await primaryRefill.fetch(fetchAll);
     if (gen === generation) {
       for (const row of ordered) remember(gen, row);
       setFull({ loadedAt: now(), ordered });
@@ -111,7 +117,7 @@ export const createKeyedCache = <T>(
       return byId.get(id) ?? null;
     }
     const gen = generation;
-    const row = await fetchById(id);
+    const row = await primaryRefill.fetch(() => fetchById(id));
     return row ? remember(gen, row) : null;
   };
 
@@ -123,7 +129,7 @@ export const createKeyedCache = <T>(
       const missing = unique(keys).filter((k) => !byKey.get(k));
       if (missing.length > 0) {
         const gen = generation;
-        const rows = await fetchByKeys(missing);
+        const rows = await primaryRefill.fetch(() => fetchByKeys(missing));
         for (const row of rows) remember(gen, row);
       }
     } else {
@@ -140,8 +146,9 @@ export const createKeyedCache = <T>(
     getById,
     getByKey,
     getByKeys,
-    invalidate: () => {
+    invalidate: (cause = "manual") => {
       generation++;
+      primaryRefill.afterInvalidation(cause === "write");
       byId.clear();
       byKey.clear();
       setFull(null);

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -123,7 +123,7 @@ export const newsSlugBase = (created: string, name: string): string =>
 const existenceCache = requestCache(() =>
   queryAll<{ id: number }>("SELECT id FROM news_posts LIMIT 1"),
 );
-registerTableInvalidation(["news_posts"], () => existenceCache.invalidate());
+registerTableInvalidation(["news_posts"], existenceCache.invalidate);
 
 /** Does at least one news post exist? (Drives the public News nav link.) */
 export const hasNewsPosts = async (): Promise<boolean> =>

--- a/src/shared/db/primary-reads.ts
+++ b/src/shared/db/primary-reads.ts
@@ -27,7 +27,9 @@ export const createPrimaryCacheRefill = (
   let primaryUntil = 0;
   return {
     afterInvalidation: (readFromPrimary) => {
-      primaryUntil = readFromPrimary ? now() + catchUpMs : 0;
+      if (readFromPrimary) {
+        primaryUntil = Math.max(primaryUntil, now() + catchUpMs);
+      }
     },
     fetch: (load) =>
       now() < primaryUntil ? runWithPrimaryReads(load) : load(),

--- a/src/shared/db/primary-reads.ts
+++ b/src/shared/db/primary-reads.ts
@@ -1,0 +1,35 @@
+import { nowMs } from "#shared/now.ts";
+import { createScopedValue } from "#shared/request-scoped.ts";
+
+/** Keep refills on the primary while a nearby replica catches up. */
+const PRIMARY_READ_AFTER_WRITE_MS = 30_000;
+
+const primaryReads = createScopedValue(() => false);
+
+/** Run database reads in `work` against the primary. */
+export const runWithPrimaryReads = <T>(work: () => T): T =>
+  primaryReads.run(true, work);
+
+/** Whether reads in the current async scope must use the primary. */
+export const mustReadFromPrimary = (): boolean => primaryReads.read();
+
+/** A cache refill that uses the primary for a short time after invalidation. */
+export interface PrimaryCacheRefill {
+  afterInvalidation: (readFromPrimary: boolean) => void;
+  fetch: <T>(load: () => Promise<T>) => Promise<T>;
+}
+
+/** Keep cache refills consistent after a local write without changing callers. */
+export const createPrimaryCacheRefill = (
+  now: () => number = nowMs,
+  catchUpMs: number = PRIMARY_READ_AFTER_WRITE_MS,
+): PrimaryCacheRefill => {
+  let primaryUntil = 0;
+  return {
+    afterInvalidation: (readFromPrimary) => {
+      primaryUntil = readFromPrimary ? now() + catchUpMs : 0;
+    },
+    fetch: (load) =>
+      now() < primaryUntil ? runWithPrimaryReads(load) : load(),
+  };
+};

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -2,7 +2,11 @@
  * Sessions table operations
  */
 
-import { registerCache, registerCacheReset } from "#shared/cache-registry.ts";
+import {
+  type CacheInvalidation,
+  registerCache,
+  registerTableInvalidation,
+} from "#shared/cache-registry.ts";
 import { hashSessionToken } from "#shared/crypto/hashing.ts";
 import type { WrappedKey } from "#shared/crypto/sealed.ts";
 import {
@@ -12,6 +16,7 @@ import {
   queryAll,
   queryOne,
 } from "#shared/db/client.ts";
+import { createPrimaryCacheRefill } from "#shared/db/primary-reads.ts";
 
 import type { Session } from "#shared/types.ts";
 
@@ -23,6 +28,7 @@ import type { Session } from "#shared/types.ts";
 const SESSION_CACHE_TTL_MS = 10_000;
 type CacheEntry = { session: Session | null; cachedAt: number };
 const sessionCache = new Map<string, CacheEntry>();
+const primaryRefill = createPrimaryCacheRefill();
 
 registerCache(() => ({ entries: sessionCache.size, name: "sessions" }));
 
@@ -55,22 +61,15 @@ const cacheSession = (token: string, session: Session | null): void => {
 };
 
 /**
- * Invalidate a session from cache
+ * Clear the entire session cache. Table registration also keeps full resets,
+ * restores, and writes able to clear it without importing this module.
  */
-const invalidateSessionCache = (token: string): void => {
-  sessionCache.delete(token);
-};
-
-/**
- * Clear the entire session cache. Writes invalidate entry-by-entry, so no
- * table registration covers this cache — the reset hook keeps full resets and
- * restores able to clear it without importing this module.
- */
-export const resetSessionCache = (): void => {
+const resetSessionCache = (cause: CacheInvalidation = "manual"): void => {
   sessionCache.clear();
+  primaryRefill.afterInvalidation(cause === "write");
 };
 
-registerCacheReset(resetSessionCache);
+registerTableInvalidation(["sessions"], resetSessionCache);
 
 /**
  * Create a new session with CSRF token, wrapped data key, and user ID
@@ -112,9 +111,11 @@ export const getSession = async (token: string): Promise<Session | null> => {
   if (cached !== undefined) return cached;
 
   // Query DB and cache result (token column contains the hash)
-  const session = await queryOne<Session>(
-    `SELECT ${SESSION_COLUMNS} FROM sessions WHERE token = ?`,
-    [tokenHash],
+  const session = await primaryRefill.fetch(() =>
+    queryOne<Session>(
+      `SELECT ${SESSION_COLUMNS} FROM sessions WHERE token = ?`,
+      [tokenHash],
+    ),
   );
   cacheSession(tokenHash, session);
   return session;
@@ -126,7 +127,6 @@ export const getSession = async (token: string): Promise<Session | null> => {
  */
 export const deleteSession = async (token: string): Promise<void> => {
   const tokenHash = await hashSessionToken(token);
-  invalidateSessionCache(tokenHash);
   await deleteByField("sessions", "token", tokenHash);
 };
 
@@ -134,7 +134,6 @@ export const deleteSession = async (token: string): Promise<void> => {
  * Delete all sessions (used when password is changed)
  */
 export const deleteAllSessions = async (): Promise<void> => {
-  resetSessionCache();
   await execute("DELETE FROM sessions");
 };
 
@@ -154,13 +153,10 @@ export const deleteOtherSessions = async (
   currentToken: string,
 ): Promise<void> => {
   const tokenHash = await hashSessionToken(currentToken);
-
-  // Clear cache except for current token hash
-  const currentEntry = sessionCache.get(tokenHash);
-  resetSessionCache();
-  if (currentEntry) {
-    sessionCache.set(tokenHash, currentEntry);
-  }
-
+  const currentSession = await getSession(currentToken);
   await execute("DELETE FROM sessions WHERE token != ?", [tokenHash]);
+
+  // The write invalidation clears every entry; the unchanged current session
+  // can be restored without another database read.
+  cacheSession(tokenHash, currentSession);
 };

--- a/src/shared/db/settings/cache.ts
+++ b/src/shared/db/settings/cache.ts
@@ -20,7 +20,10 @@
  */
 
 import { lazyRef } from "#fp";
-import { registerCache } from "#shared/cache-registry.ts";
+import {
+  type CacheInvalidation,
+  registerCache,
+} from "#shared/cache-registry.ts";
 import {
   executeWithoutCacheInvalidation,
   queryAll,
@@ -77,6 +80,11 @@ const versionProbe = requestCache<number>(async () => [
 /** The settings version this request should be validated against. */
 export const currentVersion = async (): Promise<number> =>
   (await versionProbe.getAll())[0]!;
+
+/** Clear the request memo so a settings write reloads its version from primary. */
+export const invalidateVersionProbe = (
+  cause: CacheInvalidation = "manual",
+): void => versionProbe.invalidate(cause);
 
 /** Start fetching the settings version as early as possible in a request, so
  *  the tiny query overlaps the rest of request setup; loadKeys awaits it. */

--- a/src/shared/db/settings/load.ts
+++ b/src/shared/db/settings/load.ts
@@ -13,12 +13,16 @@
  */
 
 import { unique } from "#fp";
-import { registerTableInvalidation } from "#shared/cache-registry.ts";
+import {
+  type CacheInvalidation,
+  registerTableInvalidation,
+} from "#shared/cache-registry.ts";
 import { queryAll } from "#shared/db/client.ts";
 import { applyKeys } from "#shared/db/settings/apply.ts";
 import {
   currentVersion,
   getCacheState,
+  invalidateVersionProbe,
   resetCache,
   setCacheState,
 } from "#shared/db/settings/cache.ts";
@@ -56,7 +60,8 @@ export const loadKeys = async (keys: readonly string[]): Promise<void> => {
 };
 
 /** Full invalidation — clears raw cache AND resets snapshot to defaults. */
-export const invalidateCache = (): void => {
+export const invalidateCache = (cause: CacheInvalidation = "manual"): void => {
+  invalidateVersionProbe(cause);
   setCacheState(null);
   for (const key of Object.keys(defaults) as (keyof SettingsData)[]) {
     setSnapshotField(key, defaults[key]);

--- a/src/shared/db/settings/password.ts
+++ b/src/shared/db/settings/password.ts
@@ -17,7 +17,6 @@ import {
 import type { PasswordHash, WrappedKey } from "#shared/crypto/sealed.ts";
 import { execute } from "#shared/db/client.ts";
 import { deleteAllSessions } from "#shared/db/sessions.ts";
-import { invalidateUsersCache } from "#shared/db/users.ts";
 
 export const updateUserPassword = async (
   userId: number,
@@ -52,7 +51,6 @@ export const updateUserPassword = async (
     "UPDATE users SET password_hash = ?, wrapped_data_key = ?, kek_version = 2 WHERE id = ?",
     [encryptedNewHash, newWrappedDataKey, userId],
   );
-  invalidateUsersCache();
   await deleteAllSessions();
   return true;
 };

--- a/src/shared/db/site-page-items.ts
+++ b/src/shared/db/site-page-items.ts
@@ -43,7 +43,7 @@ const fetchAllItems = (): Promise<SitePageItem[]> =>
 // Request-scoped: one query per request feeds the whole nav forest, fresh next
 // request, and cleared on any write to site_page_items.
 const itemsCache = requestCache(fetchAllItems);
-registerTableInvalidation(["site_page_items"], () => itemsCache.invalidate());
+registerTableInvalidation(["site_page_items"], itemsCache.invalidate);
 
 /** Every edge, ordered — the single read the public nav's forest is built from. */
 export const getAllPageItems = (): Promise<SitePageItem[]> =>

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -661,11 +661,16 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
 } => {
   const cache = requestCache(config.fetchAll);
   registerCache(() => ({ entries: cache.size(), name: config.name }));
-  const invalidate = (): void => {
-    cache.invalidate();
+  registerDependencies(
+    config.table.name,
+    config.dependsOn ?? [],
+    cache.invalidate,
+  );
+  return {
+    getAll: () => cache.getAll(),
+    invalidate: () => cache.invalidate(),
+    table: config.table,
   };
-  registerDependencies(config.table.name, config.dependsOn ?? [], invalidate);
-  return { getAll: () => cache.getAll(), invalidate, table: config.table };
 };
 
 /**

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -2,6 +2,7 @@
  * Users table operations
  */
 
+import type { CacheInvalidation } from "#shared/cache-registry.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import {
   hashPassword,
@@ -93,8 +94,10 @@ export const getAllUsers = (): Promise<User[]> => usersCache.getAll();
 registerCache(() => ({ entries: usersCache.size(), name: "users" }));
 
 /** Invalidate the users cache (for testing or after writes). */
-export const invalidateUsersCache = (): void => {
-  usersCache.invalidate();
+export const invalidateUsersCache = (
+  cause: CacheInvalidation = "manual",
+): void => {
+  usersCache.invalidate(cause);
   for (const listener of usersInvalidationListeners) listener();
 };
 

--- a/src/shared/request-cache.ts
+++ b/src/shared/request-cache.ts
@@ -4,17 +4,27 @@
  * Each incoming request gets a fresh cache scope. The first call to
  * getAll() fetches from the database; subsequent calls within the same
  * request return the cached result. Writes call invalidate() to clear
- * the cached data so the next read re-fetches.
+ * the cached data. Refills use the primary while replicas catch up, including
+ * when the next read happens in the request reached through a redirect.
  *
  * Outside a request context (e.g. tests), every getAll() call fetches
  * directly — no caching is applied.
  */
 
+/* jscpd:ignore-start -- imports */
 import type { CollectionCache } from "#fp";
+import type { CacheInvalidation } from "#shared/cache-registry.ts";
+import { createPrimaryCacheRefill } from "#shared/db/primary-reads.ts";
 import { createScope } from "#shared/request-scoped.ts";
+
+/* jscpd:ignore-end */
 
 /** Per-request store: maps each cache's unique key to its cached data */
 type RequestStore = Map<symbol, unknown[] | Promise<unknown[]>>;
+
+interface RequestCollectionCache<T> extends CollectionCache<T> {
+  invalidate: (cause?: CacheInvalidation) => void;
+}
 
 const cacheScope = createScope<RequestStore>();
 
@@ -31,8 +41,9 @@ export const runWithRequestCache = <T>(fn: () => T): T =>
  */
 export const requestCache = <T>(
   fetchAll: () => Promise<T[]>,
-): CollectionCache<T> => {
+): RequestCollectionCache<T> => {
   const key = Symbol();
+  const primaryRefill = createPrimaryCacheRefill();
 
   return {
     getAll: async (): Promise<T[]> => {
@@ -40,7 +51,7 @@ export const requestCache = <T>(
       // scope (see createScope), so it fetches fresh instead of serving the
       // finished request's memoised data.
       const store = cacheScope.current();
-      if (!store) return fetchAll();
+      if (!store) return primaryRefill.fetch(fetchAll);
 
       const cached = store.get(key);
       if (cached) return cached as T[] | Promise<T[]>;
@@ -56,7 +67,7 @@ export const requestCache = <T>(
       promise.catch(() => {});
       store.set(key, promise);
       try {
-        const items = await fetchAll();
+        const items = await primaryRefill.fetch(fetchAll);
         // Replace the promise with the resolved array so future
         // reads within this request get the array directly.
         if (store.get(key) === promise) store.set(key, items);
@@ -71,7 +82,8 @@ export const requestCache = <T>(
       }
     },
 
-    invalidate: (): void => {
+    invalidate: (cause = "manual"): void => {
+      primaryRefill.afterInvalidation(cause === "write");
       cacheScope.current()?.delete(key);
     },
 

--- a/test/lib/server-settings/superuser.test.ts
+++ b/test/lib/server-settings/superuser.test.ts
@@ -30,6 +30,7 @@ import {
   mockFormRequest,
   withMocks,
 } from "#test-utils/mocks.ts";
+import { statementSql } from "#test-utils/record-queries.ts";
 import {
   adminFormPost,
   createTestManagerSession,
@@ -390,10 +391,16 @@ describeWithEnv("server (admin settings superuser)", { db: true }, () => {
       test(name, async () => {
         await setupForEnable("admin@example.com");
         const { getDb: getDbFn } = await import("#shared/db/client.ts");
+        const db = getDbFn();
+        const batch = db.batch.bind(db);
         await withMocks(
           () => ({
-            batchStub: stub(getDbFn(), "batch", () =>
-              Promise.reject(rejection),
+            batchStub: stub(db, "batch", (statements, mode) =>
+              statements.some((statement) =>
+                statementSql(statement).startsWith("DELETE FROM users"),
+              )
+                ? Promise.reject(rejection)
+                : batch(statements, mode),
             ),
             fetchStub: stubFetch(new Response("Error", { status: 500 })),
           }),

--- a/test/shared/cache-registry.test.ts
+++ b/test/shared/cache-registry.test.ts
@@ -355,20 +355,20 @@ describe("cache-registry", () => {
   describe("resetAllCaches", () => {
     test("fires every table-registered invalidator and every reset hook", () => {
       let tableCalls = 0;
-      let hookCalls = 0;
+      const hookCauses: string[] = [];
       track(
         registerTableInvalidation(["listings"], () => {
           tableCalls++;
         }),
       );
       track(
-        registerCacheReset(() => {
-          hookCalls++;
+        registerCacheReset((cause = "manual") => {
+          hookCauses.push(cause);
         }),
       );
       resetAllCaches();
       expect(tableCalls).toBe(1);
-      expect(hookCalls).toBe(1);
+      expect(hookCauses).toEqual(["write"]);
     });
 
     test("fires an invalidator registered against several tables only once", () => {

--- a/test/shared/db/client.test.ts
+++ b/test/shared/db/client.test.ts
@@ -11,12 +11,15 @@ import {
   getDb,
   inPlaceholders,
   insert,
+  queryAll,
+  queryBatch,
   rawSql,
   resetAggregates,
   rowExists,
   setDb,
   update,
 } from "#shared/db/client.ts";
+import { runWithPrimaryReads } from "#shared/db/primary-reads.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { withEnv } from "#test-utils/env.ts";
 
@@ -159,6 +162,31 @@ describeWithEnv("db > client", { db: true }, () => {
     const client1 = getDb();
     const client2 = getDb();
     expect(client1).toBe(client2);
+  });
+
+  test("primary read scopes use remote write mode and local read mode", async () => {
+    const modes: unknown[] = [];
+    const batchStub = stub(getDb(), "batch", (_statements, mode) => {
+      modes.push(mode);
+      return Promise.resolve([emptyResultSet()]);
+    });
+    try {
+      await queryBatch([{ args: [], sql: "SELECT 1" }]);
+      {
+        using _env = withEnv({ DB_URL: "libsql://primary.test" });
+        await runWithPrimaryReads(() => queryAll("SELECT 1"));
+        await runWithPrimaryReads(() =>
+          queryBatch([{ args: [], sql: "SELECT 1" }]),
+        );
+      }
+      const localRows = await runWithPrimaryReads(() =>
+        queryAll<{ one: number }>("SELECT 1 AS one"),
+      );
+      expect(localRows).toEqual([{ one: 1 }]);
+      expect(modes).toEqual(["read", "write", "write"]);
+    } finally {
+      batchStub.restore();
+    }
   });
 
   test("deleteByFieldStatement builds the DELETE for one table, field and value", () => {

--- a/test/shared/db/keyed-cache.test.ts
+++ b/test/shared/db/keyed-cache.test.ts
@@ -5,6 +5,7 @@ import {
   type KeyedCache,
   type KeyedCacheConfig,
 } from "#shared/db/keyed-cache.ts";
+import { mustReadFromPrimary } from "#shared/db/primary-reads.ts";
 
 /** A minimal cached row: a numeric id and a secondary string key. */
 type Row = { id: number; key: string };
@@ -175,6 +176,27 @@ describe("db > keyed-cache", () => {
     cache.invalidate();
     await cache.getById(1); // re-fetched
     expect(calls.byId).toEqual([1, 1]);
+  });
+
+  test("refills from primary while replicas catch up after invalidation", async () => {
+    const reads: boolean[] = [];
+    const cache = createKeyedCache<Row>({
+      fetchAll: () => Promise.resolve([]),
+      fetchById: (id) => {
+        reads.push(mustReadFromPrimary());
+        return Promise.resolve(row(id));
+      },
+      idOf: (item) => item.id,
+      keyOf: (item) => item.key,
+      now,
+      ttlMs: 1000,
+    });
+
+    await cache.getById(1);
+    cache.invalidate("write");
+    await cache.getById(2);
+
+    expect(reads).toEqual([false, true]);
   });
 
   test("size reports the number of cached records", async () => {

--- a/test/shared/db/listings/delete.test.ts
+++ b/test/shared/db/listings/delete.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import {
   getAllActivityLog,
   getListingActivityLog,
@@ -10,12 +11,14 @@ import {
   getAttendeeRaw,
   getAttendeesRaw,
 } from "#shared/db/attendees/queries.ts";
-import { queryAll } from "#shared/db/client.ts";
+import { getDb, queryAll } from "#shared/db/client.ts";
 import { deleteListing } from "#shared/db/listings/delete.ts";
 import {
+  getAllListings,
   getListingWithCount,
   listingsTable,
 } from "#shared/db/listings/records.ts";
+import { LISTING_COUNT_SELECT } from "#shared/db/listings/sql.ts";
 import {
   isSessionProcessed,
   reserveSession,
@@ -34,6 +37,7 @@ import {
   createTestAttributeWithOptions,
 } from "#test-utils/db-helpers/attributes.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { withEnv } from "#test-utils/env.ts";
 import { finalizeReservedPayment } from "#test-utils/processed-payments.ts";
 import { withTestSession } from "#test-utils/session.ts";
 
@@ -267,6 +271,25 @@ describeWithEnv("db > listings", { db: true, triggers: true }, () => {
 
       const after = await getListingWithCount(listing.id);
       expect(after).toBeNull();
+    });
+
+    test("does not refill the cache from a stale replica after deletion", async () => {
+      const listing = await createTestListing({ name: "Deleted listing" });
+      const listSql = `${LISTING_COUNT_SELECT}  ORDER BY listing.created DESC, listing.id DESC`;
+      const staleReplicaResult = await getDb().execute(listSql);
+
+      await deleteListing(listing.id);
+
+      using _env = withEnv({ DB_URL: "libsql://replica.test" });
+      const replicaRead = stub(getDb(), "execute", () =>
+        Promise.resolve(staleReplicaResult),
+      );
+      try {
+        const listings = await getAllListings();
+        expect(listings.map((item) => item.id)).not.toContain(listing.id);
+      } finally {
+        replicaRead.restore();
+      }
     });
   });
 });

--- a/test/shared/db/primary-reads.test.ts
+++ b/test/shared/db/primary-reads.test.ts
@@ -32,10 +32,9 @@ describe("db > primary reads", () => {
     await refill.fetch(fetch);
     refill.afterInvalidation(false);
     await refill.fetch(fetch);
-    refill.afterInvalidation(true);
     clock += 11;
     await refill.fetch(fetch);
 
-    expect(reads).toEqual([false, true, false, false]);
+    expect(reads).toEqual([false, true, true, false]);
   });
 });

--- a/test/shared/db/primary-reads.test.ts
+++ b/test/shared/db/primary-reads.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  createPrimaryCacheRefill,
+  mustReadFromPrimary,
+  runWithPrimaryReads,
+} from "#shared/db/primary-reads.ts";
+
+describe("db > primary reads", () => {
+  test("uses the primary only inside its async scope", async () => {
+    expect(mustReadFromPrimary()).toBe(false);
+
+    await runWithPrimaryReads(async () => {
+      await Promise.resolve();
+      expect(mustReadFromPrimary()).toBe(true);
+    });
+
+    expect(mustReadFromPrimary()).toBe(false);
+  });
+
+  test("cache refills use the primary only during the catch-up window", async () => {
+    let clock = 1000;
+    const reads: boolean[] = [];
+    const refill = createPrimaryCacheRefill(() => clock, 10);
+    const fetch = (): Promise<void> => {
+      reads.push(mustReadFromPrimary());
+      return Promise.resolve();
+    };
+
+    await refill.fetch(fetch);
+    refill.afterInvalidation(true);
+    await refill.fetch(fetch);
+    refill.afterInvalidation(false);
+    await refill.fetch(fetch);
+    refill.afterInvalidation(true);
+    clock += 11;
+    await refill.fetch(fetch);
+
+    expect(reads).toEqual([false, true, false, false]);
+  });
+});

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -1,8 +1,13 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
-import { getAllCacheStats } from "#shared/cache-registry.ts";
-import { execute } from "#shared/db/client.ts";
+import {
+  getAllCacheStats,
+  invalidateCachesForTable,
+  resetAllCaches,
+} from "#shared/cache-registry.ts";
+import { executeWithoutCacheInvalidation, getDb } from "#shared/db/client.ts";
 import {
   createSession,
   deleteAllSessions,
@@ -10,9 +15,9 @@ import {
   deleteSession,
   getAllSessions,
   getSession,
-  resetSessionCache,
 } from "#shared/db/sessions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { withEnv } from "#test-utils/env.ts";
 
 describeWithEnv("db > sessions", { db: true }, () => {
   test("createSession and getSession work together", async () => {
@@ -114,6 +119,23 @@ describeWithEnv("db > sessions", { db: true }, () => {
     expect(afterTtl?.csrf_token).toBe("csrf-ttl");
   });
 
+  test("getSession does not serve an expired cached session", async () => {
+    const startTime = Date.now();
+    using time = new FakeTime(startTime);
+
+    await createSession(
+      "expired-cache",
+      "csrf-expired",
+      startTime + 1000,
+      null,
+      1,
+    );
+    await executeWithoutCacheInvalidation("DELETE FROM sessions");
+    time.now = startTime + 2000;
+
+    expect(await getSession("expired-cache")).toBeNull();
+  });
+
   // The following tests observe the cache's *effect* by mutating the DB row
   // behind the cache's back: a cached read returns the stale in-memory value,
   // while a cache miss reflects the changed DB.
@@ -121,7 +143,7 @@ describeWithEnv("db > sessions", { db: true }, () => {
   test("createSession pre-caches so a later read skips the DB", async () => {
     await createSession("precache", "csrf-pre", Date.now() + 60000, null, 1);
     // Remove the row from the DB; the cache still holds the session.
-    await execute("DELETE FROM sessions");
+    await executeWithoutCacheInvalidation("DELETE FROM sessions");
 
     const session = await getSession("precache");
     expect(session).not.toBeNull();
@@ -130,12 +152,12 @@ describeWithEnv("db > sessions", { db: true }, () => {
 
   test("getSession caches the DB result so a second read skips the DB", async () => {
     await createSession("dbcache", "csrf-db", Date.now() + 60000, null, 1);
-    resetSessionCache(); // drop the pre-cache; the DB row remains
+    invalidateCachesForTable("sessions"); // drop the pre-cache; the DB row remains
 
     const first = await getSession("dbcache"); // cache miss → DB → caches
     expect(first?.csrf_token).toBe("csrf-db");
 
-    await execute("DELETE FROM sessions"); // remove DB row; cache retains it
+    await executeWithoutCacheInvalidation("DELETE FROM sessions"); // remove DB row; cache retains it
     const second = await getSession("dbcache");
     expect(second).not.toBeNull();
     expect(second?.csrf_token).toBe("csrf-db");
@@ -146,7 +168,9 @@ describeWithEnv("db > sessions", { db: true }, () => {
     using time = new FakeTime(start);
     await createSession("ttl-requery", "csrf-old", start + 60000, null, 1);
     // Within TTL: cached (stale) value is served even after the DB changes.
-    await execute("UPDATE sessions SET csrf_token = 'csrf-new'");
+    await executeWithoutCacheInvalidation(
+      "UPDATE sessions SET csrf_token = 'csrf-new'",
+    );
     expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-old");
 
     // Past the 10s TTL: the cache entry expires and the DB is re-read.
@@ -160,14 +184,39 @@ describeWithEnv("db > sessions", { db: true }, () => {
     expect(await getSession("ghost")).toBeNull();
   });
 
-  test("resetSessionCache clears cached sessions", async () => {
+  test("session table invalidation clears cached sessions", async () => {
     await createSession("reset-me", "csrf-reset", Date.now() + 60000, null, 1);
-    await execute("DELETE FROM sessions"); // DB empty; cache still holds it
+    await executeWithoutCacheInvalidation("DELETE FROM sessions"); // DB empty; cache still holds it
 
-    resetSessionCache();
+    invalidateCachesForTable("sessions");
 
     // With the cache cleared, the read falls through to the (empty) DB.
     expect(await getSession("reset-me")).toBeNull();
+  });
+
+  test("full resets do not refill the session cache from a stale replica", async () => {
+    await createSession(
+      "reset-stale",
+      "csrf-stale",
+      Date.now() + 60000,
+      null,
+      1,
+    );
+    const staleReplicaResult = await getDb().execute(
+      "SELECT token, csrf_token, expires, wrapped_data_key, user_id FROM sessions",
+    );
+    await executeWithoutCacheInvalidation("DELETE FROM sessions");
+
+    using _env = withEnv({ DB_URL: "libsql://replica.test" });
+    const replicaRead = stub(getDb(), "execute", () =>
+      Promise.resolve(staleReplicaResult),
+    );
+    try {
+      resetAllCaches();
+      expect(await getSession("reset-stale")).toBeNull();
+    } finally {
+      replicaRead.restore();
+    }
   });
 
   test("deleteOtherSessions keeps the current session cached", async () => {
@@ -179,14 +228,14 @@ describeWithEnv("db > sessions", { db: true }, () => {
 
     // The kept session should still be cached: deleting all DB rows leaves a
     // cached read returning it, while the dropped one is gone.
-    await execute("DELETE FROM sessions");
+    await executeWithoutCacheInvalidation("DELETE FROM sessions");
     const kept = await getSession("keep");
     expect(kept).not.toBeNull();
     expect(kept?.csrf_token).toBe("csrf-keep");
   });
 
   test("registers a 'sessions' cache stat reflecting cached entries", async () => {
-    resetSessionCache();
+    invalidateCachesForTable("sessions");
     const before = getAllCacheStats().find((s) => s.name === "sessions");
     expect(before?.entries).toBe(0);
 

--- a/test/shared/request-cache.test.ts
+++ b/test/shared/request-cache.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { getAllCacheStats, registerCache } from "#shared/cache-registry.ts";
 import { holidays } from "#shared/db/holidays.ts";
+import { mustReadFromPrimary } from "#shared/db/primary-reads.ts";
 import { requestCache, runWithRequestCache } from "#shared/request-cache.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 
@@ -46,6 +47,20 @@ describe("requestCache", () => {
       cache.invalidate();
       expect(await cache.getAll()).toEqual([2]);
     });
+  });
+
+  test("refills from primary across requests while replicas catch up", async () => {
+    const reads: boolean[] = [];
+    const cache = requestCache(() => {
+      reads.push(mustReadFromPrimary());
+      return Promise.resolve([reads.length]);
+    });
+
+    cache.invalidate("write");
+    await runWithRequestCache(() => cache.getAll());
+    await runWithRequestCache(() => cache.getAll());
+
+    expect(reads).toEqual([true, true]);
   });
 
   test("fetches directly without request context", async () => {

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@libsql/client";
 import { afterAll, afterEach, beforeEach, describe } from "@std/testing/bdd";
+import { invalidateCachesForTable } from "#shared/cache-registry.ts";
 import { resetEffectiveDomain } from "#shared/config.ts";
 import { attendeeStatuses } from "#shared/db/attendee-statuses.ts";
 import { getDb, queryOne, setDb } from "#shared/db/client.ts";
@@ -7,7 +8,6 @@ import { groups } from "#shared/db/groups.ts";
 import { holidays } from "#shared/db/holidays.ts";
 import { invalidateListingsCache } from "#shared/db/listings/records.ts";
 import { logisticsAgents } from "#shared/db/logistics-agents.ts";
-import { resetSessionCache } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
 import { invalidateUsersCache } from "#shared/db/users.ts";
 import { setDemoModeForTest } from "#shared/demo/mode.ts";
@@ -54,7 +54,7 @@ const prepareTestClient = async (triggers = false): Promise<void> => {
   maybeReclaimLeakedFds();
   setupTestEncryptionKey();
   settings.setup.clearCache();
-  resetSessionCache();
+  invalidateCachesForTable("sessions");
   invalidateUsersCache();
   invalidateListingsCache();
   holidays.invalidate();
@@ -168,7 +168,7 @@ export const resetDb = (): void => {
   groups.cache.invalidate();
   logisticsAgents.invalidate();
   attendeeStatuses.invalidate();
-  resetSessionCache();
+  invalidateCachesForTable("sessions");
   setTestSession(null);
   setDemoModeForTest(false);
   resetEffectiveDomain();

--- a/test/test-utils/e2e.ts
+++ b/test/test-utils/e2e.ts
@@ -5,10 +5,10 @@
  */
 
 import { afterEach, beforeEach } from "@std/testing/bdd";
+import { invalidateCachesForTable } from "#shared/cache-registry.ts";
 import { groups } from "#shared/db/groups.ts";
 import { holidays } from "#shared/db/holidays.ts";
 import { invalidateListingsCache } from "#shared/db/listings/records.ts";
-import { resetSessionCache } from "#shared/db/sessions.ts";
 import { settings } from "#shared/db/settings.ts";
 import { invalidateUsersCache } from "#shared/db/users.ts";
 import { attendeeLineIndex } from "#test-utils/assertions.ts";
@@ -27,7 +27,7 @@ export const invalidateAllCaches = (): void => {
   invalidateListingsCache();
   groups.cache.invalidate();
   holidays.invalidate();
-  resetSessionCache();
+  invalidateCachesForTable("sessions");
 };
 
 /** Run the setup wizard and log in, landing on the admin dashboard. */


### PR DESCRIPTION
## Why

After deleting a listing, the next page could refill its cache from a replica that had not caught up yet. This made deleted data appear again until the cache expired. Full database resets and session changes had the same risk.

## What changed

- Mark cache invalidations caused by successful database writes.
- Refill shared caches from the primary database while replicas catch up.
- Keep an active primary-read window when a cache is also cleared manually.
- Pass write context through full cache resets.
- Apply the same invalidation and refill path to the session cache.
- Keep the primary-read setting scoped to the current async work.
- Keep local SQLite reads on the normal read path.
- Add stale-replica regressions for listing deletion and full session-cache resets.

## Checks

- `deno task precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-after-write consistency by briefly routing cache refills to the primary database after writes.
  * Prevented stale replica results from reappearing after updates or deletions.
  * Refined cache invalidation so write-driven changes trigger the correct refresh behavior (including settings version reads).

* **Tests**
  * Added and expanded coverage for primary-read routing, request-scoped cache refill behavior, and stale-data regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->