### PR TITLE
Own and dispose the prepareTestClient DB env scope

### DIFF
--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -329,6 +329,16 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       const html = await assertAdminHtml("/admin/guide");
       expect(html).not.toContain('id="built-sites"');
     });
+    test("cached guide is pinned to builder-off even under ambient CAN_BUILD_SITES=true", async () => {
+      using _ambient = withEnv({ CAN_BUILD_SITES: "true" });
+      // The uncached render sees the ambient CAN_BUILD_SITES=true.
+      const live = await assertAdminHtml("/admin/guide", 'id="built-sites"');
+      expect(live).toContain('id="built-sites"');
+      // The cached guide is pinned to CAN_BUILD_SITES=undefined, so it
+      // must not show the built-sites section even under the ambient flag.
+      const cached = await guide();
+      expect(cached).not.toContain('id="built-sites"');
+    });
 
     test("shows built sites section when builder is enabled", async () => {
       using _env = withEnv({ CAN_BUILD_SITES: "true" });

--- a/test/lib/test-utils/env-overlay-order.test.ts
+++ b/test/lib/test-utils/env-overlay-order.test.ts
@@ -83,6 +83,30 @@ describe("describeWithEnv DB env (restored after)", () => {
   });
 });
 
+// A mixed suite (db: true AND env) stacks: DB scope first, suite env on top.
+// The afterEach must dispose the suite env BEFORE resetDb disposes the DB
+// scope — LIFO — or env.dispose() resurrects the deleted DB_URL. This suite
+// captures the DB_URL it uses; the "restored after" suite proves it's gone.
+const mixedSuiteTempDbUrl: { value: string | undefined } = { value: undefined };
+describeWithEnv(
+  "describeWithEnv mixed DB+env (stacked)",
+  { db: true, env: { [OUTER_KEY]: "on" } },
+  () => {
+    test("sees both DB_URL and outer env during the test", () => {
+      expect(getEnv("DB_URL")?.startsWith("file:")).toBe(true);
+      mixedSuiteTempDbUrl.value = getEnv("DB_URL");
+      expect(getEnv(OUTER_KEY)).toBe("on");
+    });
+  },
+);
+
+describe("describeWithEnv mixed DB+env (restored after)", () => {
+  test("neither DB_URL nor outer env leaks the deleted temp file", () => {
+    expect(getEnv("DB_URL")).not.toBe(mixedSuiteTempDbUrl.value);
+    expect(getEnv(OUTER_KEY)).toBeUndefined();
+  });
+});
+
 // Failure path: a body that opens an inner scope but fails to dispose it
 // (simulating a body afterEach that threw before reaching its dispose call).
 // The factory afterEach must still dispose the outer env scope so the

--- a/test/lib/test-utils/env-overlay-order.test.ts
+++ b/test/lib/test-utils/env-overlay-order.test.ts
@@ -10,6 +10,11 @@ import { type EnvScope, getRealEnv, withEnv } from "#test-utils/env.ts";
 const OUTER_KEY = "TICKETS_TEST_OVERLAY_OUTER";
 const INNER_KEY = "TICKETS_TEST_OVERLAY_INNER";
 
+// Capture the real DB_URL so the DB suite can prove the overlay diverges
+// from it during the test, then the "restored after" suite proves it
+// converges back.
+const realDbUrl = getRealEnv("DB_URL");
+
 // A suite that sets an outer env var for its own tests and layers a second,
 // per-test env scope on top — the shape every built-sites suite uses (the
 // outer env from describeWithEnv plus an inner withEnv opened in the body).
@@ -57,8 +62,64 @@ describeWithEnv(
   },
 );
 
+// A DB-backed suite overlays DB_URL with a fresh temp file per test.
+// prepareTestClient must own and dispose that scope (via resetDb), so the
+// overlay does not keep pointing at the deleted temp file after the suite.
+const suiteTempDbUrl: { value: string | undefined } = { value: undefined };
+describeWithEnv("describeWithEnv DB env (temp file)", { db: true }, () => {
+  test("overlays DB_URL with a fresh temp file during the test", () => {
+    const url = getEnv("DB_URL");
+    expect(url?.startsWith("file:")).toBe(true);
+    expect(url).not.toBe(realDbUrl);
+    suiteTempDbUrl.value = url;
+  });
+});
+
+// After the DB suite, the overlay must not keep pointing at the deleted
+// temp file — proving resetDb disposed the prepareTestClient scope.
+describe("describeWithEnv DB env (restored after)", () => {
+  test("DB_URL overlay does not keep the deleted temp file from the suite", () => {
+    expect(getEnv("DB_URL")).not.toBe(suiteTempDbUrl.value);
+  });
+});
+
+// Failure path: a body that opens an inner scope but fails to dispose it
+// (simulating a body afterEach that threw before reaching its dispose call).
+// The factory afterEach must still dispose the outer env scope so the
+// suite's env does not leak into the next suite.
+describeWithEnv(
+  "describeWithEnv cleanup (body left inner scope undisposed)",
+  { env: { [OUTER_KEY]: "on" } },
+  () => {
+    // Open an inner scope in beforeEach but do NOT dispose it in afterEach —
+    // the factory afterEach must still clean up the outer scope.
+    beforeEach(() => {
+      withEnv({ [INNER_KEY]: "set" });
+    });
+
+    test("sees both scopes", () => {
+      expect(getEnv(OUTER_KEY)).toBe("on");
+      expect(getEnv(INNER_KEY)).toBe("set");
+    });
+  },
+);
+
+// After the above suite, OUTER_KEY must be gone (factory afterEach disposed
+// the outer scope despite the inner scope leaking). INNER_KEY may persist
+// (it was never disposed), but OUTER_KEY — the suite's own env — must not.
+describeWithEnv(
+  "describeWithEnv cleanup (outer env gone after leak)",
+  {},
+  () => {
+    test("does not inherit the outer env despite the inner scope leak", () => {
+      expect(getRealEnv(OUTER_KEY)).toBeUndefined();
+      expect(getEnv(OUTER_KEY)).toBeUndefined();
+    });
+  },
+);
+
 describe("describeWithEnv overlay cleanup (sanity)", () => {
-  test("the real process env is never touched", () => {
+  test("the real process env was never touched", () => {
     expect(getRealEnv(OUTER_KEY)).toBeUndefined();
     expect(getRealEnv(INNER_KEY)).toBeUndefined();
   });

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -260,12 +260,16 @@ export const describeWithEnv = (
     afterEach(() => {
       // try/finally so each teardown step runs even if an earlier one threw —
       // the DB file, env overlay, and storage dir never outlive the test.
+      // Dispose the suite env BEFORE resetDb: the scopes are stacked (DB
+      // first in prepareTestClient, then suite env on top), so LIFO means
+      // env.dispose() pops to the DB layer, then resetDb's cleanupTestDbFile
+      // uses that DB_URL to delete the file, then disposes the DB scope.
       try {
-        if (options.db) resetDb();
+        env?.dispose();
+        env = undefined;
       } finally {
         try {
-          env?.dispose();
-          env = undefined;
+          if (options.db) resetDb();
         } finally {
           teardownStorageConfig(storageDir);
           storageDir = undefined;

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -48,6 +48,11 @@ import {
   setSetupState,
 } from "#test-utils/test-state.ts";
 
+// The env scope prepareTestClient opens per test (DB_URL + trigger flag).
+// resetDb disposes it right after cleanupTestDbFile uses the overlaid DB_URL
+// to delete the temp file, so the overlay never outlives the test.
+const dbEnvScope: { current: EnvScope | undefined } = { current: undefined };
+
 const prepareTestClient = async (triggers = false): Promise<void> => {
   // Keep libsql's leaked file descriptors from exhausting the process limit
   // under high `--parallel` worker counts (see reclaim-fds.ts).
@@ -75,7 +80,8 @@ const prepareTestClient = async (triggers = false): Promise<void> => {
   const goldenPath = await getOrCreateGoldenDb();
   const path = await createTrackedTestDbFile(".db");
   await Deno.copyFile(goldenPath, path);
-  withEnv({
+  dbEnvScope.current?.dispose();
+  dbEnvScope.current = withEnv({
     DB_URL: `file:${path}`,
     DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: triggers ? undefined : "1",
   });
@@ -159,6 +165,8 @@ const cleanupTestDbFile = (): void => {
 
 export const resetDb = (): void => {
   cleanupTestDbFile();
+  dbEnvScope.current?.dispose();
+  dbEnvScope.current = undefined;
   setDb(null);
   settings.setup.clearCache();
   settings.invalidateCache();
@@ -250,11 +258,19 @@ export const describeWithEnv = (
     // inner-then-outer contract BDD suites already assume.
     fn();
     afterEach(() => {
-      if (options.db) resetDb();
-      env?.dispose();
-      env = undefined;
-      teardownStorageConfig(storageDir);
-      storageDir = undefined;
+      // try/finally so each teardown step runs even if an earlier one threw —
+      // the DB file, env overlay, and storage dir never outlive the test.
+      try {
+        if (options.db) resetDb();
+      } finally {
+        try {
+          env?.dispose();
+          env = undefined;
+        } finally {
+          teardownStorageConfig(storageDir);
+          storageDir = undefined;
+        }
+      }
     });
     // A small suite may never reach the amortised reclaim threshold, so hand
     // back its leaked descriptors when it finishes (see reclaim-fds.ts).


### PR DESCRIPTION
## What changed

Follow-up to the merged PR #1914, addressing an independent review that found a deeper env-overlay leak.

The merged PR fixed `describeWithEnv`'s afterEach hook ordering so nested `withEnv` scopes dispose before the outer env layer is cleared. But the review found that `prepareTestClient` itself opened a `withEnv` scope (for `DB_URL` and the trigger flag) and **discarded it** — never disposed. The overlay kept pointing at the temp database file even after `resetDb` deleted it. Every subsequent `withEnv` call layered on top of that leaked baseline, and disposing back through it restored the deleted-file pointer.

## Changes

- **`test/test-utils/db.ts`** — Track the DB env scope in a `const` container (`dbEnvScope.current`) and dispose it in `resetDb`, right after `cleanupTestDbFile` uses the overlaid `DB_URL` to delete the file (before any other cleanup that might throw). `prepareTestClient` disposes any leftover scope before layering a fresh one. The afterEach uses `try/finally` so `resetDb`, `env.dispose`, and storage teardown each run even when an earlier step throws.
- **`test/lib/server-guide.test.ts`** — Assert the cached guide is pinned to builder-off even under ambient `CAN_BUILD_SITES=true`, contrasting the pinned cached output against the uncached render under the same ambient flag.
- **`test/lib/test-utils/env-overlay-order.test.ts`** — Regression: a DB-backed suite proves `DB_URL` does not keep pointing at the deleted temp file after `resetDb`; a leaked-inner-scope suite proves the outer env scope is still disposed even when the body leaves a mess.

## Checks

- `nix develop -c deno task precommit` (typecheck + lint + cpd + full suite, 100% coverage)
- Regression tests verified to fail without the `dbEnvScope` disposal fix.