### PR TITLE
Add regression tests for DB env scope lifecycle and cached guide pin

### DIFF
--- a/test/lib/server-guide.test.ts
+++ b/test/lib/server-guide.test.ts
@@ -330,6 +330,14 @@ describeWithEnv("server (admin guide)", { db: true }, () => {
       expect(html).not.toContain('id="built-sites"');
     });
 
+    test("cached guide is pinned to builder-off even under ambient CAN_BUILD_SITES=true", async () => {
+      using _ambient = withEnv({ CAN_BUILD_SITES: "true" });
+      const live = await assertAdminHtml("/admin/guide", 'id="built-sites"');
+      expect(live).toContain('id="built-sites"');
+      const cached = await guide();
+      expect(cached).not.toContain('id="built-sites"');
+    });
+
     test("shows built sites section when builder is enabled", async () => {
       using _env = withEnv({ CAN_BUILD_SITES: "true" });
       await assertAdminHtml(

--- a/test/lib/test-utils/env-overlay-order.test.ts
+++ b/test/lib/test-utils/env-overlay-order.test.ts
@@ -63,3 +63,75 @@ describe("describeWithEnv overlay cleanup (sanity)", () => {
     expect(getRealEnv(INNER_KEY)).toBeUndefined();
   });
 });
+
+// A DB-backed suite overlays DB_URL with a fresh temp file per test. The DB
+// resource (tracked by prepareTestClient) must be disposed by resetDb, so the
+// overlay does not keep pointing at the deleted temp file after the suite.
+const realDbUrl = getRealEnv("DB_URL");
+const suiteTempDbUrl: { value: string | undefined } = { value: undefined };
+describeWithEnv("describeWithEnv DB env (temp file)", { db: true }, () => {
+  test("overlays DB_URL with a fresh temp file during the test", () => {
+    const url = getEnv("DB_URL");
+    expect(url?.startsWith("file:")).toBe(true);
+    expect(url).not.toBe(realDbUrl);
+    suiteTempDbUrl.value = url;
+  });
+});
+
+describe("describeWithEnv DB env (restored after)", () => {
+  test("DB_URL overlay does not keep the deleted temp file from the suite", () => {
+    expect(getEnv("DB_URL")).not.toBe(suiteTempDbUrl.value);
+  });
+});
+
+// A mixed suite (db: true AND env) stacks: DB scope first, suite env on top.
+// The afterEach must dispose the suite env BEFORE resetDb (LIFO), or
+// env.dispose() resurrects the deleted DB_URL.
+const mixedSuiteTempDbUrl: { value: string | undefined } = { value: undefined };
+describeWithEnv(
+  "describeWithEnv mixed DB+env (stacked)",
+  { db: true, env: { [OUTER_KEY]: "on" } },
+  () => {
+    test("sees both DB_URL and outer env during the test", () => {
+      expect(getEnv("DB_URL")?.startsWith("file:")).toBe(true);
+      mixedSuiteTempDbUrl.value = getEnv("DB_URL");
+      expect(getEnv(OUTER_KEY)).toBe("on");
+    });
+  },
+);
+
+describe("describeWithEnv mixed DB+env (restored after)", () => {
+  test("neither DB_URL nor outer env leaks the deleted temp file", () => {
+    expect(getEnv("DB_URL")).not.toBe(mixedSuiteTempDbUrl.value);
+    expect(getEnv(OUTER_KEY)).toBeUndefined();
+  });
+});
+
+// A body that opens an inner scope but fails to dispose it (simulating a
+// body afterEach that threw before reaching its dispose call). The factory
+// afterEach must still dispose the outer env scope.
+describeWithEnv(
+  "describeWithEnv cleanup (body left inner scope undisposed)",
+  { env: { [OUTER_KEY]: "on" } },
+  () => {
+    beforeEach(() => {
+      withEnv({ [INNER_KEY]: "set" });
+    });
+
+    test("sees both scopes", () => {
+      expect(getEnv(OUTER_KEY)).toBe("on");
+      expect(getEnv(INNER_KEY)).toBe("set");
+    });
+  },
+);
+
+describeWithEnv(
+  "describeWithEnv cleanup (outer env gone after leak)",
+  {},
+  () => {
+    test("does not inherit the outer env despite the inner scope leak", () => {
+      expect(getRealEnv(OUTER_KEY)).toBeUndefined();
+      expect(getEnv(OUTER_KEY)).toBeUndefined();
+    });
+  },
+);


### PR DESCRIPTION
## What changed

Follow-up to the merged PR #1914. Main's #1915 already fixed the `prepareTestClient` scope ownership and LIFO dispose order comprehensively (`TestDbResource`, `runCleanups`). This PR adds regression tests that verify the fix holds.

## Tests added

- **`test/lib/test-utils/env-overlay-order.test.ts`**:
  - **DB_URL restoration**: a DB-backed suite overlays `DB_URL` with a temp file; after the suite, the overlay must not keep pointing at the deleted file (proves `resetDb` disposed the scope).
  - **Mixed DB+env LIFO**: a suite with both `db: true` and `env` stacks DB scope first, suite env on top; after the suite, neither the DB_URL nor the outer env leaks (proves LIFO dispose order).
  - **Leaked inner scope**: a body that opens an inner scope but fails to dispose it (simulating a body afterEach that threw) — the factory afterEach must still dispose the outer env scope.
- **`test/lib/server-guide.test.ts`**:
  - **Cached guide pin under ambient**: the cached guide render is pinned to `CAN_BUILD_SITES=undefined` even under ambient `CAN_BUILD_SITES=true`, contrasting the pinned cached output against the uncached render under the same ambient flag.

## Checks

- `nix develop -c deno task precommit` (typecheck + lint + cpd + full suite, 100% coverage)

PR #1917 is superseded by main's #1915 and will be closed.