### PR TITLE
Stop test databases slowing down after a transaction

### DIFF
--- a/test/test-utils/db-client.test.ts
+++ b/test/test-utils/db-client.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { createTestDbClient } from "#test-utils/db-client.ts";
+import { tempDir } from "#test-utils/files.ts";
+
+/** Read back the two speed settings the connection serving `client` runs with. */
+const speedSettings = async (
+  client: Awaited<ReturnType<typeof createTestDbClient>>,
+): Promise<{ journalMode: unknown; synchronous: unknown }> => ({
+  journalMode: (await client.execute("PRAGMA journal_mode")).rows[0]
+    ?.journal_mode,
+  synchronous: (await client.execute("PRAGMA synchronous")).rows[0]
+    ?.synchronous,
+});
+
+describe("test database client", () => {
+  const openClient = async () => {
+    const dir = tempDir({ prefix: "tickets-db-client-test-" });
+    const client = await createTestDbClient(`${dir.path}/test.db`);
+    return {
+      client,
+      [Symbol.dispose]: () => {
+        client.close();
+        dir.dispose();
+      },
+    };
+  };
+
+  test("opens with journalling and disk flushing switched off", async () => {
+    using opened = await openClient();
+    expect(await speedSettings(opened.client)).toEqual({
+      journalMode: "memory",
+      synchronous: 0,
+    });
+  });
+
+  test("keeps those settings after an interactive transaction", async () => {
+    using opened = await openClient();
+    const { client } = opened;
+    await client.execute("CREATE TABLE counters (value INTEGER)");
+
+    const transaction = await client.transaction("write");
+    await transaction.execute("INSERT INTO counters (value) VALUES (1)");
+    await transaction.commit();
+
+    // libsql hands its connection to the transaction and opens a fresh one for
+    // everything after it; a fresh plain connection would report "delete" / 2.
+    expect(await speedSettings(client)).toEqual({
+      journalMode: "memory",
+      synchronous: 0,
+    });
+  });
+
+  test("still reads and writes normally after a transaction", async () => {
+    using opened = await openClient();
+    const { client } = opened;
+    await client.execute("CREATE TABLE counters (value INTEGER)");
+
+    const transaction = await client.transaction("write");
+    await transaction.execute("INSERT INTO counters (value) VALUES (7)");
+    await transaction.commit();
+    await client.execute("INSERT INTO counters (value) VALUES (11)");
+
+    const result = await client.execute(
+      "SELECT value FROM counters ORDER BY value ASC",
+    );
+    expect(result.rows.map((row) => row.value)).toEqual([7, 11]);
+  });
+});

--- a/test/test-utils/db-client.ts
+++ b/test/test-utils/db-client.ts
@@ -1,0 +1,38 @@
+import {
+  type Client,
+  createClient,
+  type TransactionMode,
+} from "@libsql/client";
+import { beginTransaction } from "#shared/db/libsql-call.ts";
+import { proxyMembers } from "#shared/proxy-members.ts";
+
+/** Speed settings every test database connection runs with. Nothing in a test
+ * database has to survive a crash, so writes never wait for the disk: with
+ * these settings a write costs about 0.02ms, without them about 4ms. */
+const FAST_WRITE_SETTINGS =
+  "PRAGMA journal_mode=MEMORY; PRAGMA synchronous=OFF;";
+
+/**
+ * Open a test database file with those speed settings, and keep them in place
+ * for the life of the client.
+ *
+ * The settings belong to one *connection*, and libsql gives its connection away
+ * whenever an interactive transaction starts (`withTransaction`), then opens a
+ * fresh, plain one for every statement that follows. So a single transaction
+ * used to leave the rest of the test file waiting on the disk for each write.
+ * Setting the replacement connection up straight away keeps every later
+ * statement fast.
+ */
+export const createTestDbClient = async (path: string): Promise<Client> => {
+  const client = createClient({ url: `file:${path}` });
+  await client.executeMultiple(FAST_WRITE_SETTINGS);
+  return proxyMembers(client, {
+    transaction: async (mode?: TransactionMode) => {
+      const transaction = await beginTransaction(client, mode);
+      // The transaction now owns the old connection; set up the new one before
+      // any other statement can land on it.
+      await client.executeMultiple(FAST_WRITE_SETTINGS);
+      return transaction;
+    },
+  });
+};

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -1,4 +1,4 @@
-import { type Client, createClient } from "@libsql/client";
+import type { Client } from "@libsql/client";
 import { afterAll, afterEach, beforeEach, describe } from "@std/testing/bdd";
 import { lazyRef } from "#fp";
 import { runCleanups } from "#scripts/cleanup.ts";
@@ -18,6 +18,7 @@ import {
   setHostEmailConfigForTest,
 } from "#shared/email.ts";
 import { setStorageConfigForTest } from "#shared/storage.ts";
+import { createTestDbClient } from "#test-utils/db-client.ts";
 import {
   type EnvScope,
   setupTestEncryptionKey,
@@ -91,8 +92,7 @@ const prepareTestClient = async (triggers = false): Promise<void> => {
   // A temp file, not ":memory:": interactive transactions (withTransaction) open
   // a second connection, and each ":memory:" connection is its own *separate*
   // empty database — a transaction would see no schema. A file is shared across
-  // connections. Durability is irrelevant in tests, so relax fsync to keep speed
-  // close to in-memory.
+  // connections. `createTestDbClient` keeps the speed settings on it.
   //
   // Copy the golden DB (schema + default status, prebuilt by the harness for
   // the whole run, else built once per isolate — see test-state.ts) rather
@@ -105,13 +105,10 @@ const prepareTestClient = async (triggers = false): Promise<void> => {
     DB_URL: `file:${path}`,
     DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: triggers ? undefined : "1",
   });
-  const client = createClient({ url: `file:${path}` });
+  const client = await createTestDbClient(path);
   setTestDbResource({ client, env, path });
   using rollback = cleanupUnlessKept(resetDb);
   setDb(client);
-  // journal_mode persists in the SQLite header from the golden; synchronous=OFF
-  // is per-connection only and must be re-applied.
-  await client.executeMultiple("PRAGMA synchronous=OFF;");
   rollback.keep();
 };
 
@@ -142,9 +139,8 @@ export const setupTransactionalTestDb = async (): Promise<
     DB_URL: `file:${path}`,
     DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: "1",
   });
-  const client = createClient({ url: `file:${path}` });
+  const client = await createTestDbClient(path);
   setDb(client);
-  await client.executeMultiple("PRAGMA synchronous=OFF;");
   return async () => {
     setDb(null);
     client.close();

--- a/test/test-utils/test-state.ts
+++ b/test/test-utils/test-state.ts
@@ -21,7 +21,6 @@
  */
 
 import { join } from "node:path";
-import { createClient } from "@libsql/client";
 import * as v from "valibot";
 import { lazyRef, once } from "#fp";
 import { signCsrfToken } from "#shared/csrf.ts";
@@ -39,6 +38,7 @@ import {
   SCHEMA_HASH,
 } from "#shared/db/migrations.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#shared/db/settings.ts";
+import { createTestDbClient } from "#test-utils/db-client.ts";
 import { setupTestEncryptionKey, withEnv } from "#test-utils/env.ts";
 import {
   TEST_ADMIN_PASSWORD,
@@ -159,11 +159,8 @@ const buildTestSchemaSql = once(async (): Promise<string> => {
 
 /** Build the full test schema plus the default attendee status into `path`. */
 const createGoldenDbAt = async (path: string): Promise<void> => {
-  const client = createClient({ url: `file:${path}` });
+  const client = await createTestDbClient(path);
   setDb(client);
-  await client.executeMultiple(
-    "PRAGMA journal_mode=MEMORY; PRAGMA synchronous=OFF;",
-  );
   await client.executeMultiple(await buildTestSchemaSql());
   await ensureDefaultAttendeeStatus();
   attendeeStatuses.invalidate();
@@ -354,9 +351,8 @@ export const writeTestState = async (dir: string): Promise<void> => {
     DB_URL: `file:${workPath}`,
     DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: "1",
   });
-  const client = createClient({ url: `file:${workPath}` });
+  const client = await createTestDbClient(workPath);
   setDb(client);
-  await client.executeMultiple("PRAGMA synchronous=OFF;");
   try {
     const { state } = await runSetupCeremony("GB");
     await Deno.writeTextFile(join(dir, STATE_JSON_FILE), JSON.stringify(state));


### PR DESCRIPTION
## What changed

Test databases are told not to journal and not to wait for the disk, because
nothing in a test has to survive a crash. Those two settings belong to a single
database *connection*.

libsql hands its connection over to each interactive transaction
(`withTransaction`), then quietly opens a fresh, plain one for every statement
that comes after it. The fresh connection does not carry the settings, so the
first transaction in a test file made every later write wait for the disk. A
write went from about 0.02ms to about 4ms, and a transaction from 0.46ms to
5.4ms.

The new shared `createTestDbClient` opens the database file, applies the two
settings, and applies them again to the replacement connection as soon as a
transaction takes the old one. All four places that opened a test database now
use it, so the settings string is written once instead of in each of them.

## Why it matters

Tests spend a lot of time writing to their own throwaway database, and this
made most of that waiting avoidable. A CPU profile of one test file went from
spending a third of its own work inside disk flushes to spending none.

## Measured on one machine

| | before | after |
| --- | --- | --- |
| whole `test/integration` folder | 51.2s | 40.0s (−22%) |
| questions-attendee-answers | 1450ms | 1001ms (−31%) |
| admin-api-listings-read | 1168ms | 822ms (−30%) |
| api-book-payments | 3312ms | 2646ms (−20%) |
| renewals | 967ms | 792ms (−18%) |

## Tests

A new `test/test-utils/db-client.test.ts` checks the settings are there when the
database opens, are still there after an interactive transaction, and that
reads and writes keep working across one. The middle test was confirmed to fail
without this change.

The full suite passes. Lint, typecheck, and the duplicate-code check are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgqCiE37jNytr2QB1BnV9i)_