### PR TITLE
Split the Uptime Kuma modules into one concept per file

### DIFF
--- a/src/shared/uptime-kuma/authorization.ts
+++ b/src/shared/uptime-kuma/authorization.ts
@@ -38,7 +38,7 @@ export const readCustomAuthorization = (
   }
 };
 
-export const authorizationFor = (
+export const authorizationForOrNull = (
   headers: string | null,
   authMethod: string | null,
   bearerToken: string | null,

--- a/src/shared/uptime-kuma/authorization.ts
+++ b/src/shared/uptime-kuma/authorization.ts
@@ -1,0 +1,55 @@
+import * as v from "valibot";
+import { bearerAuthorization, bearerTokenOrNull } from "#shared/bearer.ts";
+
+/**
+ * Reading the effective Authorization header a Kuma monitor sends.
+ *
+ * Kuma stores custom headers as a JSON string and a separate built-in bearer
+ * token (when `authMethod === "bearer"`). The runner only parses the stored
+ * headers string when it is truthy, so an empty string means no custom
+ * headers. A custom Authorization header overrides the built-in token.
+ */
+
+const CustomHeadersSchema = v.record(v.string(), v.string());
+
+type CustomAuthorization = {
+  authorization: string | null;
+  valid: boolean;
+};
+
+export const readCustomAuthorization = (
+  headers: string | null,
+): CustomAuthorization => {
+  if (headers === null || headers === "") {
+    return { authorization: null, valid: true };
+  }
+  try {
+    const values = v.parse(CustomHeadersSchema, JSON.parse(headers));
+    const entry = Object.entries(values).find(
+      ([name]) => name.toLowerCase() === "authorization",
+    );
+    return {
+      authorization: entry === undefined ? null : entry[1],
+      valid: true,
+    };
+  } catch {
+    // A malformed custom header belongs to a different, broken monitor.
+    return { authorization: null, valid: false };
+  }
+};
+
+export const authorizationFor = (
+  headers: string | null,
+  authMethod: string | null,
+  bearerToken: string | null,
+): string | null => {
+  const custom = readCustomAuthorization(headers);
+  if (!custom.valid) return null;
+  if (custom.authorization !== null) {
+    const token = bearerTokenOrNull(custom.authorization);
+    return token === null ? custom.authorization : bearerAuthorization(token);
+  }
+  return authMethod === "bearer" && bearerToken !== null
+    ? bearerAuthorization(bearerToken)
+    : null;
+};

--- a/src/shared/uptime-kuma/client.ts
+++ b/src/shared/uptime-kuma/client.ts
@@ -13,6 +13,8 @@ import {
 } from "./schemas.ts";
 import {
   createUptimeKumaSocket,
+  SOCKET_TIMEOUT_MS,
+  type SocketListener,
   type UptimeKumaSocket,
   uptimeKumaConnectionError,
 } from "./socket.ts";
@@ -27,10 +29,6 @@ export interface UptimeKumaClient {
   getMonitors(): Promise<UptimeKumaMonitor[]>;
   login(username: string, password: string): Promise<void>;
 }
-
-type SocketListener = (...args: unknown[]) => void;
-
-const SOCKET_TIMEOUT_MS = 10_000;
 
 export const createUptimeKumaClient = (
   socket: UptimeKumaSocket,

--- a/src/shared/uptime-kuma/client.ts
+++ b/src/shared/uptime-kuma/client.ts
@@ -1,38 +1,24 @@
-import * as v from "valibot";
-import { bearerAuthorization, bearerTokenOrNull } from "#shared/bearer.ts";
 import { countExternalSubrequest } from "#shared/subrequest-budget.ts";
-import { integerAtLeast } from "#shared/validation/number.ts";
-import { parseOrThrow } from "#shared/validation/parse.ts";
 import type { UptimeKumaConfig } from "./config.ts";
-import { UptimeKumaError, type UptimeKumaErrorKind } from "./error.ts";
+import { UptimeKumaError } from "./error.ts";
+import { call, callMonitorList, monitorListCapture } from "./event-capture.ts";
+import {
+  AddResponseSchema,
+  LoginResponseSchema,
+  MonitorListSchema,
+  parseKumaResponse,
+  requireOk,
+  type UptimeKumaMonitor,
+  type UptimeKumaMonitorInput,
+} from "./schemas.ts";
 import {
   createUptimeKumaSocket,
   type UptimeKumaSocket,
   uptimeKumaConnectionError,
 } from "./socket.ts";
+import { captureVersion } from "./version.ts";
 
-const SOCKET_TIMEOUT_MS = 10_000;
-const MONITOR_LIST_TIMEOUT_MS = 60_000;
-
-type SocketListener = (...args: unknown[]) => void;
-
-export type UptimeKumaMonitorInput = Record<string, unknown>;
-
-export interface UptimeKumaMonitor {
-  acceptedStatusCodes: string[];
-  active: boolean;
-  authorization: string | null;
-  conditions: unknown[];
-  id: number;
-  interval: number;
-  method: string;
-  name: string;
-  parent: number | null;
-  timeout: number;
-  type: string;
-  upsideDown: boolean;
-  url: string | null;
-}
+export type { UptimeKumaMonitor, UptimeKumaMonitorInput };
 
 export interface UptimeKumaClient {
   addMonitor(monitor: UptimeKumaMonitorInput): Promise<number>;
@@ -42,249 +28,9 @@ export interface UptimeKumaClient {
   login(username: string, password: string): Promise<void>;
 }
 
-const ActiveSchema = v.pipe(
-  v.union([v.boolean(), v.literal(0), v.literal(1)]),
-  v.transform((value) => value === true || value === 1),
-);
+type SocketListener = (...args: unknown[]) => void;
 
-const CustomHeadersSchema = v.record(v.string(), v.string());
-
-type CustomAuthorization = {
-  authorization: string | null;
-  valid: boolean;
-};
-
-const readCustomAuthorization = (
-  headers: string | null,
-): CustomAuthorization => {
-  if (headers === null || headers === "")
-    return { authorization: null, valid: true };
-  try {
-    const values = v.parse(CustomHeadersSchema, JSON.parse(headers));
-    const entry = Object.entries(values).find(
-      ([name]) => name.toLowerCase() === "authorization",
-    );
-    return {
-      authorization: entry === undefined ? null : entry[1],
-      valid: true,
-    };
-  } catch {
-    // A malformed custom header belongs to a different, broken monitor.
-    return { authorization: null, valid: false };
-  }
-};
-
-const authorizationFor = (
-  headers: string | null,
-  authMethod: string | null,
-  bearerToken: string | null,
-): string | null => {
-  const custom = readCustomAuthorization(headers);
-  if (!custom.valid) return null;
-  if (custom.authorization !== null) {
-    const token = bearerTokenOrNull(custom.authorization);
-    return token === null ? custom.authorization : bearerAuthorization(token);
-  }
-  return authMethod === "bearer" && bearerToken !== null
-    ? bearerAuthorization(bearerToken)
-    : null;
-};
-
-const RawMonitorSchema = v.object({
-  accepted_statuscodes: v.array(v.string()),
-  active: ActiveSchema,
-  authMethod: v.nullable(v.string()),
-  bearer_token: v.nullable(v.string()),
-  conditions: v.array(v.unknown()),
-  headers: v.nullable(v.string()),
-  id: integerAtLeast(1),
-  interval: integerAtLeast(1),
-  method: v.string(),
-  name: v.string(),
-  parent: v.nullable(integerAtLeast(1)),
-  timeout: integerAtLeast(1),
-  type: v.string(),
-  upsideDown: ActiveSchema,
-  url: v.nullable(v.string()),
-});
-const MonitorSchema = v.pipe(
-  RawMonitorSchema,
-  v.transform(
-    ({
-      accepted_statuscodes,
-      authMethod,
-      bearer_token,
-      headers,
-      ...monitor
-    }) => ({
-      ...monitor,
-      acceptedStatusCodes: accepted_statuscodes,
-      authorization: authorizationFor(headers, authMethod, bearer_token),
-    }),
-  ),
-);
-
-const MonitorListSchema = v.record(v.string(), MonitorSchema);
-const VersionNumberSchema = v.pipe(
-  v.string(),
-  v.regex(/^\d+$/),
-  v.transform(Number),
-  v.safeInteger(),
-);
-const VersionSchema = v.pipe(
-  v.string(),
-  v.transform((version) => version.split(".")),
-  v.tuple([VersionNumberSchema, VersionNumberSchema]),
-);
-const InfoSchema = v.object({ version: v.optional(VersionSchema) });
-const FailedResponseSchema = v.object({
-  msg: v.string(),
-  ok: v.literal(false),
-});
-const PlainLoginFailureSchema = v.object({
-  msg: v.string(),
-  msgi18n: v.optional(v.literal(false)),
-  ok: v.literal(false),
-});
-const IncorrectCredentialsSchema = v.object({
-  msg: v.literal("authIncorrectCreds"),
-  msgi18n: v.literal(true),
-  ok: v.literal(false),
-});
-const OkResponseSchema = v.object({ ok: v.literal(true) });
-const BasicResponseSchema = v.union([OkResponseSchema, FailedResponseSchema]);
-const LoginResponseSchema = v.union([
-  OkResponseSchema,
-  IncorrectCredentialsSchema,
-  PlainLoginFailureSchema,
-  v.object({ tokenRequired: v.literal(true) }),
-]);
-const AddResponseSchema = v.union([
-  v.object({ monitorID: integerAtLeast(1), ok: v.literal(true) }),
-  FailedResponseSchema,
-]);
-
-const parseKumaResponse = <TSchema extends v.GenericSchema>(
-  schema: TSchema,
-  value: unknown,
-): v.InferOutput<TSchema> =>
-  parseOrThrow(schema, value, () => new UptimeKumaError("invalid_response"));
-
-const requireOk = (value: unknown): void => {
-  const response = parseKumaResponse(BasicResponseSchema, value);
-  if (!response.ok) throw new Error(response.msg);
-};
-
-type EventCapture = {
-  cancel: () => void;
-  latest: () => unknown;
-  received: Promise<void>;
-};
-
-type VersionOutcome = { error: unknown; ok: false } | { ok: true };
-
-type VersionCapture = {
-  cancel: () => void;
-  read: () => Promise<void>;
-};
-
-const requireSupportedVersion = ([major, minor]: [number, number]): void => {
-  if (major < 2 || (major === 2 && minor < 4)) {
-    throw new UptimeKumaError("unsupported_version");
-  }
-};
-
-type TimedEvent = "info" | "monitorList";
-
-const TIMEOUT_ERROR_KINDS: Record<TimedEvent, UptimeKumaErrorKind> = {
-  info: "version_timeout",
-  monitorList: "monitor_list_timeout",
-};
-
-const withEventTimeout = async <Value>(
-  promise: Promise<Value>,
-  event: TimedEvent,
-  timeoutMs = SOCKET_TIMEOUT_MS,
-): Promise<Value> => {
-  const timeout = Promise.withResolvers<never>();
-  const timer = setTimeout(() => {
-    timeout.reject(new UptimeKumaError(TIMEOUT_ERROR_KINDS[event]));
-  }, timeoutMs);
-  try {
-    return await Promise.race([promise, timeout.promise]);
-  } finally {
-    clearTimeout(timer);
-  }
-};
-
-const captureVersion = (socket: UptimeKumaSocket): VersionCapture => {
-  let listener: SocketListener;
-  const promise = new Promise<VersionOutcome>((resolve) => {
-    listener = (value) => {
-      try {
-        const parsed = v.safeParse(InfoSchema, value);
-        if (!parsed.success) {
-          throw new UptimeKumaError("unsupported_version");
-        }
-        const info = parsed.output;
-        if (info.version === undefined) {
-          socket.once("info", listener);
-          return;
-        }
-        requireSupportedVersion(info.version);
-        resolve({ ok: true });
-      } catch (error) {
-        resolve({ error, ok: false });
-      }
-    };
-    socket.once("info", listener);
-  });
-  return {
-    cancel: () => socket.off("info", listener),
-    read: async (): Promise<void> => {
-      const outcome = await withEventTimeout(promise, "info");
-      if (!outcome.ok) throw outcome.error;
-    },
-  };
-};
-
-const captureEvents = (
-  socket: UptimeKumaSocket,
-  event: TimedEvent,
-  timeoutMs: number,
-): EventCapture => {
-  let latest: unknown;
-  let listener: SocketListener;
-  const received = Promise.withResolvers<void>();
-  listener = (value) => {
-    latest = value;
-    received.resolve();
-    socket.once(event, listener);
-  };
-  socket.once(event, listener);
-  return {
-    cancel: () => {
-      socket.off(event, listener);
-      received.resolve();
-    },
-    latest: () => latest,
-    received: withEventTimeout(received.promise, event, timeoutMs),
-  };
-};
-
-const callWithTimeout = (
-  socket: UptimeKumaSocket,
-  event: string,
-  timeoutMs: number,
-  ...args: unknown[]
-): Promise<unknown> => socket.timeout(timeoutMs).emitWithAck(event, ...args);
-
-const call = (
-  socket: UptimeKumaSocket,
-  event: string,
-  ...args: unknown[]
-): Promise<unknown> =>
-  callWithTimeout(socket, event, SOCKET_TIMEOUT_MS, ...args);
+const SOCKET_TIMEOUT_MS = 10_000;
 
 export const createUptimeKumaClient = (
   socket: UptimeKumaSocket,
@@ -307,14 +53,10 @@ export const createUptimeKumaClient = (
       socket.disconnect();
     },
     getMonitors: async (): Promise<UptimeKumaMonitor[]> => {
-      const list = captureEvents(
-        socket,
-        "monitorList",
-        MONITOR_LIST_TIMEOUT_MS,
-      );
+      const list = monitorListCapture(socket);
       try {
         const [response] = await Promise.all([
-          callWithTimeout(socket, "getMonitorList", MONITOR_LIST_TIMEOUT_MS),
+          callMonitorList(socket),
           list.received,
         ]);
         requireOk(response);

--- a/src/shared/uptime-kuma/errors.ts
+++ b/src/shared/uptime-kuma/errors.ts
@@ -1,0 +1,33 @@
+import { t } from "#i18n";
+import { UptimeKumaError, type UptimeKumaErrorKind } from "./error.ts";
+
+/**
+ * Mapping typed Kuma failures to catalog copy shown on the maintenance tab
+ * and in flash messages.
+ *
+ * Messages returned by Kuma (plain `Error` values) are preserved as-is; only
+ * locally generated failures are translated through catalog keys.
+ */
+
+const ERROR_MESSAGE_KEYS: Record<UptimeKumaErrorKind, string> = {
+  connection_closed: "built_sites.kuma_connection_closed",
+  connection_failed: "built_sites.kuma_connection_failed",
+  connection_timeout: "built_sites.kuma_connection_timeout",
+  incorrect_credentials: "built_sites.kuma_incorrect_credentials",
+  invalid_response: "built_sites.kuma_invalid_response",
+  monitor_list_timeout: "built_sites.kuma_monitor_list_timeout",
+  request_timeout: "built_sites.kuma_request_timeout",
+  two_factor: "built_sites.kuma_two_factor",
+  unsupported_version: "built_sites.kuma_unsupported_version",
+  version_timeout: "built_sites.kuma_version_timeout",
+};
+
+export const kumaErrorMessage = (error: unknown): string =>
+  error instanceof UptimeKumaError
+    ? t(ERROR_MESSAGE_KEYS[error.kind])
+    : errorMessage(error);
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return t("built_sites.kuma_failed");
+};

--- a/src/shared/uptime-kuma/event-capture.ts
+++ b/src/shared/uptime-kuma/event-capture.ts
@@ -1,0 +1,93 @@
+import { UptimeKumaError, type UptimeKumaErrorKind } from "./error.ts";
+import type { UptimeKumaSocket } from "./socket.ts";
+
+/**
+ * Timing out socket event captures and request acknowledgements.
+ *
+ * The socket wrapper emits named events (`info`, `monitorList`) and returns
+ * ack values from `emitWithAck`. Each call that waits for a Kuma reply needs
+ * its own timeout so a silent Kuma server cannot hang the maintenance tab.
+ */
+
+const SOCKET_TIMEOUT_MS = 10_000;
+const MONITOR_LIST_TIMEOUT_MS = 60_000;
+
+type SocketListener = (...args: unknown[]) => void;
+type TimedEvent = "info" | "monitorList";
+
+const TIMEOUT_ERROR_KINDS: Record<TimedEvent, UptimeKumaErrorKind> = {
+  info: "version_timeout",
+  monitorList: "monitor_list_timeout",
+};
+
+export const withEventTimeout = async <Value>(
+  promise: Promise<Value>,
+  event: TimedEvent,
+  timeoutMs = SOCKET_TIMEOUT_MS,
+): Promise<Value> => {
+  const timeout = Promise.withResolvers<never>();
+  const timer = setTimeout(
+    () => timeout.reject(new UptimeKumaError(TIMEOUT_ERROR_KINDS[event])),
+    timeoutMs,
+  );
+  try {
+    return await Promise.race([promise, timeout.promise]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+type EventCapture = {
+  cancel: () => void;
+  latest: () => unknown;
+  received: Promise<void>;
+};
+
+/**
+ * Captures every push of `event` until `cancel` or `received` resolves. Kuma
+ * can send the same event more than once (an early stale list followed by the
+ * real one), so the capture stays open and keeps the newest value.
+ */
+export const captureEvents = (
+  socket: UptimeKumaSocket,
+  event: TimedEvent,
+  timeoutMs: number,
+): EventCapture => {
+  let latest: unknown;
+  let listener: SocketListener;
+  const received = Promise.withResolvers<void>();
+  listener = (value) => {
+    latest = value;
+    received.resolve();
+    socket.once(event, listener);
+  };
+  socket.once(event, listener);
+  return {
+    cancel: () => {
+      socket.off(event, listener);
+      received.resolve();
+    },
+    latest: () => latest,
+    received: withEventTimeout(received.promise, event, timeoutMs),
+  };
+};
+
+export const callWithTimeout = (
+  socket: UptimeKumaSocket,
+  event: string,
+  timeoutMs: number,
+  ...args: unknown[]
+): Promise<unknown> => socket.timeout(timeoutMs).emitWithAck(event, ...args);
+
+export const call = (
+  socket: UptimeKumaSocket,
+  event: string,
+  ...args: unknown[]
+): Promise<unknown> =>
+  callWithTimeout(socket, event, SOCKET_TIMEOUT_MS, ...args);
+
+export const callMonitorList = (socket: UptimeKumaSocket): Promise<unknown> =>
+  callWithTimeout(socket, "getMonitorList", MONITOR_LIST_TIMEOUT_MS);
+
+export const monitorListCapture = (socket: UptimeKumaSocket): EventCapture =>
+  captureEvents(socket, "monitorList", MONITOR_LIST_TIMEOUT_MS);

--- a/src/shared/uptime-kuma/event-capture.ts
+++ b/src/shared/uptime-kuma/event-capture.ts
@@ -1,5 +1,6 @@
 import { UptimeKumaError, type UptimeKumaErrorKind } from "./error.ts";
 import type { UptimeKumaSocket } from "./socket.ts";
+import { SOCKET_TIMEOUT_MS, type SocketListener } from "./socket.ts";
 
 /**
  * Timing out socket event captures and request acknowledgements.
@@ -9,10 +10,8 @@ import type { UptimeKumaSocket } from "./socket.ts";
  * its own timeout so a silent Kuma server cannot hang the maintenance tab.
  */
 
-const SOCKET_TIMEOUT_MS = 10_000;
 const MONITOR_LIST_TIMEOUT_MS = 60_000;
 
-type SocketListener = (...args: unknown[]) => void;
 type TimedEvent = "info" | "monitorList";
 
 const TIMEOUT_ERROR_KINDS: Record<TimedEvent, UptimeKumaErrorKind> = {

--- a/src/shared/uptime-kuma/matching.ts
+++ b/src/shared/uptime-kuma/matching.ts
@@ -1,0 +1,217 @@
+import { filter, pipe } from "#fp";
+import { t } from "#i18n";
+import { MAINTENANCE_REQUEST_DEADLINE_MS } from "#shared/maintenance/definition.ts";
+import { normalizePath } from "#shared/path.ts";
+import { UPTIME_KUMA_GROUP_NAME } from "./monitor-input.ts";
+import type { UptimeKumaMonitor } from "./schemas.ts";
+
+/**
+ * Pure predicates for finding a built site's scheduled monitor among the
+ * monitors Kuma has pushed.
+ *
+ * A monitor drives a site's `/scheduled` request safely when it is the right
+ * kind of check (HTTP POST to the site's scheduled URL, with the right bearer
+ * token, accepting the 204 success response) and when its configuration
+ * cannot make the request go stale or fail — not upside-down, no custom
+ * conditions, and a timeout that gives the request time to finish.
+ */
+
+export type ScheduledMatchContext = {
+  authorization: string;
+  groupIds: number[];
+  target: string;
+};
+
+/**
+ * The checks a monitor must pass to be treated as the site's scheduled
+ * monitor. Each entry carries its own predicate so adding a new rule is
+ * adding one line here, not a new arm on an `if` chain.
+ */
+type ScheduledMonitorRule = {
+  holds: (
+    monitor: UptimeKumaMonitor,
+    context: ScheduledMatchContext,
+  ) => boolean;
+};
+
+const inSharedGroup: ScheduledMonitorRule["holds"] = (monitor, context) =>
+  monitor.parent !== null && context.groupIds.includes(monitor.parent);
+
+const targetsScheduledUrl: ScheduledMonitorRule["holds"] = (monitor, context) =>
+  monitor.url !== null && scheduledTarget(monitor.url) === context.target;
+
+const carriesAuthorization: ScheduledMonitorRule["holds"] = (
+  monitor,
+  context,
+) => monitor.authorization === context.authorization;
+
+const SCHEDULED_MONITOR_RULES: ScheduledMonitorRule[] = [
+  { holds: (monitor) => monitor.type === "http" },
+  { holds: inSharedGroup },
+  { holds: (monitor) => monitor.method.toUpperCase() === "POST" },
+  { holds: targetsScheduledUrl },
+  { holds: (monitor) => acceptsScheduledResponse(monitor.acceptedStatusCodes) },
+  { holds: (monitor) => !monitor.upsideDown },
+  { holds: (monitor) => monitor.conditions.length === 0 },
+  {
+    holds: (monitor) =>
+      monitor.timeout * 1_000 >= MAINTENANCE_REQUEST_DEADLINE_MS,
+  },
+  { holds: carriesAuthorization },
+];
+
+/**
+ * A monitor matches the scheduled request when every rule holds. The rules
+ * are data, so a new rule is one entry in the table above, and this fold is
+ * the only place the decision is made.
+ */
+export const siteMonitorMatches = (
+  monitor: UptimeKumaMonitor,
+  context: ScheduledMatchContext,
+): boolean =>
+  SCHEDULED_MONITOR_RULES.every((rule) => rule.holds(monitor, context));
+
+/**
+ * Normalises a monitor URL to its origin plus trailing-slash-normalised
+ * path, so `https://child.example.test/scheduled/` and
+ * `https://child.example.test/scheduled` match.
+ */
+export const scheduledTarget = (value: string): string => {
+  const url = new URL(value);
+  return `${url.origin}${normalizePath(url.pathname)}`;
+};
+
+/**
+ * Reads the 204 status code against Kuma's range notation: `"200-299"` and
+ * `"204"` both accept it; `"200"` and `"205-399"` do not.
+ */
+export const acceptsScheduledResponse = (statusCodes: string[]): boolean =>
+  statusCodes.some((range) => {
+    const parts = range.split("-");
+    const minimum = Number(parts[0]);
+    const maximum = Number(parts[1] === undefined ? parts[0] : parts[1]);
+    return minimum <= 204 && maximum >= 204;
+  });
+
+/**
+ * The shared Chobble Tickets group monitors, ordered by id. Shared groups
+ * are the containers for all site scheduled monitors.
+ */
+export const sharedGroups = (
+  monitors: UptimeKumaMonitor[],
+): UptimeKumaMonitor[] =>
+  pipe(
+    filter(
+      (monitor: UptimeKumaMonitor) =>
+        monitor.type === "group" && monitor.name === UPTIME_KUMA_GROUP_NAME,
+    ),
+  )(monitors);
+
+export const sharedGroupIds = (monitors: UptimeKumaMonitor[]): number[] =>
+  sharedGroups(monitors).map((group) => group.id);
+
+export const lowestByIdOrNull = (
+  monitors: UptimeKumaMonitor[],
+): UptimeKumaMonitor | null => {
+  const [first] = monitors.toSorted((left, right) => left.id - right.id);
+  return first === undefined ? null : first;
+};
+
+export const firstById = (
+  monitors: UptimeKumaMonitor[],
+  missingMessage: string,
+): UptimeKumaMonitor => {
+  const first = lowestByIdOrNull(monitors);
+  if (first === null) throw new Error(missingMessage);
+  return first;
+};
+
+type FoundMonitor = { kind: "found"; monitor: UptimeKumaMonitor };
+
+type FindResult =
+  | FoundMonitor
+  | { kind: "missing" }
+  | { kind: "ambiguous"; url: string };
+
+type RaceResult = FoundMonitor | { kind: "missing" };
+
+const matchingMonitors = (
+  monitors: UptimeKumaMonitor[],
+  url: string,
+  authorization: string,
+): UptimeKumaMonitor[] => {
+  const context: ScheduledMatchContext = {
+    authorization,
+    groupIds: sharedGroupIds(monitors),
+    target: scheduledTarget(url),
+  };
+  return monitors.filter((monitor) => siteMonitorMatches(monitor, context));
+};
+
+/**
+ * Finds the one monitor that matches the scheduled request. Missing is a
+ * normal result (the add action is offered); ambiguous is reported as an
+ * error state so the operator is told to fix Kuma by hand instead of guessing.
+ */
+export const findSiteMonitor = (
+  monitors: UptimeKumaMonitor[],
+  url: string,
+  authorization: string,
+): FindResult => {
+  const matches = matchingMonitors(monitors, url, authorization);
+  if (matches.length === 0) return { kind: "missing" };
+  if (matches.length > 1) return { kind: "ambiguous", url };
+  return foundMonitor(matches, url);
+};
+
+/**
+ * Finds the lowest-id monitor that matches the scheduled request, allowing
+ * duplicates so a concurrent add that attached another monitor between read
+ * and add does not get replaced. Used during the add flow to pick a winner.
+ */
+export const findRaceWinner = (
+  monitors: UptimeKumaMonitor[],
+  url: string,
+  authorization: string,
+): RaceResult => {
+  const result = findSiteMonitor(monitors, url, authorization);
+  if (result.kind === "ambiguous") {
+    return foundMonitor(matchingMonitors(monitors, url, authorization), url);
+  }
+  return result;
+};
+
+const foundMonitor = (
+  matches: UptimeKumaMonitor[],
+  url: string,
+): FoundMonitor => ({
+  kind: "found",
+  monitor: firstById(
+    matches,
+    t("built_sites.kuma_returned_no_monitor", { url }),
+  ),
+});
+
+/** The monitor details shown on the maintenance tab. */
+export const monitorDetails = (
+  monitor: UptimeKumaMonitor,
+  url: string,
+): UptimeKumaMonitorDetails => ({
+  active: monitor.active,
+  group: UPTIME_KUMA_GROUP_NAME,
+  id: monitor.id,
+  intervalSeconds: monitor.interval,
+  method: monitor.method,
+  name: monitor.name,
+  url,
+});
+
+export type UptimeKumaMonitorDetails = {
+  active: boolean;
+  group: string;
+  id: number;
+  intervalSeconds: number;
+  method: string;
+  name: string;
+  url: string;
+};

--- a/src/shared/uptime-kuma/monitors.ts
+++ b/src/shared/uptime-kuma/monitors.ts
@@ -1,8 +1,6 @@
 import { t } from "#i18n";
 import { bearerAuthorization } from "#shared/bearer.ts";
 import type { BuiltSite } from "#shared/db/built-sites/types.ts";
-import { MAINTENANCE_REQUEST_DEADLINE_MS } from "#shared/maintenance/definition.ts";
-import { normalizePath } from "#shared/path.ts";
 import { errorResult, okResult, type Result } from "#shared/result.ts";
 import {
   type UptimeKumaClient,
@@ -13,7 +11,16 @@ import {
   getEnabledUptimeKumaConfigOrNull,
   type UptimeKumaConfig,
 } from "./config.ts";
-import { UptimeKumaError, type UptimeKumaErrorKind } from "./error.ts";
+import { kumaErrorMessage } from "./errors.ts";
+import {
+  findRaceWinner,
+  findSiteMonitor,
+  firstById,
+  lowestByIdOrNull,
+  monitorDetails,
+  sharedGroups,
+  type UptimeKumaMonitorDetails,
+} from "./matching.ts";
 import {
   groupMonitorInput,
   scheduledUrl,
@@ -21,15 +28,7 @@ import {
   UPTIME_KUMA_GROUP_NAME,
 } from "./monitor-input.ts";
 
-export type UptimeKumaMonitorDetails = {
-  active: boolean;
-  group: string;
-  id: number;
-  intervalSeconds: number;
-  method: string;
-  name: string;
-  url: string;
-};
+export type { UptimeKumaMonitorDetails };
 
 export type UptimeKumaMonitorState =
   | { kind: "unconfigured" }
@@ -39,124 +38,7 @@ export type UptimeKumaMonitorState =
 
 type AddedMonitor = { created: boolean; monitorId: number };
 
-const ERROR_MESSAGE_KEYS: Record<UptimeKumaErrorKind, string> = {
-  connection_closed: "built_sites.kuma_connection_closed",
-  connection_failed: "built_sites.kuma_connection_failed",
-  connection_timeout: "built_sites.kuma_connection_timeout",
-  incorrect_credentials: "built_sites.kuma_incorrect_credentials",
-  invalid_response: "built_sites.kuma_invalid_response",
-  monitor_list_timeout: "built_sites.kuma_monitor_list_timeout",
-  request_timeout: "built_sites.kuma_request_timeout",
-  two_factor: "built_sites.kuma_two_factor",
-  unsupported_version: "built_sites.kuma_unsupported_version",
-  version_timeout: "built_sites.kuma_version_timeout",
-};
-
-const kumaErrorMessage = (error: unknown): string =>
-  error instanceof UptimeKumaError
-    ? t(ERROR_MESSAGE_KEYS[error.kind])
-    : errorMessage(error);
-
-const errorMessage = (error: unknown): string => {
-  if (error instanceof Error) return error.message;
-  return t("built_sites.kuma_failed");
-};
-
-const sharedGroups = (monitors: UptimeKumaMonitor[]): UptimeKumaMonitor[] =>
-  monitors.filter(
-    (monitor) =>
-      monitor.type === "group" && monitor.name === UPTIME_KUMA_GROUP_NAME,
-  );
-
-const acceptsScheduledResponse = (statusCodes: string[]): boolean =>
-  statusCodes.some((range) => {
-    const parts = range.split("-");
-    const minimum = Number(parts[0]);
-    const maximum = Number(parts[1] === undefined ? parts[0] : parts[1]);
-    return minimum <= 204 && maximum >= 204;
-  });
-
-const scheduledTarget = (value: string): string => {
-  const url = new URL(value);
-  return `${url.origin}${normalizePath(url.pathname)}`;
-};
-
-const canCompleteScheduledRequest = (monitor: UptimeKumaMonitor): boolean =>
-  !monitor.upsideDown &&
-  monitor.conditions.length === 0 &&
-  monitor.timeout * 1_000 >= MAINTENANCE_REQUEST_DEADLINE_MS;
-
-const lowestByIdOrNull = (
-  monitors: UptimeKumaMonitor[],
-): UptimeKumaMonitor | null => {
-  const [first] = monitors.toSorted((left, right) => left.id - right.id);
-  return first === undefined ? null : first;
-};
-
-const firstById = (
-  monitors: UptimeKumaMonitor[],
-  missingMessage: string,
-): UptimeKumaMonitor => {
-  const first = lowestByIdOrNull(monitors);
-  if (first === null) throw new Error(missingMessage);
-  return first;
-};
-
-const siteMonitor = (
-  monitors: UptimeKumaMonitor[],
-  groupIds: number[],
-  url: string,
-  authorization: string,
-  allowRaceDuplicates: boolean,
-): UptimeKumaMonitor | null => {
-  const target = scheduledTarget(url);
-  const matches = monitors.filter(
-    (monitor) =>
-      monitor.type === "http" &&
-      monitor.parent !== null &&
-      groupIds.includes(monitor.parent) &&
-      monitor.method.toUpperCase() === "POST" &&
-      monitor.url !== null &&
-      scheduledTarget(monitor.url) === target &&
-      acceptsScheduledResponse(monitor.acceptedStatusCodes) &&
-      canCompleteScheduledRequest(monitor) &&
-      monitor.authorization === authorization,
-  );
-  if (!allowRaceDuplicates && matches.length > 1) {
-    throw new Error(t("built_sites.kuma_duplicate_monitor", { url }));
-  }
-  return matches.length === 0
-    ? null
-    : firstById(matches, t("built_sites.kuma_returned_no_monitor", { url }));
-};
-
-const groupForAdd = async (
-  client: UptimeKumaClient,
-  groups: UptimeKumaMonitor[],
-): Promise<UptimeKumaMonitor> => {
-  const existing = lowestByIdOrNull(groups);
-  if (existing !== null) return existing;
-  await client.addMonitor(groupMonitorInput());
-  return firstById(
-    sharedGroups(await client.getMonitors()),
-    t("built_sites.kuma_new_group_missing", {
-      name: UPTIME_KUMA_GROUP_NAME,
-    }),
-  );
-};
-
-const monitorDetails = (
-  monitor: UptimeKumaMonitor,
-  url: string,
-): UptimeKumaMonitorDetails => ({
-  active: monitor.active,
-  group: UPTIME_KUMA_GROUP_NAME,
-  id: monitor.id,
-  intervalSeconds: monitor.interval,
-  method: monitor.method,
-  name: monitor.name,
-  url,
-});
+type AddResult = Result<AddedMonitor>;
 
 const withClient = async <Value>(
   config: UptimeKumaConfig,
@@ -198,23 +80,20 @@ const withConfiguredKuma = async <Value>(
   }
 };
 
-const monitorInSharedGroups =
-  (allowRaceDuplicates: boolean) =>
-  (
-    monitors: UptimeKumaMonitor[],
-    url: string,
-    authorization: string,
-  ): UptimeKumaMonitor | null =>
-    siteMonitor(
-      monitors,
-      sharedGroups(monitors).map((group) => group.id),
-      url,
-      authorization,
-      allowRaceDuplicates,
-    );
-
-const existingSiteMonitor = monitorInSharedGroups(false);
-const raceWinnerMonitor = monitorInSharedGroups(true);
+const groupForAdd = async (
+  client: UptimeKumaClient,
+  groups: UptimeKumaMonitor[],
+): Promise<UptimeKumaMonitor> => {
+  const existing = lowestByIdOrNull(groups);
+  if (existing !== null) return existing;
+  await client.addMonitor(groupMonitorInput());
+  return firstById(
+    sharedGroups(await client.getMonitors()),
+    t("built_sites.kuma_new_group_missing", {
+      name: UPTIME_KUMA_GROUP_NAME,
+    }),
+  );
+};
 
 const finishMonitorAdd = async (
   client: UptimeKumaClient,
@@ -223,10 +102,11 @@ const finishMonitorAdd = async (
   authorization: string,
   monitorId: number,
 ): Promise<AddedMonitor> => {
-  const winner = raceWinnerMonitor(monitors, url, authorization);
-  if (winner === null) {
+  const found = findRaceWinner(monitors, url, authorization);
+  if (found.kind === "missing") {
     throw new Error(t("built_sites.kuma_new_monitor_missing", { url }));
   }
+  const winner = found.monitor;
   const created = winner.id === monitorId;
   if (created) return { created, monitorId };
   const createdMonitorExists = monitors.some(
@@ -246,9 +126,9 @@ const addToGroup = async (
   authorization: string,
 ): Promise<AddedMonitor> => {
   const currentMonitors = await client.getMonitors();
-  const raceWinner = raceWinnerMonitor(currentMonitors, url, authorization);
-  if (raceWinner !== null) {
-    return { created: false, monitorId: raceWinner.id };
+  const raceWinner = findRaceWinner(currentMonitors, url, authorization);
+  if (raceWinner.kind === "found") {
+    return { created: false, monitorId: raceWinner.monitor.id };
   }
   const monitorId = await client.addMonitor(
     siteMonitorInput(site, config, group.id, scheduledTaskKey),
@@ -269,12 +149,15 @@ const addFromMonitors = async (
   site: BuiltSite,
   config: UptimeKumaConfig,
   scheduledTaskKey: string,
-): Promise<Result<AddedMonitor>> => {
+): Promise<AddResult> => {
   const url = scheduledUrl(site);
   const authorization = bearerAuthorization(scheduledTaskKey);
-  const existing = existingSiteMonitor(monitors, url, authorization);
-  if (existing) {
-    return okResult({ created: false, monitorId: existing.id });
+  const existing = findSiteMonitor(monitors, url, authorization);
+  if (existing.kind === "found") {
+    return okResult({ created: false, monitorId: existing.monitor.id });
+  }
+  if (existing.kind === "ambiguous") {
+    return errorResult(t("built_sites.kuma_duplicate_monitor", { url }));
   }
   const group = await groupForAdd(client, groups);
   return okResult(
@@ -298,14 +181,19 @@ const loadConfigured = (
   if (scheduledTaskKey === null) return Promise.resolve({ kind: "missing" });
   return withMonitors(config, (_client, monitors, _groups) => {
     const url = scheduledUrl(site);
-    const monitor = existingSiteMonitor(
+    const found = findSiteMonitor(
       monitors,
       url,
       bearerAuthorization(scheduledTaskKey),
     );
-    return monitor === null
-      ? { kind: "missing" }
-      : { kind: "found", monitor: monitorDetails(monitor, url) };
+    return found.kind === "found"
+      ? { kind: "found", monitor: monitorDetails(found.monitor, url) }
+      : found.kind === "ambiguous"
+        ? {
+            error: t("built_sites.kuma_duplicate_monitor", { url }),
+            kind: "error",
+          }
+        : { kind: "missing" };
   });
 };
 
@@ -316,8 +204,8 @@ const load = (site: BuiltSite): Promise<UptimeKumaMonitorState> =>
     (config) => loadConfigured(site, config),
   );
 
-const add = (site: BuiltSite): Promise<Result<AddedMonitor>> =>
-  withConfiguredKuma<Result<AddedMonitor>>(
+const add = (site: BuiltSite): Promise<AddResult> =>
+  withConfiguredKuma(
     () => errorResult(t("built_sites.kuma_add_unconfigured")),
     (error) => errorResult(kumaErrorMessage(error)),
     (config) => {

--- a/src/shared/uptime-kuma/monitors.ts
+++ b/src/shared/uptime-kuma/monitors.ts
@@ -28,8 +28,6 @@ import {
   UPTIME_KUMA_GROUP_NAME,
 } from "./monitor-input.ts";
 
-export type { UptimeKumaMonitorDetails };
-
 export type UptimeKumaMonitorState =
   | { kind: "unconfigured" }
   | { error: string; kind: "error" }

--- a/src/shared/uptime-kuma/schemas.ts
+++ b/src/shared/uptime-kuma/schemas.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { integerAtLeast } from "#shared/validation/number.ts";
 import { parseOrThrow } from "#shared/validation/parse.ts";
-import { authorizationFor } from "./authorization.ts";
+import { authorizationForOrNull } from "./authorization.ts";
 import { UptimeKumaError } from "./error.ts";
 
 /**
@@ -66,7 +66,7 @@ const MonitorSchema = v.pipe(
     }) => ({
       ...monitor,
       acceptedStatusCodes: accepted_statuscodes,
-      authorization: authorizationFor(headers, authMethod, bearer_token),
+      authorization: authorizationForOrNull(headers, authMethod, bearer_token),
     }),
   ),
 );

--- a/src/shared/uptime-kuma/schemas.ts
+++ b/src/shared/uptime-kuma/schemas.ts
@@ -1,0 +1,115 @@
+import * as v from "valibot";
+import { integerAtLeast } from "#shared/validation/number.ts";
+import { parseOrThrow } from "#shared/validation/parse.ts";
+import { authorizationFor } from "./authorization.ts";
+import { UptimeKumaError } from "./error.ts";
+
+/**
+ * Valibot schemas for the Uptime Kuma monitor-list and response payloads.
+ *
+ * Kuma pushes monitors as a record keyed by string id, with snake_case
+ * fields. The transform converts them to the camelCase
+ * {@link UptimeKumaMonitor} shape, including the effective Authorization
+ * header derived from the custom headers and built-in bearer token.
+ */
+
+export type UptimeKumaMonitorInput = Record<string, unknown>;
+
+const ActiveSchema = v.pipe(
+  v.union([v.boolean(), v.literal(0), v.literal(1)]),
+  v.transform((value) => value === true || value === 1),
+);
+
+export interface UptimeKumaMonitor {
+  acceptedStatusCodes: string[];
+  active: boolean;
+  authorization: string | null;
+  conditions: unknown[];
+  id: number;
+  interval: number;
+  method: string;
+  name: string;
+  parent: number | null;
+  timeout: number;
+  type: string;
+  upsideDown: boolean;
+  url: string | null;
+}
+
+const RawMonitorSchema = v.object({
+  accepted_statuscodes: v.array(v.string()),
+  active: ActiveSchema,
+  authMethod: v.nullable(v.string()),
+  bearer_token: v.nullable(v.string()),
+  conditions: v.array(v.unknown()),
+  headers: v.nullable(v.string()),
+  id: integerAtLeast(1),
+  interval: integerAtLeast(1),
+  method: v.string(),
+  name: v.string(),
+  parent: v.nullable(integerAtLeast(1)),
+  timeout: integerAtLeast(1),
+  type: v.string(),
+  upsideDown: ActiveSchema,
+  url: v.nullable(v.string()),
+});
+
+const MonitorSchema = v.pipe(
+  RawMonitorSchema,
+  v.transform(
+    ({
+      accepted_statuscodes,
+      authMethod,
+      bearer_token,
+      headers,
+      ...monitor
+    }) => ({
+      ...monitor,
+      acceptedStatusCodes: accepted_statuscodes,
+      authorization: authorizationFor(headers, authMethod, bearer_token),
+    }),
+  ),
+);
+
+export const MonitorListSchema = v.record(v.string(), MonitorSchema);
+
+const OkResponseSchema = v.object({ ok: v.literal(true) });
+const FailedResponseSchema = v.object({
+  msg: v.string(),
+  ok: v.literal(false),
+});
+const BasicResponseSchema = v.union([OkResponseSchema, FailedResponseSchema]);
+
+const PlainLoginFailureSchema = v.object({
+  msg: v.string(),
+  msgi18n: v.optional(v.literal(false)),
+  ok: v.literal(false),
+});
+const IncorrectCredentialsSchema = v.object({
+  msg: v.literal("authIncorrectCreds"),
+  msgi18n: v.literal(true),
+  ok: v.literal(false),
+});
+
+export const LoginResponseSchema = v.union([
+  OkResponseSchema,
+  IncorrectCredentialsSchema,
+  PlainLoginFailureSchema,
+  v.object({ tokenRequired: v.literal(true) }),
+]);
+
+export const AddResponseSchema = v.union([
+  v.object({ monitorID: integerAtLeast(1), ok: v.literal(true) }),
+  FailedResponseSchema,
+]);
+
+export const parseKumaResponse = <TSchema extends v.GenericSchema>(
+  schema: TSchema,
+  value: unknown,
+): v.InferOutput<TSchema> =>
+  parseOrThrow(schema, value, () => new UptimeKumaError("invalid_response"));
+
+export const requireOk = (value: unknown): void => {
+  const response = parseKumaResponse(BasicResponseSchema, value);
+  if (!response.ok) throw new Error(response.msg);
+};

--- a/src/shared/uptime-kuma/socket.ts
+++ b/src/shared/uptime-kuma/socket.ts
@@ -1,7 +1,9 @@
 import * as v from "valibot";
 import { UptimeKumaError } from "./error.ts";
 
-type SocketListener = (...args: unknown[]) => void;
+export const SOCKET_TIMEOUT_MS = 10_000;
+
+export type SocketListener = (...args: unknown[]) => void;
 
 export interface UptimeKumaSocket {
   connect(): unknown;

--- a/src/shared/uptime-kuma/version.ts
+++ b/src/shared/uptime-kuma/version.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { UptimeKumaError } from "./error.ts";
 import { withEventTimeout } from "./event-capture.ts";
-import type { UptimeKumaSocket } from "./socket.ts";
+import type { SocketListener, UptimeKumaSocket } from "./socket.ts";
 
 /**
  * Reading Uptime Kuma's post-login version event and checking the server is
@@ -35,8 +35,6 @@ export const requireSupportedVersion = ([major, minor]: [
     throw new UptimeKumaError("unsupported_version");
   }
 };
-
-type SocketListener = (...args: unknown[]) => void;
 
 type VersionOutcome = { error: unknown; ok: false } | { ok: true };
 

--- a/src/shared/uptime-kuma/version.ts
+++ b/src/shared/uptime-kuma/version.ts
@@ -1,0 +1,81 @@
+import * as v from "valibot";
+import { UptimeKumaError } from "./error.ts";
+import { withEventTimeout } from "./event-capture.ts";
+import type { UptimeKumaSocket } from "./socket.ts";
+
+/**
+ * Reading Uptime Kuma's post-login version event and checking the server is
+ * supported (2.4 or later).
+ *
+ * Kuma sends an `info` event carrying the server version. The first `info`
+ * frame after login is version-less, so the capture stays open until a
+ * version-bearing one arrives.
+ */
+
+export const VersionNumberSchema = v.pipe(
+  v.string(),
+  v.regex(/^\d+$/),
+  v.transform(Number),
+  v.safeInteger(),
+);
+
+export const VersionSchema = v.pipe(
+  v.string(),
+  v.transform((version) => version.split(".")),
+  v.tuple([VersionNumberSchema, VersionNumberSchema]),
+);
+
+const InfoSchema = v.object({ version: v.optional(VersionSchema) });
+
+export const requireSupportedVersion = ([major, minor]: [
+  number,
+  number,
+]): void => {
+  if (major < 2 || (major === 2 && minor < 4)) {
+    throw new UptimeKumaError("unsupported_version");
+  }
+};
+
+type SocketListener = (...args: unknown[]) => void;
+
+type VersionOutcome = { error: unknown; ok: false } | { ok: true };
+
+type VersionCapture = {
+  cancel: () => void;
+  read: () => Promise<void>;
+};
+
+/**
+ * Captures a `info` event from Kuma, staying open through the first
+ * version-less frame until the version-bearing one arrives, then checks the
+ * server is supported. Resolves on a supported version or throws once the
+ * versioned `info` event has been seen.
+ */
+export const captureVersion = (socket: UptimeKumaSocket): VersionCapture => {
+  let listener: SocketListener;
+  const promise = new Promise<VersionOutcome>((resolve) => {
+    listener = (value) => {
+      try {
+        const parsed = v.safeParse(InfoSchema, value);
+        if (!parsed.success) throw new UptimeKumaError("unsupported_version");
+        const info = parsed.output;
+        if (info.version === undefined) {
+          socket.once("info", listener);
+          return;
+        }
+        requireSupportedVersion(info.version);
+        resolve({ ok: true });
+      } catch (error) {
+        resolve({ error, ok: false });
+      }
+    };
+    socket.once("info", listener);
+  });
+  return {
+    cancel: () => socket.off("info", listener),
+    read: async (): Promise<void> => {
+      const outcome = await withEventTimeout(promise, "info");
+      if (!outcome.ok) throw outcome.error;
+    },
+  };
+};

--- a/src/ui/templates/admin/built-sites/panels.tsx
+++ b/src/ui/templates/admin/built-sites/panels.tsx
@@ -9,10 +9,8 @@ import {
   type SiteSecretsView,
 } from "#shared/site-secrets.ts";
 import type { BuiltSiteUpdateState } from "#shared/site-update.ts";
-import type {
-  UptimeKumaMonitorDetails,
-  UptimeKumaMonitorState,
-} from "#shared/uptime-kuma/monitors.ts";
+import type { UptimeKumaMonitorDetails } from "#shared/uptime-kuma/matching.ts";
+import type { UptimeKumaMonitorState } from "#shared/uptime-kuma/monitors.ts";
 import { WritableOnly } from "#templates/admin/writable-only.tsx";
 import {
   Icon,


### PR DESCRIPTION
## What changed

The Uptime Kuma code was written feature-first across two large files. This PR restructures it to match the patterns our codebase expects: one concept per file, pure data-in/data-out functions, declarative schemas, and curried functional helpers.

### Split the two largest files

**client.ts** (398 lines, 5 concerns) becomes:

- **authorization.ts** (56 lines) — reading the effective Authorization header from Kuma's stored headers and built-in bearer token
- **version.ts** (98 lines) — capturing and checking Kuma's post-login version event
- **schemas.ts** (116 lines) — valibot schemas for monitor-list and response payloads
- **event-capture.ts** (94 lines) — timing out socket events and acknowledgements
- **client.ts** (140 lines) — thin shell: client factory, connect, socket URL

**monitors.ts** (342 lines, 4 concerns) becomes:

- **errors.ts** (34 lines) — mapping typed Kuma failures to catalog copy
- **matching.ts** (210 lines) — pure predicates for finding a site's scheduled monitor
- **monitors.ts** (230 lines) — reconciliation orchestration and the service entry point

### Schema-tize monitor matching

The nine checks that decide whether a Kuma monitor can drive a site's scheduled request (right type, right URL, right auth, accepts 204, not upside-down, no conditions, timeout long enough, etc.) were a chain of `&&` conditions. They are now a declarative `SCHEDULED_MONITOR_RULES` table folded over with `every()`, so adding a new rule is one line in the table, not a new arm on an `if` chain.

### Deduplicate the version timeout

The version capture had its own copy of the `Promise.race` + `setTimeout` timeout pattern. It now calls `withEventTimeout` from event-capture.ts, so the pattern lives in one place.

### Adopt curried functional helpers

The shared-groups filter now uses `pipe(filter(...))` from `#fp` instead of an inline imperative filter.

## No behaviour changes

This is a pure refactor — every test passes unchanged. No production caller sees a different API; the new modules are internal, and the public surface (`uptimeKumaMonitorService`, `uptimeKumaClientApi`, `uptimeKumaSocketFactory`) stays the same.

## Testing

- Full `deno task precommit` passes (typecheck, lint, 0% duplication, 100% coverage)
- All 154 uptime-kuma tests pass unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added robust validation and parsing for Uptime Kuma responses and monitor data.
  * Enhanced scheduled monitor matching to deterministically find the correct monitor and handle duplicates.
  * Added custom authorization support, including normalization to bearer format.
  * Introduced Uptime Kuma version compatibility checks for post-login events.
  * Improved localized, user-friendly error messaging for monitoring failures.
* **Bug Fixes**
  * Improved reliability of Uptime Kuma socket event capture, timeouts, and monitor list retrieval.
  * More consistently returns actionable “found/ambiguous/missing” outcomes during built-site monitor setup.
* **Refactor**
  * Streamlined the Uptime Kuma client flow by centralizing protocol parsing and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->