### PR TITLE
Keep cutoff timestamps consistent

### DIFF
--- a/src/features/api/sms-webhook.ts
+++ b/src/features/api/sms-webhook.ts
@@ -28,7 +28,7 @@ import {
   pruneSmsMessagesBefore,
   type SmsMessageRow,
 } from "#shared/db/sms-messages.ts";
-import { nowMs, nowSeconds } from "#shared/now.ts";
+import { isoBefore, nowSeconds } from "#shared/now.ts";
 import { hmacSha256Hex } from "#shared/payment-crypto.ts";
 import { decryptField } from "#shared/sms/e2e.ts";
 import { computePhoneIndex } from "#shared/sms/phone-index.ts";
@@ -153,7 +153,7 @@ export const handleSmsWebhook = async (request: Request): Promise<Response> => {
   await smsEventHandlers[event]?.(payload);
 
   // Backstop cleanup for rows whose delivery webhook never arrived.
-  const retentionCutoff = new Date(nowMs() - RETENTION_MS).toISOString();
+  const retentionCutoff = isoBefore(RETENTION_MS);
   await pruneSmsMessagesBefore(retentionCutoff);
   await pruneProcessedSmsInboundBefore(retentionCutoff);
 

--- a/src/shared/db/address-cache.ts
+++ b/src/shared/db/address-cache.ts
@@ -20,7 +20,7 @@ import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
 import { execute, queryOne, type SqlStatement } from "#shared/db/client.ts";
 import { ADDRESS_CACHE_MS, MAINTENANCE_PRUNE_BATCH } from "#shared/limits.ts";
-import { nowMs } from "#shared/now.ts";
+import { isoBefore, nowMs } from "#shared/now.ts";
 import { defineStoredJson } from "#shared/validation/stored-json.ts";
 /* jscpd:ignore-end */
 
@@ -34,8 +34,7 @@ export const computeAddressSearchIndex = (
 ): Promise<BlindIndex> => hmacHash(`${provider}:${normalisedSearch}`);
 
 /** The oldest `created` a cache row may have and still be served. */
-const freshCutoffIso = (): string =>
-  new Date(nowMs() - ADDRESS_CACHE_MS).toISOString();
+const freshCutoffIso = (): string => isoBefore(ADDRESS_CACHE_MS);
 
 export const addressCachePruneStatement = (): SqlStatement => ({
   args: [freshCutoffIso(), MAINTENANCE_PRUNE_BATCH],

--- a/src/shared/db/processed-payments.ts
+++ b/src/shared/db/processed-payments.ts
@@ -23,7 +23,7 @@ import type {
 import { execute, insert, queryOne } from "#shared/db/client.ts";
 import { encryptPaymentReference } from "#shared/db/payment-references.ts";
 import { STALE_RESERVATION_MS } from "#shared/limits.ts";
-import { nowIso, nowMs } from "#shared/now.ts";
+import { isoBefore, nowIso, nowMs } from "#shared/now.ts";
 import { defineStoredJson } from "#shared/validation/stored-json.ts";
 
 export { STALE_RESERVATION_MS };
@@ -147,7 +147,7 @@ export const releaseReservation: (sessionId: string) => Promise<void> =
  * redirect/webhook replays the handled outcome rather than re-refunding.
  */
 export const deleteAllStaleReservations = async (): Promise<number> => {
-  const cutoff = new Date(nowMs() - STALE_RESERVATION_MS).toISOString();
+  const cutoff = isoBefore(STALE_RESERVATION_MS);
   const result = await execute(
     `DELETE FROM processed_payments WHERE ${UNRESOLVED_RESERVATION} AND processed_at < ?`,
     [cutoff],

--- a/src/shared/now.ts
+++ b/src/shared/now.ts
@@ -15,6 +15,10 @@ export const nowIso = (): string => new Date().toISOString();
 /** Epoch milliseconds for numeric comparisons */
 export const nowMs = (): number => Date.now();
 
+/** ISO timestamp a fixed duration before the current time. */
+export const isoBefore = (durationMs: number): string =>
+  new Date(nowMs() - durationMs).toISOString();
+
 /** Current time in whole epoch seconds — the unit signed-token expiry uses. */
 export const nowSeconds = (): number => Math.floor(nowMs() / 1000);
 

--- a/test/shared/now.test.ts
+++ b/test/shared/now.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import { expiresIn, nowIso, nowSeconds } from "#shared/now.ts";
+import { expiresIn, isoBefore, nowIso, nowSeconds } from "#shared/now.ts";
 
 describe("expiresIn", () => {
   test("adds the max age to the current epoch seconds", () => {
@@ -21,5 +21,12 @@ describe("nowIso", () => {
   test("returns the current instant as an ISO-8601 string", () => {
     using _time = new FakeTime(1_700_000_000_000);
     expect(nowIso()).toBe("2023-11-14T22:13:20.000Z");
+  });
+});
+
+describe("isoBefore", () => {
+  test("returns an ISO instant the given duration before now", () => {
+    using _time = new FakeTime(1_700_000_000_000);
+    expect(isoBefore(60_000)).toBe("2023-11-14T22:12:20.000Z");
   });
 });


### PR DESCRIPTION
## Summary

- Add one shared helper for timestamps before the current time.
- Use it for SMS cleanup, address cache expiry, and stale payment reservations.
- Add a fixed-time regression test for the helper.

## Checks

- Focused time, SMS webhook, address cache, and processed payment tests
- Targeted mutation tests for every changed source file
- Full `deno task precommit` in the Nix development shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when calculating time-based expiration and retention cutoffs.
  - Enhanced reliability of SMS webhook cleanup, address-cache freshness checks, and stale payment reservation removal.
  - Standardized timestamp handling using ISO-8601 values, reducing potential discrepancies across cleanup and caching operations.

- **Tests**
  - Added coverage to verify that time-based cutoff calculations produce the expected timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->