### PR TITLE
Handle Square webhook identifiers safely

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -110,6 +110,10 @@ src/shared/db/admin-features.ts:208:29  !== → !=   # nextEncrypted is string|n
 src/shared/db/admin-features.ts:208:60  !== → !=   # nextPlain is string|null and cannot be undefined
 src/shared/db/settings/json-field.ts:88:15  === → ==   # the transaction returns string|null and cannot return undefined
 src/shared/db/migrations/schema/admin-feature-triggers.ts:160:35  ?? → ||   # source.columns is undefined or an array; every array, including [], is truthy
+src/shared/square-provider.ts:55:48  ?? → ||   # amount is bigint|undefined, and its only falsy bigint is 0n, which equals the fallback
+src/shared/square-provider.ts:56:51  ?? → ||   # refunded amount is bigint|undefined, and its only falsy bigint is 0n, which equals the fallback
+src/shared/square-provider.ts:101:19  ?? → ||   # retrieveSession returns a session object or null, so every present value is truthy
+src/shared/square-provider.ts:126:59  ?? → ||   # paymentId is string|undefined, and its only falsy string is the empty fallback itself
 
 # Collection cache generation values are only compared for equality. Their
 # absolute value and direction do not matter: every invalidation changes the

--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -73,15 +73,16 @@ export const squarePaymentProvider: PaymentProvider = {
         ? (obj.payment as Record<string, unknown>)
         : obj;
 
+    const paymentId = typeof payment.id === "string" ? payment.id : null;
+    if (!paymentId && listing.type.startsWith("payment.")) {
+      throw new Error("Square payment webhook is missing id");
+    }
+
     // Extract the order ID (Square's session equivalent)
     const orderId =
-      typeof payment.order_id === "string"
-        ? payment.order_id
-        : typeof payment.id === "string"
-          ? payment.id
-          : null;
+      typeof payment.order_id === "string" ? payment.order_id : null;
 
-    if (!orderId) return Promise.resolve(null);
+    if (!orderId || !paymentId) return Promise.resolve(null);
 
     // Skip non-completed payments to avoid unnecessary API calls
     if (typeof payment.status === "string" && payment.status !== "COMPLETED") {

--- a/test/integration/server/webhooks/square.test.ts
+++ b/test/integration/server/webhooks/square.test.ts
@@ -1,0 +1,52 @@
+// jscpd:ignore-start
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { handleRequest } from "#routes";
+import { settings } from "#shared/db/settings.ts";
+import type { WebhookEvent } from "#shared/payments.ts";
+import { squareApi } from "#shared/square.ts";
+import { squarePaymentProvider } from "#shared/square-provider.ts";
+import { configureSquare } from "#test/lib/square/fixtures.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { mockWebhookRequest, withMocks } from "#test-utils/mocks.ts";
+
+// jscpd:ignore-end
+
+describeWithEnv("Square payment webhooks", { db: true }, () => {
+  test("acknowledges an unrelated payment without Square API calls", async () => {
+    await configureSquare();
+    await settings.update.paymentProvider("square");
+    const event: WebhookEvent = {
+      data: {
+        object: {
+          payment: { id: "unrelated-payment", status: "COMPLETED" },
+        },
+      },
+      id: "unrelated-payment-event",
+      type: "payment.updated",
+    };
+
+    await withMocks(
+      () => ({
+        order: stub(squareApi, "retrieveOrder"),
+        payment: stub(squareApi, "retrievePayment"),
+        verify: stub(squarePaymentProvider, "verifyWebhookSignature", () =>
+          Promise.resolve({ listing: event, valid: true as const }),
+        ),
+      }),
+      async ({ order, payment }) => {
+        const response = await handleRequest(
+          mockWebhookRequest(
+            {},
+            { "x-square-hmacsha256-signature": "square-signature" },
+          ),
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ received: true });
+        expect(order.calls).toHaveLength(0);
+        expect(payment.calls).toHaveLength(0);
+      },
+    );
+  });
+});

--- a/test/shared/square-provider.test.ts
+++ b/test/shared/square-provider.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
+import { type Spy, spy, stub } from "@std/testing/mock";
 import { setEffectiveDomainForTest } from "#shared/config.ts";
+import { setSuppressDebugLogs } from "#shared/log-settings.ts";
 import { PaymentUserError } from "#shared/payment-helpers.ts";
 import { squareApi } from "#shared/square.ts";
 import { squarePaymentProvider } from "#shared/square-provider.ts";
@@ -94,13 +95,26 @@ const expectCheckoutUserError = async (
 };
 
 describe("square-provider", () => {
+  let debug: Spy;
+
   beforeEach(async () => {
     await createTestDb();
     setEffectiveDomainForTest("example.com");
+    setSuppressDebugLogs(false);
+    debug = spy(console, "debug");
   });
 
   afterEach(() => {
+    debug.restore();
+    setSuppressDebugLogs(null);
     resetDb();
+  });
+
+  test("declares its webhook contract", () => {
+    expect(squarePaymentProvider.checkoutCompletedEventType).toBe(
+      "payment.updated",
+    );
+    expect(squarePaymentProvider.requiresWebhookSignature).toBe(true);
   });
 
   describe("retrieveSession", () => {
@@ -114,6 +128,23 @@ describe("square-provider", () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_no_meta");
           expect(result).toBeNull();
+          expect(debug.calls.at(-1)?.args).toEqual([
+            "[Square] Order order_no_meta missing required metadata fields",
+          ]);
+        },
+      );
+    });
+
+    test("logs and returns null when the order does not exist", async () => {
+      await withMocks(
+        () => stub(squareApi, "retrieveOrder", () => Promise.resolve(null)),
+        async () => {
+          expect(
+            await squarePaymentProvider.retrieveSession("order_missing"),
+          ).toBeNull();
+          expect(debug.calls.at(-1)?.args).toEqual([
+            "[Square] Order order_missing not found",
+          ]);
         },
       );
     });
@@ -229,6 +260,7 @@ describe("square-provider", () => {
           const result =
             await squarePaymentProvider.retrieveSession("order_no_tenders");
           expect(result).not.toBeNull();
+          expect(result!.paymentReference).toBe("");
           expect(result!.paymentStatus).toBe("unpaid");
         },
       );
@@ -249,6 +281,16 @@ describe("square-provider", () => {
           amountMoney: money(1000),
           id: "pay_123",
           refundedMoney: money(1000),
+          status: "COMPLETED",
+        },
+      },
+      {
+        expected: true,
+        name: "returns true when a one-cent payment is fully refunded",
+        payment: {
+          amountMoney: money(1),
+          id: "pay_123",
+          refundedMoney: money(1),
           status: "COMPLETED",
         },
       },
@@ -293,7 +335,7 @@ describe("square-provider", () => {
         expected: false,
         name: "returns false when refundedMoney is missing",
         payment: {
-          amountMoney: money(1000),
+          amountMoney: money(1),
           id: "pay_123",
           status: "COMPLETED",
         },
@@ -433,27 +475,33 @@ describe("square-provider", () => {
         type: "payment.updated",
       });
       expect(result).toBe("skip");
+      expect(debug.calls.at(-1)?.args).toEqual([
+        "[Square] Skipping webhook for non-completed payment (status=APPROVED)",
+      ]);
     });
 
-    test("returns null when no order_id or id found", async () => {
-      const result = await squarePaymentProvider.resolveWebhookSession({
-        data: {
-          object: {
-            payment: {
-              status: "COMPLETED",
+    test("rejects a payment event without a payment id", async () => {
+      await expect(
+        squarePaymentProvider.resolveWebhookSession({
+          data: {
+            object: {
+              payment: {
+                order_id: "order_without_payment",
+                status: "COMPLETED",
+              },
             },
           },
-        },
-        id: "evt_no_id",
-        type: "payment.updated",
-      });
-      expect(result).toBeNull();
+          id: "evt_no_payment",
+          type: "payment.updated",
+        }),
+      ).rejects.toThrow("Square payment webhook is missing id");
     });
 
-    test("falls back to payment id when order_id is missing", async () => {
+    test("ignores a payment id without its order id", async () => {
       await withMocks(
         () => ({
-          order: stub(squareApi, "retrieveOrder", () => Promise.resolve(null)),
+          order: stub(squareApi, "retrieveOrder"),
+          payment: stub(squareApi, "retrievePayment"),
         }),
         async (mocks) => {
           const result = await squarePaymentProvider.resolveWebhookSession({
@@ -468,11 +516,23 @@ describe("square-provider", () => {
             id: "evt_no_order",
             type: "payment.updated",
           });
-          // retrieveSession called with payment id as fallback
-          expect(mocks.order.calls[0]!.args[0]).toBe("pay_fallback_id");
-          expect(result).toBe("skip");
+          expect(result).toBeNull();
+          expect(mocks.order.calls).toHaveLength(0);
+          expect(mocks.payment.calls).toHaveLength(0);
         },
       );
+    });
+
+    test("ignores an unrelated event without payment identifiers", async () => {
+      expect(
+        await squarePaymentProvider.resolveWebhookSession({
+          data: {
+            object: {},
+          },
+          id: "evt_refund",
+          type: "refund.updated",
+        }),
+      ).toBeNull();
     });
 
     test("returns skip when order exists but has no metadata", async () => {


### PR DESCRIPTION
## Summary

- Reject malformed Square payment events that have no payment ID.
- Treat payments without an order ID, and non-payment events without identifiers, as unrelated.
- Acknowledge unrelated payments without calling the Square order or payment APIs.

## Tests

- Focused provider and HTTP webhook tests
- Targeted mutation testing: 100% (68 detected, 4 known equivalents)
- Full precommit suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Square webhook validation when payment identifiers or order references are missing.
  * Prevented unrelated payment webhooks from triggering unnecessary Square API lookups.
  * Corrected handling of missing order information and fully refunded payments.
  * Added clearer debug messages for skipped or incomplete webhook events.

* **Tests**
  * Expanded coverage for Square webhook processing, payment refunds, missing data, and unrelated events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->