### PR TITLE
Add social media sized screenshot variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,22 @@ capture. Pass their path with `--scenario`; the scenario's `name` sets the PNG
 filename directly inside `--output`. A scenario can set its own viewport when a
 wider layout is part of the screenshot.
 
+Pass `--social` (one of `facebook`, `instagram-landscape`,
+`instagram-portrait`, `instagram-square`, a comma-separated list, or `all`) to
+also write a social-media-sized copy of each screenshot next to the original.
+The runner takes the page background colour and extends one side of the canvas
+until the image reaches the target's aspect ratio, then downscales to the
+target's pixel size if the result is larger. Variants are named
+`<theme>/<name>__<target>.png` (or `<scenario-name>__<target>.png` for
+scenarios). For example, `dashboard__facebook.png` is the Facebook share size
+(1200 by 630px) of the dashboard screenshot.
+
+```bash
+deno task screenshot all --social facebook,instagram-portrait
+deno task screenshot dashboard --social all
+```
+
+
 ```bash
 # Install Deno, cache dependencies, run all checks
 ./setup.sh

--- a/scripts/screenshots.ts
+++ b/scripts/screenshots.ts
@@ -9,6 +9,7 @@ import {
   isolateElementCss,
   wasImageTrimmed,
 } from "./screenshots/checks.ts";
+import { parseRgb, type Rgb } from "./screenshots/color.ts";
 import {
   parseScreenshotOptions,
   type ScreenshotName,
@@ -23,6 +24,10 @@ import {
   startWithFailureCleanup,
   waitForHealthy,
 } from "./screenshots/server.ts";
+import {
+  applySocialTarget,
+  type SocialTargetName,
+} from "./screenshots/social.ts";
 import {
   findAvailablePort,
   startStripeMock,
@@ -261,19 +266,17 @@ const applyTheme = async (
   await submit(page, 'form[action="/admin/settings/custom-css"]');
 };
 
-interface Rgb {
-  b: number;
-  g: number;
-  r: number;
-}
-
-const parseRgb = (color: string): Rgb => {
-  const channels = color.match(/\d+/g)?.slice(0, 3).map(Number);
-  if (channels?.length !== 3) {
-    throw new Error(`Could not read screenshot background colour: ${color}`);
-  }
-  return { b: channels[2]!, g: channels[1]!, r: channels[0]! };
-};
+const readBodyBackground = async (page: Page): Promise<Rgb> =>
+  parseRgb(
+    await page.locator("body").evaluate((node) => {
+      const getStyle = Reflect.get(globalThis, "getComputedStyle");
+      const style = Reflect.apply(getStyle, globalThis, [node]);
+      if (typeof style !== "object" || style === null) {
+        throw new Error("Could not read the page style.");
+      }
+      return String(Reflect.get(style, "backgroundColor"));
+    }),
+  );
 
 const trimElementScreenshot = async (
   png: Uint8Array,
@@ -309,7 +312,7 @@ const capture = async (
   name: ScreenshotName,
   outputPath: string,
   elementSelector?: string,
-): Promise<void> => {
+): Promise<Rgb> => {
   const scene = SCENES[name];
   await page.goto(`${baseUrl}${scene.path(context)}`, {
     waitUntil: "networkidle",
@@ -317,7 +320,7 @@ const capture = async (
   await scene.prepare?.(page);
   await page.waitForFunction('document.fonts.status === "loaded"');
   await scene.verify?.(page);
-  await capturePreparedPage(page, outputPath, elementSelector);
+  return await capturePreparedPage(page, outputPath, elementSelector);
 };
 
 const capturePreparedPage = async (
@@ -325,7 +328,7 @@ const capturePreparedPage = async (
   outputPath: string,
   elementSelector?: string,
   fullPage = false,
-): Promise<void> => {
+): Promise<Rgb> => {
   if (elementSelector) {
     const initialViewport = page.viewportSize();
     if (!initialViewport) {
@@ -350,23 +353,38 @@ const capturePreparedPage = async (
         { block: "center" },
       ]),
     );
-    const backgroundColor = await page.locator("body").evaluate((node) => {
-      const getStyle = Reflect.get(globalThis, "getComputedStyle");
-      const style = Reflect.apply(getStyle, globalThis, [node]);
-      if (typeof style !== "object" || style === null) {
-        throw new Error("Could not read the page style.");
-      }
-      return String(Reflect.get(style, "backgroundColor"));
-    });
+    const background = await readBodyBackground(page);
     await trimElementScreenshot(
       await page.screenshot(),
-      parseRgb(backgroundColor),
+      background,
       outputPath,
     );
     await page.setViewportSize(initialViewport);
-    return;
+    return background;
   }
+  const background = await readBodyBackground(page);
   await page.screenshot({ fullPage, path: outputPath });
+  return background;
+};
+
+const writeSocialVariants = async (
+  sourcePath: string,
+  outputDir: string,
+  baseName: string,
+  logPrefix: string,
+  background: Rgb,
+  targets: readonly SocialTargetName[],
+): Promise<void> => {
+  for (const target of targets) {
+    const variantName = `${baseName}__${target}`;
+    await applySocialTarget(
+      sourcePath,
+      join(outputDir, `${variantName}.png`),
+      target,
+      background,
+    );
+    console.log(`${logPrefix}${variantName}.png`);
+  }
 };
 
 const captureScenario = async (
@@ -374,6 +392,7 @@ const captureScenario = async (
   page: Page,
   server: AppServer,
   outputDir: string,
+  social: readonly SocialTargetName[] = [],
 ): Promise<void> => {
   const { baseUrl } = server;
   await setupAdmin(page, baseUrl, scenario.setupUsername);
@@ -400,13 +419,21 @@ const captureScenario = async (
   });
   await page.waitForFunction('document.fonts.status === "loaded"');
   const outputPath = join(outputDir, `${scenario.name}.png`);
-  await capturePreparedPage(
+  const background = await capturePreparedPage(
     page,
     outputPath,
     scenario.elementSelector,
     scenario.fullPage,
   );
   console.log(`${scenario.name}.png`);
+  await writeSocialVariants(
+    outputPath,
+    outputDir,
+    scenario.name,
+    "",
+    background,
+    social,
+  );
 };
 
 const chromiumExecutable = async (): Promise<string | undefined> => {
@@ -449,7 +476,13 @@ const main = async (): Promise<void> => {
     const page = await context.newPage();
     page.setDefaultTimeout(TIMEOUT_MS);
     if (scenario) {
-      await captureScenario(scenario, page, server, outputDir);
+      await captureScenario(
+        scenario,
+        page,
+        server,
+        outputDir,
+        options.social ?? [],
+      );
       return;
     }
     const sceneContext = await setupApp(page, server);
@@ -466,7 +499,7 @@ const main = async (): Promise<void> => {
           elementSelector ? isolateElementCss(elementSelector) : "",
         );
         const outputPath = join(themeDir, `${name}.png`);
-        await capture(
+        const background = await capture(
           page,
           server.baseUrl,
           sceneContext,
@@ -475,6 +508,14 @@ const main = async (): Promise<void> => {
           elementSelector,
         );
         console.log(`${theme}/${name}.png`);
+        await writeSocialVariants(
+          outputPath,
+          themeDir,
+          name,
+          `${theme}/`,
+          background,
+          options.social ?? [],
+        );
       }
     }
   } finally {

--- a/scripts/screenshots/color.ts
+++ b/scripts/screenshots/color.ts
@@ -1,0 +1,13 @@
+export interface Rgb {
+  b: number;
+  g: number;
+  r: number;
+}
+
+export const parseRgb = (color: string): Rgb => {
+  const channels = color.match(/\d+/g)?.slice(0, 3).map(Number);
+  if (channels?.length !== 3) {
+    throw new Error(`Could not read screenshot background colour: ${color}`);
+  }
+  return { b: channels[2]!, g: channels[1]!, r: channels[0]! };
+};

--- a/scripts/screenshots/options.ts
+++ b/scripts/screenshots/options.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "@std/cli/parse-args";
+import { SOCIAL_TARGET_NAMES, type SocialTargetName } from "./social.ts";
 
 export const SCREENSHOT_NAMES = [
   "dashboard",
@@ -27,6 +28,7 @@ export interface ScreenshotOptions {
   names: ScreenshotName[];
   outputDir: string;
   scenarioPath?: string;
+  social?: SocialTargetName[];
   themes: ThemeName[];
 }
 
@@ -50,7 +52,7 @@ export const parseScreenshotOptions = (args: string[]): ScreenshotOptions => {
   const parsed = parseArgs(args, {
     alias: { o: "output", t: "theme" },
     default: { output: "screenshots", theme: "default" },
-    string: ["element", "output", "scenario", "theme"],
+    string: ["element", "output", "scenario", "social", "theme"],
   });
   if (parsed._.length > 1) {
     throw new Error(
@@ -68,6 +70,15 @@ export const parseScreenshotOptions = (args: string[]): ScreenshotOptions => {
       : selections(SCREENSHOT_NAMES, requestedNames, "screenshot"),
     outputDir: parsed.output,
     ...(parsed.scenario ? { scenarioPath: parsed.scenario } : {}),
+    ...(parsed.social
+      ? {
+          social: selections(
+            SOCIAL_TARGET_NAMES,
+            parsed.social,
+            "social target",
+          ),
+        }
+      : {}),
     themes: selections(THEME_NAMES, parsed.theme, "theme"),
   };
 };

--- a/scripts/screenshots/social.ts
+++ b/scripts/screenshots/social.ts
@@ -1,0 +1,81 @@
+import type { Rgb } from "./color.ts";
+
+export interface SocialTargetSize {
+  height: number;
+  width: number;
+}
+
+export const SOCIAL_TARGET_SIZES = {
+  facebook: { height: 630, width: 1200 },
+  "instagram-landscape": { height: 566, width: 1080 },
+  "instagram-portrait": { height: 1350, width: 1080 },
+  "instagram-square": { height: 1080, width: 1080 },
+} as const satisfies Record<string, SocialTargetSize>;
+
+export type SocialTargetName = keyof typeof SOCIAL_TARGET_SIZES;
+
+export const SOCIAL_TARGET_NAMES = Object.keys(
+  SOCIAL_TARGET_SIZES,
+) as SocialTargetName[];
+
+const noPadding = { bottom: 0, left: 0, right: 0, top: 0 };
+
+export interface SocialExtensionPlan {
+  extend: { bottom: number; left: number; right: number; top: number };
+  finalHeight: number;
+  finalWidth: number;
+}
+
+export const planSocialExtension = (
+  source: { height: number; width: number },
+  target: SocialTargetSize,
+): SocialExtensionPlan => {
+  const sourceRatio = source.width / source.height;
+  const targetRatio = target.width / target.height;
+  if (sourceRatio === targetRatio) {
+    return {
+      extend: noPadding,
+      finalHeight: source.height,
+      finalWidth: source.width,
+    };
+  }
+  if (sourceRatio < targetRatio) {
+    const finalWidth = Math.round(source.height * targetRatio);
+    return {
+      extend: { ...noPadding, left: finalWidth - source.width },
+      finalHeight: source.height,
+      finalWidth,
+    };
+  }
+  const finalHeight = Math.round(source.width / targetRatio);
+  return {
+    extend: { ...noPadding, bottom: finalHeight - source.height },
+    finalHeight,
+    finalWidth: source.width,
+  };
+};
+
+export const applySocialTarget = async (
+  inputPath: string,
+  outputPath: string,
+  target: SocialTargetName,
+  background: Rgb,
+): Promise<void> => {
+  const { default: sharp } = await import("sharp");
+  const size = SOCIAL_TARGET_SIZES[target];
+  const image = sharp(inputPath);
+  const meta = await image.metadata();
+  const plan = planSocialExtension(
+    { height: meta.height!, width: meta.width! },
+    size,
+  );
+  const extended = await image
+    .extend({ background, ...plan.extend })
+    .png()
+    .toBuffer();
+  const scaled =
+    plan.finalWidth > size.width
+      ? sharp(extended).resize(size.width, size.height, { fit: "fill" })
+      : sharp(extended);
+  await scaled.png().toFile(outputPath);
+};

--- a/test/scripts/screenshots-color.test.ts
+++ b/test/scripts/screenshots-color.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { parseRgb } from "#scripts/screenshots/color.ts";
+
+describe("screenshot colour", () => {
+  it("reads the red, green, and blue parts of an rgb() string", () => {
+    expect(parseRgb("rgb(255, 128, 64)")).toEqual({
+      b: 64,
+      g: 128,
+      r: 255,
+    });
+  });
+
+  it("ignores the alpha channel of an rgba() string", () => {
+    expect(parseRgb("rgba(10, 20, 30, 0.5)")).toEqual({ b: 30, g: 20, r: 10 });
+  });
+
+  it("throws when the colour is not a number triple", () => {
+    expect(() => parseRgb("transparent")).toThrow(
+      "Could not read screenshot background colour: transparent",
+    );
+  });
+
+  it("throws when the colour only has two channels", () => {
+    expect(() => parseRgb("rgb(1, 2)")).toThrow(
+      "Could not read screenshot background colour: rgb(1, 2)",
+    );
+  });
+});

--- a/test/scripts/screenshots-options.test.ts
+++ b/test/scripts/screenshots-options.test.ts
@@ -5,6 +5,7 @@ import {
   SCREENSHOT_NAMES,
   THEME_NAMES,
 } from "#scripts/screenshots/options.ts";
+import { SOCIAL_TARGET_NAMES } from "#scripts/screenshots/social.ts";
 
 describe("screenshot options", () => {
   it("captures every scene with the default theme when no options are given", () => {
@@ -52,6 +53,39 @@ describe("screenshot options", () => {
       scenarioPath: "../tickets-site/scripts/screenshots/charity-events.js",
       themes: ["default"],
     });
+  });
+
+  it("accepts a single social target", () => {
+    expect(
+      parseScreenshotOptions(["dashboard", "--social", "facebook"]),
+    ).toEqual({
+      names: ["dashboard"],
+      outputDir: "screenshots",
+      social: ["facebook"],
+      themes: ["default"],
+    });
+  });
+
+  it("accepts a comma-separated list of social targets", () => {
+    expect(
+      parseScreenshotOptions([
+        "dashboard",
+        "--social",
+        "facebook,instagram-square",
+      ]).social,
+    ).toEqual(["facebook", "instagram-square"]);
+  });
+
+  it("expands all social targets", () => {
+    expect(
+      parseScreenshotOptions(["dashboard", "--social", "all"]).social,
+    ).toEqual(SOCIAL_TARGET_NAMES);
+  });
+
+  it("rejects unknown social targets", () => {
+    expect(
+      () => parseScreenshotOptions(["dashboard", "--social", "twitter"]).social,
+    ).toThrow("Unknown social target: twitter");
   });
 
   it("rejects a scenario combined with a built-in scene", () => {

--- a/test/scripts/screenshots-social.test.ts
+++ b/test/scripts/screenshots-social.test.ts
@@ -1,0 +1,148 @@
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+import sharp from "sharp";
+import {
+  applySocialTarget,
+  planSocialExtension,
+  SOCIAL_TARGET_NAMES,
+  SOCIAL_TARGET_SIZES,
+} from "#scripts/screenshots/social.ts";
+
+describe("social target sizes", () => {
+  it("defines the recommended share sizes for facebook and instagram", () => {
+    expect(SOCIAL_TARGET_SIZES).toEqual({
+      facebook: { height: 630, width: 1200 },
+      "instagram-landscape": { height: 566, width: 1080 },
+      "instagram-portrait": { height: 1350, width: 1080 },
+      "instagram-square": { height: 1080, width: 1080 },
+    });
+  });
+
+  it("lists every target name", () => {
+    expect(SOCIAL_TARGET_NAMES).toEqual([
+      "facebook",
+      "instagram-landscape",
+      "instagram-portrait",
+      "instagram-square",
+    ]);
+  });
+});
+
+describe("planSocialExtension", () => {
+  it("extends the left edge when the source is taller than the target ratio", () => {
+    const plan = planSocialExtension(
+      { height: 400, width: 200 },
+      SOCIAL_TARGET_SIZES.facebook,
+    );
+    expect(plan.extend).toEqual({ bottom: 0, left: 562, right: 0, top: 0 });
+    expect(plan.finalHeight).toBe(400);
+    expect(plan.finalWidth).toBe(762);
+  });
+
+  it("extends the bottom edge when the source is wider than the target ratio", () => {
+    const plan = planSocialExtension(
+      { height: 100, width: 400 },
+      SOCIAL_TARGET_SIZES["instagram-portrait"],
+    );
+    expect(plan.extend).toEqual({ bottom: 400, left: 0, right: 0, top: 0 });
+    expect(plan.finalHeight).toBe(500);
+    expect(plan.finalWidth).toBe(400);
+  });
+
+  it("leaves the image untouched when the source already matches the target ratio", () => {
+    const plan = planSocialExtension(
+      { height: 630, width: 1200 },
+      SOCIAL_TARGET_SIZES.facebook,
+    );
+    expect(plan.extend).toEqual({ bottom: 0, left: 0, right: 0, top: 0 });
+    expect(plan.finalHeight).toBe(630);
+    expect(plan.finalWidth).toBe(1200);
+  });
+});
+
+describe("applySocialTarget", () => {
+  const background = { b: 255, g: 255, r: 255 };
+
+  const makeSourcePng = async (
+    path: string,
+    height: number,
+    width: number,
+  ): Promise<void> => {
+    await sharp({
+      create: {
+        background: { alpha: 1, b: 255, g: 255, r: 255 },
+        channels: 4,
+        height,
+        width,
+      },
+    } as never)
+      .png()
+      .toFile(path);
+  };
+
+  const dimensionsOf = async (
+    path: string,
+  ): Promise<{ height: number; width: number }> => {
+    const meta = await sharp(path).metadata();
+    if (!meta.width || !meta.height) {
+      throw new Error(`Could not read image: ${path}`);
+    }
+    return { height: meta.height, width: meta.width };
+  };
+
+  for (const target of SOCIAL_TARGET_NAMES) {
+    it(`extends and downscales a mobile screenshot to the ${target} size`, async () => {
+      const tmpDir = await Deno.makeTempDir({
+        prefix: `screenshots-social-${target}-`,
+      });
+      try {
+        const sourcePath = join(tmpDir, "source.png");
+        const outputPath = join(tmpDir, "variant.png");
+        await makeSourcePng(sourcePath, 1688, 780);
+        await applySocialTarget(sourcePath, outputPath, target, background);
+        expect(await dimensionsOf(outputPath)).toEqual(
+          SOCIAL_TARGET_SIZES[target],
+        );
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    });
+  }
+
+  it("keeps a source smaller than the target instead of upscaling", async () => {
+    const tmpDir = await Deno.makeTempDir({
+      prefix: "screenshots-social-small-",
+    });
+    try {
+      const sourcePath = join(tmpDir, "source.png");
+      const outputPath = join(tmpDir, "variant.png");
+      await makeSourcePng(sourcePath, 400, 200);
+      await applySocialTarget(sourcePath, outputPath, "facebook", background);
+      expect(await dimensionsOf(outputPath)).toEqual({
+        height: 400,
+        width: 762,
+      });
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  });
+
+  it("copies a source that already matches the target size", async () => {
+    const tmpDir = await Deno.makeTempDir({
+      prefix: "screenshots-social-exact-",
+    });
+    try {
+      const sourcePath = join(tmpDir, "source.png");
+      const outputPath = join(tmpDir, "variant.png");
+      await makeSourcePng(sourcePath, 630, 1200);
+      await applySocialTarget(sourcePath, outputPath, "facebook", background);
+      expect(await dimensionsOf(outputPath)).toEqual({
+        height: 630,
+        width: 1200,
+      });
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## What changed

The screenshot runner now has a `--social` flag. When set, each capture is also written as a social-media-sized copy next to the original PNG.

The runner takes the page background colour and extends the left edge of the canvas until the image reaches the target's aspect ratio (pushing the original screenshot content to the right side and leaving clear space on the left for text overlay), then downscales to the target's pixel size if the result is larger than the target.

Variants are named `<name>__<target>.png` (or `<scenario-name>__<target>.png` for scenarios), so they sit next to the originals and the default behaviour is unchanged when the flag is off.

## Why

The tickets marketing site needs a screenshot gallery for Facebook and Instagram. The existing screenshots are mobile-aspect-ratio (390×844 at 2x), which don't fit social share sizes. This flag produces correctly-sized variants from the same scenarios we already use for the regular screenshots, without changing the originals.

## Supported targets

`facebook` (1200×630), `instagram-landscape` (1080×566), `instagram-portrait` (1080×1350), `instagram-square` (1080×1080). Pass a single name, a comma-separated list, or `all`.

## Usage

```bash
deno task screenshot all --social facebook,instagram-portrait
deno task screenshot dashboard --social all
deno task screenshot --scenario ../tickets-site/scripts/screenshots/charity-events.js --social facebook
```

## How it works

- `scripts/screenshots/color.ts` — extracts the existing `Rgb` type and `parseRgb` helper so both the screenshot runner and the new social module share them.
- `scripts/screenshots/social.ts` — declares the target sizes, a pure `planSocialExtension` helper that decides which side to extend by how much (left when the source is taller than the target ratio, bottom when wider), and `applySocialTarget` that loads sharp lazily, extends the canvas, and downscales only when larger than the target.
- `scripts/screenshots/options.ts` — `--social` flag parsed with the existing `selections` helper, consistent with `--theme`.
- `scripts/screenshots.ts` — `capturePreparedPage` / `capture` / `captureScenario` now return the page background colour, and the runner calls `writeSocialVariants` after every capture when `--social` is set.

## Tests

New unit tests cover the pure `planSocialExtension` helper (left/bottom/no-op cases), `parseRgb`, and `applySocialTarget` against real sharp-processed PNGs for every target. The existing options tests cover the new `--social` flag (single, comma-separated, `all`, unknown). All new files have 100% line and branch coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--social` option to the screenshot runner.
  - Generate social-media-ready screenshot variants for selected platforms or all supported targets.
  - Social images are automatically extended, resized, and named according to the documented convention.

- **Documentation**
  - Updated screenshot documentation with supported values, behavior details, and command examples.

- **Tests**
  - Added coverage for social target parsing, image sizing, background handling, and output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->