### PR TITLE
Keep maintenance task sync on the primary

### DIFF
--- a/src/shared/maintenance/claims.ts
+++ b/src/shared/maintenance/claims.ts
@@ -1,10 +1,5 @@
 import { generateSecureToken } from "#shared/crypto/utils.ts";
-import {
-  executeBatch,
-  inPlaceholders,
-  queryAll,
-  queryOne,
-} from "#shared/db/client.ts";
+import { execute, inPlaceholders, queryOne } from "#shared/db/client.ts";
 
 const DATABASE_NOW_MS =
   "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
@@ -19,40 +14,21 @@ export const syncMaintenanceTaskRows = async (
   enabledNames: readonly string[],
   disabledNames: readonly string[],
 ): Promise<void> => {
-  const declaredNames = [...enabledNames, ...disabledNames];
-  if (declaredNames.length === 0) return;
-  // Most wakes already match. Read the tiny declared set before opening a write
-  // transaction, then change only rows that actually differ.
-  const existing = new Set(
-    (
-      await queryAll<{ name: string }>(
-        `SELECT name FROM maintenance_tasks
-          WHERE name IN (${inPlaceholders(declaredNames)})`,
-        declaredNames,
-      )
-    ).map(({ name }) => name),
-  );
-  const inserts = enabledNames
-    .filter((name) => !existing.has(name))
-    .map((name) => ({
-      args: [name],
-      sql: `INSERT OR IGNORE INTO maintenance_tasks (name, next_run_at)
-          VALUES (?, ${DATABASE_NOW_MS})`,
-    }));
-  const existingDisabled = disabledNames.filter((name) => existing.has(name));
-  const removals =
-    existingDisabled.length === 0
-      ? []
-      : [
-          {
-            args: [...existingDisabled],
-            sql: `DELETE FROM maintenance_tasks
-               WHERE name IN (${inPlaceholders(existingDisabled)})
-                  AND lease_token IS NULL`,
-          },
-        ];
-  const statements = [...inserts, ...removals];
-  if (statements.length > 0) await executeBatch(statements);
+  if (enabledNames.length > 0) {
+    await execute(
+      `INSERT OR IGNORE INTO maintenance_tasks (name, next_run_at)
+       VALUES ${enabledNames.map(() => `(?, ${DATABASE_NOW_MS})`).join(", ")}`,
+      [...enabledNames],
+    );
+  }
+  if (disabledNames.length > 0) {
+    await execute(
+      `DELETE FROM maintenance_tasks
+        WHERE name IN (${inPlaceholders(disabledNames)})
+          AND lease_token IS NULL`,
+      [...disabledNames],
+    );
+  }
 };
 
 export const claimNextMaintenanceTask = async (

--- a/src/shared/maintenance/definition.ts
+++ b/src/shared/maintenance/definition.ts
@@ -47,6 +47,7 @@ export const maintenanceStartupCalls = (
   const settingsRead = tasks.some((task) => task.check.settingsKeys.length > 0)
     ? 1
     : 0;
+  // Task sync can issue one idempotent insert and one guarded delete.
   const database =
     2 +
     settingsRead +

--- a/test/shared/maintenance/claims.test.ts
+++ b/test/shared/maintenance/claims.test.ts
@@ -56,7 +56,7 @@ describeWithEnv("maintenance task claims", { db: true }, () => {
     expect(claims.filter((claim) => claim === null).length).toBe(1);
   });
 
-  test("does not open a write batch when task rows already match", async () => {
+  test("uses direct idempotent writes instead of a batch", async () => {
     await syncMaintenanceTaskRows([TASK], []);
     using batch = stub(getDb(), "batch", () =>
       Promise.reject(

--- a/test/shared/maintenance/definition.test.ts
+++ b/test/shared/maintenance/definition.test.ts
@@ -20,7 +20,7 @@ const task = (
   });
 
 describe("maintenance task declarations", () => {
-  test("totals every startup call and the shared settings and sync reads", () => {
+  test("totals every startup call and the shared settings and sync calls", () => {
     expect(maintenanceStartupCalls([])).toEqual({
       database: 0,
       external: 0,


### PR DESCRIPTION
## Summary

- Sync enabled maintenance tasks with one direct idempotent insert.
- Remove disabled task rows with a direct lease-guarded delete.
- Avoid both lagging replica reads and libsql batch transactions.

## Why

A review on #1889 found that its task existence check could read a stale Turso replica and wrongly skip a needed write. #1889 merged before that feedback was addressed. Direct idempotent writes keep the primary correct without bringing back the batch `BEGIN` failure.

## Testing

- `deno task precommit`
- `deno task precommit:mutation` (`83/83` mutants detected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved maintenance task synchronization with safer, idempotent updates.
  - Prevented active maintenance leases from being removed during synchronization.

- **Tests**
  - Updated maintenance synchronization test descriptions to reflect direct updates and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->