### PR TITLE
Tighten the tests behind the database host and backup names

### DIFF
--- a/src/shared/db/host.ts
+++ b/src/shared/db/host.ts
@@ -1,11 +1,8 @@
-import * as v from "valibot";
-
 /**
  * Who runs a database, worked out from its address alone. This module is pure:
  * callers pass a URL, it never reads the environment.
  */
-const DatabaseHostSchema = v.picklist(["bunny", "turso", "local", "other"]);
-export type DatabaseHost = v.InferOutput<typeof DatabaseHostSchema>;
+export type DatabaseHost = "bunny" | "turso" | "local" | "other";
 
 /** The address endings that name the company running a hosted database. */
 const HOSTED_ENDINGS: Record<"bunny" | "turso", string> = {

--- a/test/shared/db/backup-storage.test.ts
+++ b/test/shared/db/backup-storage.test.ts
@@ -42,6 +42,11 @@ describeWithEnv("backup storage", { db: true }, () => {
       expect(dbName()).toBe("my-site-myorg");
     });
 
+    test("drops only the part before the first dash", () => {
+      using _env = withEnv({ DB_URL: "libsql://a-tickets.lite.bunnydb.net" });
+      expect(dbName()).toBe("tickets");
+    });
+
     test("returns full hostname segment when no dash", () => {
       using _env = withEnv({ DB_URL: "libsql://standalone.turso.io" });
       expect(dbName()).toBe("standalone");

--- a/test/ui/templates/admin/debug/rendering.test.tsx
+++ b/test/ui/templates/admin/debug/rendering.test.tsx
@@ -64,6 +64,7 @@ describe("admin debug template rendering", () => {
       "debug.field.custom_domain",
       "debug.field.subdomain_suffix",
       "debug.field.registered_subdomain",
+      "debug.field.database_host",
     ] as const;
 
     for (const label of missingValueLabels) {
@@ -120,7 +121,7 @@ describe("admin debug template rendering", () => {
           subdomainSuffix: "subdomain-suffix-marker",
         },
         database: {
-          host: "turso",
+          host: "turso" as const,
           hostConfigured: true,
           schemaHash: "schema-hash-marker",
           schemaInSync: true,


### PR DESCRIPTION
## What this changes

A small follow-up to #1940, which merged before these three fixes landed. Mutation testing on the files that PR touched found three gaps — a change could be made to the code and no test would notice.

- **The database host names are now a plain list of words.** They were declared through a validation helper, but nothing ever validated anything with it — it only existed to make the type. So the four names ("bunny", "turso", "local", "other") could be changed to anything without a single test failing. Written as a plain type, they cannot drift unnoticed.
- **The debug page test now checks the blank database host row.** When no database address is set the page shows a dash; nothing was checking that, so the dash could vanish silently.
- **Backup names now have a test for a short first part.** Backup names drop everything before the first dash in the address. Every existing test used a long prefix, so a change to *where* the cut is made still passed. The new case uses a one-letter prefix, which only passes when the cut is in the right place.

No behaviour changes for anyone using the site.

## Testing

- `deno task precommit` passes.
- The three files now score 100% on mutation testing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEUznr4J4EDCqJV244WfSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEUznr4J4EDCqJV244WfSJ)_