### PR TITLE
Stop grouped suites leaking CAN_BUILD_SITES across the env overlay

### DIFF
--- a/test/integration/server/catalog-transfer.test.ts
+++ b/test/integration/server/catalog-transfer.test.ts
@@ -448,277 +448,290 @@ describeWithEnv("catalog-transfer", { db: true }, () => {
   });
 });
 
-describeWithEnv("catalog-transfer review fixes", { db: true }, () => {
-  test("rejects a zero-capacity listing", async () => {
-    const result = await importCatalog({
-      kind: "listing",
-      listing: { maxAttendees: 0, name: "Zero Cap" },
-      version: 1,
+describeWithEnv(
+  "catalog-transfer review fixes",
+  {
+    db: true,
+    env: { CAN_BUILD_SITES: undefined },
+  },
+  () => {
+    test("rejects a zero-capacity listing", async () => {
+      const result = await importCatalog({
+        kind: "listing",
+        listing: { maxAttendees: 0, name: "Zero Cap" },
+        version: 1,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.error).toContain("listing.maxAttendees");
     });
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.error).toContain("listing.maxAttendees");
-  });
 
-  test("rejects a day-price key that is not a day count", async () => {
-    const result = await importCatalog({
-      kind: "listing",
-      listing: {
-        dayPrices: { weekday: 100 },
-        maxAttendees: 1,
-        name: "Bad Day",
-      },
-      version: 1,
-    });
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.error).toContain("day count");
-  });
-
-  test("rejects a duplicate parent reference", async () => {
-    await createTestListing({ name: "Dup Parent" });
-    const result = await importCatalog({
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Dup Child" },
-      parents: ["Dup Parent", "Dup Parent"],
-      version: 1,
-    });
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.error).toContain("referenced more than once");
-  });
-
-  test("rejects a parent that is itself a child (single-level nesting)", async () => {
-    const grandparent = await createTestListing({ name: "Grandparent" });
-    const parent = await createTestListing({ name: "Middle" });
-    await listingChildren.setIds(grandparent.id, [parent.id]);
-    const result = await importCatalog({
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Deep Child" },
-      parents: ["Middle"],
-      version: 1,
-    });
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.error).toContain("offered as a child");
-  });
-
-  test("strips webhook URL and use-defaults for an editor import", async () => {
-    const result = await importCatalog(
-      {
+    test("rejects a day-price key that is not a day count", async () => {
+      const result = await importCatalog({
         kind: "listing",
         listing: {
-          maxAttendees: 5,
-          name: "Editor Listing",
-          useDefaults: true,
-          webhookUrl: "https://example.com/hook",
+          dayPrices: { weekday: 100 },
+          maxAttendees: 1,
+          name: "Bad Day",
         },
         version: 1,
-      },
-      "editor",
-    );
-    if (!result.ok) throw new Error(result.error);
-    const imported = (await getListingWithCount(result.value.id))!;
-    expect(imported.webhook_url).toBe("");
-    expect(imported.use_defaults).toBe(false);
-  });
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.error).toContain("day count");
+    });
 
-  test("keeps the webhook URL for a non-editor import", async () => {
-    const result = await importCatalog(
-      {
+    test("rejects a duplicate parent reference", async () => {
+      await createTestListing({ name: "Dup Parent" });
+      const result = await importCatalog({
         kind: "listing",
-        listing: {
-          maxAttendees: 5,
-          name: "Owner Listing",
-          webhookUrl: "https://example.com/hook",
-        },
+        listing: { maxAttendees: 1, name: "Dup Child" },
+        parents: ["Dup Parent", "Dup Parent"],
         version: 1,
-      },
-      "owner",
-    );
-    if (!result.ok) throw new Error(result.error);
-    const imported = (await getListingWithCount(result.value.id))!;
-    expect(imported.webhook_url).toBe("https://example.com/hook");
-  });
-
-  test("clears assign-built-site when the builder is not configured", async () => {
-    expect(await importBuiltSiteListing("No Builder")).toBe(false);
-  });
-
-  test("clears uses-logistics when logistics is disabled", async () => {
-    expect(await importLogisticsListing("Logi Off")).toBe(false);
-  });
-
-  test("keeps uses-logistics when logistics is enabled", async () => {
-    settings.setForTest(featureSetting("logistics"));
-    expect(await importLogisticsListing("Logi On")).toBe(true);
-  });
-
-  test("clears package overrides for a non-package group membership", async () => {
-    const group = await createTestGroup({ name: "Regular Group" });
-    const result = await importCatalog({
-      groups: [{ group: "Regular Group", packagePrice: 500, quantity: 3 }],
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Joiner", unitPrice: 900 },
-      version: 1,
-    });
-    if (!result.ok) throw new Error(result.error);
-    const row = (await getGroupPackagePrices(group.id)).find(
-      (r) => r.listing_id === result.value.id,
-    )!;
-    // The override is dropped because the group isn't a package.
-    expect(row.package_price).toBeNull();
-    expect(row.quantity).toBe(1);
-  });
-
-  test("clears member overrides when importing a non-package group", async () => {
-    await createTestListing({ name: "Plain Member", unitPrice: 800 });
-    const result = await importCatalog({
-      group: { name: "Plain Group" },
-      kind: "group",
-      members: [{ listing: "Plain Member", packagePrice: 200, quantity: 5 }],
-      version: 1,
-    });
-    if (!result.ok) throw new Error(result.error);
-    const row = (await getGroupPackagePrices(result.value.id))[0]!;
-    expect(row.package_price).toBeNull();
-    expect(row.quantity).toBe(1);
-  });
-
-  test("rejects a parent that is a hidden-package member", async () => {
-    const pkg = await createTestGroup({ isPackage: true, name: "Hidden Pkg" });
-    // createTestGroup can't set hide_package_listings, so set it directly and
-    // refresh the cached group set the import reads.
-    await execute("UPDATE groups SET hide_package_listings = 1 WHERE id = ?", [
-      pkg.id,
-    ]);
-    const { groups } = await import("#shared/db/groups.ts");
-    groups.cache.invalidate();
-    const parent = await createTestListing({ name: "Pkg Parent" });
-    await assignListingsToGroup([parent.id], pkg.id);
-    const result = await importCatalog({
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Kid" },
-      parents: ["Pkg Parent"],
-      version: 1,
-    });
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.error).toContain("hidden package");
-  });
-
-  test("imports a listing with many parents in one batched insert", async () => {
-    // More parents than the per-request N+1 guard (25) and the transaction
-    // round-trip cap (~30) would allow one query/insert each — proves the
-    // batched nested-parent check and the set-wise edge insert.
-    const { listingsTable } = await import("#shared/db/listings/records.ts");
-    const { computeSlugIndex } = await import("#shared/db/listings/table.ts");
-    const parentNames = Array.from({ length: 30 }, (_, i) => `Parent ${i}`);
-    for (const name of parentNames) {
-      const slug = name.toLowerCase().replace(/\s+/g, "-");
-      await listingsTable.insert({
-        // Supply dayPrices so insert doesn't read them back per row (which would
-        // trip the N+1 guard across this 30-row setup loop).
-        dayPrices: {},
-        maxAttendees: 1,
-        maxPrice: 0,
-        name,
-        slug,
-        slugIndex: await computeSlugIndex(slug),
       });
-    }
-    const result = await importCatalog({
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Many Kids" },
-      parents: parentNames,
-      version: 1,
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.error).toContain("referenced more than once");
     });
-    if (!result.ok) throw new Error(result.error);
-    expect((await listingParents.getIds(result.value.id)).length).toBe(30);
-  });
 
-  test("imports a listing that belongs to many groups", async () => {
-    // More groups than the per-request N+1 guard (25) would allow one
-    // compatibility SELECT each — proves group-compat validation batch-loads the
-    // siblings for every referenced group instead of one query per group. Insert
-    // the groups directly (like the many-parents case) rather than via
-    // createTestGroup, whose trailing getAllGroups() would itself trip the read
-    // guard 30 times over in this one test context.
-    const { computeGroupSlugIndex, groups } = await import(
-      "#shared/db/groups.ts"
-    );
-    const groupNames = Array.from({ length: 30 }, (_, i) => `Group ${i}`);
-    for (const name of groupNames) {
-      const slug = name.toLowerCase().replace(/\s+/g, "-");
-      await groups.table.insert({
-        name,
-        slug,
-        slugIndex: await computeGroupSlugIndex(slug),
+    test("rejects a parent that is itself a child (single-level nesting)", async () => {
+      const grandparent = await createTestListing({ name: "Grandparent" });
+      const parent = await createTestListing({ name: "Middle" });
+      await listingChildren.setIds(grandparent.id, [parent.id]);
+      const result = await importCatalog({
+        kind: "listing",
+        listing: { maxAttendees: 1, name: "Deep Child" },
+        parents: ["Middle"],
+        version: 1,
       });
-    }
-    const result = await importCatalog({
-      groups: groupNames.map((group) => ({ group })),
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Joins Many" },
-      version: 1,
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.error).toContain("offered as a child");
     });
-    if (!result.ok) throw new Error(result.error);
-    expect((await listingGroups.getIds(result.value.id)).length).toBe(30);
-  });
 
-  test("imports a child listing that also belongs to a regular group", async () => {
-    // A child (has a parent) that joins a non-package group exercises the
-    // package-membership guard over a real, non-package group set — it must find
-    // no package and let the parent edge through.
-    await createTestListing({ name: "Edge Parent" });
-    await createTestGroup({ name: "Plain Joiner Group" });
-    const result = await importCatalog({
-      groups: [{ group: "Plain Joiner Group" }],
-      kind: "listing",
-      listing: { maxAttendees: 1, name: "Grouped Kid" },
-      parents: ["Edge Parent"],
-      version: 1,
+    test("strips webhook URL and use-defaults for an editor import", async () => {
+      const result = await importCatalog(
+        {
+          kind: "listing",
+          listing: {
+            maxAttendees: 5,
+            name: "Editor Listing",
+            useDefaults: true,
+            webhookUrl: "https://example.com/hook",
+          },
+          version: 1,
+        },
+        "editor",
+      );
+      if (!result.ok) throw new Error(result.error);
+      const imported = (await getListingWithCount(result.value.id))!;
+      expect(imported.webhook_url).toBe("");
+      expect(imported.use_defaults).toBe(false);
     });
-    if (!result.ok) throw new Error(result.error);
-    expect((await listingParents.getIds(result.value.id)).length).toBe(1);
-    expect((await listingGroups.getIds(result.value.id)).length).toBe(1);
-  });
 
-  test("hides the webhook URL from an editor export", async () => {
-    const listing = await createTestListing({
-      name: "Hooked",
-      webhookUrl: "https://example.com/hook",
+    test("keeps the webhook URL for a non-editor import", async () => {
+      const result = await importCatalog(
+        {
+          kind: "listing",
+          listing: {
+            maxAttendees: 5,
+            name: "Owner Listing",
+            webhookUrl: "https://example.com/hook",
+          },
+          version: 1,
+        },
+        "owner",
+      );
+      if (!result.ok) throw new Error(result.error);
+      const imported = (await getListingWithCount(result.value.id))!;
+      expect(imported.webhook_url).toBe("https://example.com/hook");
     });
-    // The editor blob must not carry the PII sink URL the edit form hides…
-    const editorBlob = unwrapExport(await exportListing(listing.id, "editor"));
-    expect(editorBlob.listing.webhookUrl).toBeUndefined();
-    // …but staff still round-trip it.
-    const ownerBlob = unwrapExport(await exportListing(listing.id, "owner"));
-    expect(ownerBlob.listing.webhookUrl).toBe("https://example.com/hook");
-  });
 
-  test("batches many memberships into at most two statements", async () => {
-    // The interactive transaction caps at 30 statements, so a large group's
-    // memberships must not be one statement each. membershipStatements collapses
-    // them into one group_listings insert plus one group_day insert.
-    const { membershipStatements } = await import(
-      "#routes/admin/catalog-transfer/membership.ts"
-    );
-    const memberships = Array.from({ length: 40 }, (_, i) => ({
-      dayPrices: { 1: 500 },
-      groupId: 7,
-      listingId: i + 1,
-      packagePrice: null,
-      quantity: 1,
-    }));
-    const statements = membershipStatements(memberships);
-    expect(statements.length).toBe(2);
-    // Every member appears in the single group_listings insert (3 args each:
-    // group_id, listing_id, quantity — the flat price override, when present,
-    // lives in the separate listing_prices insert).
-    expect(statements[0]!.args.length).toBe(40 * 3);
-  });
-});
+    test("clears assign-built-site when the builder is not configured", async () => {
+      expect(await importBuiltSiteListing("No Builder")).toBe(false);
+    });
+
+    test("clears uses-logistics when logistics is disabled", async () => {
+      expect(await importLogisticsListing("Logi Off")).toBe(false);
+    });
+
+    test("keeps uses-logistics when logistics is enabled", async () => {
+      settings.setForTest(featureSetting("logistics"));
+      expect(await importLogisticsListing("Logi On")).toBe(true);
+    });
+
+    test("clears package overrides for a non-package group membership", async () => {
+      const group = await createTestGroup({ name: "Regular Group" });
+      const result = await importCatalog({
+        groups: [{ group: "Regular Group", packagePrice: 500, quantity: 3 }],
+        kind: "listing",
+        listing: { maxAttendees: 1, name: "Joiner", unitPrice: 900 },
+        version: 1,
+      });
+      if (!result.ok) throw new Error(result.error);
+      const row = (await getGroupPackagePrices(group.id)).find(
+        (r) => r.listing_id === result.value.id,
+      )!;
+      // The override is dropped because the group isn't a package.
+      expect(row.package_price).toBeNull();
+      expect(row.quantity).toBe(1);
+    });
+
+    test("clears member overrides when importing a non-package group", async () => {
+      await createTestListing({ name: "Plain Member", unitPrice: 800 });
+      const result = await importCatalog({
+        group: { name: "Plain Group" },
+        kind: "group",
+        members: [{ listing: "Plain Member", packagePrice: 200, quantity: 5 }],
+        version: 1,
+      });
+      if (!result.ok) throw new Error(result.error);
+      const row = (await getGroupPackagePrices(result.value.id))[0]!;
+      expect(row.package_price).toBeNull();
+      expect(row.quantity).toBe(1);
+    });
+
+    test("rejects a parent that is a hidden-package member", async () => {
+      const pkg = await createTestGroup({
+        isPackage: true,
+        name: "Hidden Pkg",
+      });
+      // createTestGroup can't set hide_package_listings, so set it directly and
+      // refresh the cached group set the import reads.
+      await execute(
+        "UPDATE groups SET hide_package_listings = 1 WHERE id = ?",
+        [pkg.id],
+      );
+      const { groups } = await import("#shared/db/groups.ts");
+      groups.cache.invalidate();
+      const parent = await createTestListing({ name: "Pkg Parent" });
+      await assignListingsToGroup([parent.id], pkg.id);
+      const result = await importCatalog({
+        kind: "listing",
+        listing: { maxAttendees: 1, name: "Kid" },
+        parents: ["Pkg Parent"],
+        version: 1,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.error).toContain("hidden package");
+    });
+
+    test("imports a listing with many parents in one batched insert", async () => {
+      // More parents than the per-request N+1 guard (25) and the transaction
+      // round-trip cap (~30) would allow one query/insert each — proves the
+      // batched nested-parent check and the set-wise edge insert.
+      const { listingsTable } = await import("#shared/db/listings/records.ts");
+      const { computeSlugIndex } = await import("#shared/db/listings/table.ts");
+      const parentNames = Array.from({ length: 30 }, (_, i) => `Parent ${i}`);
+      for (const name of parentNames) {
+        const slug = name.toLowerCase().replace(/\s+/g, "-");
+        await listingsTable.insert({
+          // Supply dayPrices so insert doesn't read them back per row (which would
+          // trip the N+1 guard across this 30-row setup loop).
+          dayPrices: {},
+          maxAttendees: 1,
+          maxPrice: 0,
+          name,
+          slug,
+          slugIndex: await computeSlugIndex(slug),
+        });
+      }
+      const result = await importCatalog({
+        kind: "listing",
+        listing: { maxAttendees: 1, name: "Many Kids" },
+        parents: parentNames,
+        version: 1,
+      });
+      if (!result.ok) throw new Error(result.error);
+      expect((await listingParents.getIds(result.value.id)).length).toBe(30);
+    });
+
+    test("imports a listing that belongs to many groups", async () => {
+      // More groups than the per-request N+1 guard (25) would allow one
+      // compatibility SELECT each — proves group-compat validation batch-loads the
+      // siblings for every referenced group instead of one query per group. Insert
+      // the groups directly (like the many-parents case) rather than via
+      // createTestGroup, whose trailing getAllGroups() would itself trip the read
+      // guard 30 times over in this one test context.
+      const { computeGroupSlugIndex, groups } = await import(
+        "#shared/db/groups.ts"
+      );
+      const groupNames = Array.from({ length: 30 }, (_, i) => `Group ${i}`);
+      for (const name of groupNames) {
+        const slug = name.toLowerCase().replace(/\s+/g, "-");
+        await groups.table.insert({
+          name,
+          slug,
+          slugIndex: await computeGroupSlugIndex(slug),
+        });
+      }
+      const result = await importCatalog({
+        groups: groupNames.map((group) => ({ group })),
+        kind: "listing",
+        listing: { maxAttendees: 1, name: "Joins Many" },
+        version: 1,
+      });
+      if (!result.ok) throw new Error(result.error);
+      expect((await listingGroups.getIds(result.value.id)).length).toBe(30);
+    });
+
+    test("imports a child listing that also belongs to a regular group", async () => {
+      // A child (has a parent) that joins a non-package group exercises the
+      // package-membership guard over a real, non-package group set — it must find
+      // no package and let the parent edge through.
+      await createTestListing({ name: "Edge Parent" });
+      await createTestGroup({ name: "Plain Joiner Group" });
+      const result = await importCatalog({
+        groups: [{ group: "Plain Joiner Group" }],
+        kind: "listing",
+        listing: { maxAttendees: 1, name: "Grouped Kid" },
+        parents: ["Edge Parent"],
+        version: 1,
+      });
+      if (!result.ok) throw new Error(result.error);
+      expect((await listingParents.getIds(result.value.id)).length).toBe(1);
+      expect((await listingGroups.getIds(result.value.id)).length).toBe(1);
+    });
+
+    test("hides the webhook URL from an editor export", async () => {
+      const listing = await createTestListing({
+        name: "Hooked",
+        webhookUrl: "https://example.com/hook",
+      });
+      // The editor blob must not carry the PII sink URL the edit form hides…
+      const editorBlob = unwrapExport(
+        await exportListing(listing.id, "editor"),
+      );
+      expect(editorBlob.listing.webhookUrl).toBeUndefined();
+      // …but staff still round-trip it.
+      const ownerBlob = unwrapExport(await exportListing(listing.id, "owner"));
+      expect(ownerBlob.listing.webhookUrl).toBe("https://example.com/hook");
+    });
+
+    test("batches many memberships into at most two statements", async () => {
+      // The interactive transaction caps at 30 statements, so a large group's
+      // memberships must not be one statement each. membershipStatements collapses
+      // them into one group_listings insert plus one group_day insert.
+      const { membershipStatements } = await import(
+        "#routes/admin/catalog-transfer/membership.ts"
+      );
+      const memberships = Array.from({ length: 40 }, (_, i) => ({
+        dayPrices: { 1: 500 },
+        groupId: 7,
+        listingId: i + 1,
+        packagePrice: null,
+        quantity: 1,
+      }));
+      const statements = membershipStatements(memberships);
+      expect(statements.length).toBe(2);
+      // Every member appears in the single group_listings insert (3 args each:
+      // group_id, listing_id, quantity — the flat price override, when present,
+      // lives in the separate listing_prices insert).
+      expect(statements[0]!.args.length).toBe(40 * 3);
+    });
+  },
+);
 
 describeWithEnv(
   "catalog-transfer with the builder enabled",

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -26,9 +26,8 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
     ...expected: Parameters<typeof cachedGuide>
   ): Promise<string> => {
     using _env = withEnv({ CAN_BUILD_SITES: undefined });
-    // Await so the env pin stays in force for the whole first render —
-    // cachedGuide returns a promise, and a bare return lets the `using`
-    // dispose before the render reads CAN_BUILD_SITES.
+    // The env pin must cover the whole first render, so await the cached page
+    // before the `using` scope disposes.
     const html = await cachedGuide(...expected);
     return html;
   };

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -26,7 +26,11 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
     ...expected: Parameters<typeof cachedGuide>
   ): Promise<string> => {
     using _env = withEnv({ CAN_BUILD_SITES: undefined });
-    return cachedGuide(...expected);
+    // Await so the env pin stays in force for the whole first render —
+    // cachedGuide returns a promise, and a bare return lets the `using`
+    // dispose before the render reads CAN_BUILD_SITES.
+    const html = await cachedGuide(...expected);
+    return html;
   };
 
   describe("GET /admin/guide", () => {

--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -18,8 +18,16 @@ import { withEnv } from "#test-utils/env.ts";
 describeWithEnv("server (admin guide)", { db: true }, () => {
   // The guide's default rendering is identical in every test (static help
   // content from the standard fixture), so it is rendered once and shared;
-  // only the tests that alter config below fetch their own copy.
-  const guide = cachedAdminPage("/admin/guide");
+  // only the tests that alter config below fetch their own copy. The cached
+  // render is pinned to CAN_BUILD_SITES unset so the snapshot never depends on
+  // whatever the ambient overlay happens to carry when it is first fetched.
+  const cachedGuide = cachedAdminPage("/admin/guide");
+  const guide = async (
+    ...expected: Parameters<typeof cachedGuide>
+  ): Promise<string> => {
+    using _env = withEnv({ CAN_BUILD_SITES: undefined });
+    return cachedGuide(...expected);
+  };
 
   describe("GET /admin/guide", () => {
     testRequiresAuth("/admin/guide");

--- a/test/lib/test-utils/env-overlay-order.test.ts
+++ b/test/lib/test-utils/env-overlay-order.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { getEnv } from "#shared/env.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { type EnvScope, getRealEnv, withEnv } from "#test-utils/env.ts";
+
+// A suite that turns a feature on for its own tests, and layers a second env
+// scope on top (the shape every built-sites suite uses: the outer env from
+// describeWithEnv plus a per-test inner scope). The inner scope's dispose must
+// run BEFORE the outer env's dispose, or it restores the stale "feature on"
+// layer after the outer clear — leaking CAN_BUILD_SITES into the next suite.
+describeWithEnv(
+  "describeWithEnv nested env (feature on)",
+  { env: { CAN_BUILD_SITES: "true" } },
+  () => {
+    let inner: EnvScope | undefined;
+    beforeEach(() => {
+      inner = withEnv({ TICKETS_NESTED_ENV_PROBE: "set" });
+    });
+    afterEach(() => {
+      inner?.dispose();
+      inner = undefined;
+    });
+
+    test("sees the feature enabled inside the suite", () => {
+      expect(getEnv("CAN_BUILD_SITES")).toBe("true");
+    });
+  },
+);
+
+// A later suite that never touches CAN_BUILD_SITES. The real environment never
+// held it, so if the overlay is clean the lookup is undefined. Before the
+// hook-order fix this read "true" — the previous suite's inner dispose had
+// restored the "feature on" layer after the outer clear, so the overlay kept
+// leaking it across the suite boundary.
+describeWithEnv("describeWithEnv nested env (ambient after)", {}, () => {
+  test("does not inherit the previous suite's CAN_BUILD_SITES", () => {
+    expect(getRealEnv("CAN_BUILD_SITES")).toBeUndefined();
+    expect(getEnv("CAN_BUILD_SITES")).toBeUndefined();
+  });
+});
+
+// The same contract for an env var the inner scope owns, so the regression
+// also catches a nested-scope leak of a key the outer env never carried.
+describeWithEnv(
+  "describeWithEnv nested env (inner key ambient after)",
+  {},
+  () => {
+    test("does not inherit the inner scope's probe key", () => {
+      expect(getRealEnv("TICKETS_NESTED_ENV_PROBE")).toBeUndefined();
+      expect(getEnv("TICKETS_NESTED_ENV_PROBE")).toBeUndefined();
+    });
+  },
+);
+
+describe("describeWithEnv overlay cleanup (sanity)", () => {
+  test("the real process env was never touched", () => {
+    expect(getRealEnv("CAN_BUILD_SITES")).toBeUndefined();
+    expect(getRealEnv("TICKETS_NESTED_ENV_PROBE")).toBeUndefined();
+  });
+});

--- a/test/lib/test-utils/env-overlay-order.test.ts
+++ b/test/lib/test-utils/env-overlay-order.test.ts
@@ -17,17 +17,17 @@ describeWithEnv(
   "describeWithEnv nested env (outer on)",
   { env: { [OUTER_KEY]: "on" } },
   () => {
-    let inner: EnvScope | undefined;
+    let inner: EnvScope;
     beforeEach(() => {
       inner = withEnv({ [INNER_KEY]: "set" });
     });
     afterEach(() => {
-      inner?.dispose();
-      inner = undefined;
+      inner.dispose();
     });
 
-    test("sees the outer env enabled inside the suite", () => {
+    test("sees the outer and inner env enabled inside the suite", () => {
       expect(getEnv(OUTER_KEY)).toBe("on");
+      expect(getEnv(INNER_KEY)).toBe("set");
     });
   },
 );

--- a/test/lib/test-utils/env-overlay-order.test.ts
+++ b/test/lib/test-utils/env-overlay-order.test.ts
@@ -4,58 +4,62 @@ import { getEnv } from "#shared/env.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { type EnvScope, getRealEnv, withEnv } from "#test-utils/env.ts";
 
-// A suite that turns a feature on for its own tests, and layers a second env
-// scope on top (the shape every built-sites suite uses: the outer env from
-// describeWithEnv plus a per-test inner scope). The inner scope's dispose must
-// run BEFORE the outer env's dispose, or it restores the stale "feature on"
-// layer after the outer clear — leaking CAN_BUILD_SITES into the next suite.
+// Test-only keys the real process environment never carries, so these
+// assertions check the overlay alone and never trip on a feature flag the
+// runner happens to be launched with.
+const OUTER_KEY = "TICKETS_TEST_OVERLAY_OUTER";
+const INNER_KEY = "TICKETS_TEST_OVERLAY_INNER";
+
+// A suite that sets an outer env var for its own tests and layers a second,
+// per-test env scope on top — the shape every built-sites suite uses (the
+// outer env from describeWithEnv plus an inner withEnv opened in the body).
 describeWithEnv(
-  "describeWithEnv nested env (feature on)",
-  { env: { CAN_BUILD_SITES: "true" } },
+  "describeWithEnv nested env (outer on)",
+  { env: { [OUTER_KEY]: "on" } },
   () => {
     let inner: EnvScope | undefined;
     beforeEach(() => {
-      inner = withEnv({ TICKETS_NESTED_ENV_PROBE: "set" });
+      inner = withEnv({ [INNER_KEY]: "set" });
     });
     afterEach(() => {
       inner?.dispose();
       inner = undefined;
     });
 
-    test("sees the feature enabled inside the suite", () => {
-      expect(getEnv("CAN_BUILD_SITES")).toBe("true");
+    test("sees the outer env enabled inside the suite", () => {
+      expect(getEnv(OUTER_KEY)).toBe("on");
     });
   },
 );
 
-// A later suite that never touches CAN_BUILD_SITES. The real environment never
-// held it, so if the overlay is clean the lookup is undefined. Before the
-// hook-order fix this read "true" — the previous suite's inner dispose had
-// restored the "feature on" layer after the outer clear, so the overlay kept
-// leaking it across the suite boundary.
+// A later suite that never touches the outer key. The overlay must be clean
+// after the previous suite, so the lookup falls through to the (empty) real
+// environment. This is the contract that breaks if a nested withEnv scope
+// disposes AFTER describeWithEnv's own afterEach: the inner dispose restores
+// the outer env layer over the cleared overlay, leaking it across the suite
+// boundary.
 describeWithEnv("describeWithEnv nested env (ambient after)", {}, () => {
-  test("does not inherit the previous suite's CAN_BUILD_SITES", () => {
-    expect(getRealEnv("CAN_BUILD_SITES")).toBeUndefined();
-    expect(getEnv("CAN_BUILD_SITES")).toBeUndefined();
+  test("does not inherit the previous suite's outer env", () => {
+    expect(getRealEnv(OUTER_KEY)).toBeUndefined();
+    expect(getEnv(OUTER_KEY)).toBeUndefined();
   });
 });
 
-// The same contract for an env var the inner scope owns, so the regression
-// also catches a nested-scope leak of a key the outer env never carried.
+// The inner scope's own key must not leak either, for the same reason.
 describeWithEnv(
   "describeWithEnv nested env (inner key ambient after)",
   {},
   () => {
-    test("does not inherit the inner scope's probe key", () => {
-      expect(getRealEnv("TICKETS_NESTED_ENV_PROBE")).toBeUndefined();
-      expect(getEnv("TICKETS_NESTED_ENV_PROBE")).toBeUndefined();
+    test("does not inherit the inner scope's key", () => {
+      expect(getRealEnv(INNER_KEY)).toBeUndefined();
+      expect(getEnv(INNER_KEY)).toBeUndefined();
     });
   },
 );
 
 describe("describeWithEnv overlay cleanup (sanity)", () => {
-  test("the real process env was never touched", () => {
-    expect(getRealEnv("CAN_BUILD_SITES")).toBeUndefined();
-    expect(getRealEnv("TICKETS_NESTED_ENV_PROBE")).toBeUndefined();
+  test("the real process env is never touched", () => {
+    expect(getRealEnv(OUTER_KEY)).toBeUndefined();
+    expect(getRealEnv(INNER_KEY)).toBeUndefined();
   });
 });

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -240,6 +240,15 @@ export const describeWithEnv = (
       if (options.env) env = withEnv(options.env);
       storageDir = applyStorageConfig(options.storage);
     });
+    // Register the suite body before this suite's own afterEach. Sibling
+    // afterEach hooks run in registration order, so a nest of `withEnv` scopes
+    // opened inside the body must dispose BEFORE the env layer created here —
+    // otherwise the inner scope's dispose restores the stale "env on" layer
+    // *after* this afterEach cleared it, leaving the overlay leaking the
+    // suite's env (e.g. CAN_BUILD_SITES="true") into the next suite. Putting
+    // `fn()` first makes this teardown the last to run, matching the standard
+    // inner-then-outer contract BDD suites already assume.
+    fn();
     afterEach(() => {
       if (options.db) resetDb();
       env?.dispose();
@@ -252,7 +261,6 @@ export const describeWithEnv = (
     afterAll(() => {
       reclaimLeakedFdsNow();
     });
-    fn();
   });
 };
 


### PR DESCRIPTION
## What changed

A grouped test suite that turned `CAN_BUILD_SITES` on for its own tests could leak that setting into the next suite sharing its isolate, so a later test that expects the builder to be off (like `ignores assign_built_site when CAN_BUILD_SITES is not set`) saw it as on and failed. This was the leak behind PR #1904's failing CI.

The leak is fixed at its source, and the two suites the task centres on now declare their own state instead of relying on the ambient overlay.

## Why

`describeWithEnv` registered its own `afterEach` *before* the suite body, so a `withEnv` scope opened inside the body (the shape every built-sites suite uses: the outer env from `describeWithEnv` plus a per-test inner scope) disposed **after** the outer env layer was cleared. The inner dispose restored the stale "feature on" overlay layer, leaving `CAN_BUILD_SITES="true"` stuck in the overlay for the next suite.

Registering the body (`fn()`) before the `afterEach` restores the inner-then-outer dispose order BDD suites already assume — the outer env layer is now cleared last, so the overlay returns to baseline after every test.

## Changes

- `test/test-utils/db.ts` — register the suite body before the env/DB `afterEach`, so the overlay layer `describeWithEnv` creates is disposed last.
- `test/lib/server-guide.test.ts` — pin the cached guide render to `CAN_BUILD_SITES` unset, so the shared snapshot never depends on whatever the ambient overlay carries when it is first fetched.
- `test/integration/server/catalog-transfer.test.ts` — pin `CAN_BUILD_SITES` unset for the `catalog-transfer review fixes` suite (most of its diff is Biome re-indenting the suite body after the header wrapped to multiple lines).
- `test/lib/test-utils/env-overlay-order.test.ts` — regression test that fails before the reorder and passes after.

## How it was reproduced

Reproduced on `split/canonical-booking-lines` (PR #1904): the exact CI group-18 (8 workers → 32 groups) failed `ignores assign_built_site when CAN_BUILD_SITES is not set`. Bisecting the group narrowed the source to `test/features/admin/built-sites/update.test.ts`, whose first `describeWithEnv` (outer `CAN_BUILD_SITES="true"` env + a per-test inner `withEnv`) left the overlay on `CAN_BUILD_SITES="true"` after every test. With this fix that group passes 554/554 and the standalone repro passes 21/21.

## Checks

- `nix develop -c deno task precommit` (typecheck + lint + cpd + full suite)
- Regression test confirmed red before the reorder, green after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the catalog transfer integration suite to run with consistent builder-site settings by explicitly having `CAN_BUILD_SITES` unset.
  * Adjusted admin guide rendering test helpers to pin snapshot output to `CAN_BUILD_SITES` being unset during initial render.
  * Added coverage to verify nested environment overlay cleanup order and prevent overlay leakage across test suite boundaries.
  * Refined test environment overlay setup/teardown ordering to ensure inner overlays dispose before the outer layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->