### PR TITLE
Harden payment, SMS webhook, and order gallery tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1380,3 +1380,19 @@ production module — a small production change that was out of scope for the
 test-only PR. Starting point: add `export` to the `const REFRESH_DELAY_MS`
 declaration, then replace the hard-coded `199` in the "waits for the debounce
 delay" test with `REFRESH_DELAY_MS - 1`.
+
+## Split the sms-webhook test suite
+
+*Origin: Codex review on PR #1909 (independent test hardening).*
+
+`test/features/api/sms-webhook.test.ts` is 461 lines (the ~400-line target
+applies to test files too). It bundles three concerns that can stand alone:
+phone-index normalisation/unit tests (`describeWithEnv({ encryptionKey: true })`),
+attendee phone-index DB tests (`describeWithEnv({ db: true })`), and the webhook
+handler tests (`describeWithEnv({ db: true })`). The file was already 427 lines
+on main; the independent-test-hardening PR added 34 lines of new webhook coverage.
+Splitting now was deferred because the PR's brief was test hardening, not test
+reorganisation. Starting point: move the two phone-index describe blocks into
+`test/shared/sms/phone-index.test.ts`, keeping the `makeAttendee` /
+`storedPhoneIndex` helpers in whichever file needs them (or lift to `#test-utils`
+if both do). The webhook test file drops to ~380 lines.

--- a/TODO.md
+++ b/TODO.md
@@ -1366,3 +1366,17 @@ cold-start PR would balloon the diff with unrelated mechanical test moves and
 re-conflict with the import-only changes that are the actual subject of the
 PR. The ~400-line target is guidance, and the cold-start PR's brief was
 explicitly about import-graph narrowing, not test reorganisation.
+
+## Export REFRESH_DELAY_MS for test reuse
+
+*Origin: CodeRabbit review on PR #1909 (independent test hardening).*
+
+`src/ui/client/admin/order-gallery.ts` declares `const REFRESH_DELAY_MS = 200`
+privately. The debounce-timing test in `test/ui/client/admin/order-gallery.test.ts`
+hard-codes `199` and `1` to assert the exact 200 ms boundary. Importing the
+production constant (`REFRESH_DELAY_MS - 1` then `1`) would keep the test aligned
+if the delay changes. This requires exporting `REFRESH_DELAY_MS` from the
+production module — a small production change that was out of scope for the
+test-only PR. Starting point: add `export` to the `const REFRESH_DELAY_MS`
+declaration, then replace the hard-coded `199` in the "waits for the debounce
+delay" test with `REFRESH_DELAY_MS - 1`.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -51,6 +51,7 @@ src/features/admin/entity-pages.ts:307:24  ?? → ||   # opts.query is a URLSear
 src/features/admin/site-content-page.ts:78:38  ?? → ||   # extraTabs is an array when present, and arrays are always truthy
 src/ui/templates/admin/holidays.tsx:79:45  ?? → ||   # values is a render-values object when present, so it is always truthy
 src/ui/client/admin/manual-checkin.ts:59:36  ?? → ||   # textContent is string|null; its only falsy string is the empty fallback itself
+src/ui/client/admin/order-gallery.ts:105:34  ?? → ||   # states is a record object when present, so it is always truthy
 
 # `x ?? F` vs `x || F` differ only when x is falsy-but-not-null; these are all
 # cases where x can't be such a value, or F equals the only one it can be.
@@ -914,3 +915,12 @@ src/features/api/payment-processing/package-pricing.ts:228:45  false → true   
 src/features/api/payment-processing/package-pricing.ts:243:19  false → true   # hideListings changes node visibility only, while edgeDrifted reads node keys and child structure, never visibility
 src/features/api/payment-processing/package-pricing.ts:260:60  ?? → ||   # intent.allocations is an array or undefined, and arrays (including []) are truthy
 src/features/api/payment-processing/package-pricing.ts:296:51  ?? → ||   # the allocated quantity is non-negative and the fallback is 0, so both operators agree for 0 and undefined
+
+# processed-payments failure_data label: the "processed_payments.failure_data"
+# context string only surfaces in errors thrown inside defineStoredJson.read/.write.
+# parseSessionFailure catches every read error and substitutes CORRUPT_FAILURE, and
+# markSessionFailed only writes valid StoredPaymentFailure inputs (its public type
+# guards the schema), so the write path never throws. The label is unobservable
+# through the public API regardless of its value.
+src/shared/db/processed-payments.ts:260:43  processed_payments.failure_data → ""   # write-path label: write never throws on valid input, and the label lives only in its error message
+src/shared/db/processed-payments.ts:287:7  processed_payments.failure_data → ""   # read-path label: read errors are caught and replaced with CORRUPT_FAILURE before the message can be observed

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -916,11 +916,11 @@ src/features/api/payment-processing/package-pricing.ts:243:19  false → true   
 src/features/api/payment-processing/package-pricing.ts:260:60  ?? → ||   # intent.allocations is an array or undefined, and arrays (including []) are truthy
 src/features/api/payment-processing/package-pricing.ts:296:51  ?? → ||   # the allocated quantity is non-negative and the fallback is 0, so both operators agree for 0 and undefined
 
-# processed-payments failure_data label: the "processed_payments.failure_data"
-# context string only surfaces in errors thrown inside defineStoredJson.read/.write.
-# parseSessionFailure catches every read error and substitutes CORRUPT_FAILURE, and
-# markSessionFailed only writes valid StoredPaymentFailure inputs (its public type
-# guards the schema), so the write path never throws. The label is unobservable
-# through the public API regardless of its value.
-src/shared/db/processed-payments.ts:260:43  processed_payments.failure_data → ""   # write-path label: write never throws on valid input, and the label lives only in its error message
+# processed-payments read-path failure_data label: the
+# "processed_payments.failure_data" context string surfaces only in errors
+# thrown inside defineStoredJson.read. parseSessionFailure catches every read
+# error and substitutes CORRUPT_FAILURE, so the label never reaches an
+# observable assertion. The write-path label is killed by a direct test that
+# passes an invalid StoredPaymentFailure to markSessionFailed and asserts the
+# error message carries the label.
 src/shared/db/processed-payments.ts:287:7  processed_payments.failure_data → ""   # read-path label: read errors are caught and replaced with CORRUPT_FAILURE before the message can be observed

--- a/test/features/api/sms-webhook.test.ts
+++ b/test/features/api/sms-webhook.test.ts
@@ -260,7 +260,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
     expect(await res.json()).toEqual({ error: "Invalid payload" });
   });
 
-  test("cleanup preserves a provider-message row within retention", async () => {
+  test("cleanup preserves a provider-message row within retention and prunes an expired one", async () => {
     await configure();
     const attendee = await makeAttendee();
     await recordSmsMessage({
@@ -268,9 +268,18 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
       listingId: 1,
       providerId: "msg-fresh",
     });
+    await recordSmsMessage({
+      attendeeId: attendee.id,
+      listingId: 1,
+      providerId: "msg-stale",
+    });
     await execute(
       "UPDATE sms_messages SET created = datetime('now', '-1 day') WHERE provider_id = ?",
       ["msg-fresh"],
+    );
+    await execute(
+      "UPDATE sms_messages SET created = datetime('now', '-31 days') WHERE provider_id = ?",
+      ["msg-stale"],
     );
 
     await postWebhook({ event: "sms:sent", payload: {} });
@@ -278,6 +287,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
     expect((await getSmsMessageByProviderId("msg-fresh"))?.provider_id).toBe(
       "msg-fresh",
     );
+    expect(await getSmsMessageByProviderId("msg-stale")).toBeNull();
   });
 
   test("delivered logs against the attendee and clears the row", async () => {

--- a/test/features/api/sms-webhook.test.ts
+++ b/test/features/api/sms-webhook.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import { handleRequest } from "#routes";
 import {
   findAttendeeIdByPhoneIndex,
@@ -194,11 +195,17 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
 
   test("timestamp at the future tolerance boundary succeeds", async () => {
     await configure();
-    const res = await postWebhook(
-      { event: "sms:sent", payload: {} },
-      { timestamp: currentTimestamp(300) },
-    );
-    expect(res.status).toBe(200);
+    const clock = new FakeTime(Date.now());
+    try {
+      const ts = String(Math.floor(Date.now() / 1000) + 300);
+      const res = await postWebhook(
+        { event: "sms:sent", payload: {} },
+        { timestamp: ts },
+      );
+      expect(res.status).toBe(200);
+    } finally {
+      clock.restore();
+    }
   });
 
   test("missing timestamp fails", async () => {

--- a/test/features/api/sms-webhook.test.ts
+++ b/test/features/api/sms-webhook.test.ts
@@ -5,7 +5,7 @@ import {
   findAttendeeIdByPhoneIndex,
   setAttendeePhoneIndexIfEmpty,
 } from "#shared/db/attendee-phone-index.ts";
-import { queryOne } from "#shared/db/client.ts";
+import { execute, queryOne } from "#shared/db/client.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   getSmsMessageByProviderId,
@@ -170,6 +170,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
   test("404 when the webhook secret is not configured", async () => {
     const res = await postWebhook({ event: "sms:received", payload: {} });
     expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not configured" });
   });
 
   test("401 on an invalid signature", async () => {
@@ -181,11 +182,22 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
       },
     );
     expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Invalid signature" });
   });
 
   test("valid signature with a current timestamp succeeds", async () => {
     await configure();
     const res = await postWebhook({ event: "sms:received", payload: {} });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("timestamp at the future tolerance boundary succeeds", async () => {
+    await configure();
+    const res = await postWebhook(
+      { event: "sms:sent", payload: {} },
+      { timestamp: currentTimestamp(300) },
+    );
     expect(res.status).toBe(200);
   });
 
@@ -238,12 +250,34 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
     await configure();
     const res = await postWebhook(null, { rawBody: "not json" });
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON" });
   });
 
   test("400 on a payload missing the event", async () => {
     await configure();
     const res = await postWebhook({ payload: {} });
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid payload" });
+  });
+
+  test("cleanup preserves a provider-message row within retention", async () => {
+    await configure();
+    const attendee = await makeAttendee();
+    await recordSmsMessage({
+      attendeeId: attendee.id,
+      listingId: 1,
+      providerId: "msg-fresh",
+    });
+    await execute(
+      "UPDATE sms_messages SET created = datetime('now', '-1 day') WHERE provider_id = ?",
+      ["msg-fresh"],
+    );
+
+    await postWebhook({ event: "sms:sent", payload: {} });
+
+    expect((await getSmsMessageByProviderId("msg-fresh"))?.provider_id).toBe(
+      "msg-fresh",
+    );
   });
 
   test("delivered logs against the attendee and clears the row", async () => {

--- a/test/shared/db/processed-payments.test.ts
+++ b/test/shared/db/processed-payments.test.ts
@@ -1,12 +1,16 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import { encrypt } from "#shared/crypto/encryption.ts";
 import type { EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
 import { getDb, insert } from "#shared/db/client.ts";
 import {
+  clearSessionTokens,
   decryptSessionTokens,
+  encryptTicketTokens,
   finalizeSessionIfUnresolved,
   isSessionProcessed,
+  isUnresolvedReservation,
   markSessionFailed,
   parseSessionFailure,
   reserveSession,
@@ -209,6 +213,52 @@ describeWithEnv("db > processed payments", { db: true }, () => {
     });
   });
 
+  test("distinguishes unresolved rows from both terminal outcomes", () => {
+    const base = {
+      failure_data: "" as const,
+      payment_reference: "" as const,
+      payment_session_id: "state-shape",
+      processed_at: "2026-07-18T00:00:00.000Z",
+      provider_refunded_at: "",
+      ticket_tokens: "" as const,
+    };
+    expect(isUnresolvedReservation({ ...base, attendee_id: null })).toBe(true);
+    expect(isUnresolvedReservation({ ...base, attendee_id: 1 })).toBe(false);
+    expect(
+      isUnresolvedReservation({
+        ...base,
+        attendee_id: null,
+        failure_data: "encrypted" as EnvKeyEncrypted,
+      }),
+    ).toBe(false);
+  });
+
+  test("rethrows the original non-constraint error", async () => {
+    const sentinel = new Error("write transport failed");
+    const client = getDb();
+    const original = client.execute.bind(client);
+    let first = true;
+    using executeStub = stub(client, "execute", (...args) => {
+      if (first) {
+        first = false;
+        return Promise.reject(sentinel);
+      }
+      return original(...args);
+    });
+    await expect(reserveSession("non-constraint")).rejects.toBe(sentinel);
+    expect(executeStub.calls).toHaveLength(1);
+  });
+
+  test("encrypts multiple ticket tokens with their separator", async () => {
+    expect(
+      await decryptSessionTokens(await encryptTicketTokens(["one", "two"])),
+    ).toBe("one+two");
+  });
+
+  test("returns an exact empty token value without decrypting", async () => {
+    expect(await decryptSessionTokens("")).toBe("");
+  });
+
   describe("finalizeSessionIfUnresolved", () => {
     test("stamps attendee_id on an unresolved reservation, leaving tokens untouched", async () => {
       await reserveSession("sess_heal");
@@ -219,6 +269,15 @@ describeWithEnv("db > processed payments", { db: true }, () => {
       expect(row.attendee_id).toBe(42);
       // The ledger-replay heal never writes ticket_tokens.
       expect(row.ticket_tokens).toBe("");
+      expect(row.payment_reference).toBe("");
+    });
+
+    test("stores a supplied payment reference while healing", async () => {
+      await reserveSession("sess_heal_reference");
+      await finalizeSessionIfUnresolved("sess_heal_reference", 42, "pi_healed");
+      const row = (await isSessionProcessed("sess_heal_reference"))!;
+      expect(row.attendee_id).toBe(42);
+      expect(row.payment_reference).not.toBe("");
     });
 
     test("is a no-op once resolved — preserves a racing delivery's attendee and tokens", async () => {
@@ -238,6 +297,15 @@ describeWithEnv("db > processed payments", { db: true }, () => {
 
     test("is a no-op if the session was pruned", async () => {
       await finalizeSessionIfUnresolved("sess_gone", 1);
+    });
+
+    test("clears stored ticket tokens", async () => {
+      await reserveSession("sess_clear_tokens");
+      await finalizeReservedPayment("sess_clear_tokens", 7, "secret-token");
+      await clearSessionTokens("sess_clear_tokens");
+      expect(
+        (await isSessionProcessed("sess_clear_tokens"))!.ticket_tokens,
+      ).toBe("");
     });
   });
 });

--- a/test/shared/db/processed-payments.test.ts
+++ b/test/shared/db/processed-payments.test.ts
@@ -15,12 +15,17 @@ import {
   parseSessionFailure,
   reserveSession,
   STALE_RESERVATION_MS,
+  type StoredPaymentFailure,
 } from "#shared/db/processed-payments.ts";
 import { nowMs } from "#shared/now.ts";
+import { getTestPrivateKey } from "#test-utils/crypto.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
-import { finalizeReservedPayment } from "#test-utils/processed-payments.ts";
+import {
+  expectProcessedPaymentReference,
+  finalizeReservedPayment,
+} from "#test-utils/processed-payments.ts";
 
 describeWithEnv("db > processed payments", { db: true }, () => {
   describe("reserveSession", () => {
@@ -186,6 +191,14 @@ describeWithEnv("db > processed payments", { db: true }, () => {
       });
     });
 
+    test("markSessionFailed throws a labelled error for an invalid failure", async () => {
+      await expect(
+        markSessionFailed("sess_invalid", {
+          error: 42 as unknown as string,
+        } as StoredPaymentFailure),
+      ).rejects.toThrow("processed_payments.failure_data");
+    });
+
     test("re-throws non-unique-constraint errors", async () => {
       await getDb().execute("DROP TABLE processed_payments");
 
@@ -275,9 +288,12 @@ describeWithEnv("db > processed payments", { db: true }, () => {
     test("stores a supplied payment reference while healing", async () => {
       await reserveSession("sess_heal_reference");
       await finalizeSessionIfUnresolved("sess_heal_reference", 42, "pi_healed");
-      const row = (await isSessionProcessed("sess_heal_reference"))!;
-      expect(row.attendee_id).toBe(42);
-      expect(row.payment_reference).not.toBe("");
+      await expectProcessedPaymentReference(
+        42,
+        "sess_heal_reference",
+        "pi_healed",
+        await getTestPrivateKey(),
+      );
     });
 
     test("is a no-op once resolved — preserves a racing delivery's attendee and tokens", async () => {

--- a/test/ui/client/admin/order-gallery.test.ts
+++ b/test/ui/client/admin/order-gallery.test.ts
@@ -237,7 +237,8 @@ describe("initOrderGallery", () => {
     const label = page
       .cardFor("listing:5")
       .querySelector("[data-order-state-label]");
-    if (label) label.textContent = "Checking availability";
+    expect(label).not.toBeNull();
+    label!.textContent = "Checking availability";
     page.tick("select_package_7", true);
     await settle();
 

--- a/test/ui/client/admin/order-gallery.test.ts
+++ b/test/ui/client/admin/order-gallery.test.ts
@@ -149,6 +149,30 @@ describe("initOrderGallery", () => {
     await settle();
   });
 
+  test("records a selected card only once", async () => {
+    const page = harness();
+    page.tick("select_package_7", true);
+    page.tick("select_package_7", true);
+    expect(page.orderField.value).toBe("package:7");
+    await settle();
+  });
+
+  test("does not record a card that was unticked before it was selected", async () => {
+    const page = harness();
+    page.tick("select_package_7", false);
+    expect(page.orderField.value).toBe("");
+    await settle();
+  });
+
+  test("removes the second selected card from the recorded order", async () => {
+    const page = harness();
+    page.tick("select_package_7", true);
+    page.tick("select_5", true);
+    page.tick("select_5", false);
+    expect(page.orderField.value).toBe("package:7");
+    await settle();
+  });
+
   test("a change outside any card leaves the recorded order alone", async () => {
     const page = harness();
     page.tick("select_5", true);
@@ -184,6 +208,17 @@ describe("initOrderGallery", () => {
     ]);
   });
 
+  test("waits for the debounce delay before checking availability", async () => {
+    const page = harness();
+    page.tick("select_package_7", true);
+    await clock.time!.tickAsync(199);
+    expect(page.requests).toHaveLength(0);
+
+    await clock.time!.tickAsync(1);
+    await clock.time!.runMicrotasks();
+    expect(page.requests).toHaveLength(1);
+  });
+
   test("applies returned states: labels, greying, and the date nudge", async () => {
     const page = harness();
     page.responses.push({
@@ -199,6 +234,10 @@ describe("initOrderGallery", () => {
       },
       ok: true,
     });
+    const label = page
+      .cardFor("listing:5")
+      .querySelector("[data-order-state-label]");
+    if (label) label.textContent = "Checking availability";
     page.tick("select_package_7", true);
     await settle();
 
@@ -242,6 +281,19 @@ describe("initOrderGallery", () => {
     await settle();
     expect(page.boxFor("select_5").disabled).toBe(false);
     expect(page.cardFor("listing:5").dataset.orderState).toBe("unavailable");
+  });
+
+  test("disables an unticked card when it is unavailable", async () => {
+    const page = harness();
+    page.responses.push({
+      body: {
+        states: { "listing:5": { label: "Sold out", state: "unavailable" } },
+      },
+      ok: true,
+    });
+    page.changeField('input[name="start_date"]');
+    await settle();
+    expect(page.boxFor("select_5").disabled).toBe(true);
   });
 
   test("ignores non-OK responses and cards the payload does not name", async () => {


### PR DESCRIPTION
Adds targeted, mutation-resistant coverage for three production modules whose behaviour was already on main but under-tested. No production code changes — every test imports and exercises the real production code.

## What changed

### Processed payments
Covers the unresolved-vs-terminal row lifecycle, error propagation, token encryption/clearing, and payment-reference healing:
- Distinguishes unresolved reservations from both terminal outcomes (finalised success and recorded failure) through `isUnresolvedReservation`.
- Rethrows non-constraint errors through `reserveSession` without entering the UNIQUE-recovery path, using a stub instead of dropping and recreating the table.
- Encrypts multiple ticket tokens with their `+` separator, and short-circuits the empty-token decrypt.
- Heals a payment reference while stamping an unresolved reservation (asserting the exact decrypted value through the production helper), and clears stored ticket tokens after the redirect consumes them.
- Throws a labelled error for an invalid `StoredPaymentFailure` passed to `markSessionFailed`, covering the write-path error label.

### SMS webhook
Covers exact response bodies, the future-tolerance boundary, and cleanup preservation:
- Asserts the exact `{ error }` / `{ ok }` response body for every status path, not just the HTTP status.
- Covers the +300 s future-tolerance boundary that succeeds (main already had the +302 s failure case).
- Preserves a provider-message row within the 30-day retention window and prunes an expired one (31 days old) when an unrelated webhook fires the backstop prune.

### Order gallery
Covers duplicate selection, unticking/removal, exact debounce timing, stale-label replacement, and unavailable-card disabling:
- Records a selected card only once (a duplicate tick is idempotent).
- Does not record a card unticked before it was ever selected.
- Removes the second of two selected cards from the recorded order.
- Waits the exact 200 ms debounce before firing the availability fetch (199 ms = no request, +1 ms = one request).
- Replaces a stale loading label with the returned state label (asserting the label element exists first).
- Disables an unticked card when the payload marks it unavailable.

## Mutation testing

All three modules reach 100% mutation kill rate. Two known-equivalent mutants are recorded in `scripts/mutation/equivalent-mutants.txt`:
- `order-gallery.ts:105:34  ?? -> ||` — `states` is a record object when present, so it is always truthy.
- `processed-payments.ts:287:7` — the read-path `failure_data` error label is caught and replaced with `CORRUPT_FAILURE` before any test can observe it. The write-path label is killed by a direct test that passes an invalid `StoredPaymentFailure`.

## Verification

- `deno task test:files` on all three test files: 74 tests pass.
- `deno task test:quality-audit`: no new findings in the touched files.
- Targeted mutation runs (`--harness` for the two DB/app-backed modules): 100% kill rate across all three.
- `deno task precommit`: passes.