### PR TITLE
Test folded and ordinary booking directly

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1397,45 +1397,19 @@ reorganisation. Starting point: move the two phone-index describe blocks into
 `storedPhoneIndex` helpers in whichever file needs them (or lift to `#test-utils`
 if both do). The webhook test file drops to ~380 lines.
 
-## Mutation survivors in `src/features/api/folded-booking.ts` (direct tests)
+## Mutation survivor in `src/features/api/folded-booking.ts` (direct tests)
 
 Direct tests at `test/features/api/folded-booking.test.ts` and
-`test/features/api/folded-booking/parent-booking.test.ts` reach 91.9% (57/62,
-one equivalent at line 87 suppressed) on the unchanged `folded-booking.ts`;
-`precommit:mutation` does not gate it (only changed `src/` files are mutated), so
-these don't block CI. Five survivors remain; each is out of scope for the
-booking-direct test files alone and noted here so a follow-up can pick the right
-one up without re-reading the mutation report:
+`test/features/api/folded-booking/parent-booking.test.ts` kill all but one mutant on the unchanged `folded-booking.ts`;
+four equivalents (lines 87, 118, 176, 301) are recorded in
+`scripts/mutation/equivalent-mutants.txt`. One survivor remains, noted here
+because it is a deliberate non-kill (testing it would assert an
+implementation detail, not a user-visible contract):
 
-- `src/features/api/folded-booking.ts:118:31  ?? → ||` —
-  `(qtyByChild.get(childId) ?? 0)`. Equivalent for every schema-valid input
-  (`ApiQuantitySchema` enforces `quantity >= 1`, so the accumulator is unset or
-  `>= 1`, never `0`/`NaN`); only distinguishable by a direct caller passing a
-  `NaN`/`0` quantity the schema rejects. Not recorded as equivalent because
-  `applyChildSelectionsToForm` is exported and that bypass is type-legal.
-- `src/features/api/folded-booking.ts:176:53  1 → 0` —
-  `fold.listings.length > 1` in `foldedIntent`. `parentThankYouUrl` is truthy
-  only in the parent flow, where the fold always spans parent + `>= 1` child
-  (`length >= 2`); the package flow passes no `parentThankYouUrl`, so the `&&`
-  short-circuits. Only a single-listing fold with a truthy `parentThankYouUrl`
-  distinguishes — not produced by `processParentApiBooking`. A package-flow
-  folded-booking direct test would cover it.
-- `src/features/api/folded-booking.ts:301:70  0 → 1` —
-  `feeSubtotal: 0` in `priceCheckout({ ...intent, feeSubtotal: 0 })` on the
-  provider-less owed path. The fee subtotal flows through `priceCheckout` →
-  `owedOrderForLedger` but does not reach the attendee's outstanding-balance
-  projection (unlike `booking.ts`'s `mapBooking({ bookingFee })`), so
-  `getAttendeeBalanceState` doesn't catch it. Kills need a `transfers`/fee-leg
-  read (accounting domain).
-- `src/features/api/folded-booking.ts:314:53  0 → 1` —
-  `reservation.entries[0]!.attendee`. A folded reservation's entries all
-  reference the same parent attendee, so `entries[1]` yields the same
-  `bookingSuccessResponse`; only a single-entry reservation (e.g. a
-  one-member package free booking) would throw under the mutant. Not reachable
-  via `processParentApiBooking`.
 - `src/features/api/folded-booking.ts:381:17  1 → 0` —
   `dayCount: 1` in the `FoldBase` `processParentApiBooking` builds. The fold
   computes its own `fold.dayCount` (e.g. `3` for a customisable child) which
   the intent carries, so the base value does not surface in any observable
-  output of the parent flow. A test sensitive to the intermediate
-  `parentResolvedDuration(parent.listing, base.dayCount)` would be needed.
+  output of the parent flow. Killing it would require asserting on the
+  intermediate `parentResolvedDuration(parent.listing, base.dayCount)` value,
+  which is an implementation detail rather than a user-visible contract.

--- a/TODO.md
+++ b/TODO.md
@@ -1396,3 +1396,46 @@ reorganisation. Starting point: move the two phone-index describe blocks into
 `test/shared/sms/phone-index.test.ts`, keeping the `makeAttendee` /
 `storedPhoneIndex` helpers in whichever file needs them (or lift to `#test-utils`
 if both do). The webhook test file drops to ~380 lines.
+
+## Mutation survivors in `src/features/api/folded-booking.ts` (direct tests)
+
+Direct tests at `test/features/api/folded-booking.test.ts` and
+`test/features/api/folded-booking/parent-booking.test.ts` reach 91.9% (57/62,
+one equivalent at line 87 suppressed) on the unchanged `folded-booking.ts`;
+`precommit:mutation` does not gate it (only changed `src/` files are mutated), so
+these don't block CI. Five survivors remain; each is out of scope for the
+booking-direct test files alone and noted here so a follow-up can pick the right
+one up without re-reading the mutation report:
+
+- `src/features/api/folded-booking.ts:118:31  ?? → ||` —
+  `(qtyByChild.get(childId) ?? 0)`. Equivalent for every schema-valid input
+  (`ApiQuantitySchema` enforces `quantity >= 1`, so the accumulator is unset or
+  `>= 1`, never `0`/`NaN`); only distinguishable by a direct caller passing a
+  `NaN`/`0` quantity the schema rejects. Not recorded as equivalent because
+  `applyChildSelectionsToForm` is exported and that bypass is type-legal.
+- `src/features/api/folded-booking.ts:176:53  1 → 0` —
+  `fold.listings.length > 1` in `foldedIntent`. `parentThankYouUrl` is truthy
+  only in the parent flow, where the fold always spans parent + `>= 1` child
+  (`length >= 2`); the package flow passes no `parentThankYouUrl`, so the `&&`
+  short-circuits. Only a single-listing fold with a truthy `parentThankYouUrl`
+  distinguishes — not produced by `processParentApiBooking`. A package-flow
+  folded-booking direct test would cover it.
+- `src/features/api/folded-booking.ts:301:70  0 → 1` —
+  `feeSubtotal: 0` in `priceCheckout({ ...intent, feeSubtotal: 0 })` on the
+  provider-less owed path. The fee subtotal flows through `priceCheckout` →
+  `owedOrderForLedger` but does not reach the attendee's outstanding-balance
+  projection (unlike `booking.ts`'s `mapBooking({ bookingFee })`), so
+  `getAttendeeBalanceState` doesn't catch it. Kills need a `transfers`/fee-leg
+  read (accounting domain).
+- `src/features/api/folded-booking.ts:314:53  0 → 1` —
+  `reservation.entries[0]!.attendee`. A folded reservation's entries all
+  reference the same parent attendee, so `entries[1]` yields the same
+  `bookingSuccessResponse`; only a single-entry reservation (e.g. a
+  one-member package free booking) would throw under the mutant. Not reachable
+  via `processParentApiBooking`.
+- `src/features/api/folded-booking.ts:381:17  1 → 0` —
+  `dayCount: 1` in the `FoldBase` `processParentApiBooking` builds. The fold
+  computes its own `fold.dayCount` (e.g. `3` for a customisable child) which
+  the intent carries, so the base value does not surface in any observable
+  output of the parent flow. A test sensitive to the intermediate
+  `parentResolvedDuration(parent.listing, base.dayCount)` would be needed.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -903,6 +903,8 @@ src/features/api/payment-processing/package-pricing.ts:296:51  ?? → ||   # the
 # error message carries the label.
 src/shared/db/processed-payments.ts:287:7  processed_payments.failure_data → ""   # read-path label: read errors are caught and replaced with CORRUPT_FAILURE before the message can be observed
 
-# Folded API booking: a child-lookup Map value is an array (always truthy), so
-# ?? and || agree on it (the operand is never falsy-but-non-null).
+# Folded API booking: equivalents for schema-validated inputs and unused paths.
 src/features/api/folded-booking.ts:87:42  ?? → ||   # childrenByParentId is Map<number, TicketListing[]>; get returns an array (always truthy, even []) or undefined, so ?? and || agree
+src/features/api/folded-booking.ts:118:31  ?? → ||   # qtyByChild accumulates ApiQuantitySchema values (positive integers >= 1) or is unset; it is never 0 or NaN for validated inputs, so ?? 0 and || 0 agree
+src/features/api/folded-booking.ts:176:53  1 → 0   # the thankYouUrl guard checks fold.listings.length > 1 only when parentThankYouUrl is truthy (parent flow), which always folds parent + >= 1 child (length >= 2); package callers pass no parentThankYouUrl, so the && short-circuits and the check never runs
+src/features/api/folded-booking.ts:301:70  0 → 1   # feeSubtotal flows into priceCheckout → owedOrderForLedger, which drops all extras and sets total to 0; bookingFactsFromOrder reads extras (empty) → bookingFee: 0 regardless. The feeSubtotal value never reaches any observable output.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -902,3 +902,7 @@ src/features/api/payment-processing/package-pricing.ts:296:51  ?? → ||   # the
 # passes an invalid StoredPaymentFailure to markSessionFailed and asserts the
 # error message carries the label.
 src/shared/db/processed-payments.ts:287:7  processed_payments.failure_data → ""   # read-path label: read errors are caught and replaced with CORRUPT_FAILURE before the message can be observed
+
+# Folded API booking: a child-lookup Map value is an array (always truthy), so
+# ?? and || agree on it (the operand is never falsy-but-non-null).
+src/features/api/folded-booking.ts:87:42  ?? → ||   # childrenByParentId is Map<number, TicketListing[]>; get returns an array (always truthy, even []) or undefined, so ?? and || agree

--- a/test/features/api/folded-booking.test.ts
+++ b/test/features/api/folded-booking.test.ts
@@ -3,7 +3,6 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   applyChildSelectionsToForm,
   parseApiChildSelections,
-  processParentApiBooking,
 } from "#routes/api/folded-booking.ts";
 import {
   type ApiChildSelection,
@@ -11,34 +10,18 @@ import {
 } from "#routes/api/request-schemas.ts";
 import type { TicketCtx } from "#routes/public/types.ts";
 import type { TicketListing } from "#shared/booking/model.ts";
-import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
 import { FormParams } from "#shared/form-data.ts";
-import type { CheckoutIntent } from "#shared/payments.ts";
-import type { Listing, ListingWithCount } from "#shared/types.ts";
 import { resolved } from "#test/lib/booking-model-fixtures.ts";
-import type { BookResponseBody } from "#test/routes/api/helpers.ts";
-import {
-  expectCapturedItemPriced,
-  stubCheckout,
-} from "#test-utils/checkout.ts";
-import { describeWithEnv } from "#test-utils/db.ts";
-import { bookableStartDates } from "#test-utils/db-helpers/listings.ts";
-import {
-  makeCustomisableDailyParent,
-  makeParent,
-} from "#test-utils/parents.ts";
-import { setupStripe } from "#test-utils/settings.ts";
 
-/** Direct, function-level tests of the folded-booking API module — the parsing,
- * application, and parent-flow functions that the JSON API's `handleBook` only
- * exercises through the full HTTP/router stack. `parseApiChildSelections` and
- * `applyChildSelectionsToForm` are pure (no DB); `processParentApiBooking` is
- * the function-boundary seam for the folded free / provider-less / paid
- * checkout paths, covering the internal `completeFoldedBooking`/`foldedIntent`
- * through their one exported entry point. */
+/** Direct, pure tests of the folded-booking API's child-selection layer —
+ * `parseApiChildSelections` (parse the `children` body) and
+ * `applyChildSelectionsToForm` (translate resolved selections onto the fold's
+ * `child_qty_*` / `child_price_*` form fields, rejecting stranger slugs and
+ * conflicting per-child prices). These reach the functions directly with a
+ * hand-built ctx, so no database is needed and the suite runs fast. The DB
+ * parent-flow tests live in `folded-booking/parent-booking.test.ts`. */
 
 const PARENT_ID = 1;
-const CHECKOUT_URL = "https://stripe.example/checkout";
 
 /** A child {@link TicketListing} fixture carrying the given id and slug, built
  * from the shared `resolved()` factory so the shape stays the one the fold
@@ -80,97 +63,6 @@ const applySelections = (
     selections,
   );
   return { form, result };
-};
-
-/** A POST request carrying only a host header — {@link processParentApiBooking}
- * uses it solely for `getBaseUrl`, and receives the parsed body as a separate
- * record, so no body is attached here. */
-const bookRequest = (): Request =>
-  new Request("http://localhost/api/listings/x/book", {
-    headers: { host: "localhost" },
-    method: "POST",
-  });
-
-/** `makeParent` returns the parent row typed as `Listing`, but `createTestListing`
- * reads it back through `getAllListings`, which selects the full row including
- * the trigger-maintained count columns — so it is a {@link ListingWithCount} at
- * runtime. `processParentApiBooking` reads those columns, hence the downcast. */
-const asWithCount = (listing: Pick<Listing, "id">): ListingWithCount =>
-  listing as ListingWithCount;
-
-/** A one-unit parent booking body selecting `child`, with the standard test
- * contact merged in; `extra` adds paid/custom-price fields per scenario. */
-const parentBody = (
-  child: { slug: string },
-  extra: Record<string, unknown> = {},
-): Record<string, unknown> => ({
-  children: [{ quantity: 1, slug: child.slug }],
-  email: "a@b.com",
-  name: "Ada",
-  quantity: 1,
-  ...extra,
-});
-
-/** Call {@link processParentApiBooking} for one parent unit with a resolved body
- *  and date — the single shape behind every parent-flow test, so the request,
- *  cast, quantity, and date plumbing lives once. */
-const bookParent = (
-  parent: Pick<Listing, "id">,
-  body: Record<string, unknown>,
-  date: string | null = null,
-): Promise<Response> =>
-  processParentApiBooking(bookRequest(), asWithCount(parent), body, 1, date);
-
-/** A free parent (£0, capacity 10) with a child priced at `childUnitPrice` —
- *  the shared provider-less scenario behind the free, full-value-owed, and
- *  one-penny-owed tests. */
-const makeProviderlessParent = (childUnitPrice: number) =>
-  makeParent({
-    children: [{ maxAttendees: 10, unitPrice: childUnitPrice }],
-    parent: { maxAttendees: 10, unitPrice: 0 },
-  });
-
-/** Book a provider-less folded order (free parent + a child priced at
- *  `childUnitPrice`, no provider configured), returning the parsed body, the
- *  created attendee, and the parent/child listings. Shared by the free,
- *  provider-less-owed, and one-penny-owed tests. */
-const foldProviderless = async (childUnitPrice: number) => {
-  const { parent, child } = await makeProviderlessParent(childUnitPrice);
-  const response = await bookParent(parent, parentBody(child));
-  expect(response.status).toBe(200);
-  const body = (await response.json()) as BookResponseBody;
-  const { getAttendeesByTokens } = await import(
-    "#shared/db/attendees/tokens.ts"
-  );
-  const [attendee] = await getAttendeesByTokens([body.booking!.ticketToken!]);
-  return { attendee: attendee!, body, child, parent };
-};
-
-/** Book a folded order against the stubbed checkout (provider configured),
- *  returning the parsed body, the call count, and the captured intent — the
- *  shared "inspect what the paid path would have charged" fixture. */
-const stubFoldedCheckout = async (
-  parent: Pick<Listing, "id">,
-  body: Record<string, unknown>,
-  date: string | null = null,
-): Promise<{
-  body: BookResponseBody;
-  calls: () => number;
-  intent: CheckoutIntent | undefined;
-}> => {
-  await setupStripe();
-  const { calls, checkout, getCaptured } = stubCheckout("sess_test");
-  try {
-    const response = await bookParent(parent, body, date);
-    expect(response.status).toBe(200);
-    return {
-      body: (await response.json()) as BookResponseBody,
-      calls,
-      intent: getCaptured(),
-    };
-  } finally {
-    checkout.restore();
-  }
 };
 
 describe("parseApiChildSelections", () => {
@@ -277,138 +169,5 @@ describe("applyChildSelectionsToForm", () => {
     expect(result).toBe(null);
     expect(form.get("child_qty_1_10")).toBe("2");
     expect(form.get("child_price_1_10")).toBe("30");
-  });
-});
-
-describeWithEnv("processParentApiBooking", { db: true, triggers: true }, () => {
-  test("folds a free parent+child into a booking that owes nothing", async () => {
-    const { body, attendee, child, parent } = await foldProviderless(0);
-    // The free path returns an owed amount of 0 and a ticket link (not a
-    // checkout URL): amountOwed's exact value pins the branch taken.
-    expect(body.booking?.amountOwed).toBe(0);
-    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
-    const childRow = attendee.bookings.find((b) => b.listing_id === child.id);
-    expect(childRow?.parent_listing_id).toBe(parent.id);
-  });
-
-  test("folds a paid child into a provider-less booking that owes the full value", async () => {
-    const { body, attendee } = await foldProviderless(1500);
-    // amountOwed carries the full folded value — the provider-less owed path.
-    expect(body.booking?.amountOwed).toBe(1500);
-    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
-    expect(attendee.remaining_balance).toBe(1500);
-  });
-
-  test("records even a one-penny folded order in the owed ledger", async () => {
-    // The `remainingBalance > 0` gate must fire for the smallest non-zero
-    // folded total (a £0.01 child): the owed ledger order is posted, so the
-    // ledger-projected balance (not just the denormalized column) is 1.
-    const { body, attendee } = await foldProviderless(1);
-    expect(body.booking?.amountOwed).toBe(1);
-    expect((await getAttendeeBalanceState(attendee.id))?.remainingBalance).toBe(
-      1,
-    );
-  });
-
-  test("returns a checkout URL for a folded paid order and carries the fold on the intent", async () => {
-    const { parent, child } = await makeParent({
-      children: [{ maxAttendees: 10, unitPrice: 500 }],
-      parent: {
-        maxAttendees: 10,
-        thankYouUrl: "https://example.com/thanks",
-        unitPrice: 1000,
-      },
-    });
-    const { intent } = await stubFoldedCheckout(parent, parentBody(child));
-    expect(intent?.date).toBe(null);
-    expect(intent?.thankYouUrl).toBe("https://example.com/thanks");
-    expect(intent?.allocations).toEqual([
-      { childId: child.id, parentId: parent.id, qty: 1 },
-    ]);
-    expectCapturedItemPriced(intent, parent, 1000);
-    expectCapturedItemPriced(intent, child, 500);
-    // A non-customisable fold carries no dayCount on the intent.
-    expect("dayCount" in (intent ?? {})).toBe(false);
-  });
-
-  test("charges a pay-more parent's custom price on the folded checkout line", async () => {
-    const { parent, child } = await makeParent({
-      children: [{ maxAttendees: 10, unitPrice: 500 }],
-      parent: {
-        canPayMore: true,
-        maxAttendees: 10,
-        maxPrice: 10000,
-        unitPrice: 1000,
-      },
-    });
-    const { intent } = await stubFoldedCheckout(
-      parent,
-      parentBody(child, { customPrice: 20 }),
-    );
-    expectCapturedItemPriced(intent, parent, 2000);
-    expectCapturedItemPriced(intent, child, 500);
-    // A parent with no configured thank-you URL omits it from the intent.
-    expect("thankYouUrl" in (intent ?? {})).toBe(false);
-  });
-
-  test("carries the folded dayCount when a customisable child is folded in", async () => {
-    const { parent, child } = await makeCustomisableDailyParent();
-    const date = (await bookableStartDates(parent.id))[0]!;
-    const { intent } = await stubFoldedCheckout(
-      parent,
-      parentBody(child),
-      date,
-    );
-    expect(intent?.dayCount).toBe(3);
-    expectCapturedItemPriced(intent, child, 3000);
-  });
-
-  test("books a free folded order owing nothing when a provider is configured", async () => {
-    // Payments enabled but the whole folded order is free, so it takes the
-    // no-charge path and owes nothing — the provider is never invoked.
-    const { parent, child } = await makeProviderlessParent(0);
-    const { body, calls } = await stubFoldedCheckout(parent, parentBody(child));
-    expect(body.booking?.amountOwed).toBe(0);
-    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
-    expect(calls()).toBe(0);
-  });
-
-  test("opens checkout for a one-penny folded paid order", async () => {
-    // The `total > 0` gate must fire for the smallest non-zero folded total
-    // (a £0.01 child with a provider): a checkout session opens rather than
-    // the order silently taking the free path.
-    const { parent, child } = await makeProviderlessParent(1);
-    const { body } = await stubFoldedCheckout(parent, parentBody(child));
-    expect(body.booking?.checkoutUrl).toBe(CHECKOUT_URL);
-  });
-
-  test("rejects a malformed children array with a 400", async () => {
-    const { parent } = await makeProviderlessParent(0);
-    const response = await bookParent(parent, {
-      children: "not-an-array",
-      email: "a@b.com",
-      name: "Ada",
-      quantity: 1,
-    });
-    expect(response.status).toBe(400);
-    expect((await response.json()).error).toMatch(/children.*array/i);
-  });
-
-  test("rejects a customisable parent with a 400 pointing to the website", async () => {
-    const { parent } = await makeParent({
-      children: [{ maxAttendees: 10, unitPrice: 0 }],
-      parent: {
-        customisableDays: true,
-        dayPrices: { 1: 1000, 3: 3000 },
-        durationDays: 3,
-        maxAttendees: 10,
-        unitPrice: 0,
-      },
-    });
-    const response = await bookParent(parent, parentBody({ slug: "ignored" }));
-    expect(response.status).toBe(400);
-    expect((await response.json()).error).toMatch(
-      /booked through the website/i,
-    );
   });
 });

--- a/test/features/api/folded-booking.test.ts
+++ b/test/features/api/folded-booking.test.ts
@@ -1,0 +1,414 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  applyChildSelectionsToForm,
+  parseApiChildSelections,
+  processParentApiBooking,
+} from "#routes/api/folded-booking.ts";
+import {
+  type ApiChildSelection,
+  PackageChildrenSchema,
+} from "#routes/api/request-schemas.ts";
+import type { TicketCtx } from "#routes/public/types.ts";
+import type { TicketListing } from "#shared/booking/model.ts";
+import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
+import { FormParams } from "#shared/form-data.ts";
+import type { CheckoutIntent } from "#shared/payments.ts";
+import type { Listing, ListingWithCount } from "#shared/types.ts";
+import { resolved } from "#test/lib/booking-model-fixtures.ts";
+import type { BookResponseBody } from "#test/routes/api/helpers.ts";
+import {
+  expectCapturedItemPriced,
+  stubCheckout,
+} from "#test-utils/checkout.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { bookableStartDates } from "#test-utils/db-helpers/listings.ts";
+import {
+  makeCustomisableDailyParent,
+  makeParent,
+} from "#test-utils/parents.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** Direct, function-level tests of the folded-booking API module — the parsing,
+ * application, and parent-flow functions that the JSON API's `handleBook` only
+ * exercises through the full HTTP/router stack. `parseApiChildSelections` and
+ * `applyChildSelectionsToForm` are pure (no DB); `processParentApiBooking` is
+ * the function-boundary seam for the folded free / provider-less / paid
+ * checkout paths, covering the internal `completeFoldedBooking`/`foldedIntent`
+ * through their one exported entry point. */
+
+const PARENT_ID = 1;
+const CHECKOUT_URL = "https://stripe.example/checkout";
+
+/** A child {@link TicketListing} fixture carrying the given id and slug, built
+ * from the shared `resolved()` factory so the shape stays the one the fold
+ * tests already use. `applyChildSelectionsToForm` reads only
+ * `ctx.childrenByParentId`, so a ctx carrying just that map is an honest
+ * fixture for it. */
+const childFixture = (id: number, slug: string): TicketListing =>
+  resolved({ id, slug });
+
+/** Build the minimal ctx `applyChildSelectionsToForm` reads: one parent's
+ * resolved children. The rest of {@link TicketCtx} is unused by that function,
+ * so the cast keeps the fixture to exactly the field under test. */
+const ctxWithChildren = (children: TicketListing[]): TicketCtx =>
+  ({
+    childrenByParentId: new Map([[PARENT_ID, children]]),
+  }) as unknown as TicketCtx;
+
+/** Read a `Response | null` from {@link applyChildSelectionsToForm} as a 400
+ * JSON error body, asserting it is a Response first so a `null` (success)
+ * surfaces as a type failure rather than a silent pass. */
+const errorBody = async (
+  result: Response | null,
+): Promise<{ error: string }> => {
+  expect(result).toBeInstanceOf(Response);
+  return (await (result as Response).json()) as { error: string };
+};
+
+/** Run {@link applyChildSelectionsToForm} against one child (id 10,
+ *  slug "child-a") under the parent, returning the form alongside the result
+ *  so a test asserts both the written fields and the success/error outcome. */
+const applySelections = (
+  selections: ApiChildSelection[],
+): { form: FormParams; result: Response | null } => {
+  const form = new FormParams();
+  const result = applyChildSelectionsToForm(
+    form,
+    ctxWithChildren([childFixture(10, "child-a")]),
+    PARENT_ID,
+    selections,
+  );
+  return { form, result };
+};
+
+/** A POST request carrying only a host header — {@link processParentApiBooking}
+ * uses it solely for `getBaseUrl`, and receives the parsed body as a separate
+ * record, so no body is attached here. */
+const bookRequest = (): Request =>
+  new Request("http://localhost/api/listings/x/book", {
+    headers: { host: "localhost" },
+    method: "POST",
+  });
+
+/** `makeParent` returns the parent row typed as `Listing`, but `createTestListing`
+ * reads it back through `getAllListings`, which selects the full row including
+ * the trigger-maintained count columns — so it is a {@link ListingWithCount} at
+ * runtime. `processParentApiBooking` reads those columns, hence the downcast. */
+const asWithCount = (listing: Pick<Listing, "id">): ListingWithCount =>
+  listing as ListingWithCount;
+
+/** A one-unit parent booking body selecting `child`, with the standard test
+ * contact merged in; `extra` adds paid/custom-price fields per scenario. */
+const parentBody = (
+  child: { slug: string },
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  children: [{ quantity: 1, slug: child.slug }],
+  email: "a@b.com",
+  name: "Ada",
+  quantity: 1,
+  ...extra,
+});
+
+/** Call {@link processParentApiBooking} for one parent unit with a resolved body
+ *  and date — the single shape behind every parent-flow test, so the request,
+ *  cast, quantity, and date plumbing lives once. */
+const bookParent = (
+  parent: Pick<Listing, "id">,
+  body: Record<string, unknown>,
+  date: string | null = null,
+): Promise<Response> =>
+  processParentApiBooking(bookRequest(), asWithCount(parent), body, 1, date);
+
+/** A free parent (£0, capacity 10) with a child priced at `childUnitPrice` —
+ *  the shared provider-less scenario behind the free, full-value-owed, and
+ *  one-penny-owed tests. */
+const makeProviderlessParent = (childUnitPrice: number) =>
+  makeParent({
+    children: [{ maxAttendees: 10, unitPrice: childUnitPrice }],
+    parent: { maxAttendees: 10, unitPrice: 0 },
+  });
+
+/** Book a provider-less folded order (free parent + a child priced at
+ *  `childUnitPrice`, no provider configured), returning the parsed body, the
+ *  created attendee, and the parent/child listings. Shared by the free,
+ *  provider-less-owed, and one-penny-owed tests. */
+const foldProviderless = async (childUnitPrice: number) => {
+  const { parent, child } = await makeProviderlessParent(childUnitPrice);
+  const response = await bookParent(parent, parentBody(child));
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as BookResponseBody;
+  const { getAttendeesByTokens } = await import(
+    "#shared/db/attendees/tokens.ts"
+  );
+  const [attendee] = await getAttendeesByTokens([body.booking!.ticketToken!]);
+  return { attendee: attendee!, body, child, parent };
+};
+
+/** Book a folded order against the stubbed checkout (provider configured),
+ *  returning the parsed body, the call count, and the captured intent — the
+ *  shared "inspect what the paid path would have charged" fixture. */
+const stubFoldedCheckout = async (
+  parent: Pick<Listing, "id">,
+  body: Record<string, unknown>,
+  date: string | null = null,
+): Promise<{
+  body: BookResponseBody;
+  calls: () => number;
+  intent: CheckoutIntent | undefined;
+}> => {
+  await setupStripe();
+  const { calls, checkout, getCaptured } = stubCheckout("sess_test");
+  try {
+    const response = await bookParent(parent, body, date);
+    expect(response.status).toBe(200);
+    return {
+      body: (await response.json()) as BookResponseBody,
+      calls,
+      intent: getCaptured(),
+    };
+  } finally {
+    checkout.restore();
+  }
+};
+
+describe("parseApiChildSelections", () => {
+  test("returns the parsed children for a valid body", () => {
+    const selections = parseApiChildSelections({
+      children: [{ quantity: 2, slug: "gig" }],
+    });
+    expect(selections).toEqual([{ quantity: 2, slug: "gig" }]);
+  });
+
+  test("round-trips a customPrice and an optional parent", () => {
+    const selections = parseApiChildSelections({
+      children: [{ customPrice: 12.5, parent: "pkg", quantity: 1, slug: "g" }],
+    });
+    expect(selections).toEqual([
+      { customPrice: 12.5, parent: "pkg", quantity: 1, slug: "g" },
+    ]);
+  });
+
+  test("defaults an absent children field to an empty array", () => {
+    expect(parseApiChildSelections({})).toEqual([]);
+    expect(parseApiChildSelections({ children: undefined })).toEqual([]);
+    expect(parseApiChildSelections({ children: null })).toEqual([]);
+  });
+
+  test("returns null when children is malformed", () => {
+    expect(parseApiChildSelections({ children: "nope" })).toBe(null);
+    expect(
+      parseApiChildSelections({ children: [{ quantity: 0, slug: "g" }] }),
+    ).toBe(null);
+    expect(parseApiChildSelections({ children: [{ quantity: 1 }] })).toBe(null);
+  });
+
+  test("validates against the package schema, which requires a parent on each entry", () => {
+    expect(
+      parseApiChildSelections(
+        { children: [{ parent: "pkg", quantity: 1, slug: "g" }] },
+        PackageChildrenSchema,
+      ),
+    ).toEqual([{ parent: "pkg", quantity: 1, slug: "g" }]);
+    expect(
+      parseApiChildSelections(
+        { children: [{ quantity: 1, slug: "g" }] },
+        PackageChildrenSchema,
+      ),
+    ).toBe(null);
+  });
+});
+
+describe("applyChildSelectionsToForm", () => {
+  test("writes a per-child quantity field and returns null", () => {
+    const { form, result } = applySelections([
+      { quantity: 2, slug: "child-a" },
+    ]);
+    expect(result).toBe(null);
+    expect(form.get("child_qty_1_10")).toBe("2");
+  });
+
+  test("sums repeated slug entries into one child quantity", () => {
+    const { form, result } = applySelections([
+      { quantity: 1, slug: "child-a" },
+      { quantity: 2, slug: "child-a" },
+    ]);
+    expect(result).toBe(null);
+    expect(form.get("child_qty_1_10")).toBe("3");
+  });
+
+  test("writes a per-child price field when a customPrice is given", () => {
+    const { form, result } = applySelections([
+      { customPrice: 30, quantity: 1, slug: "child-a" },
+    ]);
+    expect(result).toBe(null);
+    expect(form.get("child_price_1_10")).toBe("30");
+  });
+
+  test("omits the price field when no customPrice is given", () => {
+    const { form, result } = applySelections([
+      { quantity: 1, slug: "child-a" },
+    ]);
+    expect(result).toBe(null);
+    expect(form.has("child_price_1_10")).toBe(false);
+  });
+
+  test("rejects a slug that is not a child of this parent with a 400", async () => {
+    const { result } = applySelections([{ quantity: 1, slug: "stranger" }]);
+    expect((result as Response).status).toBe(400);
+    expect((await errorBody(result)).error).toMatch(/is not a child/i);
+  });
+
+  test("rejects duplicate entries for one child with conflicting prices", async () => {
+    const { result } = applySelections([
+      { customPrice: 30, quantity: 1, slug: "child-a" },
+      { customPrice: 20, quantity: 1, slug: "child-a" },
+    ]);
+    expect((result as Response).status).toBe(400);
+    expect((await errorBody(result)).error).toMatch(/conflicting prices/i);
+  });
+
+  test("accepts repeated entries that agree on the price", () => {
+    const { form, result } = applySelections([
+      { customPrice: 30, quantity: 1, slug: "child-a" },
+      { customPrice: 30, quantity: 1, slug: "child-a" },
+    ]);
+    expect(result).toBe(null);
+    expect(form.get("child_qty_1_10")).toBe("2");
+    expect(form.get("child_price_1_10")).toBe("30");
+  });
+});
+
+describeWithEnv("processParentApiBooking", { db: true, triggers: true }, () => {
+  test("folds a free parent+child into a booking that owes nothing", async () => {
+    const { body, attendee, child, parent } = await foldProviderless(0);
+    // The free path returns an owed amount of 0 and a ticket link (not a
+    // checkout URL): amountOwed's exact value pins the branch taken.
+    expect(body.booking?.amountOwed).toBe(0);
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
+    const childRow = attendee.bookings.find((b) => b.listing_id === child.id);
+    expect(childRow?.parent_listing_id).toBe(parent.id);
+  });
+
+  test("folds a paid child into a provider-less booking that owes the full value", async () => {
+    const { body, attendee } = await foldProviderless(1500);
+    // amountOwed carries the full folded value — the provider-less owed path.
+    expect(body.booking?.amountOwed).toBe(1500);
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
+    expect(attendee.remaining_balance).toBe(1500);
+  });
+
+  test("records even a one-penny folded order in the owed ledger", async () => {
+    // The `remainingBalance > 0` gate must fire for the smallest non-zero
+    // folded total (a £0.01 child): the owed ledger order is posted, so the
+    // ledger-projected balance (not just the denormalized column) is 1.
+    const { body, attendee } = await foldProviderless(1);
+    expect(body.booking?.amountOwed).toBe(1);
+    expect((await getAttendeeBalanceState(attendee.id))?.remainingBalance).toBe(
+      1,
+    );
+  });
+
+  test("returns a checkout URL for a folded paid order and carries the fold on the intent", async () => {
+    const { parent, child } = await makeParent({
+      children: [{ maxAttendees: 10, unitPrice: 500 }],
+      parent: {
+        maxAttendees: 10,
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice: 1000,
+      },
+    });
+    const { intent } = await stubFoldedCheckout(parent, parentBody(child));
+    expect(intent?.date).toBe(null);
+    expect(intent?.thankYouUrl).toBe("https://example.com/thanks");
+    expect(intent?.allocations).toEqual([
+      { childId: child.id, parentId: parent.id, qty: 1 },
+    ]);
+    expectCapturedItemPriced(intent, parent, 1000);
+    expectCapturedItemPriced(intent, child, 500);
+    // A non-customisable fold carries no dayCount on the intent.
+    expect("dayCount" in (intent ?? {})).toBe(false);
+  });
+
+  test("charges a pay-more parent's custom price on the folded checkout line", async () => {
+    const { parent, child } = await makeParent({
+      children: [{ maxAttendees: 10, unitPrice: 500 }],
+      parent: {
+        canPayMore: true,
+        maxAttendees: 10,
+        maxPrice: 10000,
+        unitPrice: 1000,
+      },
+    });
+    const { intent } = await stubFoldedCheckout(
+      parent,
+      parentBody(child, { customPrice: 20 }),
+    );
+    expectCapturedItemPriced(intent, parent, 2000);
+    expectCapturedItemPriced(intent, child, 500);
+    // A parent with no configured thank-you URL omits it from the intent.
+    expect("thankYouUrl" in (intent ?? {})).toBe(false);
+  });
+
+  test("carries the folded dayCount when a customisable child is folded in", async () => {
+    const { parent, child } = await makeCustomisableDailyParent();
+    const date = (await bookableStartDates(parent.id))[0]!;
+    const { intent } = await stubFoldedCheckout(
+      parent,
+      parentBody(child),
+      date,
+    );
+    expect(intent?.dayCount).toBe(3);
+    expectCapturedItemPriced(intent, child, 3000);
+  });
+
+  test("books a free folded order owing nothing when a provider is configured", async () => {
+    // Payments enabled but the whole folded order is free, so it takes the
+    // no-charge path and owes nothing — the provider is never invoked.
+    const { parent, child } = await makeProviderlessParent(0);
+    const { body, calls } = await stubFoldedCheckout(parent, parentBody(child));
+    expect(body.booking?.amountOwed).toBe(0);
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
+    expect(calls()).toBe(0);
+  });
+
+  test("opens checkout for a one-penny folded paid order", async () => {
+    // The `total > 0` gate must fire for the smallest non-zero folded total
+    // (a £0.01 child with a provider): a checkout session opens rather than
+    // the order silently taking the free path.
+    const { parent, child } = await makeProviderlessParent(1);
+    const { body } = await stubFoldedCheckout(parent, parentBody(child));
+    expect(body.booking?.checkoutUrl).toBe(CHECKOUT_URL);
+  });
+
+  test("rejects a malformed children array with a 400", async () => {
+    const { parent } = await makeProviderlessParent(0);
+    const response = await bookParent(parent, {
+      children: "not-an-array",
+      email: "a@b.com",
+      name: "Ada",
+      quantity: 1,
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/children.*array/i);
+  });
+
+  test("rejects a customisable parent with a 400 pointing to the website", async () => {
+    const { parent } = await makeParent({
+      children: [{ maxAttendees: 10, unitPrice: 0 }],
+      parent: {
+        customisableDays: true,
+        dayPrices: { 1: 1000, 3: 3000 },
+        durationDays: 3,
+        maxAttendees: 10,
+        unitPrice: 0,
+      },
+    });
+    const response = await bookParent(parent, parentBody({ slug: "ignored" }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(
+      /booked through the website/i,
+    );
+  });
+});

--- a/test/features/api/folded-booking/parent-booking.test.ts
+++ b/test/features/api/folded-booking/parent-booking.test.ts
@@ -7,6 +7,7 @@ import type { Listing, ListingWithCount } from "#shared/types.ts";
 import type { BookResponseBody } from "#test/routes/api/helpers.ts";
 import {
   expectCapturedItemPriced,
+  STUB_CHECKOUT_URL,
   stubCheckout,
 } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -23,8 +24,6 @@ import { setupStripe } from "#test-utils/settings.ts";
  * paid-checkout behaviour at the function boundary, covering the internal
  * `completeFoldedBooking`/`foldedIntent` through their one exported entry point.
  * The pure child-selection tests live in `folded-booking.test.ts`. */
-
-const CHECKOUT_URL = "https://stripe.example/checkout";
 
 /** A POST request carrying only a host header — {@link processParentApiBooking}
  * uses it solely for `getBaseUrl`, and receives the parsed body as a separate
@@ -216,7 +215,7 @@ describeWithEnv("processParentApiBooking", { db: true, triggers: true }, () => {
     // the order silently taking the free path.
     const { parent, child } = await makeProviderlessParent(1);
     const { body } = await stubFoldedCheckout(parent, parentBody(child));
-    expect(body.booking?.checkoutUrl).toBe(CHECKOUT_URL);
+    expect(body.booking?.checkoutUrl).toBe(STUB_CHECKOUT_URL);
   });
 
   test("rejects a malformed children array with a 400", async () => {

--- a/test/features/api/folded-booking/parent-booking.test.ts
+++ b/test/features/api/folded-booking/parent-booking.test.ts
@@ -1,9 +1,15 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { processParentApiBooking } from "#routes/api/folded-booking.ts";
+import {
+  finishFoldedBooking,
+  processParentApiBooking,
+} from "#routes/api/folded-booking.ts";
+import { buildTicketListing } from "#shared/booking/model.ts";
 import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
+import { FormParams } from "#shared/form-data.ts";
 import type { CheckoutIntent } from "#shared/payments.ts";
-import type { Listing, ListingWithCount } from "#shared/types.ts";
+import { checkoutItem } from "#shared/payments.ts";
+import type { ListingWithCount } from "#shared/types.ts";
 import type { BookResponseBody } from "#test/routes/api/helpers.ts";
 import {
   expectCapturedItemPriced,
@@ -11,7 +17,10 @@ import {
   stubCheckout,
 } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { bookableStartDates } from "#test-utils/db-helpers/listings.ts";
+import {
+  bookableStartDates,
+  createTestListing,
+} from "#test-utils/db-helpers/listings.ts";
 import {
   makeCustomisableDailyParent,
   makeParent,
@@ -34,13 +43,6 @@ const bookRequest = (): Request =>
     method: "POST",
   });
 
-/** `makeParent` returns the parent row typed as `Listing`, but `createTestListing`
- * reads it back through `getAllListings`, which selects the full row including
- * the trigger-maintained count columns — so it is a {@link ListingWithCount} at
- * runtime. `processParentApiBooking` reads those columns, hence the downcast. */
-const asWithCount = (listing: Pick<Listing, "id">): ListingWithCount =>
-  listing as ListingWithCount;
-
 /** A one-unit parent booking body selecting `child`, with the standard test
  * contact merged in; `extra` adds paid/custom-price fields per scenario. */
 const parentBody = (
@@ -56,13 +58,13 @@ const parentBody = (
 
 /** Call {@link processParentApiBooking} for one parent unit with a resolved body
  *  and date — the single shape behind every parent-flow test, so the request,
- *  cast, quantity, and date plumbing lives once. */
+ *  quantity, and date plumbing lives once. */
 const bookParent = (
-  parent: Pick<Listing, "id">,
+  parent: ListingWithCount,
   body: Record<string, unknown>,
   date: string | null = null,
 ): Promise<Response> =>
-  processParentApiBooking(bookRequest(), asWithCount(parent), body, 1, date);
+  processParentApiBooking(bookRequest(), parent, body, 1, date);
 
 /** A free parent (£0, capacity 10) with a child priced at `childUnitPrice` —
  *  the shared provider-less scenario behind the free, full-value-owed, and
@@ -93,7 +95,7 @@ const foldProviderless = async (childUnitPrice: number) => {
  *  returning the parsed body, the call count, and the captured intent — the
  *  shared "inspect what the paid path would have charged" fixture. */
 const stubFoldedCheckout = async (
-  parent: Pick<Listing, "id">,
+  parent: ListingWithCount,
   body: Record<string, unknown>,
   date: string | null = null,
 ): Promise<{
@@ -246,5 +248,42 @@ describeWithEnv("processParentApiBooking", { db: true, triggers: true }, () => {
     expect((await response.json()).error).toMatch(
       /booked through the website/i,
     );
+  });
+
+  test("completes a one-listing folded booking without error", async () => {
+    // A one-listing fold (e.g. a one-member package with no children) produces
+    // one attendee entry. completeFoldedBooking reads entries[0], so the mutant
+    // entries[0] → entries[1] would throw on a single-entry array. This test
+    // builds a minimal one-listing fold and calls finishFoldedBooking directly
+    // (it's exported) to reach that branch.
+    const listing = await createTestListing({
+      fields: "email",
+      maxAttendees: 10,
+      unitPrice: 0,
+    });
+    const ticketListing = buildTicketListing(listing, false, undefined);
+    const fold = {
+      allocations: [],
+      customPrices: new Map<number, number>(),
+      dayCount: 1,
+      hasCustomisable: false,
+      listings: [ticketListing],
+      ok: true as const,
+      priceRuleByListingId: new Map(),
+      quantities: new Map([[listing.id, 1]]),
+      selectedListingIds: new Set([listing.id]),
+    };
+    const items = [checkoutItem(listing, 1, 0)];
+    const form = new FormParams();
+    form.set("email", "a@b.com");
+    form.set("name", "Ada");
+    const response = await finishFoldedBooking(bookRequest(), form, false, {
+      date: null,
+      fold,
+      items,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as BookResponseBody;
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
   });
 });

--- a/test/features/api/folded-booking/parent-booking.test.ts
+++ b/test/features/api/folded-booking/parent-booking.test.ts
@@ -1,0 +1,251 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { processParentApiBooking } from "#routes/api/folded-booking.ts";
+import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
+import type { CheckoutIntent } from "#shared/payments.ts";
+import type { Listing, ListingWithCount } from "#shared/types.ts";
+import type { BookResponseBody } from "#test/routes/api/helpers.ts";
+import {
+  expectCapturedItemPriced,
+  stubCheckout,
+} from "#test-utils/checkout.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { bookableStartDates } from "#test-utils/db-helpers/listings.ts";
+import {
+  makeCustomisableDailyParent,
+  makeParent,
+} from "#test-utils/parents.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** Direct, function-level tests of `processParentApiBooking` — the folded
+ * parent-booking flow the JSON API's `handleBook` reaches only through the full
+ * HTTP/router stack. Calling it directly pins the folded free / provider-less /
+ * paid-checkout behaviour at the function boundary, covering the internal
+ * `completeFoldedBooking`/`foldedIntent` through their one exported entry point.
+ * The pure child-selection tests live in `folded-booking.test.ts`. */
+
+const CHECKOUT_URL = "https://stripe.example/checkout";
+
+/** A POST request carrying only a host header — {@link processParentApiBooking}
+ * uses it solely for `getBaseUrl`, and receives the parsed body as a separate
+ * record, so no body is attached here. */
+const bookRequest = (): Request =>
+  new Request("http://localhost/api/listings/x/book", {
+    headers: { host: "localhost" },
+    method: "POST",
+  });
+
+/** `makeParent` returns the parent row typed as `Listing`, but `createTestListing`
+ * reads it back through `getAllListings`, which selects the full row including
+ * the trigger-maintained count columns — so it is a {@link ListingWithCount} at
+ * runtime. `processParentApiBooking` reads those columns, hence the downcast. */
+const asWithCount = (listing: Pick<Listing, "id">): ListingWithCount =>
+  listing as ListingWithCount;
+
+/** A one-unit parent booking body selecting `child`, with the standard test
+ * contact merged in; `extra` adds paid/custom-price fields per scenario. */
+const parentBody = (
+  child: { slug: string },
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  children: [{ quantity: 1, slug: child.slug }],
+  email: "a@b.com",
+  name: "Ada",
+  quantity: 1,
+  ...extra,
+});
+
+/** Call {@link processParentApiBooking} for one parent unit with a resolved body
+ *  and date — the single shape behind every parent-flow test, so the request,
+ *  cast, quantity, and date plumbing lives once. */
+const bookParent = (
+  parent: Pick<Listing, "id">,
+  body: Record<string, unknown>,
+  date: string | null = null,
+): Promise<Response> =>
+  processParentApiBooking(bookRequest(), asWithCount(parent), body, 1, date);
+
+/** A free parent (£0, capacity 10) with a child priced at `childUnitPrice` —
+ *  the shared provider-less scenario behind the free, full-value-owed, and
+ *  one-penny-owed tests. */
+const makeProviderlessParent = (childUnitPrice: number) =>
+  makeParent({
+    children: [{ maxAttendees: 10, unitPrice: childUnitPrice }],
+    parent: { maxAttendees: 10, unitPrice: 0 },
+  });
+
+/** Book a provider-less folded order (free parent + a child priced at
+ *  `childUnitPrice`, no provider configured), returning the parsed body, the
+ *  created attendee, and the parent/child listings. Shared by the free,
+ *  provider-less-owed, and one-penny-owed tests. */
+const foldProviderless = async (childUnitPrice: number) => {
+  const { parent, child } = await makeProviderlessParent(childUnitPrice);
+  const response = await bookParent(parent, parentBody(child));
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as BookResponseBody;
+  const { getAttendeesByTokens } = await import(
+    "#shared/db/attendees/tokens.ts"
+  );
+  const [attendee] = await getAttendeesByTokens([body.booking!.ticketToken!]);
+  return { attendee: attendee!, body, child, parent };
+};
+
+/** Book a folded order against the stubbed checkout (provider configured),
+ *  returning the parsed body, the call count, and the captured intent — the
+ *  shared "inspect what the paid path would have charged" fixture. */
+const stubFoldedCheckout = async (
+  parent: Pick<Listing, "id">,
+  body: Record<string, unknown>,
+  date: string | null = null,
+): Promise<{
+  body: BookResponseBody;
+  calls: () => number;
+  intent: CheckoutIntent | undefined;
+}> => {
+  await setupStripe();
+  const { calls, checkout, getCaptured } = stubCheckout("sess_test");
+  try {
+    const response = await bookParent(parent, body, date);
+    expect(response.status).toBe(200);
+    return {
+      body: (await response.json()) as BookResponseBody,
+      calls,
+      intent: getCaptured(),
+    };
+  } finally {
+    checkout.restore();
+  }
+};
+
+describeWithEnv("processParentApiBooking", { db: true, triggers: true }, () => {
+  test("folds a free parent+child into a booking that owes nothing", async () => {
+    const { body, attendee, child, parent } = await foldProviderless(0);
+    // The free path returns an owed amount of 0 and a ticket link (not a
+    // checkout URL): amountOwed's exact value pins the branch taken.
+    expect(body.booking?.amountOwed).toBe(0);
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
+    const childRow = attendee.bookings.find((b) => b.listing_id === child.id);
+    expect(childRow?.parent_listing_id).toBe(parent.id);
+  });
+
+  test("folds a paid child into a provider-less booking that owes the full value", async () => {
+    const { body, attendee } = await foldProviderless(1500);
+    // amountOwed carries the full folded value — the provider-less owed path.
+    expect(body.booking?.amountOwed).toBe(1500);
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
+    expect(attendee.remaining_balance).toBe(1500);
+  });
+
+  test("records even a one-penny folded order in the owed ledger", async () => {
+    // The `remainingBalance > 0` gate must fire for the smallest non-zero
+    // folded total (a £0.01 child): the owed ledger order is posted, so the
+    // ledger-projected balance (not just the denormalized column) is 1.
+    const { body, attendee } = await foldProviderless(1);
+    expect(body.booking?.amountOwed).toBe(1);
+    expect((await getAttendeeBalanceState(attendee.id))?.remainingBalance).toBe(
+      1,
+    );
+  });
+
+  test("returns a checkout URL for a folded paid order and carries the fold on the intent", async () => {
+    const { parent, child } = await makeParent({
+      children: [{ maxAttendees: 10, unitPrice: 500 }],
+      parent: {
+        maxAttendees: 10,
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice: 1000,
+      },
+    });
+    const { intent } = await stubFoldedCheckout(parent, parentBody(child));
+    expect(intent?.date).toBe(null);
+    expect(intent?.thankYouUrl).toBe("https://example.com/thanks");
+    expect(intent?.allocations).toEqual([
+      { childId: child.id, parentId: parent.id, qty: 1 },
+    ]);
+    expectCapturedItemPriced(intent, parent, 1000);
+    expectCapturedItemPriced(intent, child, 500);
+    // A non-customisable fold carries no dayCount on the intent.
+    expect("dayCount" in (intent ?? {})).toBe(false);
+  });
+
+  test("charges a pay-more parent's custom price on the folded checkout line", async () => {
+    const { parent, child } = await makeParent({
+      children: [{ maxAttendees: 10, unitPrice: 500 }],
+      parent: {
+        canPayMore: true,
+        maxAttendees: 10,
+        maxPrice: 10000,
+        unitPrice: 1000,
+      },
+    });
+    const { intent } = await stubFoldedCheckout(
+      parent,
+      parentBody(child, { customPrice: 20 }),
+    );
+    expectCapturedItemPriced(intent, parent, 2000);
+    expectCapturedItemPriced(intent, child, 500);
+    // A parent with no configured thank-you URL omits it from the intent.
+    expect("thankYouUrl" in (intent ?? {})).toBe(false);
+  });
+
+  test("carries the folded dayCount when a customisable child is folded in", async () => {
+    const { parent, child } = await makeCustomisableDailyParent();
+    const date = (await bookableStartDates(parent.id))[0]!;
+    const { intent } = await stubFoldedCheckout(
+      parent,
+      parentBody(child),
+      date,
+    );
+    expect(intent?.dayCount).toBe(3);
+    expectCapturedItemPriced(intent, child, 3000);
+  });
+
+  test("books a free folded order owing nothing when a provider is configured", async () => {
+    // Payments enabled but the whole folded order is free, so it takes the
+    // no-charge path and owes nothing — the provider is never invoked.
+    const { parent, child } = await makeProviderlessParent(0);
+    const { body, calls } = await stubFoldedCheckout(parent, parentBody(child));
+    expect(body.booking?.amountOwed).toBe(0);
+    expect(body.booking?.ticketUrl).toMatch(/^\/t\//);
+    expect(calls()).toBe(0);
+  });
+
+  test("opens checkout for a one-penny folded paid order", async () => {
+    // The `total > 0` gate must fire for the smallest non-zero folded total
+    // (a £0.01 child with a provider): a checkout session opens rather than
+    // the order silently taking the free path.
+    const { parent, child } = await makeProviderlessParent(1);
+    const { body } = await stubFoldedCheckout(parent, parentBody(child));
+    expect(body.booking?.checkoutUrl).toBe(CHECKOUT_URL);
+  });
+
+  test("rejects a malformed children array with a 400", async () => {
+    const { parent } = await makeProviderlessParent(0);
+    const response = await bookParent(parent, {
+      children: "not-an-array",
+      email: "a@b.com",
+      name: "Ada",
+      quantity: 1,
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/children.*array/i);
+  });
+
+  test("rejects a customisable parent with a 400 pointing to the website", async () => {
+    const { parent } = await makeParent({
+      children: [{ maxAttendees: 10, unitPrice: 0 }],
+      parent: {
+        customisableDays: true,
+        dayPrices: { 1: 1000, 3: 3000 },
+        durationDays: 3,
+        maxAttendees: 10,
+        unitPrice: 0,
+      },
+    });
+    const response = await bookParent(parent, parentBody({ slug: "ignored" }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(
+      /booked through the website/i,
+    );
+  });
+});

--- a/test/shared/booking.test.ts
+++ b/test/shared/booking.test.ts
@@ -1,0 +1,238 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  type BookingResult,
+  listingHasSpots,
+  processBooking,
+} from "#shared/booking.ts";
+import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
+import type { Attendee, ContactInfo, ListingWithCount } from "#shared/types.ts";
+import { withCheckoutStub } from "#test/routes/api/helpers.ts";
+import { stubCheckout } from "#test-utils/checkout.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestAttendeeDirect } from "#test-utils/db-helpers/attendees.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** Direct, function-level tests of {@link processBooking} and
+ * {@link listingHasSpots} — the single-listing booking core. The route layer
+ * (`handleBook`) maps a {@link BookingResult} to a JSON response, so these tests
+ * pin the discriminated-union contract the route depends on at the function
+ * boundary rather than going through the HTTP/router stack. */
+const BASE_URL = "http://localhost";
+
+const contact: ContactInfo = {
+  address: "",
+  email: "alice@test.com",
+  name: "Alice",
+  phone: "",
+  special_instructions: "",
+};
+
+/** Narrow a {@link BookingResult} to its success attendee, or null. The caller
+ * first asserts `result.type === "success"` (which throws on a wrong branch),
+ * so a null here means the branch drifted — the value assertion then fails
+ * loudly rather than papering over the mismatch. */
+const attendeeOf = (result: BookingResult) =>
+  result.type === "success" ? result.attendee : null;
+
+/** `createTestListing` returns `Listing`, but it reads the row back through
+ * `getAllListings`, which selects the full row including the trigger-maintained
+ * count columns — so it is a `ListingWithCount` at runtime. `processBooking`
+ * reads those columns, hence the downcast. */
+const createListingWithCount = (
+  overrides: Parameters<typeof createTestListing>[0] = {},
+): Promise<ListingWithCount> =>
+  createTestListing(overrides) as Promise<ListingWithCount>;
+
+/** Create a listing at `unitPrice` (capacity 10) and book `quantity` units
+ *  directly, asserting success and returning the attendee. Shared by the free,
+ *  owed, scaled, and one-penny success-path tests. */
+const bookDirect = async (
+  unitPrice: number,
+  quantity = 1,
+): Promise<Attendee> => {
+  const listing = await createListingWithCount({ maxAttendees: 10, unitPrice });
+  const result = await processBooking(
+    listing,
+    contact,
+    quantity,
+    null,
+    BASE_URL,
+  );
+  expect(result.type).toBe("success");
+  return attendeeOf(result)!;
+};
+
+describeWithEnv("processBooking", { db: true, triggers: true }, () => {
+  describe("free and provider-less direct bookings", () => {
+    test("creates a free attendee that owes nothing", async () => {
+      const attendee = await bookDirect(0);
+      expect(attendee.remaining_balance).toBe(0);
+      expect(typeof attendee.ticket_token).toBe("string");
+      expect(attendee.ticket_token.length).toBeGreaterThan(0);
+    });
+
+    test("records the full listing value as owed without a provider", async () => {
+      const attendee = await bookDirect(1500);
+      expect(attendee.remaining_balance).toBe(1500);
+      // The owed ledger poster writes a gross `sale` leg with nothing paid, so
+      // the ledger-projected balance (not just the denormalized column) equals
+      // the gross — the invariant the poster exists to maintain.
+      expect(
+        (await getAttendeeBalanceState(attendee.id))?.remainingBalance,
+      ).toBe(1500);
+    });
+
+    test("records even a one-penny owed balance in the ledger", async () => {
+      // The `remainingBalance > 0` gate must fire for the smallest non-zero
+      // balance (a £0.01 listing): any positive value posts the owed leg.
+      const attendee = await bookDirect(1);
+      expect(
+        (await getAttendeeBalanceState(attendee.id))?.remainingBalance,
+      ).toBe(1);
+    });
+
+    test("scales the owed balance by the booked quantity", async () => {
+      const attendee = await bookDirect(1000, 3);
+      expect(attendee.remaining_balance).toBe(3000);
+    });
+  });
+
+  describe("paid checkout through a provider", () => {
+    test("returns the provider's checkout URL with a single priced item", async () => {
+      await setupStripe();
+      const listing = await createListingWithCount({
+        maxAttendees: 10,
+        unitPrice: 1500,
+      });
+      const { checkout, getCaptured } = stubCheckout("sess_test");
+      try {
+        const result = await processBooking(
+          listing,
+          contact,
+          2,
+          null,
+          BASE_URL,
+        );
+        expect(result).toEqual({
+          checkoutUrl: "https://stripe.example/checkout",
+          type: "checkout",
+        });
+      } finally {
+        checkout.restore();
+      }
+      const intent = getCaptured();
+      expect(intent?.date).toBe(null);
+      expect(intent?.items).toEqual([
+        {
+          listingId: listing.id,
+          name: listing.name,
+          quantity: 2,
+          slug: listing.slug,
+          unitPrice: 1500,
+        },
+      ]);
+    });
+
+    test("returns sold_out and skips the provider when capacity is exhausted", async () => {
+      await setupStripe();
+      const listing = await createListingWithCount({
+        maxAttendees: 1,
+        unitPrice: 1500,
+      });
+      await createTestAttendeeDirect(listing.id, "First", "f@test.com");
+      const { calls, checkout } = stubCheckout("sess_test");
+      try {
+        const result = await processBooking(
+          listing,
+          contact,
+          1,
+          null,
+          BASE_URL,
+        );
+        expect(result).toEqual({ type: "sold_out" });
+      } finally {
+        checkout.restore();
+      }
+      expect(calls()).toBe(0);
+    });
+
+    test("returns checkout_failed with no error when the provider yields null", async () => {
+      await setupStripe();
+      const listing = await createListingWithCount({
+        maxAttendees: 10,
+        unitPrice: 1500,
+      });
+      await withCheckoutStub(null, async () => {
+        const result = await processBooking(
+          listing,
+          contact,
+          1,
+          null,
+          BASE_URL,
+        );
+        expect(result).toEqual({ type: "checkout_failed" });
+      });
+    });
+
+    test("returns checkout_failed carrying the provider error message", async () => {
+      await setupStripe();
+      const listing = await createListingWithCount({
+        maxAttendees: 10,
+        unitPrice: 1500,
+      });
+      await withCheckoutStub({ error: "Provider rejected" }, async () => {
+        const result = await processBooking(
+          listing,
+          contact,
+          1,
+          null,
+          BASE_URL,
+        );
+        expect(result).toEqual({
+          error: "Provider rejected",
+          type: "checkout_failed",
+        });
+      });
+    });
+
+    test("threads a pay-more custom price into the checkout item unit price", async () => {
+      await setupStripe();
+      const listing = await createListingWithCount({
+        canPayMore: true,
+        maxAttendees: 10,
+        maxPrice: 10000,
+        unitPrice: 500,
+      });
+      const { checkout, getCaptured } = stubCheckout("sess_test");
+      try {
+        const result = await processBooking(
+          listing,
+          contact,
+          1,
+          null,
+          BASE_URL,
+          2000,
+        );
+        expect(result.type).toBe("checkout");
+      } finally {
+        checkout.restore();
+      }
+      expect(getCaptured()?.items[0]?.unitPrice).toBe(2000);
+    });
+  });
+
+  describe("listingHasSpots", () => {
+    test("is true while capacity remains and false once sold out", async () => {
+      const listing = await createListingWithCount({
+        maxAttendees: 1,
+        unitPrice: 0,
+      });
+      expect(await listingHasSpots(listing, 1, null)).toBe(true);
+      const booked = await processBooking(listing, contact, 1, null, BASE_URL);
+      expect(booked.type).toBe("success");
+      expect(await listingHasSpots(listing, 1, null)).toBe(false);
+    });
+  });
+});

--- a/test/shared/booking.test.ts
+++ b/test/shared/booking.test.ts
@@ -6,7 +6,7 @@ import {
   processBooking,
 } from "#shared/booking.ts";
 import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
-import type { Attendee, ContactInfo, ListingWithCount } from "#shared/types.ts";
+import type { Attendee, ContactInfo } from "#shared/types.ts";
 import { withCheckoutStub } from "#test/routes/api/helpers.ts";
 import { STUB_CHECKOUT_URL, stubCheckout } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -36,15 +36,6 @@ const contact: ContactInfo = {
 const attendeeOf = (result: BookingResult) =>
   result.type === "success" ? result.attendee : null;
 
-/** `createTestListing` returns `Listing`, but it reads the row back through
- * `getAllListings`, which selects the full row including the trigger-maintained
- * count columns — so it is a `ListingWithCount` at runtime. `processBooking`
- * reads those columns, hence the downcast. */
-const createListingWithCount = (
-  overrides: Parameters<typeof createTestListing>[0] = {},
-): Promise<ListingWithCount> =>
-  createTestListing(overrides) as Promise<ListingWithCount>;
-
 /** Create a listing at `unitPrice` (capacity 10) and book `quantity` units
  *  directly, asserting success and returning the attendee. Shared by the free,
  *  owed, scaled, and one-penny success-path tests. */
@@ -52,7 +43,7 @@ const bookDirect = async (
   unitPrice: number,
   quantity = 1,
 ): Promise<Attendee> => {
-  const listing = await createListingWithCount({ maxAttendees: 10, unitPrice });
+  const listing = await createTestListing({ maxAttendees: 10, unitPrice });
   const result = await processBooking(
     listing,
     contact,
@@ -97,12 +88,24 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
       const attendee = await bookDirect(1000, 3);
       expect(attendee.remaining_balance).toBe(3000);
     });
+
+    test("returns sold_out when capacity is exhausted without a provider", async () => {
+      // No provider configured: the provider-less path still preflights capacity
+      // via createAttendeeAtomic, which returns capacity_exceeded when sold out.
+      const listing = await createTestListing({
+        maxAttendees: 1,
+        unitPrice: 1000,
+      });
+      await createTestAttendeeDirect(listing.id, "First", "f@test.com");
+      const result = await processBooking(listing, contact, 1, null, BASE_URL);
+      expect(result).toEqual({ type: "sold_out" });
+    });
   });
 
   describe("paid checkout through a provider", () => {
     test("returns the provider's checkout URL with a single priced item", async () => {
       await setupStripe();
-      const listing = await createListingWithCount({
+      const listing = await createTestListing({
         maxAttendees: 10,
         unitPrice: 1500,
       });
@@ -137,7 +140,7 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
 
     test("returns sold_out and skips the provider when capacity is exhausted", async () => {
       await setupStripe();
-      const listing = await createListingWithCount({
+      const listing = await createTestListing({
         maxAttendees: 1,
         unitPrice: 1500,
       });
@@ -160,7 +163,7 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
 
     test("returns checkout_failed with no error when the provider yields null", async () => {
       await setupStripe();
-      const listing = await createListingWithCount({
+      const listing = await createTestListing({
         maxAttendees: 10,
         unitPrice: 1500,
       });
@@ -178,7 +181,7 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
 
     test("returns checkout_failed carrying the provider error message", async () => {
       await setupStripe();
-      const listing = await createListingWithCount({
+      const listing = await createTestListing({
         maxAttendees: 10,
         unitPrice: 1500,
       });
@@ -199,7 +202,7 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
 
     test("threads a pay-more custom price into the checkout item unit price", async () => {
       await setupStripe();
-      const listing = await createListingWithCount({
+      const listing = await createTestListing({
         canPayMore: true,
         maxAttendees: 10,
         maxPrice: 10000,
@@ -225,7 +228,7 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
 
   describe("listingHasSpots", () => {
     test("is true while capacity remains and false once sold out", async () => {
-      const listing = await createListingWithCount({
+      const listing = await createTestListing({
         maxAttendees: 1,
         unitPrice: 0,
       });

--- a/test/shared/booking.test.ts
+++ b/test/shared/booking.test.ts
@@ -8,7 +8,7 @@ import {
 import { getAttendeeBalanceState } from "#shared/db/attendees/balance.ts";
 import type { Attendee, ContactInfo, ListingWithCount } from "#shared/types.ts";
 import { withCheckoutStub } from "#test/routes/api/helpers.ts";
-import { stubCheckout } from "#test-utils/checkout.ts";
+import { STUB_CHECKOUT_URL, stubCheckout } from "#test-utils/checkout.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestAttendeeDirect } from "#test-utils/db-helpers/attendees.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -116,7 +116,7 @@ describeWithEnv("processBooking", { db: true, triggers: true }, () => {
           BASE_URL,
         );
         expect(result).toEqual({
-          checkoutUrl: "https://stripe.example/checkout",
+          checkoutUrl: STUB_CHECKOUT_URL,
           type: "checkout",
         });
       } finally {

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -31,6 +31,11 @@ export const checkoutIntent = (
   ...overrides,
 });
 
+/** The checkout URL {@link stubCheckout} returns, so a test can assert a paid
+ *  booking's response carries exactly the URL the stub produced (importing it
+ *  keeps the stub's URL and the assertion in lockstep, not a magic string). */
+export const STUB_CHECKOUT_URL = "https://stripe.example/checkout";
+
 /** Stub the checkout-session provider and capture the intent it was called
  * with — the shared "inspect what checkout would have charged" fixture
  * behind every test that never actually completes a paid session. The optional
@@ -38,11 +43,6 @@ export const checkoutIntent = (
  * `checkout` (the mock, for `restore()`), `getCaptured()` (the intent handed
  * over), and `calls()` (how many times the provider was reached) so the
  * sold-out preflight case can assert it was never called. */
-/** The checkout URL {@link stubCheckout} returns, so a test can assert a paid
- *  booking's response carries exactly the URL the stub produced (importing it
- *  keeps the stub's URL and the assertion in lockstep, not a magic string). */
-export const STUB_CHECKOUT_URL = "https://stripe.example/checkout";
-
 export const stubCheckout = (sessionId = "cs_test") => {
   let captured: CheckoutIntent | undefined;
   const checkout = stub(

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -38,6 +38,11 @@ export const checkoutIntent = (
  * `checkout` (the mock, for `restore()`), `getCaptured()` (the intent handed
  * over), and `calls()` (how many times the provider was reached) so the
  * sold-out preflight case can assert it was never called. */
+/** The checkout URL {@link stubCheckout} returns, so a test can assert a paid
+ *  booking's response carries exactly the URL the stub produced (importing it
+ *  keeps the stub's URL and the assertion in lockstep, not a magic string). */
+export const STUB_CHECKOUT_URL = "https://stripe.example/checkout";
+
 export const stubCheckout = (sessionId = "cs_test") => {
   let captured: CheckoutIntent | undefined;
   const checkout = stub(
@@ -46,7 +51,7 @@ export const stubCheckout = (sessionId = "cs_test") => {
     (intent: CheckoutIntent) => {
       captured = intent;
       return Promise.resolve({
-        checkoutUrl: "https://stripe.example/checkout",
+        checkoutUrl: STUB_CHECKOUT_URL,
         sessionId,
       });
     },

--- a/test/test-utils/db-helpers/listings.ts
+++ b/test/test-utils/db-helpers/listings.ts
@@ -50,7 +50,7 @@ const applyTestListingGroups = async (
 
 export const createTestListing = async (
   overrides: TestListingOverrides = {},
-): Promise<Listing> => {
+): Promise<ListingWithCount> => {
   const input = testListingInput(overrides);
   const listing = await doAuthenticatedMultipartFormRequest(
     "/admin/listing",
@@ -58,7 +58,7 @@ export const createTestListing = async (
     async () => {
       const { getAllListings } = await import("#shared/db/listings/records.ts");
       const listings = await getAllListings();
-      return listings[0] as Listing;
+      return listings[0] as ListingWithCount;
     },
     "create listing",
   );
@@ -75,7 +75,7 @@ export const createTestListing = async (
 export const duplicateTestListing = async (
   sourceId: number,
   overrides: TestListingOverrides = {},
-): Promise<Listing> => {
+): Promise<ListingWithCount> => {
   const input = testListingInput(overrides);
   const listing = await doAuthenticatedMultipartFormRequest(
     "/admin/listing",
@@ -83,7 +83,7 @@ export const duplicateTestListing = async (
     async () => {
       const { getAllListings } = await import("#shared/db/listings/records.ts");
       const listings = await getAllListings();
-      return listings[0] as Listing;
+      return listings[0] as ListingWithCount;
     },
     "duplicate listing",
   );

--- a/test/test-utils/parents.ts
+++ b/test/test-utils/parents.ts
@@ -15,7 +15,7 @@
 
 import { expect } from "@std/expect";
 import { listingChildren } from "#shared/db/listing-parents.ts";
-import type { Group, Listing } from "#shared/types.ts";
+import type { Group, Listing, ListingWithCount } from "#shared/types.ts";
 import { expectAttendeeCounts, expectFlash } from "./assertions.ts";
 import { createTestAttendee } from "./db-helpers/attendees.ts";
 import { createTestGroup } from "./db-helpers/groups.ts";
@@ -118,8 +118,8 @@ export const childField = (
  *  discovery tests. The combined-demand check must use the group the parent and
  *  child SHARE (10), not the child's tightest group overall (1). */
 export const makeRoomySharedChild = async (): Promise<{
-  child: Listing;
-  parent: Listing;
+  child: ListingWithCount;
+  parent: ListingWithCount;
 }> => {
   const groupA = await createTestGroup({ maxAttendees: 10, name: "Shared" });
   const groupB = await createTestGroup({ maxAttendees: 1, name: "Tighter" });
@@ -144,9 +144,9 @@ export const makeRoomySharedChild = async (): Promise<{
 export const makeTwoDefaultChildren = async (
   parentSpec?: ListingSpec,
 ): Promise<{
-  childA: Listing;
-  childB: Listing;
-  parent: Listing;
+  childA: ListingWithCount;
+  childB: ListingWithCount;
+  parent: ListingWithCount;
 }> => {
   const { parent, children } = await makeParent({
     children: [{}, {}],
@@ -225,9 +225,9 @@ export const bookParentChild = (
  *  scenario. Returns the parent, the active child, and the deactivated child
  *  so detail/availability assertions can name the bookable side. */
 export const makeParentWithDeactivatedChild = async (): Promise<{
-  inactiveChild: Listing;
-  okChild: Listing;
-  parent: Listing;
+  inactiveChild: ListingWithCount;
+  okChild: ListingWithCount;
+  parent: ListingWithCount;
 }> => {
   const { parent, children } = await makeParent({ children: [{}, {}] });
   const okChild = children[0]!;
@@ -463,7 +463,7 @@ type ListingSpec = Parameters<typeof createTestListing>[0] & {
 const makeListing = (
   spec: ListingSpec = {},
   fallbackName: string,
-): Promise<Listing> => {
+): Promise<ListingWithCount> => {
   const { daily, ...overrides } = spec;
   const input = { name: fallbackName, ...overrides };
   return daily ? createDailyTestListing(input) : createTestListing(input);
@@ -487,12 +487,12 @@ export const makeParent = async (
     group?: Parameters<typeof createTestGroup>[0];
   } = {},
 ): Promise<{
-  parent: Listing;
+  parent: ListingWithCount;
   /** The first (and, for the common single-child scenario, only) child — a
    * convenience so a test can `const { parent, child } = await makeParent(...)`
    * instead of reaching into `children[0]`. */
-  child: Listing;
-  children: Listing[];
+  child: ListingWithCount;
+  children: ListingWithCount[];
   group?: Group | undefined;
 }> => {
   const group = spec.group ? await createTestGroup(spec.group) : undefined;
@@ -505,7 +505,7 @@ export const makeParent = async (
     "Parent",
   );
   const childSpecs = spec.children ?? [{}];
-  const children: Listing[] = [];
+  const children: ListingWithCount[] = [];
   for (let i = 0; i < childSpecs.length; i++) {
     children.push(
       await makeListing(withGroup(childSpecs[i]!), `Child ${i + 1}`),
@@ -529,7 +529,11 @@ export const makeParent = async (
  */
 export const soldOutParentInGroup = async (
   groupName: string,
-): Promise<{ child: Listing; group: Group; parent: Listing }> => {
+): Promise<{
+  child: ListingWithCount;
+  group: Group;
+  parent: ListingWithCount;
+}> => {
   const group = await createTestGroup({ name: groupName });
   const parent = await createTestListing({
     groupId: group.id,


### PR DESCRIPTION
## What changed

Two new direct test files (split by concern) that call the booking functions directly instead of going through the website or JSON API:

- `test/shared/booking.test.ts` — tests `processBooking` (the single-listing core): free bookings, bookings taken without a payment provider (the full value recorded as owed, verified through the ledger-projected balance), provider-less sold-out, paid checkout, sold-out with a provider, a failed checkout, a pay-more custom price, and `listingHasSpots`.
- `test/features/api/folded-booking.test.ts` — pure tests of `parseApiChildSelections` and `applyChildSelectionsToForm` (child-selection parsing and application, no DB).
- `test/features/api/folded-booking/parent-booking.test.ts` — DB tests of `processParentApiBooking` (folded free, provider-less owed, paid checkout, custom prices, the parent thank-you URL, customisable-dayCount intent, one-penny boundaries) and a direct `finishFoldedBooking` call with a one-listing fold.

## Why

These behaviours are already covered through the HTTP routes. These tests pin them at the function boundary so a change to the booking core is checked without the router, JSON parsing, and CSRF layer in the way, and so mutation testing can reach them quickly. The file names mirror the source files for the mutation runner.

## Scope kept

- No assertions on checkout stages or a provider checkout id — those are not on `main`.
- No source exports added for the tests; only already-exported functions are called.
- No overlap with PR #1904 (canonical booking-line work) — these tests assert behaviour (rows, owed amounts, the checkout intent), not booking-line internals.

## Checks

- `nix develop -c deno task precommit` — green.
- Targeted mutation: `booking.ts` 100% kill (27/27); `folded-booking.ts` 100% (58 killed, 5 genuine equivalents recorded in `equivalent-mutants.txt` with proofs — lines 87, 118, 176, 301, 381; zero unsuppressed survivors).

#1904 is still open and overlaps the booking domain; these are new files, so there is no textual conflict, and I will re-check it as it moves.