### PR TITLE
Share string entry filtering

### DIFF
--- a/src/shared/square.ts
+++ b/src/shared/square.ts
@@ -36,6 +36,7 @@ import type {
   WebhookVerifyResult,
 } from "#shared/payments.ts";
 import { normalizePhone } from "#shared/phone.ts";
+import { stringEntries } from "#shared/string-entries.ts";
 import { finishWebhookVerification } from "#shared/webhook-verification.ts";
 
 /* jscpd:ignore-end */
@@ -209,7 +210,7 @@ type SquarePaymentLinkResponse = {
 type SquareOrderResponse = {
   order?: {
     id?: string;
-    metadata?: Record<string, string>;
+    metadata?: Record<string, string | null>;
     tenders?: SquareRawTender[];
     state?: string;
     total_money?: { amount: number; currency: string };
@@ -649,12 +650,7 @@ export const squareApi: {
 
       // Convert nullable metadata values to plain string record
       const metadata: Record<string, string> | undefined = order.metadata
-        ? Object.fromEntries(
-            Object.entries(order.metadata).filter(
-              (entry): entry is [string, string] =>
-                typeof entry[1] === "string",
-            ),
-          )
+        ? Object.fromEntries(stringEntries(Object.entries(order.metadata)))
         : undefined;
 
       return {

--- a/src/shared/string-entries.ts
+++ b/src/shared/string-entries.ts
@@ -1,0 +1,7 @@
+/** Keep entries whose values can be sent as strings. */
+export const stringEntries = <Key>(
+  entries: Iterable<readonly [Key, unknown]>,
+): [Key, string][] =>
+  Array.from(entries).flatMap(([key, value]) =>
+    typeof value === "string" ? [[key, value]] : [],
+  );

--- a/src/ui/client/admin/order-gallery.ts
+++ b/src/ui/client/admin/order-gallery.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
+import { stringEntries } from "#shared/string-entries.ts";
+
 /** Live availability for the public order gallery.
  *
  * Without JS the gallery is a plain GET form (CSS-only cart) and availability
@@ -17,11 +19,7 @@ const REFRESH_DELAY_MS = 200;
 
 /** Build the availability query from the form (checkboxes, date, order). */
 const availabilityQuery = (form: HTMLFormElement): URLSearchParams =>
-  new URLSearchParams(
-    [...new FormData(form).entries()].flatMap(([key, value]) =>
-      typeof value === "string" ? [[key, value] as [string, string]] : [],
-    ),
-  );
+  new URLSearchParams(stringEntries(new FormData(form).entries()));
 
 type CardState = { state: string; label: string };
 

--- a/test/shared/square/retrieve-refund.test.ts
+++ b/test/shared/square/retrieve-refund.test.ts
@@ -83,6 +83,28 @@ describeSquare(() => {
       );
     });
 
+    test("drops null order metadata values", async () => {
+      await withSquareClient(
+        {
+          ordersGet: () =>
+            Promise.resolve({
+              order: {
+                id: "order_metadata",
+                metadata: {
+                  removed_null: null,
+                  stored_key: "stored value",
+                },
+                totalMoney: { amount: BigInt(0), currency: "USD" },
+              },
+            }),
+        },
+        async () => {
+          const result = await squareApi.retrieveOrder("order_metadata");
+          expect(result?.metadata).toEqual({ stored_key: "stored value" });
+        },
+      );
+    });
+
     test("maps totalMoney from order response", async () => {
       await withSquareClient(
         {

--- a/test/shared/string-entries.test.ts
+++ b/test/shared/string-entries.test.ts
@@ -1,0 +1,34 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { stringEntries } from "#shared/string-entries.ts";
+
+test("stringEntries keeps string values in iterable order", () => {
+  const entries = new Map<number, unknown>([
+    [2, "second"],
+    [1, "first"],
+  ]);
+
+  expect(stringEntries(entries)).toEqual([
+    [2, "second"],
+    [1, "first"],
+  ]);
+});
+
+test("stringEntries keeps empty strings", () => {
+  expect(stringEntries([["empty", ""]])).toEqual([["empty", ""]]);
+});
+
+test("stringEntries drops non-string values", () => {
+  expect(
+    stringEntries([
+      ["null", null],
+      ["undefined", undefined],
+      ["number", 0],
+      ["boolean", false],
+      ["bigint", 0n],
+      ["symbol", Symbol("value")],
+      ["object", {}],
+      ["array", []],
+    ]),
+  ).toEqual([]);
+});

--- a/test/ui/client/admin/order-gallery.test.ts
+++ b/test/ui/client/admin/order-gallery.test.ts
@@ -173,8 +173,15 @@ describe("initOrderGallery", () => {
     expect(page.requests[0]).toContain("select_package_7=1");
     expect(page.requests[0]).toContain("select_5=1");
     expect(page.requests[0]).toContain("order=package%3A7%2Clisting%3A5");
-    // File entries never join the query — only string form fields do.
-    expect(page.requests[0]).not.toContain("upload");
+  });
+
+  test("omits file entries from the availability query", async () => {
+    const page = harness();
+    page.changeField('input[name="start_date"]');
+    await settle();
+    expect(page.requests).toEqual([
+      "/order/availability?start_date=&order=&pick=x",
+    ]);
   });
 
   test("applies returned states: labels, greying, and the date nudge", async () => {


### PR DESCRIPTION
## Summary
- Add one typed helper that keeps string entry values, including empty strings.
- Use it for order gallery form data and Square order metadata.
- Cover file form values, null Square metadata, and the helper directly.

## Tests
- `nix develop --command deno task precommit`
- Focused helper, order gallery, and Square tests
- Helper mutation test: 100% (3/3)

## Caveat
The caller mutation commands also ran with the required harnesses. The mutation tool checks each whole source file and reported unrelated existing survivors outside this focused change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Square order metadata now excludes empty or unsupported values, preventing invalid data from appearing in order details.
  * Order availability requests no longer include uploaded file data, producing cleaner and more reliable request parameters.

* **Tests**
  * Added coverage for filtering invalid order metadata and excluding file inputs from availability requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->