### PR TITLE
Retry temporary BunnyDB 421 read failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,9 +666,10 @@ logging and table-scoped cache invalidation stay automatic.
   error. The write lock is acquired with a short retry so concurrent writers
   serialize rather than failing; a database that stays locked surfaces as
   `DatabaseBusyError`. Read-only statements and batches also retry fleeting
-  upstream gateway errors (Turso 502/503/504). Interactive transactions and
-  write paths retry only `SQLITE_BUSY`; gateway 5xx errors are never replayed
-  because the operation may have committed before the gateway timed out. Note the trade-off: an interactive transaction locks the
+  upstream HTTP errors (BunnyDB 421 and Turso 502/503/504). Interactive
+  transactions and write paths retry only `SQLITE_BUSY`; upstream HTTP errors
+  are never replayed because the operation may have committed before the
+  response arrived. Note the trade-off: an interactive transaction locks the
   database for writing until it commits or rolls back (with a timeout), so keep
   the work inside it tight — do any expensive non-DB computation before opening
   it, and prefer a plain batch whenever no inter-step logic is actually needed.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -824,8 +824,8 @@ src/shared/db/client.ts:129:71  replace → ""   # REPLACEs classify as "insert"
 # DB client (client.ts) — nullish-coalescing fallbacks whose left side can never
 # be a falsy non-null value, so `??` and `||` pick the same branch on every input.
 src/shared/db/client.ts:105:73  ?? → ||   # writeSqlOf's CTE capture is anchored on the literal "UPDATE" (6+ chars), never ""; a missing capture is undefined either way
-src/shared/db/client.ts:364:57  ?? → ||   # `args` is `InValue[] | undefined`; every array (including []) is truthy, so only undefined reaches the fallback under both operators
-src/shared/db/client.ts:374:36  ?? → ||   # queryOne's row comes from resultRows — libsql rows are always objects (truthy); a miss yields undefined, where ?? and || both produce null
+src/shared/db/client.ts:373:57  ?? → ||   # `args` is `InValue[] | undefined`; every array (including []) is truthy, so only undefined reaches the fallback under both operators
+src/shared/db/client.ts:383:36  ?? → ||   # queryOne's row comes from resultRows — libsql rows are always objects (truthy); a miss yields undefined, where ?? and || both produce null
 
 # DB client (client.ts) — sentinel symbol descriptions.
 src/shared/db/client.ts:160:31  guarded-db-client → ""   # Symbol("guarded-db-client") description is debug-only metadata; the double-wrap check branches on the symbol's identity, and GUARDED_CLIENT is module-private so no test can observe the description

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -164,13 +164,26 @@ const databaseRoundTrip = <T>(operation: string, run: () => T): T => {
   return run();
 };
 
-const executeWithRoundTripGuard = (
-  target: Pick<Client, "execute">,
-  operation: string,
-) =>
-  wrapExecute(target, (_statement, execute) =>
-    databaseRoundTrip(operation, execute),
-  );
+type AroundExecute = Parameters<typeof wrapExecute>[1];
+
+const executeWithRoundTrip =
+  (around: AroundExecute) =>
+  (target: Pick<Client, "execute">, operation: string) =>
+    wrapExecute(target, (statement, execute) =>
+      around(statement, () => databaseRoundTrip(operation, execute)),
+    );
+
+const executeWithRoundTripGuard = executeWithRoundTrip((_statement, execute) =>
+  execute(),
+);
+
+/** Count and retry a bare client statement. Transaction statements use only the
+ * round-trip guard above because their surrounding write must not be replayed. */
+const executeWithTransientRetry = executeWithRoundTrip((statement, execute) =>
+  retryOnTransientDatabaseError(execute, {
+    retryUpstream: isReadSql(sqlOf(statement)),
+  }),
+);
 
 const transactionWithRoundTripGuard = (transaction: Transaction): Transaction =>
   proxyMembers(transaction, {
@@ -199,7 +212,7 @@ const withRoundTripGuard = (client: Client): Client => {
     [GUARDED_CLIENT]: true,
     batch: (statements: InStatement[], mode?: TransactionMode) =>
       databaseRoundTrip("batch", () => client.batch(statements, mode)),
-    execute: executeWithRoundTripGuard(client, "statement"),
+    execute: executeWithTransientRetry(client, "statement"),
     executeMultiple: (sql: string): Promise<void> =>
       databaseRoundTrip("script", () => client.executeMultiple(sql)),
     migrate: (statements: InStatement[]): Promise<ResultSet[]> =>
@@ -255,12 +268,13 @@ const isDatabaseLocked = (error: unknown): boolean =>
   error instanceof Error &&
   /SQLITE_BUSY|database is locked/i.test(error.message);
 
-/** The libsql server's own gateway briefly failing — it timed out (504) or was
- *  momentarily unreachable (502/503), which the client surfaces as a
- *  SERVER_ERROR LibsqlError naming the HTTP status. Worth a retry on a read;
- *  a genuine client or server fault (400/500) would only be replayed by one. */
+/** The libsql server briefly rejecting a fresh connection (421) or its gateway
+ *  timing out / becoming momentarily unreachable (502/503/504), which the
+ *  client surfaces as a SERVER_ERROR LibsqlError naming the HTTP status. Worth
+ *  a retry on a read; a genuine client or server fault (400/500) would only be
+ *  replayed by one. */
 const TRANSIENT_UPSTREAM_STATUS_RE =
-  /Server returned HTTP status (?:502|503|504)\b/;
+  /Server returned HTTP status (?:421|502|503|504)\b/;
 
 const isTransientUpstreamError = (error: unknown): boolean =>
   error instanceof LibsqlError &&
@@ -289,9 +303,9 @@ const isReadSql = (sql: string): boolean => READ_SQL_RE.test(writeSqlOf(sql));
  *   - a contended write lock (SQLITE_BUSY) is always retried — the lock was
  *     never taken, so nothing ran; a lock that outlasts the retries surfaces as
  *     {@link DatabaseBusyError} (the request layer's friendly busy page);
- *   - a fleeting upstream gateway error (502/503/504) is retried only on reads
- *     (`retryUpstream`): a 5xx on a write may have landed server-side before the
- *     gateway timed out, and replaying it would double-apply, so writes and the
+ *   - a fleeting upstream HTTP 421/502/503/504 is retried only on reads
+ *     (`retryUpstream`): the same response on a write may arrive after the write
+ *     landed server-side, and replaying it would double-apply, so writes and the
  *     transactions that hold them never retry upstream errors. A hiccup that
  *     outlasts the retries rethrows its original error, so a sustained outage
  *     still reaches the error log as itself.
@@ -314,12 +328,7 @@ type StatementRunner<T> = (sql: string, args?: InValue[]) => Promise<T>;
 
 const executeTrackedStatement: StatementRunner<ResultSet> = (sql, args) =>
   trackSql(sql, () =>
-    retryOnTransientDatabaseError(
-      () => (args ? getDb().execute({ args, sql }) : getDb().execute(sql)),
-      // A 5xx on anything but a read may have side effects that committed
-      // before the gateway timed out, so only reads retry upstream errors.
-      { retryUpstream: isReadSql(sql) },
-    ),
+    args ? getDb().execute({ args, sql }) : getDb().execute(sql),
   );
 
 /** A SQL statement and its optional bound args — the shared parameters of the
@@ -572,7 +581,7 @@ export const executeBatchWithoutCacheInvalidation = async (
 /** A read/write batch with a fixed mode, or one chosen when it runs. */
 type BatchExecutor = (statements: SqlStatement[]) => Promise<ResultSet[]>;
 
-/** The read batch executors retry a fleeting upstream 5xx on the strength of
+/** The read batch executors retry a fleeting upstream HTTP failure because
  *  every statement being a side-effect-free SELECT, so a write smuggled into
  *  one is rejected loudly here rather than risk a double-apply on a retry. */
 const requireReadStatements = (statements: SqlStatement[]): void => {
@@ -588,7 +597,7 @@ const requireReadStatements = (statements: SqlStatement[]): void => {
 /** Create a batch executor for a fixed or per-call transaction mode. `retryUpstream`
  *  is a property of the executor, not re-derived from each statement: the read
  *  executors ({@link queryBatch}, {@link queryBatchPrimary}) always retry a
- *  fleeting upstream 5xx (their statements are validated SELECTs — no side
+ *  fleeting recognized upstream failure (their statements are validated SELECTs — no side
  *  effects to double-apply); the write executors never do. */
 const batchFor =
   (
@@ -659,8 +668,8 @@ type TransactionWork<T> = (tx: TxScope) => Promise<T>;
  * success and rolling back on any error. Cache invalidations fire once after a
  * successful commit (a rollback fires none). A write lock lost while beginning or
  * committing throws SQLITE_BUSY, which {@link withTransaction} treats as
- * retryable; a fleeting upstream gateway error is not retried here (a 5xx at
- * begin or commit may have landed, and replaying the writes would double-apply),
+ * retryable; a fleeting upstream error is not retried here (one at begin or
+ * commit may arrive after the writes landed, and replaying them would double-apply),
  * so every such error propagates.
  */
 const runWriteTransactionOnce = async <T>(
@@ -742,9 +751,9 @@ export const withTransaction = <T>(work: TransactionWork<T>): Promise<T> => {
   const run = (async (): Promise<T> => {
     await writeQueue.tail.catch(() => undefined);
     return retryOnTransientDatabaseError(() => runWriteTransactionOnce(work), {
-      // A transaction holds writes: a 5xx at begin or commit may have landed,
-      // so a retried transaction would replay its writes. Don't retry upstream
-      // errors here — only lock contention (which never ran anything).
+      // A transaction holds writes: an upstream failure at begin or commit may
+      // arrive after they landed, so a retried transaction would replay them.
+      // Only retry lock contention, which never ran anything.
       retryUpstream: false,
     });
   })();

--- a/test/shared/db/client/upstream-errors.test.ts
+++ b/test/shared/db/client/upstream-errors.test.ts
@@ -11,20 +11,27 @@ import {
   type SqlStatement,
   setDb,
 } from "#shared/db/client.ts";
+import { MIGRATION_IDS } from "#shared/db/migrations/registry.ts";
+import {
+  initDb,
+  invalidateInitDbCache,
+  LATEST_UPDATE,
+  SCHEMA_HASH,
+} from "#shared/db/migrations.ts";
 import { emptyResultSet } from "#test-utils/db-helpers/result-set.ts";
 
 /**
  * The transient upstream retry: the libsql server itself occasionally answers
- * a round trip with a fleeting gateway failure (a Turso 502/503/504, which the
- * client surfaces as a SERVER_ERROR LibsqlError naming the HTTP status). Those
- * retry on the shared 50/150/350ms backoff — but only on reads: a 5xx on a
- * write may have landed server-side before the gateway timed out, and replaying
- * it would double-apply, so writes (and the transactions that hold them) are not
- * retried for upstream errors. A hiccup that outlasts the retries rethrows the
- * original error (a sustained outage should still reach the error log), unlike
- * an exhausted write lock which becomes DatabaseBusyError. SQLITE_BUSY is always
- * safe to retry — the lock was never taken, so nothing ran. Any other failure
- * — a non-transient status, a non-SERVER_ERROR code, or a plain Error with a
+ * a round trip with a fleeting HTTP failure. The client surfaces BunnyDB 421
+ * and Turso 502/503/504 responses as a SERVER_ERROR naming the status. Those
+ * retry on the shared 50/150/350ms backoff — but only on reads: the same response
+ * on a write may arrive after it landed server-side, and replaying it would
+ * double-apply, so writes (and the transactions that hold them) are not retried
+ * for upstream errors. A hiccup that outlasts the retries rethrows the original
+ * error (a sustained outage should still reach the error log), unlike an
+ * exhausted write lock which becomes DatabaseBusyError. SQLITE_BUSY is always
+ * safe to retry — the lock was never taken, so nothing ran. Any other failure —
+ * a non-transient status, a non-SERVER_ERROR code, or a plain Error with a
  * lookalike message — fails immediately without a retry.
  */
 describe("db > client transient upstream retry", () => {
@@ -35,9 +42,12 @@ describe("db > client transient upstream retry", () => {
   const clientWithBatch = (run: () => Promise<ResultSet[]>): Client =>
     ({ batch: run }) as unknown as Client;
 
-  afterEach(() => setDb(null));
+  afterEach(() => {
+    invalidateInitDbCache();
+    setDb(null);
+  });
 
-  for (const status of [502, 503, 504]) {
+  for (const status of [421, 502, 503, 504]) {
     test(`a fleeting upstream ${status} retries and succeeds`, async () => {
       using time = new FakeTime();
       let attempts = 0;
@@ -56,6 +66,47 @@ describe("db > client transient upstream retry", () => {
       expect(attempts).toBe(2);
     });
   }
+
+  test("a fleeting upstream 421 on a write is not retried", async () => {
+    let attempts = 0;
+    setDb(
+      clientWith(() => {
+        attempts++;
+        return Promise.reject(upstreamError(421));
+      }),
+    );
+    await expect(execute("INSERT INTO t (x) VALUES (1)")).rejects.toThrow(
+      "SERVER_ERROR: Server returned HTTP status 421",
+    );
+    expect(attempts).toBe(1);
+  });
+
+  test("initDb retries a fleeting 421 on its initial schema probe", async () => {
+    using time = new FakeTime();
+    let attempts = 0;
+    setDb(
+      clientWith(() => {
+        attempts++;
+        return attempts === 1
+          ? Promise.reject(upstreamError(421))
+          : Promise.resolve({
+              ...emptyResultSet(),
+              rows: [
+                { key: "latest_db_update", value: LATEST_UPDATE },
+                { key: "db_schema_hash", value: SCHEMA_HASH },
+                {
+                  key: "applied_migrations",
+                  value: String(MIGRATION_IDS.length),
+                },
+              ] as unknown as ResultSet["rows"],
+            });
+      }),
+    );
+    const initialized = initDb();
+    await time.tickAsync(50);
+    await initialized;
+    expect(attempts).toBe(2);
+  });
 
   test("an upstream hiccup that outlasts the retries rethrows the original error", async () => {
     using time = new FakeTime();
@@ -140,8 +191,8 @@ describe("db > client transient upstream retry", () => {
     ["a PRAGMA", "PRAGMA table_info(t)"],
   ] as const) {
     test(`a fleeting upstream 504 on ${label} is not retried`, async () => {
-      // A 5xx on anything but a read may have committed its side effects
-      // before the gateway timed out; replaying it could double-apply, so
+      // An upstream HTTP failure on anything but a read may arrive after its
+      // side effects committed; replaying it could double-apply, so
       // only positively recognized SELECTs retry upstream errors. Every
       // CTE-led write — INSERT, UPDATE, DELETE, or REPLACE — is a write: the
       // CTE prefix must not trip the read-only retry gate. DDL and PRAGMA


### PR DESCRIPTION
## What changed

- Treat BunnyDB HTTP 421 as a temporary read failure alongside 502, 503, and 504.
- Put the bounded retry on the shared single-statement client path, so ordinary reads and the first `initDb` schema probe use the same mechanism.
- Keep writes and transaction statements non-retrying for upstream HTTP failures because their commit state may be unclear.
- Keep propagating the original error unchanged when all retries fail.

## Why

A fresh edge isolate can receive a temporary BunnyDB HTTP 421 while checking the database schema. That probe bypassed the existing safe read retry and failed the request immediately.

## Verification

- Regression tests first reproduced both the ordinary read failure and the cold `initDb` probe failure.
- Focused client, transaction, and round-trip tests pass.
- Mutation testing: 100.0% (`216/216` detected, 7 known equivalents suppressed).
- Full pinned `deno task precommit` passes on Deno 2.5.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary database and upstream connection errors.
  - Read-only operations can now retry after eligible transient errors, including HTTP 421, 502, 503, and 504 responses.
  - Write operations are not automatically replayed when an upstream error may indicate the request already succeeded.

- **Documentation**
  - Clarified transaction, batch, and retry behavior for upstream failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->