### PR TITLE
Write booking through the API as a story

### DIFF
--- a/specs/bookings/booking-through-the-api.feature
+++ b/specs/bookings/booking-through-the-api.feature
@@ -1,0 +1,38 @@
+@story:bookings.booking-through-the-api
+@owner:bookings @risk:high
+@actor:customer @actor:organiser
+@edition:managed @edition:self-hosted
+Feature: Another system books a stay through the booking API
+  An organiser can let another system book on their customers' behalf — a
+  website of their own, or a partner's. What that system is told, and what it is
+  allowed to book, must match what a customer would get on the site itself.
+
+  @rule:bookings.a-stay-booked-through-the-api-holds-its-days
+  Rule: A stay booked through the API holds every day it covers
+    The system asks which days are open, books one, and gets a ticket back. The
+    stay it made is a real stay: it covers the listing's whole length, and those
+    days are held against everyone else.
+
+    @case:api.a-stay-booked-through-the-api
+    Scenario: Another system books a three-day stay
+      Given the organiser opens the booking API
+      And a Cabin that is booked 3 days at a time, with room for 1 place a day
+      When another system books the first Cabin day the API offers
+      Then the system is given a ticket
+      And the organiser sees the stay runs for 3 days
+      And no Cabin stay can start on any of those 3 days
+
+  @rule:bookings.the-api-refuses-a-stay-that-reaches-a-full-day
+  Rule: The API refuses a stay that reaches a day with no room
+    A system asking about a day is told the truth, and a system that books
+    anyway is refused — the same rule the site's own pages follow.
+
+    @case:api.a-full-middle-day-is-refused
+    Scenario: The middle day of the stay is already full
+      Given the organiser opens the booking API
+      And a Cabin that is booked 3 days at a time, with room for 2 places a day
+      And 2 Cabin places are booked for one day, on the second day the API offers
+      When another system asks about the first Cabin day the API offers
+      Then the API says there is no room
+      And booking that day anyway is refused
+      And the Cabin holds only the 1 stay it already had

--- a/test/e2e/duration-days/api-http.test.ts
+++ b/test/e2e/duration-days/api-http.test.ts
@@ -1,12 +1,10 @@
 import { expect } from "@std/expect";
-import { beforeEach, describe, it as test } from "@std/testing/bdd";
-import { addDays } from "#shared/dates.ts";
+import { describe, it as test } from "@std/testing/bdd";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import { getListingWithCount } from "#shared/db/listings/records.ts";
-import { settings } from "#shared/db/settings.ts";
 import { MAX_DURATION_DAYS } from "#shared/types.ts";
 import { assertJson, fetchListingExportCsv } from "#test-utils/assertions.ts";
-import { describeWithEnv, rawListingRange } from "#test-utils/db.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import { createDailyTestListing } from "#test-utils/db-helpers/listings.ts";
 import { awaitTestRequest, mockFormRequest } from "#test-utils/mocks.ts";
@@ -102,84 +100,6 @@ describeWithEnv("e2e: multi-day bookings — API & HTTP", { db: true }, () => {
         (body: { listing: { duration_days: number } }) => {
           expect(body.listing.duration_days).toBe(1);
         },
-      );
-    });
-  });
-
-  describe("public booking API", () => {
-    beforeEach(async () => {
-      await settings.update.showPublicApi(true);
-    });
-
-    /** Fetch the listing's bookable start dates as the public API reports them. */
-    const fetchAvailableDates = async (slug: string): Promise<string[]> => {
-      const body = await assertJson<{
-        listing: { availableDates: string[] };
-      }>(apiRequest(`/api/listings/${slug}`), 200);
-      return body.listing.availableDates;
-    };
-
-    test("POST /api/listings/:slug/book on a 3-day listing stores a 3-day range", async () => {
-      const listing = await createDailyTestListing({
-        durationDays: 3,
-        maxAttendees: 5,
-      });
-      const dates = await fetchAvailableDates(listing.slug);
-      expect(dates.length).toBeGreaterThan(0);
-
-      await assertJson(
-        apiRequest(`/api/listings/${listing.slug}/book`, {
-          body: {
-            date: dates[0],
-            email: "multi@test.com",
-            name: "Multi Day",
-          },
-          method: "POST",
-        }),
-        200,
-        (body: { booking?: { ticketToken?: string } }) => {
-          expect(body.booking?.ticketToken).toBeDefined();
-        },
-      );
-
-      const range = await rawListingRange(listing.id);
-      expect(range!.start_at).toBe(`${dates[0]}T00:00:00Z`);
-      const expectedEnd = new Date(
-        new Date(`${dates[0]}T00:00:00Z`).getTime() + 3 * 86_400_000,
-      ).toISOString();
-      expect(range!.end_at).toBe(expectedEnd);
-    });
-
-    test("availability and booking reject a start date whose middle day is full", async () => {
-      const listing = await createDailyTestListing({
-        durationDays: 3,
-        maxAttendees: 2,
-      });
-      const dates = await fetchAvailableDates(listing.slug);
-      const start = dates[0]!;
-      const middle = addDays(start, 1);
-      await bookAttendee(listing, {
-        date: middle,
-        durationDays: 1,
-        quantity: 2,
-      });
-
-      await assertJson(
-        apiRequest(
-          `/api/listings/${listing.slug}/availability?date=${start}&quantity=1`,
-        ),
-        200,
-        (body: { available: boolean }) => {
-          expect(body.available).toBe(false);
-        },
-      );
-
-      await assertJson(
-        apiRequest(`/api/listings/${listing.slug}/book`, {
-          body: { date: start, email: "blocked@test.com", name: "Blocked" },
-          method: "POST",
-        }),
-        409,
       );
     });
   });

--- a/test/scripts/specs/catalog.test.ts
+++ b/test/scripts/specs/catalog.test.ts
@@ -20,6 +20,7 @@ describe("Cucumber story catalog", () => {
       "bookings.backup-and-restore",
       "bookings.book-through-the-site",
       "bookings.booking-several-days",
+      "bookings.booking-through-the-api",
       "bookings.changes-after-people-have-booked",
       "bookings.changing-how-long-a-stay-lasts",
       "bookings.day-limits-shared-across-listings",

--- a/test/specs/steps/booking-api.ts
+++ b/test/specs/steps/booking-api.ts
@@ -1,0 +1,130 @@
+// jscpd:ignore-start
+
+import { Given, Then, When } from "@cucumber/cucumber";
+import { expect } from "@std/expect";
+import {
+  type ApiAnswer,
+  apiBooks,
+  apiSaysThereIsRoom,
+  daysTheApiOffers,
+  openTheApi,
+} from "#test/specs/support/booking-api.ts";
+import {
+  guest,
+  newestStayOn,
+  stayListing,
+  staysOn,
+} from "#test/specs/support/stays.ts";
+import {
+  requiredWorldValue,
+  type TicketsWorld,
+} from "#test/specs/support/world.ts";
+import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
+
+// jscpd:ignore-end
+
+/** What the API last answered. */
+const lastAnswer = (world: TicketsWorld): ApiAnswer =>
+  requiredWorldValue(world.apiAnswer, "what the API answered");
+
+/** The first day the API offers for a listing, remembered so the story's later
+ * steps talk about the same day. */
+const firstDayOffered = async (
+  world: TicketsWorld,
+  name: string,
+): Promise<string> => {
+  if (world.apiFirstDay === undefined) {
+    const offered = await daysTheApiOffers(world, name);
+    const first = offered[0];
+    if (first === undefined) {
+      throw new Error(`The API offers no day at all on the ${name}`);
+    }
+    world.apiFirstDay = first;
+  }
+  return world.apiFirstDay;
+};
+
+Given("the organiser opens the booking API", (): Promise<void> => openTheApi());
+
+Given(
+  "{int} {word} places are booked for one day, on the second day the API offers",
+  async function (
+    this: TicketsWorld,
+    places: number,
+    name: string,
+  ): Promise<void> {
+    const { addDays } = await import("#shared/dates.ts");
+    const middle = addDays(await firstDayOffered(this, name), 1);
+    // A one-day booking, so only the middle day of the coming stay is full.
+    const booked = await bookAttendee(stayListing(this, name), {
+      date: middle,
+      durationDays: 1,
+      quantity: places,
+    });
+    if (!booked.success) throw new Error(`Could not fill the ${name} middle`);
+  },
+);
+
+When(
+  "another system books the first {word} day the API offers",
+  async function (this: TicketsWorld, name: string): Promise<void> {
+    const day = await firstDayOffered(this, name);
+    this.stayStartsOn = day;
+    this.apiAnswer = await apiBooks(this, name, day, guest(1).who);
+    this.attendeeId = await newestStayOn(this, name);
+  },
+);
+
+Then("the system is given a ticket", function (this: TicketsWorld): void {
+  const { body, status } = lastAnswer(this);
+  expect(status).toBe(200);
+  // A ticket the customer can actually open, not merely a success code.
+  const booking = body.booking as { ticketToken?: string } | undefined;
+  expect(typeof booking?.ticketToken).toBe("string");
+  expect(booking?.ticketToken).not.toBe("");
+});
+
+When(
+  "another system asks about the first {word} day the API offers",
+  async function (this: TicketsWorld, name: string): Promise<void> {
+    this.apiRoomAnswer = await apiSaysThereIsRoom(
+      this,
+      name,
+      await firstDayOffered(this, name),
+    );
+    this.apiListing = name;
+  },
+);
+
+Then("the API says there is no room", function (this: TicketsWorld): void {
+  expect(requiredWorldValue(this.apiRoomAnswer, "what the API said")).toBe(
+    false,
+  );
+});
+
+Then(
+  "booking that day anyway is refused",
+  async function (this: TicketsWorld): Promise<void> {
+    const name = requiredWorldValue(this.apiListing, "the listing asked about");
+    const answer = await apiBooks(
+      this,
+      name,
+      await firstDayOffered(this, name),
+      guest(2).who,
+    );
+    // 409 is the site's own "no room left" answer; any other code would mean
+    // it was turned away for some unrelated reason.
+    expect(answer.status).toBe(409);
+  },
+);
+
+Then(
+  "the {word} holds only the {int} stay it already had",
+  async function (
+    this: TicketsWorld,
+    name: string,
+    stays: number,
+  ): Promise<void> {
+    expect((await staysOn(this, name)).length).toBe(stays);
+  },
+);

--- a/test/specs/support/booking-api.ts
+++ b/test/specs/support/booking-api.ts
@@ -50,11 +50,16 @@ export const daysTheApiOffers = async (
     `/api/listings/${stayListing(world, name).slug}`,
   );
   expect(status).toBe(200);
-  const listing = body.listing as { availableDates?: string[] } | undefined;
-  if (!listing?.availableDates) {
-    throw new Error(`The API told us nothing about the ${name}`);
+  const { availableDates } = (body.listing ?? {}) as Record<string, unknown>;
+  // Every day has to be a day. A list carrying anything else is a broken
+  // promise to the systems that read it, even when the first day is fine.
+  if (
+    !Array.isArray(availableDates) ||
+    availableDates.some((day) => typeof day !== "string")
+  ) {
+    throw new Error(`The API did not list the days the ${name} offers`);
   }
-  return listing.availableDates;
+  return availableDates;
 };
 
 /** Whether the API says a stay starting on this day can still be booked. */

--- a/test/specs/support/booking-api.ts
+++ b/test/specs/support/booking-api.ts
@@ -1,14 +1,15 @@
 /**
  * Booking through the site's own booking API — the way another system books on
- * a customer's behalf. Every call goes through the real endpoints with a real
- * key, so a story proves what an outside caller can actually do.
+ * a customer's behalf. The booking API needs no key, so every call here is made
+ * without one: a story must fail if the endpoints ever start demanding
+ * authorisation, because real callers would stop working that day.
  */
 
 import { expect } from "@std/expect";
 import { settings } from "#shared/db/settings.ts";
 import { stayListing } from "#test/specs/support/stays.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
-import { apiRequest } from "#test-utils/session.ts";
+import { mockRequest } from "#test-utils/mocks.ts";
 
 /** What the API answered: the code it sent back, and the body it sent with it. */
 export interface ApiAnswer {
@@ -20,7 +21,19 @@ const ask = async (
   path: string,
   options: { body?: Record<string, unknown>; method?: string } = {},
 ): Promise<ApiAnswer> => {
-  const response = await apiRequest(path, options);
+  const { handleRequest } = await import("#routes");
+  const method = options.method ?? "GET";
+  const response = await handleRequest(
+    mockRequest(path, {
+      ...(options.body === undefined
+        ? {}
+        : {
+            body: JSON.stringify(options.body),
+            headers: { "content-type": "application/json" },
+          }),
+      method,
+    }),
+  );
   return { body: await response.json(), status: response.status };
 };
 
@@ -55,7 +68,13 @@ export const apiSaysThereIsRoom = async (
     `/api/listings/${slug}/availability?date=${day}&quantity=1`,
   );
   expect(status).toBe(200);
-  return body.available === true;
+  // The answer has to be the yes-or-no the API documents. A missing or renamed
+  // field would otherwise read as "no room" and pass a refusal story silently.
+  const { available } = body;
+  if (typeof available !== "boolean") {
+    throw new Error(`The API did not say whether there is room: ${status}`);
+  }
+  return available;
 };
 
 /** Book a stay through the API, keeping whatever it answered — a story can

--- a/test/specs/support/booking-api.ts
+++ b/test/specs/support/booking-api.ts
@@ -1,0 +1,76 @@
+/**
+ * Booking through the site's own booking API — the way another system books on
+ * a customer's behalf. Every call goes through the real endpoints with a real
+ * key, so a story proves what an outside caller can actually do.
+ */
+
+import { expect } from "@std/expect";
+import { settings } from "#shared/db/settings.ts";
+import { stayListing } from "#test/specs/support/stays.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
+import { apiRequest } from "#test-utils/session.ts";
+
+/** What the API answered: the code it sent back, and the body it sent with it. */
+export interface ApiAnswer {
+  body: Record<string, unknown>;
+  status: number;
+}
+
+const ask = async (
+  path: string,
+  options: { body?: Record<string, unknown>; method?: string } = {},
+): Promise<ApiAnswer> => {
+  const response = await apiRequest(path, options);
+  return { body: await response.json(), status: response.status };
+};
+
+/** The organiser opens the booking API up to other systems. */
+export const openTheApi = (): Promise<void> =>
+  settings.update.showPublicApi(true);
+
+/** The days the API says a listing can be booked from. */
+export const daysTheApiOffers = async (
+  world: TicketsWorld,
+  name: string,
+): Promise<string[]> => {
+  const { body, status } = await ask(
+    `/api/listings/${stayListing(world, name).slug}`,
+  );
+  expect(status).toBe(200);
+  const listing = body.listing as { availableDates?: string[] } | undefined;
+  if (!listing?.availableDates) {
+    throw new Error(`The API told us nothing about the ${name}`);
+  }
+  return listing.availableDates;
+};
+
+/** Whether the API says a stay starting on this day can still be booked. */
+export const apiSaysThereIsRoom = async (
+  world: TicketsWorld,
+  name: string,
+  day: string,
+): Promise<boolean> => {
+  const slug = stayListing(world, name).slug;
+  const { body, status } = await ask(
+    `/api/listings/${slug}/availability?date=${day}&quantity=1`,
+  );
+  expect(status).toBe(200);
+  return body.available === true;
+};
+
+/** Book a stay through the API, keeping whatever it answered — a story can
+ * then prove either the booking or the refusal. */
+export const apiBooks = async (
+  world: TicketsWorld,
+  name: string,
+  day: string,
+  who: string,
+): Promise<ApiAnswer> =>
+  ask(`/api/listings/${stayListing(world, name).slug}/book`, {
+    body: {
+      date: day,
+      email: `${who.toLowerCase().replaceAll(" ", ".")}@example.com`,
+      name: who,
+    },
+    method: "POST",
+  });

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -9,6 +9,10 @@ import type {
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
 export interface TicketsWorld extends World {
+  apiAnswer?: { body: Record<string, unknown>; status: number };
+  apiFirstDay?: string;
+  apiListing?: string;
+  apiRoomAnswer?: boolean;
   attendeeId?: number;
   attendeeIds?: number[];
   attendeeName?: string;

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -1,6 +1,7 @@
 import type { World } from "@cucumber/cucumber";
 import { type CleanupTask, runCleanups } from "#scripts/cleanup.ts";
 import type { Listing } from "#shared/types.ts";
+import type { ApiAnswer } from "#test/specs/support/booking-api.ts";
 import type { BookingAttempt } from "#test/specs/support/public-booking.ts";
 import type {
   JourneyCatalogSpec,
@@ -9,7 +10,7 @@ import type {
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
 export interface TicketsWorld extends World {
-  apiAnswer?: { body: Record<string, unknown>; status: number };
+  apiAnswer?: ApiAnswer;
   apiFirstDay?: string;
   apiListing?: string;
   apiRoomAnswer?: boolean;


### PR DESCRIPTION
## What changed

A new story covering the booking API — the way another system books on a customer's behalf, from the organiser's own website or a partner's.

**Another system books a stay through the booking API**

- **A stay booked through the API holds every day it covers.** The system asks which days are open, books one, and gets a ticket back. What it made is a real stay: it runs the listing's whole length, and no one else can start a stay on any of those days.
- **The API refuses a stay that reaches a day with no room.** A system that asks about a day is told the truth, and a system that books anyway is turned away — the same rule the site's own pages follow. Nothing is left behind by the refused attempt.

Every step goes through the real endpoints, **with no key** — the booking API is open by design, so a story that authenticated would keep passing on the day the endpoints started demanding a key while every real integration broke. That the scenarios pass at all is the proof the API is still open to callers.

The story also insists the API keeps its word about the shape of its answers: the days it lists must all be days, and its yes-or-no about room must be a yes or a no. A missing or renamed field fails the story where it goes missing, rather than quietly reading as "no room" and letting a refusal scenario pass on a broken endpoint.

## What stayed a direct test

The admin API checks in the same file are about JSON shapes and about clamping an out-of-range stay length — technical contracts with no journey behind them, and the kind of thing a story must never be the only cover of. They stay exactly where they are.

## Checks

`deno task precommit` passes in full — typecheck, lint, duplication at 0%, the whole test suite, and 100% line and branch coverage. All 72 Cucumber scenarios (480 steps) pass. No production code changed.