### PR TITLE
Write the listing-change and race journeys as stories

### DIFF
--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -174,7 +174,9 @@ problem:
   merely being undone in the books,
 - the ordinary "duration changed" history entry, when only the exceptional
   overflow warning was carried across,
-- that a booking still exists, as opposed to merely having no refund against it.
+- that a booking still exists, as opposed to merely having no refund against it,
+- that a race was settled by capacity rather than by one request simply failing,
+- the exact reason a refusal was given, where only its absence was checked.
 
 Then finish the job:
 
@@ -217,7 +219,51 @@ missing form, a 500, or a redirect to login all produce the same absence. Assert
 the **specific reason** the site gives — ideally by importing the production
 message builder rather than copying its wording. The same applies to an admin
 action: assert the flash the operator is shown, not merely that a redirect
-happened.
+happened, and to an unchanged row count, which any failure produces.
+
+Two sharper versions of the same trap:
+
+- **A refusal must leave nothing behind.** Prove the row is absent, not just
+  that a later booking still fits. A scenario with a limit of 3 refused a
+  2-place booking and then probed with 1 place: had the refused booking leaked a
+  row, the probe would *still* have passed on the one place left over. Assert
+  the refused thing does not exist.
+- **Both halves of a race need proving.** When two requests run at once, assert
+  the loser was turned away *for want of room*. Counting one winner and one row
+  passes just as well when the loser died on a validation error.
+
+### Never build the expectation from the code under test
+
+A `Then` that calls the same production helper that produced the value proves
+nothing: change the helper and both sides move together. A download's date
+column was checked with `csvDateRange`, the very function that writes it, so
+changing its exclusive-end arithmetic would have kept the story green. Write the
+expected value out in the step from the story's own numbers.
+
+This is not the same as importing a production *constant* or *message*, which
+you should do — a wording or a day-name list is a shared fact, not the
+calculation under test.
+
+### Cucumber mechanics that bite
+
+These cost hours each, and none of them fail in a way that names the cause.
+
+- **A step function's parameter count must match its expression's.** Cucumber
+  binds arguments by position against the parameters in the step text, so a
+  shared implementation with an optional trailing parameter (`(a, b?) => …`)
+  reports the wrong arity and silently mis-binds — the symptom was a page
+  request with no listing resolved, several steps later. If two steps take
+  different numbers of parameters, give them **separate step functions** over a
+  shared plain helper. Curry the helper, never the step's signature.
+- **Plurals belong in the pattern, not in a second step.** `{int} days long`
+  does not match "1 day long". Write `{int} day(s) long`, which matches both.
+  Note the `(s)` is pattern syntax — never write it in a Scenario's own text.
+- **Two definitions matching one step text is an Ambiguous error**, and a
+  generic `{word}` step will collide with the literal ones already registered.
+  Before adding a generic step, grep for the literals it would swallow. Merge
+  them only when their assertions are genuinely the same; if a literal asserts
+  *more* (a conservation check, an extra surface), keep it and word the new step
+  differently.
 
 ### The clock and the calendar
 
@@ -259,6 +305,16 @@ count towards it. Two consequences bite regularly:
 And the rule that catches both: a story may never be the only cover of a
 production line or branch.
 
+**A green coverage number does not mean the contract survived.** Coverage counts
+lines, and a technical contract is usually about *conditions*, not lines. A
+direct test of two simultaneous multi-day bookings was replaced by a story, and
+coverage stayed at 100% because other tests walked the same lines — but nothing
+directly exercised the dated range-capacity check under a race any more. When
+the test you are deleting is about concurrency, a query budget, an exact stored
+shape, or an ordering guarantee, keep a direct test for it *and* write the
+story. Say in a comment which story it sits beside, so nobody deletes it again
+as a duplicate.
+
 ### Say what the product actually does
 
 Plain language must still be true. "The organiser hands the money back"
@@ -266,3 +322,20 @@ described a choice that returns nothing to the customer's card — it records
 credit owed to them. A reader would have learned the opposite of the truth. When
 naming a money decision, a status, or an outcome, check what the code does
 before you name it.
+
+**The Feature's own prose is a claim.** The narrative under `Feature:` and the
+paragraph under each `Rule:` are published in the story catalog as statements
+about the product, and *nothing executes them*. A Feature description promising
+that "the room they take up is still counted" survived after the scenario that
+would have tested it was removed — so the catalog would have published a
+guarantee the product does not give, with every scenario passing. Describe only
+what the Rules below actually exercise. When you remove a scenario, re-read the
+prose above it.
+
+**When the story fails because the product does not do that, do not soften the
+story.** This is the most valuable thing a migration finds, and the temptation
+is to reword the `Then` until it goes green. Instead: delete the scenario, leave
+the original test where it is, and write the question up in `TODO.md` with what
+you expected, what the product does, and the ways it could be settled. Say it in
+the pull request too. A scenario weakened to match behaviour nobody chose is
+worse than no scenario — it makes the accident look intended.

--- a/TODO.md
+++ b/TODO.md
@@ -1667,3 +1667,35 @@ generated API docs — a moved export silently disappears from them otherwise.
 
 Starting point: the "Hybrid Encryption" section of `src/shared/crypto/keys.ts`,
 and `grep -rn "encryptWithOwnerKey\|decryptWithOwnerKey\|hybridEncrypt" src/`.
+
+---
+
+## Decide what happens to undated bookings when a listing starts being booked by the day
+
+*Origin: found while migrating the multi-day tests to stories (PR for batch 8).*
+
+A listing booked as one date can be switched to being booked by the day. The
+people who booked before the switch have no day of their own (`start_at` is
+NULL), and the per-day capacity count deliberately excludes them on a daily
+listing — see the null-start_at case in
+`test/e2e/duration-days/booking-flows.test.ts`.
+
+The effect is that a full listing stops being full the moment it is switched. A
+Hall with room for 2, with both places taken, accepts a further booking on any
+day after the switch, so it ends up holding 3 people. The listing's *total*
+check still counts them (`attendeesApi.hasAvailableSpots(id, 1)` with no date
+returns false), so the two checks disagree.
+
+This may be intended — an undated booking genuinely has no day to block — but
+nothing states the intent, and an organiser switching a sold-out listing would
+not expect it to reopen. Worth an explicit decision: either give the undated
+bookings a day at the point of the switch, count them against every day, or
+refuse the switch while undated bookings exist.
+
+It was out of scope for the migration, which only moves existing tests into
+stories. A story asserting "people booked before the change still take up room"
+was written and then removed, because the product does not do that today.
+
+Starting point: `attendeesApi.hasAvailableSpots` and the per-day capacity SQL in
+`src/shared/db/attendees/capacity.ts`, plus the listing-type switch in
+`src/features/admin/listings-edit.ts`.

--- a/specs/bookings/booking-several-days.feature
+++ b/specs/bookings/booking-several-days.feature
@@ -53,6 +53,31 @@ Feature: A customer books a stay of several days
       Then they are told the Cabin has no room for those days
       And the Cabin still holds only the 2 stays it had
 
+  @rule:bookings.longer-stays-leave-fewer-days-to-start-on
+  Rule: Longer stays leave fewer days to start on
+    A stay has to finish inside the window the listing takes bookings for, so
+    the longer each stay is, the fewer days it can start on.
+
+    @case:stay.a-longer-stay-offers-fewer-start-days
+    Scenario: Two listings take bookings the same distance ahead
+      Given a Cabin that is booked 1 day at a time, with room for 5 places a day
+      And a Lodge that is booked 5 days at a time, with room for 5 places a day
+      When a customer looks at the days the Cabin offers
+      And a customer looks at the days the Lodge offers
+      Then the Lodge offers fewer days to start on than the Cabin
+      And the Lodge still offers some days
+
+  @rule:bookings.only-one-of-two-stays-booked-at-once-is-taken
+  Rule: Only one of two stays booked at the same moment is taken
+    Two customers can press Continue on the last place at the same moment. One
+    of them gets it and the other is refused — the day never goes over.
+
+    @case:stay.two-customers-race-for-the-last-stay
+    Scenario: Two customers book the last stay at the same moment
+      Given a Cabin that is booked 2 days at a time, with room for 1 place a day
+      When two customers try to book a Cabin stay starting in 10 days at once
+      Then only one of them got the stay
+
   @rule:bookings.a-stay-cannot-run-into-a-closed-day
   Rule: A stay is never offered a start day that runs into a closed day
     A holiday closes a day. A stay that would cover it cannot start, even when

--- a/specs/bookings/changes-after-people-have-booked.feature
+++ b/specs/bookings/changes-after-people-have-booked.feature
@@ -1,0 +1,38 @@
+@story:bookings.changes-after-people-have-booked
+@owner:bookings @risk:high
+@actor:organiser @actor:customer
+@edition:managed @edition:self-hosted
+Feature: A listing changes after people have already booked
+  An organiser can close a day of the week, make stays longer, or start booking
+  a listing by the day when it was not before. Whatever they change, the people
+  who already booked keep what they were sold — and the room they take up is
+  still counted.
+
+  @rule:bookings.closing-a-day-leaves-booked-stays-alone
+  @surface:admin
+  Rule: Closing a day of the week leaves the stays already booked alone
+    A stay booked before the day was closed keeps every day it covers. Only new
+    stays are kept off it.
+
+    @case:changes.a-closed-weekday-keeps-the-stay
+    Scenario: The organiser stops opening on a day a stay already covers
+      Given a Cabin that is booked 3 days at a time, with room for 5 places a day
+      And a customer booked a Cabin stay starting in 10 days
+      When the organiser stops opening the Cabin on the second day of that stay
+      Then the organiser sees the stay runs for 3 days
+      And the Cabin no longer offers a start day 10 days from now
+
+  @rule:bookings.a-stay-stretched-past-the-booking-window-is-kept
+  @surface:admin
+  Rule: A stay stretched past how far ahead people can book is still kept
+    Making stays longer can push one already booked past the last day the
+    listing takes bookings for. That stay was sold in good faith, so it keeps
+    its days — but no new stay can start there.
+
+    @case:changes.a-stay-stretched-past-the-window
+    Scenario: The organiser makes stays longer than the booking window allows
+      Given a Cabin that takes bookings 10 days ahead, 1 day at a time
+      And a customer booked a Cabin stay starting in 9 days
+      When the organiser makes each Cabin stay 5 days long
+      Then the organiser sees that stay now runs for 5 days
+      And the Cabin no longer offers a start day 9 days from now

--- a/specs/bookings/changes-after-people-have-booked.feature
+++ b/specs/bookings/changes-after-people-have-booked.feature
@@ -3,10 +3,9 @@
 @actor:organiser @actor:customer
 @edition:managed @edition:self-hosted
 Feature: A listing changes after people have already booked
-  An organiser can close a day of the week, make stays longer, or start booking
-  a listing by the day when it was not before. Whatever they change, the people
-  who already booked keep what they were sold — and the room they take up is
-  still counted.
+  An organiser can close a day of the week, or make stays longer than the
+  window the listing takes bookings for. Either way, the people who already
+  booked keep the days they were sold; only new bookings are turned away.
 
   @rule:bookings.closing-a-day-leaves-booked-stays-alone
   @surface:admin

--- a/test/e2e/duration-days/capacity.test.ts
+++ b/test/e2e/duration-days/capacity.test.ts
@@ -1,9 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { getAvailableDates } from "#shared/dates.ts";
 import { attendeesApi } from "#shared/db/attendees/api.ts";
-import { getActiveHolidays } from "#shared/db/holidays.ts";
-import { getListingWithCount } from "#shared/db/listings/records.ts";
 import { buildTemplateData } from "#shared/email-renderer.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
@@ -57,30 +54,6 @@ describeWithEnv(
         expect(
           await attendeesApi.hasAvailableSpots(listing.id, 1, "2026-06-13", 1),
         ).toBe(true);
-      });
-    });
-
-    describe("available dates filtering", () => {
-      test("single-day listing offers more start dates than multi-day for same window", async () => {
-        const single = await createDailyTestListing({
-          durationDays: 1,
-          maxAttendees: 10,
-        });
-        const multi = await createDailyTestListing({
-          durationDays: 5,
-          maxAttendees: 10,
-        });
-        const holidays = await getActiveHolidays();
-        const singleDates = getAvailableDates(
-          (await getListingWithCount(single.id))!,
-          holidays,
-        );
-        const multiDates = getAvailableDates(
-          (await getListingWithCount(multi.id))!,
-          holidays,
-        );
-        // Multi-day has fewer start dates because the tail must fit in the window.
-        expect(singleDates.length).toBeGreaterThan(multiDates.length);
       });
     });
 

--- a/test/e2e/duration-days/edge-cases.test.ts
+++ b/test/e2e/duration-days/edge-cases.test.ts
@@ -12,6 +12,30 @@ import {
 
 describeWithEnv("e2e: multi-day bookings — edge cases", { db: true }, () => {
   describe("edge cases: realistic unusual scenarios", () => {
+    /**
+     * The dated range-capacity SQL settling two simultaneous multi-day inserts.
+     * The story `@case:stay.two-customers-race-for-the-last-stay` tells the same
+     * race in the customers' terms; this owns the direct contract, because the
+     * other concurrency test (`create-attendee-atomic.test.ts`) races an undated
+     * standard listing and so never touches the range check.
+     */
+    test("two simultaneous multi-day bookings for one place — only one is taken", async () => {
+      const listing = await createDailyTestListing({
+        durationDays: 2,
+        maxAttendees: 1,
+      });
+      const results = await Promise.all(
+        ["a@test.com", "b@test.com"].map((email) =>
+          bookAttendee(listing, {
+            date: "2026-06-12",
+            durationDays: 2,
+            email,
+          }),
+        ),
+      );
+      expect(results.filter(({ success }) => success).length).toBe(1);
+    });
+
     test("9: listing type switch from standard to daily preserves existing attendees", async () => {
       // Standard listing gets attendees, then admin switches to daily.
       // Existing attendees have null start_at/end_at (no date).

--- a/test/e2e/duration-days/edge-cases.test.ts
+++ b/test/e2e/duration-days/edge-cases.test.ts
@@ -1,11 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { getAvailableDates } from "#shared/dates.ts";
 import { attendeesApi } from "#shared/db/attendees/api.ts";
 import { checkGroupCapAfterDurationChange } from "#shared/db/attendees/update.ts";
-import { getActiveHolidays } from "#shared/db/holidays.ts";
-import { getListingWithCount } from "#shared/db/listings/records.ts";
-import { describeWithEnv, rawListingRange } from "#test-utils/db.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import {
@@ -15,86 +12,6 @@ import {
 
 describeWithEnv("e2e: multi-day bookings — edge cases", { db: true }, () => {
   describe("edge cases: realistic unusual scenarios", () => {
-    test("2: bookable_days change does not corrupt existing bookings", async () => {
-      // Book a 3-day range Mon-Tue-Wed, then admin removes Tuesday from bookable_days.
-      // Existing booking stays in the DB. New bookings covering Tuesday are blocked.
-      const listing = await createDailyTestListing({
-        durationDays: 3,
-        maxAttendees: 10,
-        maximumDaysAfter: 60,
-      });
-      // Book starting 2026-06-08 (Mon) → covers Mon, Tue, Wed.
-      await bookAttendee(listing, { date: "2026-06-08", durationDays: 3 });
-
-      // Admin removes Tuesday from bookable days.
-      await updateTestListing(listing.id, {
-        bookableDays: [
-          "Monday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-          "Sunday",
-        ],
-      });
-
-      // The old booking still occupies those days in the DB.
-      const range = await rawListingRange(listing.id);
-      expect(range).not.toBeNull();
-
-      // New bookings starting on Monday should be blocked because the range
-      // would include Tuesday (now non-bookable).
-      const fresh = (await getListingWithCount(listing.id))!;
-      const holidays = await getActiveHolidays();
-      const dates = getAvailableDates(fresh, holidays);
-      // A start date that would require Tuesday should not appear.
-      // 2026-06-08 is Monday → 3-day range hits Tuesday → excluded.
-      expect(dates).not.toContain("2026-06-08");
-    });
-
-    test("3: duration increase extends booking past maximum_days_after (allowed, existing booking)", async () => {
-      // An existing booking was valid when created. Admin extends duration.
-      // The stored end_at now extends past the booking window — the system
-      // allows this for existing bookings (they were booked in good faith).
-      const listing = await createDailyTestListing({
-        durationDays: 1,
-        maxAttendees: 5,
-        maximumDaysAfter: 10,
-      });
-      // Book on day 9 (within the 10-day window).
-      await bookAttendee(listing, { date: "2026-06-09" });
-      // Extend to 5 days → end_at is now day 14, past the window.
-      await updateTestListing(listing.id, { durationDays: 5 });
-      const range = await rawListingRange(listing.id);
-      expect(range!.end_at).toBe("2026-06-14T00:00:00.000Z");
-      // But no new bookings should be offered on day 9 since the range
-      // would extend to day 14, past the window.
-      const fresh = (await getListingWithCount(listing.id))!;
-      const dates = getAvailableDates(fresh, await getActiveHolidays());
-      expect(dates).not.toContain("2026-06-09");
-    });
-
-    test("4: concurrent at-capacity multi-day bookings — only one wins", async () => {
-      const listing = await createDailyTestListing({
-        durationDays: 2,
-        maxAttendees: 1,
-      });
-      const [a, b] = await Promise.all([
-        bookAttendee(listing, {
-          date: "2026-06-12",
-          durationDays: 2,
-          email: "a@test.com",
-        }),
-        bookAttendee(listing, {
-          date: "2026-06-12",
-          durationDays: 2,
-          email: "b@test.com",
-        }),
-      ]);
-      const winners = [a.success, b.success].filter(Boolean);
-      expect(winners.length).toBe(1);
-    });
-
     test("9: listing type switch from standard to daily preserves existing attendees", async () => {
       // Standard listing gets attendees, then admin switches to daily.
       // Existing attendees have null start_at/end_at (no date).
@@ -115,33 +32,6 @@ describeWithEnv("e2e: multi-day bookings — edge cases", { db: true }, () => {
       // The 2 existing attendees (no date) should still block capacity.
       // hasAvailableSpots with no date checks total.
       expect(await attendeesApi.hasAvailableSpots(listing.id, 1)).toBe(false);
-    });
-
-    test("10: duration longer than booking window yields fewer available dates", async () => {
-      // duration=5, maximum_days_after=7. The 5-day range must fit in
-      // the 7-day window, so only ~3 start dates are possible. A 1-day
-      // listing with the same window would have ~7.
-      const long = await createDailyTestListing({
-        durationDays: 5,
-        maxAttendees: 10,
-        maximumDaysAfter: 7,
-      });
-      const short = await createDailyTestListing({
-        durationDays: 1,
-        maxAttendees: 10,
-        maximumDaysAfter: 7,
-      });
-      const holidays = await getActiveHolidays();
-      const longDates = getAvailableDates(
-        (await getListingWithCount(long.id))!,
-        holidays,
-      );
-      const shortDates = getAvailableDates(
-        (await getListingWithCount(short.id))!,
-        holidays,
-      );
-      expect(shortDates.length).toBeGreaterThan(longDates.length);
-      expect(longDates.length).toBeGreaterThan(0);
     });
 
     test("checkGroupCapAfterDurationChange sort comparator with equal-start ranges", async () => {

--- a/test/scripts/specs/catalog.test.ts
+++ b/test/scripts/specs/catalog.test.ts
@@ -20,6 +20,7 @@ describe("Cucumber story catalog", () => {
       "bookings.backup-and-restore",
       "bookings.book-through-the-site",
       "bookings.booking-several-days",
+      "bookings.changes-after-people-have-booked",
       "bookings.changing-how-long-a-stay-lasts",
       "bookings.day-limits-shared-across-listings",
       "bookings.ordering-several-things-at-once",

--- a/test/specs/steps/listing-changes.ts
+++ b/test/specs/steps/listing-changes.ts
@@ -10,7 +10,7 @@ import {
 import {
   daysOfferedFor,
   expectRefusedForWantOfRoom,
-  visitorTriesToBook,
+  visitorFillsInBooking,
 } from "#test/specs/support/public-booking.ts";
 import {
   dayFromToday,
@@ -92,11 +92,15 @@ When(
   ): Promise<void> {
     const listing = stayListing(this, name);
     const day = dayFromToday(this, startsIn);
-    // Both press Continue together, so the site has to settle the race itself.
-    const attempts = await Promise.all([
-      visitorTriesToBook(listing, { ...guest(1), day }),
-      visitorTriesToBook(listing, { ...guest(2), day }),
-    ]);
+    // Both customers fill the form in first. Only once both are waiting do they
+    // press Continue, so one cannot quietly finish before the other starts and
+    // turn the race into two ordinary bookings.
+    const waiting = await Promise.all(
+      [guest(1), guest(2)].map((who) =>
+        visitorFillsInBooking(listing, { ...who, day }),
+      ),
+    );
+    const attempts = await Promise.all(waiting.map(({ press }) => press()));
     this.raceWinners = attempts.filter(({ wasBooked }) => wasBooked).length;
     const loser = attempts.find(({ wasBooked }) => !wasBooked);
     // Left unset when both were taken, so the Then names what went wrong.

--- a/test/specs/steps/listing-changes.ts
+++ b/test/specs/steps/listing-changes.ts
@@ -9,6 +9,7 @@ import {
 } from "#test/specs/support/listing-changes.ts";
 import {
   daysOfferedFor,
+  expectRefusedForWantOfRoom,
   visitorTriesToBook,
 } from "#test/specs/support/public-booking.ts";
 import {
@@ -97,6 +98,9 @@ When(
       visitorTriesToBook(listing, { ...guest(2), day }),
     ]);
     this.raceWinners = attempts.filter(({ wasBooked }) => wasBooked).length;
+    const loser = attempts.find(({ wasBooked }) => !wasBooked);
+    // Left unset when both were taken, so the Then names what went wrong.
+    if (loser) this.raceLoser = loser;
     this.raceListing = name;
   },
 );
@@ -105,8 +109,14 @@ Then(
   "only one of them got the stay",
   async function (this: TicketsWorld): Promise<void> {
     expect(requiredWorldValue(this.raceWinners, "who got the stay")).toBe(1);
-    // And the listing holds that one stay only — the day never went over.
     const name = requiredWorldValue(this.raceListing, "the listing raced for");
+    // The other one has to be turned away for want of room: a validation or
+    // server error would otherwise pass for the site settling the race.
+    expectRefusedForWantOfRoom(
+      requiredWorldValue(this.raceLoser, "the customer who missed out"),
+      name,
+    );
+    // And the listing holds that one stay only — the day never went over.
     expect((await staysOn(this, name)).length).toBe(1);
   },
 );

--- a/test/specs/steps/listing-changes.ts
+++ b/test/specs/steps/listing-changes.ts
@@ -1,0 +1,112 @@
+// jscpd:ignore-start
+
+import { Given, Then, When } from "@cucumber/cucumber";
+import { expect } from "@std/expect";
+import { addDays } from "#shared/dates.ts";
+import {
+  stopOpeningOn,
+  weekdayOf,
+} from "#test/specs/support/listing-changes.ts";
+import {
+  daysOfferedFor,
+  visitorTriesToBook,
+} from "#test/specs/support/public-booking.ts";
+import {
+  dayFromToday,
+  guest,
+  openStayListing,
+  stayListing,
+  staysOn,
+} from "#test/specs/support/stays.ts";
+import {
+  requiredWorldValue,
+  type TicketsWorld,
+} from "#test/specs/support/world.ts";
+import { offeredDaysOf } from "./stays-booking.ts";
+
+// jscpd:ignore-end
+
+/** The first day of the stay the Scenario booked. */
+const stayStart = (world: TicketsWorld): string =>
+  requiredWorldValue(world.stayStartsOn, "the stay's first day");
+
+Given(
+  "a {word} that takes bookings {int} days ahead, {int} day(s) at a time",
+  async function (
+    this: TicketsWorld,
+    name: string,
+    ahead: number,
+    days: number,
+  ): Promise<void> {
+    await openStayListing(this, name, days, 5, { bookAheadDays: ahead });
+  },
+);
+
+When(
+  "the organiser stops opening the {word} on the second day of that stay",
+  async function (this: TicketsWorld, name: string): Promise<void> {
+    await stopOpeningOn(this, name, weekdayOf(addDays(stayStart(this), 1)));
+  },
+);
+
+Then(
+  "the {word} no longer offers a start day {int} days from now",
+  async function (
+    this: TicketsWorld,
+    name: string,
+    startsIn: number,
+  ): Promise<void> {
+    // A stay reaching a day the listing no longer takes cannot start at all,
+    // so the day drops off the chooser the customer is shown.
+    expect(await daysOfferedFor(stayListing(this, name))).not.toContain(
+      dayFromToday(this, startsIn),
+    );
+  },
+);
+
+Then(
+  "the {word} offers fewer days to start on than the {word}",
+  function (this: TicketsWorld, fewer: string, more: string): void {
+    expect(offeredDaysOf(this, fewer).length).toBeLessThan(
+      offeredDaysOf(this, more).length,
+    );
+  },
+);
+
+Then(
+  "the {word} still offers some days",
+  function (this: TicketsWorld, name: string): void {
+    // Fewer must not mean none: a listing whose stays fit the window at all
+    // still has to be bookable.
+    expect(offeredDaysOf(this, name).length).toBeGreaterThan(0);
+  },
+);
+
+When(
+  "two customers try to book a {word} stay starting in {int} days at once",
+  async function (
+    this: TicketsWorld,
+    name: string,
+    startsIn: number,
+  ): Promise<void> {
+    const listing = stayListing(this, name);
+    const day = dayFromToday(this, startsIn);
+    // Both press Continue together, so the site has to settle the race itself.
+    const attempts = await Promise.all([
+      visitorTriesToBook(listing, { ...guest(1), day }),
+      visitorTriesToBook(listing, { ...guest(2), day }),
+    ]);
+    this.raceWinners = attempts.filter(({ wasBooked }) => wasBooked).length;
+    this.raceListing = name;
+  },
+);
+
+Then(
+  "only one of them got the stay",
+  async function (this: TicketsWorld): Promise<void> {
+    expect(requiredWorldValue(this.raceWinners, "who got the stay")).toBe(1);
+    // And the listing holds that one stay only — the day never went over.
+    const name = requiredWorldValue(this.raceListing, "the listing raced for");
+    expect((await staysOn(this, name)).length).toBe(1);
+  },
+);

--- a/test/specs/steps/stays-booking.ts
+++ b/test/specs/steps/stays-booking.ts
@@ -3,6 +3,7 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { addDays, formatDateRangeLabel } from "#shared/dates.ts";
+import { getAttendeeRaw } from "#shared/db/attendees/queries.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
 import {
   daysOfferedFor,
@@ -211,20 +212,30 @@ When(
   },
 );
 
-/** What the organiser reads on the booking's own page. The label must name the
- * stay's first and last day, so a stay stored a day short or long fails. */
+/** How long the stay runs, checked two ways that cannot both drift together.
+ *
+ * The days the site stored are compared against the day the story started on
+ * plus its own number of days — arithmetic the site's own wording plays no part
+ * in. Then the booking's page is read, so the organiser is shown a label naming
+ * exactly those days. Checking only the label would let a change to how ranges
+ * are worded pass unnoticed, because the expected label is built by the same
+ * helper the page uses. */
 export const expectStayRunsFor = async (
   world: TicketsWorld,
   days: number,
 ): Promise<void> => {
-  const browser = await adminBrowser(world);
-  await browser.visit(`/admin/attendees/${world.attendeeId}`);
   const first = stayStart(world);
+  const dayAfterTheLast = addDays(first, days);
+  const bookingId = requiredWorldValue(world.attendeeId, "the booking");
+  const browser = await adminBrowser(world);
+  await browser.visit(`/admin/attendees/${bookingId}`);
+  const stored = await getAttendeeRaw(bookingId);
+  if (!stored) throw new Error(`Booking ${bookingId} has gone`);
+  expect(stored.date).toBe(first);
+  // The site stores the day after the last day held.
+  expect(stored.end_date).toBe(dayAfterTheLast);
   expect(browser.pageText).toContain(
-    formatDateRangeLabel(
-      `${first}T00:00:00Z`,
-      `${addDays(first, days)}T00:00:00Z`,
-    ),
+    formatDateRangeLabel(`${first}T00:00:00Z`, `${dayAfterTheLast}T00:00:00Z`),
   );
 };
 

--- a/test/specs/steps/stays-booking.ts
+++ b/test/specs/steps/stays-booking.ts
@@ -212,14 +212,9 @@ When(
   },
 );
 
-/** How long the stay runs, checked two ways that cannot both drift together.
- *
- * The days the site stored are compared against the day the story started on
- * plus its own number of days — arithmetic the site's own wording plays no part
- * in. Then the booking's page is read, so the organiser is shown a label naming
- * exactly those days. Checking only the label would let a change to how ranges
- * are worded pass unnoticed, because the expected label is built by the same
- * helper the page uses. */
+/** How long the stay runs, checked against the story's own days as well as the
+ * page. The label alone would not do: it is built by the same helper the page
+ * renders with, so a miscalculated range would match itself. */
 export const expectStayRunsFor = async (
   world: TicketsWorld,
   days: number,

--- a/test/specs/steps/stays-booking.ts
+++ b/test/specs/steps/stays-booking.ts
@@ -30,9 +30,19 @@ import { createTestHoliday } from "#test-utils/db-helpers/holidays.ts";
 const stayStart = (world: TicketsWorld): string =>
   requiredWorldValue(world.stayStartsOn, "the stay's first day");
 
-/** The days the page offered when the customer looked. */
+/** The days a listing's page offered when the customer looked at it. */
+export const offeredDaysOf = (world: TicketsWorld, name: string): string[] =>
+  requiredWorldValue(
+    world.daysOffered?.get(name),
+    `the days the ${name} page offered`,
+  );
+
+/** The days the page offered the last time a customer looked. */
 const offeredDays = (world: TicketsWorld): string[] =>
-  requiredWorldValue(world.daysOffered, "the days the page offered");
+  offeredDaysOf(
+    world,
+    requiredWorldValue(world.daysOfferedLastLook, "the listing looked at"),
+  );
 
 /** The day the organiser closed for a holiday. */
 const closedDay = (world: TicketsWorld): string =>
@@ -195,7 +205,9 @@ When(
 When(
   "a customer looks at the days the {word} offers",
   async function (this: TicketsWorld, name: string): Promise<void> {
-    this.daysOffered = await daysOfferedFor(stayListing(this, name));
+    this.daysOffered ??= new Map();
+    this.daysOffered.set(name, await daysOfferedFor(stayListing(this, name)));
+    this.daysOfferedLastLook = name;
   },
 );
 

--- a/test/specs/support/form-controls.test.ts
+++ b/test/specs/support/form-controls.test.ts
@@ -9,6 +9,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   optionsOffered,
+  tickedCheckboxes,
   whyValueCannotBeSent,
 } from "#test/specs/support/form-controls.ts";
 
@@ -131,5 +132,80 @@ describe("what a visitor can send", () => {
         "The page offers no date to choose",
       );
     });
+  });
+});
+describe("a box that cannot be changed or cannot hold the number", () => {
+  const lengthBox = (attributes: string) =>
+    `<input type="number" name="duration_days" ${attributes}>`;
+
+  test("refuses a box the page shows but will not let anyone edit", () => {
+    expect(
+      whyValueCannotBeSent(
+        lengthBox('value="1" readonly'),
+        "duration_days",
+        "5",
+      ),
+    ).toBe("the duration_days box cannot be changed");
+  });
+
+  test("refuses a number above what the box takes", () => {
+    expect(
+      whyValueCannotBeSent(lengthBox('min="1" max="3"'), "duration_days", "5"),
+    ).toBe("the duration_days box takes nothing above 3");
+  });
+
+  test("refuses a number below what the box takes", () => {
+    expect(
+      whyValueCannotBeSent(lengthBox('min="2" max="9"'), "duration_days", "1"),
+    ).toBe("the duration_days box takes nothing below 2");
+  });
+
+  test("allows a number inside what the box takes", () => {
+    expect(
+      whyValueCannotBeSent(lengthBox('min="1" max="9"'), "duration_days", "5"),
+    ).toBeNull();
+  });
+
+  test("leaves a box with no limits alone", () => {
+    expect(
+      whyValueCannotBeSent(lengthBox('value="1"'), "duration_days", "5"),
+    ).toBeNull();
+  });
+
+  test("has no range to break for a word or an empty box", () => {
+    const box = '<input type="text" name="name" min="2" max="3">';
+    expect(whyValueCannotBeSent(box, "name", "Ada")).toBeNull();
+    expect(whyValueCannotBeSent(box, "name", "")).toBeNull();
+  });
+});
+
+describe("the days a page has ticked", () => {
+  const day = (value: string, attributes = "checked") =>
+    `<input type="checkbox" name="bookable_days" value="${value}" ${attributes}>`;
+
+  test("lists only the ticked ones", () => {
+    expect(
+      tickedCheckboxes(
+        `${day("Monday")}${day("Tuesday", "")}`,
+        "bookable_days",
+      ),
+    ).toEqual(["Monday"]);
+  });
+
+  test("leaves out a day nobody could untick", () => {
+    // A hidden box carries the value but offers no way to clear it, and a
+    // switched-off checkbox cannot be clicked either.
+    const fixed = '<input type="hidden" name="bookable_days" value="Sunday">';
+    const off = day("Friday", "checked disabled");
+    expect(
+      tickedCheckboxes(`${day("Monday")}${fixed}${off}`, "bookable_days"),
+    ).toEqual(["Monday"]);
+  });
+
+  test("leaves out another field's ticked boxes", () => {
+    const other = '<input type="checkbox" name="fields" value="email" checked>';
+    expect(
+      tickedCheckboxes(`${day("Monday")}${other}`, "bookable_days"),
+    ).toEqual(["Monday"]);
   });
 });

--- a/test/specs/support/form-controls.ts
+++ b/test/specs/support/form-controls.ts
@@ -50,11 +50,59 @@ export const optionsOffered = (html: string, field: string): string[] => {
   );
 };
 
+/** One attribute's value on a control, or null when it does not carry it. */
+const attribute = (tag: string, named: string): string | null =>
+  tag.match(new RegExp(`${named}="([^"]*)"`))?.[1] ?? null;
+
+/** Why a number box will not take this number, or null when it will. A box that
+ * only accepts 1 to 3 cannot send 5, however happily a post carrying 5 is
+ * accepted. */
+const whyNumberIsOutOfRange = (
+  box: string,
+  field: string,
+  chosen: string,
+): string | null => {
+  const number = Number(chosen);
+  // An empty box, or anything that is not a number, has no range to break.
+  if (chosen === "" || !Number.isFinite(number)) return null;
+  const least = attribute(box, "min");
+  if (least !== null && number < Number(least)) {
+    return `the ${field} box takes nothing below ${least}`;
+  }
+  const most = attribute(box, "max");
+  if (most !== null && number > Number(most)) {
+    return `the ${field} box takes nothing above ${most}`;
+  }
+  return null;
+};
+
+/** The values a page has already ticked for one field, counting only real
+ * checkboxes a person could untick. A day carried by a hidden box instead is
+ * left out, because nobody can untick that. */
+export const tickedCheckboxes = (html: string, field: string): string[] => {
+  const ticked: string[] = [];
+  for (const box of html.matchAll(/<input\s([^>]*)>/g)) {
+    const tag = box[1]!;
+    const value = attribute(tag, "value");
+    if (
+      tag.includes('type="checkbox"') &&
+      tag.includes(`name="${field}"`) &&
+      tag.includes("checked") &&
+      !tag.includes("disabled") &&
+      value !== null
+    ) {
+      ticked.push(value);
+    }
+  }
+  return ticked;
+};
+
 /**
  * Why a visitor could not send this value through the page's own control, or
- * null when they could. A control must be rendered, not switched off, and able
- * to carry the value: a dropdown has to offer it as a usable option, and a
- * hidden box has to already hold it, because the visitor cannot type over one.
+ * null when they could. A control must be rendered, not switched off or
+ * read-only, and able to carry the value: a dropdown has to offer it as a
+ * usable option, a hidden box has to already hold it because the visitor cannot
+ * type over one, and a number box has to accept it within its own limits.
  */
 export const whyValueCannotBeSent = (
   html: string,
@@ -78,8 +126,9 @@ export const whyValueCannotBeSent = (
   const box = boxFor(html, field);
   if (!box) return `the page has no ${field} to fill in`;
   if (box.includes("disabled")) return `the ${field} box is switched off`;
+  if (box.includes("readonly")) return `the ${field} box cannot be changed`;
   if (box.includes('type="hidden"') && !box.includes(`value="${chosen}"`)) {
     return `the ${field} box is fixed at something other than "${chosen}"`;
   }
-  return null;
+  return whyNumberIsOutOfRange(box, field, chosen);
 };

--- a/test/specs/support/listing-changes.ts
+++ b/test/specs/support/listing-changes.ts
@@ -6,9 +6,9 @@
 import { expect } from "@std/expect";
 import { DAY_NAMES } from "#shared/day-names.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
+import { tickedCheckboxes } from "#test/specs/support/form-controls.ts";
 import { stayListing } from "#test/specs/support/stays.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
-import { extractFormEntries } from "#test-utils/test-browser.ts";
 
 /** The name of the weekday a date falls on, in the words the site uses. */
 export const weekdayOf = (day: string): string => {
@@ -28,9 +28,10 @@ export const stopOpeningOn = async (
 ): Promise<void> => {
   const browser = await adminBrowser(world);
   await browser.visit(`/admin/listing/${stayListing(world, name).id}/edit`);
-  const ticked = extractFormEntries(browser.currentHtml)
-    .filter(([field]) => field === "bookable_days")
-    .map(([, day]) => day);
+  // Only days carried by a real, usable checkbox count: a day rendered as a
+  // fixed hidden box is one nobody could untick, so the story must fail rather
+  // than post an edit no organiser could make.
+  const ticked = tickedCheckboxes(browser.currentHtml, "bookable_days");
   expect(ticked).toContain(weekday);
   await browser.submitForm(
     { bookable_days: ticked.filter((day) => day !== weekday) },

--- a/test/specs/support/listing-changes.ts
+++ b/test/specs/support/listing-changes.ts
@@ -1,0 +1,40 @@
+/**
+ * Changes an organiser makes to a listing after people have already booked.
+ *
+ * These go through the listing's own edit form, but not through the story
+ * browser: clearing one of the bookable-day checkboxes is a change the browser
+ * helper cannot express by merging values over the rendered form — it can tick
+ * a box, not clear one.
+ */
+
+import { stayListing } from "#test/specs/support/stays.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
+import { updateTestListing } from "#test-utils/db-helpers/listings.ts";
+
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+/** The name of the weekday a date falls on. */
+export const weekdayOf = (day: string): string => {
+  const name = WEEKDAYS[new Date(`${day}T00:00:00Z`).getUTCDay()];
+  if (name === undefined) throw new Error(`Not a day: ${day}`);
+  return name;
+};
+
+/** The organiser stops opening a listing on one day of the week. */
+export const stopOpeningOn = async (
+  world: TicketsWorld,
+  name: string,
+  weekday: string,
+): Promise<void> => {
+  await updateTestListing(stayListing(world, name).id, {
+    bookableDays: WEEKDAYS.filter((day) => day !== weekday),
+  });
+};

--- a/test/specs/support/listing-changes.ts
+++ b/test/specs/support/listing-changes.ts
@@ -1,40 +1,40 @@
 /**
- * Changes an organiser makes to a listing after people have already booked.
- *
- * These go through the listing's own edit form, but not through the story
- * browser: clearing one of the bookable-day checkboxes is a change the browser
- * helper cannot express by merging values over the rendered form — it can tick
- * a box, not clear one.
+ * Changes an organiser makes to a listing after people have already booked,
+ * driven through the listing's own edit page.
  */
 
+import { expect } from "@std/expect";
+import { DAY_NAMES } from "#shared/day-names.ts";
+import { adminBrowser } from "#test/specs/support/browser.ts";
 import { stayListing } from "#test/specs/support/stays.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
-import { updateTestListing } from "#test-utils/db-helpers/listings.ts";
+import { extractFormEntries } from "#test-utils/test-browser.ts";
 
-const WEEKDAYS = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-];
-
-/** The name of the weekday a date falls on. */
+/** The name of the weekday a date falls on, in the words the site uses. */
 export const weekdayOf = (day: string): string => {
-  const name = WEEKDAYS[new Date(`${day}T00:00:00Z`).getUTCDay()];
+  // DAY_NAMES runs Sunday first, the same order a date reports its weekday in.
+  const name = DAY_NAMES[new Date(`${day}T00:00:00Z`).getUTCDay()];
   if (name === undefined) throw new Error(`Not a day: ${day}`);
   return name;
 };
 
-/** The organiser stops opening a listing on one day of the week. */
+/** The organiser stops opening a listing on one day of the week, by unticking
+ * that day on the listing's own edit form. The days that stay ticked are read
+ * off the served page, so a page that stops offering them fails the story. */
 export const stopOpeningOn = async (
   world: TicketsWorld,
   name: string,
   weekday: string,
 ): Promise<void> => {
-  await updateTestListing(stayListing(world, name).id, {
-    bookableDays: WEEKDAYS.filter((day) => day !== weekday),
-  });
+  const browser = await adminBrowser(world);
+  await browser.visit(`/admin/listing/${stayListing(world, name).id}/edit`);
+  const ticked = extractFormEntries(browser.currentHtml)
+    .filter(([field]) => field === "bookable_days")
+    .map(([, day]) => day);
+  expect(ticked).toContain(weekday);
+  await browser.submitForm(
+    { bookable_days: ticked.filter((day) => day !== weekday) },
+    "Save Changes",
+  );
+  expect(browser.containsText("Listing updated")).toBe(true);
 };

--- a/test/specs/support/public-booking.ts
+++ b/test/specs/support/public-booking.ts
@@ -55,14 +55,20 @@ const expectControlCanSend = (
   expect(whyValueCannotBeSent(html, field, chosen)).toBeNull();
 };
 
-/** Try to place an order through a page the site serves. Returns what the
- * visitor was shown rather than throwing, so a story can prove a refusal as
- * well as a booking. */
-export const visitorTriesToOrder = async (
+/** An order filled in and waiting on the visitor to press Continue. Splitting
+ * the two lets a story hold several visitors at the form and release them
+ * together, which is the only way to make a race a real race. */
+export interface FilledOrder {
+  press: () => Promise<BookingAttempt>;
+}
+
+/** Open a page the site serves and fill the order in, checking as it goes that
+ * a visitor could really send every value. Nothing is submitted yet. */
+export const visitorFillsInOrder = async (
   path: string,
   lines: OrderLine[],
   choices: BookingChoices,
-): Promise<BookingAttempt> => {
+): Promise<FilledOrder> => {
   const browser = new TestBrowser();
   await browser.visit(path);
   for (const { listing } of lines) {
@@ -90,25 +96,51 @@ export const visitorTriesToOrder = async (
   for (const [field, chosen] of Object.entries(fields)) {
     expectControlCanSend(browser.currentHtml, field, chosen);
   }
-  await browser.submitForm(fields, "Continue");
-  return { browser, wasBooked: browser.pageText.includes(THANK_YOU) };
+  return {
+    press: async () => {
+      await browser.submitForm(fields, "Continue");
+      return { browser, wasBooked: browser.pageText.includes(THANK_YOU) };
+    },
+  };
 };
+
+/** Fill the order in and press Continue straight away — what all but the race
+ * stories want. */
+export const visitorTriesToOrder = async (
+  path: string,
+  lines: OrderLine[],
+  choices: BookingChoices,
+): Promise<BookingAttempt> =>
+  (await visitorFillsInOrder(path, lines, choices)).press();
+
+/** The path and lines for one listing's own public page, so filling one in and
+ * ordering from one both describe it the same way. */
+export const oneListingOrder = (
+  listing: Listing,
+  choices: BookingChoices,
+): [path: string, lines: OrderLine[]] => [
+  `/ticket/${listing.slug}`,
+  [
+    {
+      listing,
+      ...(choices.places === undefined ? {} : { places: choices.places }),
+    },
+  ],
+];
+
+/** Fill in one listing's own page, ready to press Continue later. */
+export const visitorFillsInBooking = (
+  listing: Listing,
+  choices: BookingChoices,
+): Promise<FilledOrder> =>
+  visitorFillsInOrder(...oneListingOrder(listing, choices), choices);
 
 /** Try to book one listing, on its own public page. */
 export const visitorTriesToBook = (
   listing: Listing,
   choices: BookingChoices,
 ): Promise<BookingAttempt> =>
-  visitorTriesToOrder(
-    `/ticket/${listing.slug}`,
-    [
-      {
-        listing,
-        ...(choices.places === undefined ? {} : { places: choices.places }),
-      },
-    ],
-    choices,
-  );
+  visitorTriesToOrder(...oneListingOrder(listing, choices), choices);
 
 /** Book through the public page and insist it worked, for the setup and the
  * happy paths that are not themselves about being refused. */

--- a/test/specs/support/stays.ts
+++ b/test/specs/support/stays.ts
@@ -60,11 +60,18 @@ export const openStayListing = async (
   name: string,
   days: number,
   placesADay: number,
-  options: { customerPicksDays?: boolean; groupId?: number } = {},
+  options: {
+    bookAheadDays?: number;
+    customerPicksDays?: boolean;
+    groupId?: number;
+  } = {},
 ): Promise<Listing> => {
   const listing = await createDailyTestListing({
     durationDays: days,
     maxAttendees: placesADay,
+    ...(options.bookAheadDays === undefined
+      ? {}
+      : { maximumDaysAfter: options.bookAheadDays }),
     // Room to book several places at once, and the site's own thank-you page, so
     // a story reads what the customer is actually shown.
     maxQuantity: placesADay,

--- a/test/specs/support/stays.ts
+++ b/test/specs/support/stays.ts
@@ -10,6 +10,7 @@ import { addDays } from "#shared/dates.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import type { Attendee, Listing } from "#shared/types.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
+import { whyValueCannotBeSent } from "#test/specs/support/form-controls.ts";
 import {
   requiredWorldValue,
   type TicketsWorld,
@@ -119,8 +120,14 @@ export const changeStayLength = async (
 ): Promise<string> => {
   const browser = await adminBrowser(world);
   await browser.visit(`/admin/listing/${stayListing(world, name).id}/edit`);
-  expect(browser.currentHtml).toContain('name="duration_days"');
-  await browser.submitForm({ duration_days: String(days) }, "Save Changes");
+  const length = String(days);
+  // The organiser has to be able to send this length: a box that is missing,
+  // disabled, or fixed at another value would mean they cannot make the change
+  // at all, however happily the form post is accepted.
+  expect(
+    whyValueCannotBeSent(browser.currentHtml, "duration_days", length),
+  ).toBeNull();
+  await browser.submitForm({ duration_days: length }, "Save Changes");
   expect(browser.containsText("Listing updated")).toBe(true);
   return browser.pageText;
 };

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -20,7 +20,8 @@ export interface TicketsWorld extends World {
   closedDayOn?: string;
   confirmName?: string;
   customerBrowser?: TestBrowser;
-  daysOffered?: string[];
+  daysOffered?: Map<string, string[]>;
+  daysOfferedLastLook?: string;
   duplicateId?: number;
   duplicateToken?: string;
   evidenceValues: Map<string, string>;
@@ -42,6 +43,8 @@ export interface TicketsWorld extends World {
   orderDay?: string;
   placeholderId?: number;
   questionId?: number;
+  raceListing?: string;
+  raceWinners?: number;
   refundCalls?: () => number;
   secondBody?: string;
   secondStatus?: number;

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -1,6 +1,7 @@
 import type { World } from "@cucumber/cucumber";
 import { type CleanupTask, runCleanups } from "#scripts/cleanup.ts";
 import type { Listing } from "#shared/types.ts";
+import type { BookingAttempt } from "#test/specs/support/public-booking.ts";
 import type {
   JourneyCatalogSpec,
   OrderJourneyCtx,
@@ -44,6 +45,7 @@ export interface TicketsWorld extends World {
   placeholderId?: number;
   questionId?: number;
   raceListing?: string;
+  raceLoser?: BookingAttempt;
   raceWinners?: number;
   refundCalls?: () => number;
   secondBody?: string;


### PR DESCRIPTION
## What changed

More multi-day booking tests rewritten as stories.

**A new story — a listing changes after people have already booked**

- The organiser stops opening on a day of the week that a booked stay already covers. The stay keeps all three of its days, and only new stays are kept off that day.
- The organiser makes stays longer than the window the listing takes bookings for. The stay already sold keeps its stretched days, but the day it starts on stops being offered to anyone new.

**Two rules added to the multi-day booking story**

- **Longer stays leave fewer days to start on.** A stay has to finish inside the booking window, so a five-day listing offers fewer start days than a one-day one — but still offers some. This merges two near-identical tests that lived in separate files.
- **Two customers racing for the last stay get one booking between them.** Both press Continue at the same moment; exactly one is taken and the listing ends up holding one stay.

## Something the migration turned up

One of the tests being migrated was about a listing that starts being booked by the day when it was booked as one date before. Written out as a story — "people booked before the change still take up room" — it failed, because that is not what the site does.

The people who booked before the switch have no day of their own, and the per-day count deliberately skips them. So a listing with both its places taken stops being full the moment it is switched, and can end up holding three people where it has room for two. The listing's own total check still counts them, so the two checks disagree.

That may well be intended, but nothing says so, and an organiser switching a sold-out listing would not expect it to reopen. It is outside a migration whose job is to move existing tests, so it is written up in `TODO.md` with the three ways it could be settled. The story asserting the behaviour was removed rather than left passing on a claim the product does not make, and the original test stays where it is.

## What stayed a direct test

The checks of the group-limit reconciler and the capacity helpers are technical contracts, not journeys, so they stay as direct tests — a story may never be the only thing covering a line of the product.

## Checks

`deno task precommit` passes in full — typecheck, lint, duplication at 0%, the whole test suite, and 100% line and branch coverage. All 70 Cucumber scenarios (463 steps) pass. No production code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga3qdj1PzXyZTcjmXZRqz7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Booking Availability**
  - Added coverage for how booking windows affect available start dates, especially for longer stays.
  - Prevented overbooking when multiple customers attempt to reserve the final available stay simultaneously.

- **Listing Changes**
  - Existing bookings remain valid when available weekdays or booking windows are changed.
  - New bookings are restricted according to the updated listing rules.

- **Documentation**
  - Recorded an open product decision regarding undated bookings when switching to daily booking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->