### PR TITLE
Give maintenance its own database budget

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -82,8 +82,9 @@ src/shared/accounting/manual-entries.ts:209:29  ?? → ||   # guard error messag
 src/shared/checkout-ledger.ts:35:72  ?? → ||   # find(...)?.amount: number|undefined; the only falsy-non-null amount is 0 and 0 ?? 0 === 0 || 0
 src/features/settings-bundles.ts:247:40  ?? → ||   # bundle is a readonly string[] or undefined; every present array, including [], is truthy
 src/shared/scheduled-access.ts:16:20  ?? → ||   # the optional regex capture is non-empty because the capture uses +, so only undefined reaches the null fallback
-src/shared/maintenance/runner.ts:181:5  0 → 1   # every non-empty run needs at least two startup calls, so both allowances skip it; an empty run makes no calls
-src/shared/maintenance/runner.ts:193:23  ?? → ||   # wakePolicy is a non-empty MaintenanceWakePolicy value or undefined, so only undefined reaches the fallback
+src/shared/maintenance/runner.ts:183:5  0 → 1   # every non-empty run needs at least two startup calls, so both allowances skip it; an empty run makes no calls
+src/shared/maintenance/runner.ts:190:5  0 → 1   # every non-empty run needs at least two database startup calls, so both allowances skip it; an empty run makes no calls
+src/shared/maintenance/runner.ts:202:23  ?? → ||   # wakePolicy is a non-empty MaintenanceWakePolicy value or undefined, so only undefined reaches the fallback
 src/shared/builder.ts:201:44  ?? → ||   # dbToken is string|undefined and the fallback is "", so its only falsy string already equals the fallback
 src/shared/builder.ts:202:35  ?? → ||   # dbProvider is a non-empty provider value or undefined, so only undefined reaches the fallback
 src/shared/builder.ts:207:36  ?? → ||   # dbProvider is a non-empty provider value or undefined, so only undefined reaches the fallback

--- a/src/shared/maintenance/definition.ts
+++ b/src/shared/maintenance/definition.ts
@@ -1,5 +1,10 @@
+import { BUNNY_SUBREQUEST_LIMIT } from "#shared/subrequest-budget.ts";
+
 export const MAINTENANCE_MIN_INTERVAL_MS = 60_000;
-export const MAINTENANCE_REQUEST_CALL_LIMIT = 40;
+const MAINTENANCE_REQUEST_CALL_RESERVE = 8;
+export const MAINTENANCE_REQUEST_CALL_LIMIT =
+  BUNNY_SUBREQUEST_LIMIT - MAINTENANCE_REQUEST_CALL_RESERVE;
+export const MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT = 40;
 const MAINTENANCE_RESERVED_CALLS = 8;
 export const MAINTENANCE_TASK_CALL_LIMIT =
   MAINTENANCE_REQUEST_CALL_LIMIT - MAINTENANCE_RESERVED_CALLS;
@@ -130,9 +135,12 @@ export const defineMaintenanceTasks = <
     validateTask(task);
   }
   const startup = maintenanceStartupCalls(tasks);
-  if (startup.total > MAINTENANCE_REQUEST_CALL_LIMIT) {
+  if (
+    startup.database > MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT ||
+    startup.total > MAINTENANCE_REQUEST_CALL_LIMIT
+  ) {
     throw new Error(
-      `Maintenance checks declare ${startup.total} startup calls; maximum is ${MAINTENANCE_REQUEST_CALL_LIMIT}`,
+      `Maintenance checks declare ${startup.database} database and ${startup.total} total startup calls; maximums are ${MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT} and ${MAINTENANCE_REQUEST_CALL_LIMIT}`,
     );
   }
   return tasks;

--- a/src/shared/maintenance/runner.ts
+++ b/src/shared/maintenance/runner.ts
@@ -15,6 +15,7 @@ import {
   MAINTENANCE_MIN_INTERVAL_MS,
   MAINTENANCE_RELEASE_HEADROOM_MS,
   MAINTENANCE_REQUEST_CALL_LIMIT,
+  MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT,
   MAINTENANCE_REQUEST_DEADLINE_MS,
   type MaintenanceTaskDeclaration,
   type MaintenanceWakePolicy,
@@ -48,6 +49,7 @@ const taskFits = (
   task: MaintenanceTaskDeclaration,
   remaining: { database: number; external: number; total: number },
 ): boolean =>
+  task.maxDatabaseCalls <= remaining.database - TASK_RUNNER_CALL_RESERVE &&
   task.maxExternalCalls <= remaining.external &&
   taskCalls(task) <= remaining.total - TASK_RUNNER_CALL_RESERVE;
 
@@ -176,12 +178,19 @@ const runMaintenance = (
 ): Promise<void> => {
   const requestDeadline =
     options.requestDeadline ?? Date.now() + MAINTENANCE_REQUEST_DEADLINE_MS;
-  const used = getSubrequestUsage().total;
+  const used = getSubrequestUsage();
   const combinedAllowance = Math.max(
     0,
     Math.min(
       options.combinedAllowance ?? MAINTENANCE_REQUEST_CALL_LIMIT,
-      MAINTENANCE_REQUEST_CALL_LIMIT - used,
+      MAINTENANCE_REQUEST_CALL_LIMIT - used.total,
+    ),
+  );
+  const databaseAllowance = Math.max(
+    0,
+    Math.min(
+      combinedAllowance,
+      MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT - used.database,
     ),
   );
   const externalAllowance = Math.min(
@@ -194,7 +203,7 @@ const runMaintenance = (
   );
   const startup = maintenanceStartupCalls(candidates);
   if (
-    startup.database > combinedAllowance ||
+    startup.database > databaseAllowance ||
     startup.external > externalAllowance ||
     startup.total > combinedAllowance
   ) {
@@ -202,7 +211,7 @@ const runMaintenance = (
   }
   return withSubrequestAllowance(
     {
-      database: combinedAllowance,
+      database: databaseAllowance,
       external: externalAllowance,
       total: combinedAllowance,
     },

--- a/test/shared/maintenance/definition.test.ts
+++ b/test/shared/maintenance/definition.test.ts
@@ -4,11 +4,13 @@ import {
   defineMaintenanceTasks,
   MAINTENANCE_RELEASE_HEADROOM_MS,
   MAINTENANCE_REQUEST_CALL_LIMIT,
+  MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT,
   MAINTENANCE_TASK_CALL_LIMIT,
   type MaintenanceTaskDeclaration,
   maintenanceStartupCalls,
   maintenanceTaskByName,
 } from "#shared/maintenance/definition.ts";
+import { BUNNY_SUBREQUEST_LIMIT } from "#shared/subrequest-budget.ts";
 import { maintenanceDeclaration } from "./fixtures.ts";
 
 const task = (
@@ -44,7 +46,9 @@ describe("maintenance task declarations", () => {
     ).toEqual({ database: 8, external: 9, total: 17 });
   });
 
-  test("reserves eight calls and one second for scheduler bookkeeping", () => {
+  test("keeps scheduler work below Bunny's request limits", () => {
+    expect(BUNNY_SUBREQUEST_LIMIT - MAINTENANCE_REQUEST_CALL_LIMIT).toBe(8);
+    expect(MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT).toBe(40);
     expect(MAINTENANCE_REQUEST_CALL_LIMIT - MAINTENANCE_TASK_CALL_LIMIT).toBe(
       8,
     );
@@ -109,15 +113,29 @@ describe("maintenance task declarations", () => {
     ).not.toThrow();
   });
 
-  test("rejects activation checks that cannot fit the request", () => {
+  test("rejects activation checks above the database request limit", () => {
     expect(() =>
       defineMaintenanceTasks([
         task({
-          check: { maxDatabaseCalls: MAINTENANCE_REQUEST_CALL_LIMIT },
+          check: {
+            maxDatabaseCalls: MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT - 1,
+          },
         }),
       ]),
     ).toThrow(
-      `Maintenance checks declare ${MAINTENANCE_REQUEST_CALL_LIMIT + 2} startup calls; maximum is ${MAINTENANCE_REQUEST_CALL_LIMIT}`,
+      `Maintenance checks declare ${MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT + 1} database and ${MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT + 1} total startup calls; maximums are ${MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT} and ${MAINTENANCE_REQUEST_CALL_LIMIT}`,
+    );
+  });
+
+  test("rejects activation checks above the combined request limit", () => {
+    expect(() =>
+      defineMaintenanceTasks([
+        task({
+          check: { maxExternalCalls: MAINTENANCE_REQUEST_CALL_LIMIT - 1 },
+        }),
+      ]),
+    ).toThrow(
+      `Maintenance checks declare 2 database and ${MAINTENANCE_REQUEST_CALL_LIMIT + 1} total startup calls; maximums are ${MAINTENANCE_REQUEST_DATABASE_CALL_LIMIT} and ${MAINTENANCE_REQUEST_CALL_LIMIT}`,
     );
   });
 

--- a/test/shared/maintenance/runner.test.ts
+++ b/test/shared/maintenance/runner.test.ts
@@ -4,6 +4,7 @@ import { execute, queryOne } from "#shared/db/client.ts";
 import {
   defineMaintenanceTasks,
   MAINTENANCE_MIN_INTERVAL_MS,
+  MAINTENANCE_TASK_CALL_LIMIT,
   type MaintenanceTaskDeclaration,
 } from "#shared/maintenance/definition.ts";
 import { maintenance } from "#shared/maintenance/runner.ts";
@@ -454,6 +455,50 @@ describeWithEnv("maintenance runner", { db: true }, () => {
     });
 
     expect(calls).toEqual(["ran"]);
+  });
+
+  test("prior external calls leave the separate database allowance available", async () => {
+    let ran = false;
+    const tasks = defineMaintenanceTasks([
+      declaration(
+        "external_headroom",
+        () => {
+          ran = true;
+        },
+        { maxDatabaseCalls: MAINTENANCE_TASK_CALL_LIMIT },
+      ),
+    ]);
+
+    await runWithSubrequestBudget(async () => {
+      countSubrequest("external", "earlier provider call 1");
+      countSubrequest("external", "earlier provider call 2");
+      countSubrequest("external", "earlier provider call 3");
+      await maintenance.run(tasks);
+    });
+
+    expect(ran).toBe(true);
+  });
+
+  test("prior database calls preserve the database request ceiling", async () => {
+    let ran = false;
+    const tasks = defineMaintenanceTasks([
+      declaration(
+        "database_headroom",
+        () => {
+          ran = true;
+        },
+        { maxDatabaseCalls: MAINTENANCE_TASK_CALL_LIMIT },
+      ),
+    ]);
+
+    await runWithSubrequestBudget(async () => {
+      countSubrequest("database", "earlier database call 1");
+      countSubrequest("database", "earlier database call 2");
+      countSubrequest("database", "earlier database call 3");
+      await maintenance.run(tasks);
+    });
+
+    expect(ran).toBe(false);
   });
 
   test("zero external allowance leaves external tasks due", async () => {


### PR DESCRIPTION
## Summary

- Reserve eight of Bunny's 50 request calls and let maintenance use the remaining 42.
- Keep maintenance database work under a separate 40-call limit.
- Start tasks only when their database, external, and total call costs all fit after earlier request work.

## Tests

- Focused maintenance tests: 43 passed
- Mutation tests: 100% for both changed maintenance files
- Full precommit checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added separate tracking and enforcement for database and external maintenance-call budgets.
  * Improved validation and error reporting when maintenance startup work exceeds database or combined request limits.
  * Prevented external requests from incorrectly reducing the available database-call allowance.

* **Tests**
  * Added coverage for scheduler limits and independent database/external request budgets.
  * Updated activation-check validation tests for the refined limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->