### PR TITLE
Keep changed settings fresh after database writes

### DIFF
--- a/src/shared/db/settings/cache.ts
+++ b/src/shared/db/settings/cache.ts
@@ -29,6 +29,7 @@ import {
   queryAll,
   type SqlStatement,
 } from "#shared/db/client.ts";
+import { createPrimaryCacheRefill } from "#shared/db/primary-reads.ts";
 import { recordSettingRead } from "#shared/db/settings-audit.ts";
 import { addPendingWork } from "#shared/pending-work.ts";
 import { requestCache } from "#shared/request-cache.ts";
@@ -46,6 +47,9 @@ const [getCacheState, setCacheState] = lazyRef<CacheState>(() => ({
   version: -1,
 }));
 
+/** Keep the version and its setting values on the same primary-backed view. */
+export const settingsReadRefill = createPrimaryCacheRefill();
+
 registerCache(() => ({
   entries: getCacheState().values.size,
   name: "settings",
@@ -60,9 +64,10 @@ export { getCacheState, setCacheState };
  * (a fresh database) it is absent, which reads as version 0.
  */
 export const getCurrentSettingsVersion = async (): Promise<number> => {
-  const rows = await queryAll<{ value: string }>(
-    "SELECT value FROM settings WHERE key = ?",
-    [CONFIG_KEYS.SETTINGS_VERSION],
+  const rows = await settingsReadRefill.fetch(() =>
+    queryAll<{ value: string }>("SELECT value FROM settings WHERE key = ?", [
+      CONFIG_KEYS.SETTINGS_VERSION,
+    ]),
   );
   return Number.parseInt(rows[0]?.value ?? "0", 10);
 };
@@ -81,10 +86,13 @@ const versionProbe = requestCache<number>(async () => [
 export const currentVersion = async (): Promise<number> =>
   (await versionProbe.getAll())[0]!;
 
-/** Clear the request memo so a settings write reloads its version from primary. */
+/** Clear the request memo so a settings write reloads its version and values from primary. */
 export const invalidateVersionProbe = (
   cause: CacheInvalidation = "manual",
-): void => versionProbe.invalidate(cause);
+): void => {
+  settingsReadRefill.afterInvalidation(cause === "write");
+  versionProbe.invalidate();
+};
 
 /** Start fetching the settings version as early as possible in a request, so
  *  the tiny query overlaps the rest of request setup; loadKeys awaits it. */

--- a/src/shared/db/settings/load.ts
+++ b/src/shared/db/settings/load.ts
@@ -25,6 +25,7 @@ import {
   invalidateVersionProbe,
   resetCache,
   setCacheState,
+  settingsReadRefill,
 } from "#shared/db/settings/cache.ts";
 import {
   defaults,
@@ -48,11 +49,13 @@ export const loadKeys = async (keys: readonly string[]): Promise<void> => {
   const s = cached.version === version ? cached : resetCache(version);
   const missing = unique([...keys]).filter((k) => !s.loaded.has(k));
   if (missing.length === 0) return;
-  const rows = await queryAll<{ key: string; value: string }>(
-    `SELECT key, value FROM settings WHERE key IN (${missing
-      .map(() => "?")
-      .join(", ")})`,
-    missing,
+  const rows = await settingsReadRefill.fetch(() =>
+    queryAll<{ key: string; value: string }>(
+      `SELECT key, value FROM settings WHERE key IN (${missing
+        .map(() => "?")
+        .join(", ")})`,
+      missing,
+    ),
   );
   for (const row of rows) s.values.set(row.key, row.value);
   await applyKeys(missing, s.values);

--- a/test/shared/db/settings/load.test.ts
+++ b/test/shared/db/settings/load.test.ts
@@ -9,6 +9,7 @@ import {
 } from "#shared/db/settings.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { withEnv } from "#test-utils/env.ts";
+import { statementSql } from "#test-utils/record-queries.ts";
 
 describeWithEnv("db > settings > load", { db: true }, () => {
   test("reloads setting values from primary after a write", async () => {
@@ -16,6 +17,10 @@ describeWithEnv("db > settings > load", { db: true }, () => {
     const staleReplicaResult = await getDb().execute({
       args: [CONFIG_KEYS.PAYMENT_PROVIDER],
       sql: "SELECT key, value FROM settings WHERE key = ?",
+    });
+    const staleVersionResult = await getDb().execute({
+      args: [CONFIG_KEYS.SETTINGS_VERSION],
+      sql: "SELECT value FROM settings WHERE key = ?",
     });
 
     await execute("UPDATE settings SET value = ? WHERE key = ?", [
@@ -25,8 +30,12 @@ describeWithEnv("db > settings > load", { db: true }, () => {
     await bumpSettingsVersion();
 
     using _env = withEnv({ DB_URL: "libsql://replica.test" });
-    const replicaRead = stub(getDb(), "execute", () =>
-      Promise.resolve(staleReplicaResult),
+    const replicaRead = stub(getDb(), "execute", (statement) =>
+      Promise.resolve(
+        statementSql(statement).startsWith("SELECT value FROM settings")
+          ? staleVersionResult
+          : staleReplicaResult,
+      ),
     );
     try {
       await settings.loadKeys([CONFIG_KEYS.PAYMENT_PROVIDER]);

--- a/test/shared/db/settings/load.test.ts
+++ b/test/shared/db/settings/load.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { execute, getDb } from "#shared/db/client.ts";
+import {
+  bumpSettingsVersion,
+  CONFIG_KEYS,
+  settings,
+} from "#shared/db/settings.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { withEnv } from "#test-utils/env.ts";
+
+describeWithEnv("db > settings > load", { db: true }, () => {
+  test("reloads setting values from primary after a write", async () => {
+    await settings.update.paymentProvider("stripe");
+    const staleReplicaResult = await getDb().execute({
+      args: [CONFIG_KEYS.PAYMENT_PROVIDER],
+      sql: "SELECT key, value FROM settings WHERE key = ?",
+    });
+
+    await execute("UPDATE settings SET value = ? WHERE key = ?", [
+      "square",
+      CONFIG_KEYS.PAYMENT_PROVIDER,
+    ]);
+    await bumpSettingsVersion();
+
+    using _env = withEnv({ DB_URL: "libsql://replica.test" });
+    const replicaRead = stub(getDb(), "execute", () =>
+      Promise.resolve(staleReplicaResult),
+    );
+    try {
+      await settings.loadKeys([CONFIG_KEYS.PAYMENT_PROVIDER]);
+      expect(settings.paymentProvider).toBe("square");
+    } finally {
+      replicaRead.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Why

A settings reload could read the new version from the primary database and then read old setting values from a replica that had not caught up. The old values were stamped with the new version and stayed cached.

This follows up on #1859 and resolves its final Codex review thread.

## What changed

- Use one primary-refill window for the settings version and setting values.
- Keep both queries on the same primary-backed database view after a write or full reset.
- Add a regression that supplies a stale replica value and proves the primary value is cached.

## Checks

- `deno task precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved settings loading to reliably pull the latest values after writes.
  - Enhanced version-check and cache invalidation coordination to keep settings consistent even when replica data is stale.
- **Tests**
  - Added a new test suite to confirm `settings.loadKeys()` reloads an updated payment setting value after a prior write.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->