### PR TITLE
Add stable Stripe and Square refund idempotency keys

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -893,8 +893,8 @@ src/shared/runtime.ts:67:45  ?? → ||   # nodeCompatVersion is string|undefined
 src/shared/runtime.ts:68:18  ?? → ||   # os is string|undefined and falls back to "", so both operators agree
 src/shared/runtime.ts:70:43  ?? → ||   # typescriptVersion is string|undefined and falls back to "", so both operators agree
 src/shared/runtime.ts:71:38  ?? → ||   # userAgent is string|undefined and falls back to "", so both operators agree
-src/shared/square.ts:643:18  ?? → ||   # the callback returns true while missing clients and caught errors return null; both operators produce the same boolean
-src/shared/square.ts:713:37  ?? → ||   # locations is an array or undefined; arrays are truthy and undefined takes [] under both operators
+src/shared/square.ts:644:18  ?? → ||   # the callback returns true while missing clients and caught errors return null; both operators produce the same boolean
+src/shared/square.ts:714:37  ?? → ||   # locations is an array or undefined; arrays are truthy and undefined takes [] under both operators
 src/ui/client/dom.ts:13:19  = → +=   # createElement returns a new button with className "", so both assignments produce the supplied class string
 
 # Paid-payment processing: private defaults are always supplied by their only

--- a/src/shared/payment-idempotency.ts
+++ b/src/shared/payment-idempotency.ts
@@ -1,0 +1,23 @@
+import { toBase64Url } from "#shared/crypto/utils.ts";
+import type { PaymentProviderType } from "#shared/types.ts";
+
+/**
+ * Stable refund idempotency key for a single provider payment. The same
+ * provider-and-payment pair always produces the same key, so a retried
+ * webhook redelivery of the same refund resolves to one provider-side refund
+ * instead of a second charge-back. A different provider's refund for the same
+ * payment reference hashes to a different key, so the two never collide.
+ *
+ * SHA-256 base64url is 43 characters, within each provider's idempotency-key
+ * length limit.
+ */
+export const refundIdempotencyKey = async (
+  provider: PaymentProviderType,
+  paymentReference: string,
+): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${provider}-refund:${paymentReference}`),
+  );
+  return toBase64Url(new Uint8Array(digest));
+};

--- a/src/shared/square.ts
+++ b/src/shared/square.ts
@@ -31,6 +31,7 @@ import {
   type SignedTestWebhook,
   signedTestWebhook,
 } from "#shared/payment-helpers.ts";
+import { refundIdempotencyKey } from "#shared/payment-idempotency.ts";
 import type {
   CheckoutIntent,
   WebhookEvent,
@@ -634,7 +635,7 @@ export const squareApi: {
           amount: payment.amountMoney!.amount,
           currency: payment.amountMoney!.currency as string,
         },
-        idempotencyKey: crypto.randomUUID(),
+        idempotencyKey: await refundIdempotencyKey("square", paymentId),
         paymentId,
       });
       return true;

--- a/src/shared/stripe.ts
+++ b/src/shared/stripe.ts
@@ -6,6 +6,7 @@ import {
   assembleCheckoutMetadata,
   buildProviderLineItems,
 } from "#shared/payment-helpers.ts";
+import { refundIdempotencyKey } from "#shared/payment-idempotency.ts";
 import type { CheckoutIntent, SetupWebhookEndpoint } from "#shared/payments.ts";
 import type {
   StripeCheckoutLineItemParams,
@@ -104,11 +105,14 @@ export interface StripeApi {
 export const stripeApi: StripeApi = {
   cleanupOldWebhookEndpoints,
   createCheckoutSession,
-  refundPayment: (intentId) =>
-    stripeClientRuntime.run(
-      (client) => client.refunds.create({ payment_intent: intentId }),
+  refundPayment: async (intentId) => {
+    const idempotencyKey = await refundIdempotencyKey("stripe", intentId);
+    return stripeClientRuntime.run(
+      (client) =>
+        client.refunds.create({ payment_intent: intentId }, idempotencyKey),
       ErrorCode.STRIPE_REFUND,
-    ),
+    );
+  },
   retrieveCheckoutSession: (id) =>
     stripeClientRuntime.run(
       (client) => client.checkout.sessions.retrieve(id),

--- a/src/shared/stripe/client.ts
+++ b/src/shared/stripe/client.ts
@@ -88,6 +88,7 @@ export interface StripeClient {
   refunds: {
     create: (
       params: Pick<Stripe.RefundCreateParams, "payment_intent">,
+      idempotencyKey?: string,
     ) => Promise<StripeRefund>;
   };
   webhookEndpoints: {
@@ -142,8 +143,10 @@ export const createStripeClient = (
         ),
     },
     refunds: {
-      create: (params) =>
-        call("POST", "/v1/refunds", params, StripeRefundSchema),
+      create: (params, idempotencyKey) =>
+        call("POST", "/v1/refunds", params, StripeRefundSchema, {
+          idempotencyKey,
+        }),
     },
     webhookEndpoints: {
       create: (params) =>

--- a/src/shared/stripe/request.ts
+++ b/src/shared/stripe/request.ts
@@ -22,6 +22,15 @@ type StripeParams = Readonly<Record<string, StripeFormValue>>;
 type Method = "DELETE" | "GET" | "POST";
 type ResponseSchema<T> = v.BaseSchema<unknown, T, v.BaseIssue<unknown>>;
 
+/**
+ * Per-request options. `idempotencyKey` overrides the default per-POST retry
+ * key so a caller can supply a stable, provider-and-payment-scoped key that
+ * survives webhook redelivery — see {@link refundIdempotencyKey}.
+ */
+export interface StripeRequestOptions {
+  idempotencyKey?: string | undefined;
+}
+
 export interface StripeClientConfig {
   apiBase?: string;
   fetch?: Fetch;
@@ -253,13 +262,15 @@ export const createStripeRequest = (
     path: string,
     params: StripeParams,
     schema: ResponseSchema<T>,
+    options: StripeRequestOptions = {},
   ): Promise<T> => {
     const encoded = encodeStripeForm(params);
     const url = `${config.apiBase}${path}${method === "GET" && encoded ? `?${encoded}` : ""}`;
     const idempotencyKey =
-      method === "POST" && config.maxNetworkRetries > 0
+      options.idempotencyKey ??
+      (method === "POST" && config.maxNetworkRetries > 0
         ? `tickets-stripe-retry-${crypto.randomUUID()}`
-        : undefined;
+        : undefined);
     const headers = new Headers({
       Accept: "application/json",
       Authorization: `Bearer ${config.secretKey}`,

--- a/src/shared/stripe/request.ts
+++ b/src/shared/stripe/request.ts
@@ -25,7 +25,8 @@ type ResponseSchema<T> = v.BaseSchema<unknown, T, v.BaseIssue<unknown>>;
 /**
  * Per-request options. `idempotencyKey` overrides the default per-POST retry
  * key so a caller can supply a stable, provider-and-payment-scoped key that
- * survives webhook redelivery — see {@link refundIdempotencyKey}.
+ * survives webhook redelivery (see `refundIdempotencyKey` in
+ * `#shared/payment-idempotency.ts`).
  */
 export interface StripeRequestOptions {
   idempotencyKey?: string | undefined;

--- a/test/lib/stripe/refund-header-probe.ts
+++ b/test/lib/stripe/refund-header-probe.ts
@@ -1,0 +1,27 @@
+import type { StripeClient } from "#shared/stripe/client.ts";
+import { createStripeClient } from "#shared/stripe/client.ts";
+
+/**
+ * Build a Stripe client whose fetch records the Idempotency-Key header sent
+ * on each request and answers a succeeded refund. Shared by the tests that
+ * assert which idempotency key reaches the wire for a refund POST.
+ *
+ * `capturedKey` reads the header value from the most recent request, so a test
+ * can assert the exact key (or its absence) after calling `refunds.create`.
+ */
+export const refundHeaderProbe = (
+  secretKey = "sk_test_secret",
+  maxNetworkRetries = 1,
+): { capturedKey: () => string | null; client: StripeClient } => {
+  let key: string | null = null;
+  const client = createStripeClient(secretKey, {
+    fetch: (_input, init = {}) => {
+      key = new Headers(init.headers).get("idempotency-key");
+      return Promise.resolve(
+        Response.json({ id: "re_1", status: "succeeded" }),
+      );
+    },
+    maxNetworkRetries,
+  });
+  return { capturedKey: () => key, client };
+};

--- a/test/lib/stripe/refund-header-probe.ts
+++ b/test/lib/stripe/refund-header-probe.ts
@@ -11,9 +11,11 @@ import { createStripeClient } from "#shared/stripe/client.ts";
  */
 export const refundHeaderProbe = (
   secretKey = "sk_test_secret",
-  maxNetworkRetries = 1,
 ): { capturedKey: () => string | null; client: StripeClient } => {
   let key: string | null = null;
+  // One retry allowed so a retry-generated key WOULD exist by default; the
+  // caller's key must take precedence over it, which is what the shared tests
+  // assert. With zero retries the override has nothing to override.
   const client = createStripeClient(secretKey, {
     fetch: (_input, init = {}) => {
       key = new Headers(init.headers).get("idempotency-key");
@@ -21,7 +23,7 @@ export const refundHeaderProbe = (
         Response.json({ id: "re_1", status: "succeeded" }),
       );
     },
-    maxNetworkRetries,
+    maxNetworkRetries: 1,
   });
   return { capturedKey: () => key, client };
 };

--- a/test/shared/payment-idempotency.test.ts
+++ b/test/shared/payment-idempotency.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { refundIdempotencyKey } from "#shared/payment-idempotency.ts";
+
+describe("refundIdempotencyKey", () => {
+  test("returns the same SHA-256 base64url key across repeated calls", async () => {
+    // A retried webhook redelivery of the same refund must reuse one key so
+    // the provider treats the second call as a duplicate, not a new refund.
+    const first = await refundIdempotencyKey("stripe", "pi_test_123");
+    const second = await refundIdempotencyKey("stripe", "pi_test_123");
+
+    expect(first).toBe("4dTbWaPKog42IKlMoGjEdBKFRwdimMkUghDo1fj8RTg");
+    expect(second).toBe(first);
+    expect(first).toHaveLength(43);
+  });
+
+  test("differs for distinct payment references within one provider", async () => {
+    const a = await refundIdempotencyKey("stripe", "pi_a");
+    const b = await refundIdempotencyKey("stripe", "pi_b");
+
+    expect(a).not.toBe(b);
+  });
+
+  test("differs across providers for the same payment reference", async () => {
+    // The provider is part of the hash input so a Stripe refund and a Square
+    // refund that happen to share a reference can never collapse onto the
+    // same provider-side idempotency key.
+    const stripe = await refundIdempotencyKey("stripe", "shared_ref");
+    const square = await refundIdempotencyKey("square", "shared_ref");
+
+    expect(stripe).not.toBe(square);
+    expect(stripe).toBe("NBpJPsWKjwtahHlU0m8xDmhpHufgo56DK2HHnxS9vK4");
+    expect(square).toBe("8Sf-TR7PpauZyJcM5pZgovL1QP7pU48G_wMkIl5RnfM");
+  });
+});

--- a/test/shared/square/retrieve-refund.test.ts
+++ b/test/shared/square/retrieve-refund.test.ts
@@ -300,8 +300,46 @@ describeSquare(() => {
           expect(refundArgs.paymentId).toBe("pay_refund_me");
           expect(refundArgs.amountMoney.amount).toBe(BigInt(4200));
           expect(refundArgs.amountMoney.currency).toBe("USD");
-          expect(typeof refundArgs.idempotencyKey).toBe("string");
-          expect(refundArgs.idempotencyKey.length).toBeGreaterThan(0);
+          // The key is a pure function of (provider, payment id), so a webhook
+          // redelivery of the same refund reuses it and Square deduplicates
+          // the second call instead of charging back a second time.
+          expect(refundArgs.idempotencyKey).toBe(
+            "94jKDa73RqRmoCUbDHE2CCc5rNAMtKDdSERbYIImwK0",
+          );
+        },
+      );
+    });
+
+    test("reuses the same idempotency key across repeated refunds of one payment", async () => {
+      // Two refund attempts for the same Square payment must hand Square the
+      // same idempotency key, so a retried webhook redelivery cannot create a
+      // second refund. The key is deterministic, not a fresh random per call.
+      await withSquareClient(
+        {
+          paymentsGet: () =>
+            Promise.resolve({
+              payment: {
+                amountMoney: { amount: BigInt(1000), currency: "GBP" },
+                id: "pay_repeat",
+                orderId: "order_repeat",
+                status: "COMPLETED",
+              },
+            }),
+          refundsRefundPayment: () =>
+            Promise.resolve({
+              refund: { id: "refund_repeat", status: "PENDING" },
+            }),
+        },
+        async ({ refundsRefundPayment }) => {
+          await squareApi.refundPayment("pay_repeat");
+          await squareApi.refundPayment("pay_repeat");
+
+          expect(refundsRefundPayment.calls).toHaveLength(2);
+          const [first, second] = refundsRefundPayment.calls.map(
+            (call) => (call.args[0] as RefundPaymentInput).idempotencyKey,
+          );
+          expect(first).toBe(second);
+          expect(first).toBe("Zo9WnE2h_fa7qTOrXREnPmK-WsI5dcg2LE4-0mMYwao");
         },
       );
     });

--- a/test/shared/stripe-provider/operations.test.ts
+++ b/test/shared/stripe-provider/operations.test.ts
@@ -134,6 +134,31 @@ describeStripe("stripe-provider", () => {
         },
       );
     });
+
+    test("passes a stable SHA-256 idempotency key derived from the payment intent", async () => {
+      // A webhook redelivery of the same refund must reach Stripe with the
+      // same Idempotency-Key so the second call is deduplicated, not charged
+      // again. The key is a pure function of (provider, payment reference),
+      // so it is reproducible here without re-running the hash.
+      const client = await stripeClient();
+      const createStub = stub(client.refunds, "create", () =>
+        Promise.resolve({ id: "re_stable", status: "succeeded" }),
+      );
+      await withMocks(
+        () => createStub,
+        async () => {
+          expect(await stripePaymentProvider.refundPayment("pi_stable")).toBe(
+            true,
+          );
+        },
+      );
+
+      const [params, idempotencyKey] = createStub.calls[0]!.args;
+      expect(params).toEqual({ payment_intent: "pi_stable" });
+      expect(idempotencyKey).toBe(
+        "zMXoB60J9cW7f7GxpMobuLm6VM5BATENKpD_jsjvf4g",
+      );
+    });
   });
 
   describe("sanitizeStripeError edge cases", () => {

--- a/test/shared/stripe/client.test.ts
+++ b/test/shared/stripe/client.test.ts
@@ -67,3 +67,22 @@ test("maps every used Stripe operation to its endpoint", async () => {
     { body: "", method: "DELETE", path: "/v1/webhook_endpoints/we%2F1" },
   ]);
 });
+
+test("sends the supplied idempotency key as the Idempotency-Key header on a refund", async () => {
+  let capturedKey: string | null = null;
+  const client = createStripeClient("sk_test_client", {
+    fetch: (_input, init = {}) => {
+      capturedKey = new Headers(init.headers).get("idempotency-key");
+      return Promise.resolve(
+        Response.json({ id: "re_1", status: "succeeded" }),
+      );
+    },
+    // Zero retries so no default retry key is generated: the only key on the
+    // wire is the one the caller passed through refunds.create.
+    maxNetworkRetries: 0,
+  });
+
+  await client.refunds.create({ payment_intent: "pi_1" }, "stable-refund-key");
+
+  expect(capturedKey).toBe("stable-refund-key");
+});

--- a/test/shared/stripe/client.test.ts
+++ b/test/shared/stripe/client.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { createStripeClient } from "#shared/stripe/client.ts";
+import { refundHeaderProbe } from "#test/lib/stripe/refund-header-probe.ts";
 import { stripeResponseFor } from "#test/lib/stripe/responses.ts";
 
 test("maps every used Stripe operation to its endpoint", async () => {
@@ -69,20 +70,13 @@ test("maps every used Stripe operation to its endpoint", async () => {
 });
 
 test("sends the supplied idempotency key as the Idempotency-Key header on a refund", async () => {
-  let capturedKey: string | null = null;
-  const client = createStripeClient("sk_test_client", {
-    fetch: (_input, init = {}) => {
-      capturedKey = new Headers(init.headers).get("idempotency-key");
-      return Promise.resolve(
-        Response.json({ id: "re_1", status: "succeeded" }),
-      );
-    },
-    // Zero retries so no default retry key is generated: the only key on the
-    // wire is the one the caller passed through refunds.create.
-    maxNetworkRetries: 0,
-  });
+  // One retry allowed so a retry-generated key WOULD exist by default; the
+  // caller's key must take precedence over it (nullish-coalescing, not a
+  // fallback swap). With zero retries the override would be untestable,
+  // since no retry key is ever generated to override.
+  const { client, capturedKey } = refundHeaderProbe("sk_test_client");
 
   await client.refunds.create({ payment_intent: "pi_1" }, "stable-refund-key");
 
-  expect(capturedKey).toBe("stable-refund-key");
+  expect(capturedKey()).toBe("stable-refund-key");
 });

--- a/test/shared/stripe/client.test.ts
+++ b/test/shared/stripe/client.test.ts
@@ -70,10 +70,8 @@ test("maps every used Stripe operation to its endpoint", async () => {
 });
 
 test("sends the supplied idempotency key as the Idempotency-Key header on a refund", async () => {
-  // One retry allowed so a retry-generated key WOULD exist by default; the
-  // caller's key must take precedence over it (nullish-coalescing, not a
-  // fallback swap). With zero retries the override would be untestable,
-  // since no retry key is ever generated to override.
+  // The probe enables one retry, so a retry-generated key would exist by
+  // default; the caller's key must take precedence over it.
   const { client, capturedKey } = refundHeaderProbe("sk_test_client");
 
   await client.refunds.create({ payment_intent: "pi_1" }, "stable-refund-key");

--- a/test/shared/stripe/request.test.ts
+++ b/test/shared/stripe/request.test.ts
@@ -18,6 +18,7 @@ import {
   withSubrequestAllowance,
 } from "#shared/subrequest-budget.ts";
 import { stripeCheckoutSession } from "#test/lib/stripe/fixtures.ts";
+import { refundHeaderProbe } from "#test/lib/stripe/refund-header-probe.ts";
 
 const checkoutParams = (): StripeCheckoutSessionCreateParams => ({
   cancel_url: "https://example.com/cancel",
@@ -305,18 +306,11 @@ describe("Stripe request transport", () => {
     // null/undefined, while logical-or (||) would replace "" with the retry
     // key. Real callers pass a 43-char SHA-256 key or undefined, but locking
     // this keeps the ?? intent explicit.
-    let key: string | null = "unset";
-    const client = createStripeClient("sk_test_secret", {
-      fetch: (_input, init) => {
-        key = new Headers(init?.headers).get("idempotency-key");
-        return Promise.resolve(
-          Response.json({ id: "re_1", status: "succeeded" }),
-        );
-      },
-      maxNetworkRetries: 1,
-    });
+    const { client, capturedKey } = refundHeaderProbe();
+
     await client.refunds.create({ payment_intent: "pi_1" }, "");
-    expect(key).toBeNull();
+
+    expect(capturedKey()).toBeNull();
   });
 
   test("does not retry when Stripe forbids it", async () => {

--- a/test/shared/stripe/request.test.ts
+++ b/test/shared/stripe/request.test.ts
@@ -299,6 +299,26 @@ describe("Stripe request transport", () => {
     expect(key).toMatch(/^tickets-stripe-retry-[0-9a-f-]+$/);
   });
 
+  test("treats an empty-string override as no key, not as the retry default", async () => {
+    // An explicitly-empty idempotency key must NOT be swallowed into the
+    // random retry default: nullish coalescing (??) only falls through on
+    // null/undefined, while logical-or (||) would replace "" with the retry
+    // key. Real callers pass a 43-char SHA-256 key or undefined, but locking
+    // this keeps the ?? intent explicit.
+    let key: string | null = "unset";
+    const client = createStripeClient("sk_test_secret", {
+      fetch: (_input, init) => {
+        key = new Headers(init?.headers).get("idempotency-key");
+        return Promise.resolve(
+          Response.json({ id: "re_1", status: "succeeded" }),
+        );
+      },
+      maxNetworkRetries: 1,
+    });
+    await client.refunds.create({ payment_intent: "pi_1" }, "");
+    expect(key).toBeNull();
+  });
+
   test("does not retry when Stripe forbids it", async () => {
     const { calls, client } = oneCallErrorClient(
       Response.json(


### PR DESCRIPTION
A retried webhook redelivery of the same refund used to reach the payment provider with a fresh idempotency key, so the provider could treat the second call as a new refund rather than a duplicate.

## What changed

This adds one small, provider-and-payment-scoped key that is stable across retries, and threads it through the Stripe and Square refund paths.

- **New `src/shared/payment-idempotency.ts`** — `refundIdempotencyKey(provider, paymentReference)` returns a deterministic SHA-256 base64url key (43 characters, within each provider key-length limit). The same provider-and-payment pair always produces the same key; a different provider for the same payment reference hashes to a different key, so the two never collide.
- **Stripe** — `stripe.ts` `refundPayment` computes this key for the payment intent and passes it to `client.refunds.create`. The request transport (`stripe/request.ts`) gained an optional `idempotencyKey` on its request options (preferred over the per-POST random retry key), and the client surface (`stripe/client.ts`) forwards the key into the `Idempotency-Key` header.
- **Square** — `square.ts` `refundPayment` hands `refundIdempotencyKey("square", paymentId)` to the SDK refund instead of a fresh `crypto.randomUUID()`.

Nothing else about the refund flow changes — the key is the same shape each provider already expected, it is just stable now.

## Why this matters

When a webhook is redelivered (Stripe retries on non-2xx; Square retries similarly), a refund retried for the same payment must resolve to one provider-side refund, not a second charge-back. A random per-call key defeats that; a deterministic `(provider, payment)` key makes the second call a deduplicate of the first. Different providers hashing to different keys also stops a Stripe refund and a Square refund that happen to share a reference from collapsing onto one provider key.

## Tests

Direct tests proving the mechanism end to end:

- `test/shared/payment-idempotency.test.ts` — the key is deterministic, differs across payment references, differs across providers for the same reference, and is the SHA-256 base64url value (43 chars).
- `test/shared/stripe/client.test.ts` — `refunds.create(params, key)` sends exactly that value as the `Idempotency-Key` header.
- `test/shared/stripe-provider/operations.test.ts` — `stripePaymentProvider.refundPayment(intent)` passes the SHA-256-derived stable key (asserted as the exact constant).
- `test/shared/square/retrieve-refund.test.ts` — strengthened the existing weak "is a string" assertions to the exact stable key, and added a test that two refunds of the same payment reuse one key (webhook redelivery safety).
- `test/shared/stripe/request.test.ts` — locks the nullish-coalescing semantics so an explicit empty override is not swallowed into the random retry default.

## Mutation testing

Targeted exhaustive mutation at 100% kill on the changed source: `payment-idempotency.ts`, `stripe/client.ts`, `stripe/request.ts`. The Stripe and Square refund call sites are covered by exact-key assertions that kill operator and provider swaps.

## Notes for review

PR #1905 overlaps the Square provider files. This change is deliberately narrow (one line in `square.ts` `refundPayment`, and the Stripe side lives in files #1905 does not touch), so rebasing after #1905 moves or merges is straightforward. The two `square.ts` entries in `scripts/mutation/equivalent-mutants.txt` were re-pinned to their new line numbers after the added import shifted them down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic, provider-scoped idempotency keys for Square and Stripe refunds to consistently identify repeated refund requests.
  - Introduced support for caller-provided idempotency keys in Stripe refund requests.
- **Tests**
  - Added unit coverage for deterministic key generation, cross-provider differences, repeated refund idempotency reuse, and exact request/header behavior (including explicit empty-string override handling).
- **Chores**
  - Updated mutation-tester equivalent-mutant suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->