### PR TITLE
Write add-ons sold on their own as a story

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1705,3 +1705,25 @@ was written and then removed, because the product does not do that today.
 Starting point: `attendeesApi.hasAvailableSpots` and the per-day capacity SQL in
 `src/shared/db/attendees/capacity.ts`, plus the listing-type switch in
 `src/features/admin/listings-edit.ts`.
+
+---
+
+## Tell the story of a refused "stop selling this on its own"
+
+*Origin: reviewer suggestion (Codex) on PR #1952.*
+
+The site refuses to stop selling an add-on on its own when doing so would leave
+another add-on with no way to be bought — `strippedPageOrphanedAddOn` in
+`src/shared/listings-actions.ts` re-runs the reachability guard and blocks the
+save. The story `bookings.add-ons-sold-on-their-own` covers only the plain
+cases, where nothing depends on the page, and its rule is worded to say so.
+
+The refusal is an operator-facing rule worth telling: the organiser is stopped,
+and told which add-on would be stranded. It was left out of that PR because
+setting it up needs a child-scoped optional modifier, which no story support
+builds yet — a bigger piece of scaffolding than the migration it sat in.
+
+Starting point: `strippedPageOrphanedAddOn` and
+`firstChildUnreachableAddOnForListings` in `src/shared/db/modifier-resolve.ts`,
+plus whichever direct test already covers the guard, for the shape of the
+fixture.

--- a/specs/bookings/add-ons-sold-on-their-own.feature
+++ b/specs/bookings/add-ons-sold-on-their-own.feature
@@ -38,8 +38,9 @@ Feature: An add-on that can also be bought on its own
 
   @rule:bookings.the-organiser-can-open-and-close-the-page-again
   @surface:admin
-  Rule: The organiser can open and close that page whenever they like
+  Rule: The organiser can open that page, and close it again
     Marking an ordinary add-on opens its page; unmarking it closes it again.
+    These are the plain cases, where nothing else was relying on that page.
 
     @case:add-ons.marking-one-opens-its-page
     Scenario: The organiser starts selling an add-on on its own

--- a/specs/bookings/add-ons-sold-on-their-own.feature
+++ b/specs/bookings/add-ons-sold-on-their-own.feature
@@ -1,0 +1,64 @@
+@story:bookings.add-ons-sold-on-their-own
+@owner:bookings @risk:medium
+@actor:customer @actor:organiser
+@edition:managed @edition:self-hosted
+Feature: An add-on that can also be bought on its own
+  Some things are only sold alongside something else — a seat cover with a
+  chair, a guide with a tour. An organiser can also mark one of those as
+  something people may buy on its own. It then gets its own page and its own
+  place in the list, while still being offered as an add-on where it belongs.
+
+  @rule:bookings.only-an-add-on-marked-for-it-has-its-own-page
+  Rule: Only an add-on marked as sellable on its own has a page of its own
+    An ordinary add-on has no page a customer could reach. Marking it opens one.
+
+    @case:add-ons.the-marked-one-can-be-opened
+    Scenario: A customer opens an add-on that is sold on its own
+      Given a Chair sold with a Cover that can also be bought on its own
+      Then a customer can open the Cover's own page
+
+    @case:add-ons.an-ordinary-add-on-cannot-be-opened
+    Scenario: A customer tries to open an ordinary add-on
+      Given a Chair sold with a Strap that is only an add-on
+      Then a customer cannot open the Strap's own page
+
+  @rule:bookings.an-add-on-sold-on-its-own-is-listed-like-anything-else
+  Rule: An add-on sold on its own is listed like anything else
+    It appears in the list of what is for sale with its own booking link, and it
+    is not described as an add-on there — because here, it is not one.
+
+    @case:add-ons.it-appears-in-the-list-with-its-own-link
+    Scenario: A customer looks at everything for sale
+      Given a Chair sold with a Cover that can also be bought on its own
+      When a customer looks at everything for sale
+      Then the Cover is offered with a link to its own page
+      And the Cover is not called an add-on there
+      And the Chair is still offered too
+
+  @rule:bookings.the-organiser-can-open-and-close-the-page-again
+  @surface:admin
+  Rule: The organiser can open and close that page whenever they like
+    Marking an ordinary add-on opens its page; unmarking it closes it again.
+
+    @case:add-ons.marking-one-opens-its-page
+    Scenario: The organiser starts selling an add-on on its own
+      Given a Chair sold with a Strap that is only an add-on
+      When the organiser starts selling the Strap on its own
+      Then a customer can open the Strap's own page
+
+    @case:add-ons.unmarking-one-closes-its-page
+    Scenario: The organiser stops selling an add-on on its own
+      Given a Chair sold with a Cover that can also be bought on its own
+      When the organiser stops selling the Cover on its own
+      Then a customer cannot open the Cover's own page
+
+  @rule:bookings.a-hidden-package-keeps-its-parts-hidden
+  Rule: A hidden bundle keeps its parts hidden whatever they are marked
+    An organiser can hide what a bundle is made of. Those parts stay hidden even
+    when one of them is marked as sellable on its own — the bundle's own choice
+    comes first.
+
+    @case:add-ons.a-hidden-bundle-part-stays-hidden
+    Scenario: A customer tries to open part of a hidden bundle
+      Given a hidden Bundle whose Cushion could be bought on its own
+      Then a customer cannot open the Cushion's own page

--- a/specs/bookings/add-ons-sold-on-their-own.feature
+++ b/specs/bookings/add-ons-sold-on-their-own.feature
@@ -6,7 +6,7 @@ Feature: An add-on that can also be bought on its own
   Some things are only sold alongside something else — a seat cover with a
   chair, a guide with a tour. An organiser can also mark one of those as
   something people may buy on its own. It then gets its own page and its own
-  place in the list, while still being offered as an add-on where it belongs.
+  place in the list, and it is still offered with the thing it goes with.
 
   @rule:bookings.only-an-add-on-marked-for-it-has-its-own-page
   Rule: Only an add-on marked as sellable on its own has a page of its own
@@ -34,6 +34,7 @@ Feature: An add-on that can also be bought on its own
       Then the Cover is offered with a link to its own page
       And the Cover is not called an add-on there
       And the Chair is still offered too
+      And the Cover is still offered when booking the Chair
 
   @rule:bookings.the-organiser-can-open-and-close-the-page-again
   @surface:admin

--- a/test/integration/server/bookable-alone.test.ts
+++ b/test/integration/server/bookable-alone.test.ts
@@ -15,7 +15,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
-import { groups } from "#shared/db/groups.ts";
 import { listingChildren } from "#shared/db/listing-parents.ts";
 import { listingsTable } from "#shared/db/listings/records.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -32,7 +31,6 @@ import {
   apiListingSlugs,
   makeParent,
   publicBody,
-  ticketPageStatus,
 } from "#test-utils/parents.ts";
 import { adminGet } from "#test-utils/session.ts";
 import { enablePublicSite } from "#test-utils/settings.ts";
@@ -48,42 +46,6 @@ describeWithEnv(
   "server > bookable_alone child surfaces",
   { db: true, triggers: true },
   () => {
-    describe("standalone booking page", () => {
-      test("a bookable_alone child's /ticket page renders (200), not 404", async () => {
-        const { child } = await parentWithFlaggedChild();
-        await enablePublicSite();
-        const response = await handleRequest(
-          mockRequest(`/ticket/${child.slug}`),
-        );
-        expect(response.status).toBe(200);
-        const body = await response.text();
-        expect(body).toContain("Solo Widget");
-      });
-
-      test("a plain (non-flagged) child under the same shape still 404s", async () => {
-        // Regression floor: only the flag opens the page; a plain child is
-        // rejected by the slug guard exactly as before.
-        const { child } = await makeParent({
-          children: [{ name: "Folded Only" }],
-          parent: { name: "Picker" },
-        });
-        expect(await ticketPageStatus(child.slug)).toBe(404);
-      });
-    });
-
-    describe("public listing cards (/listings)", () => {
-      test("a bookable_alone child shows a Book CTA, not the add-on note", async () => {
-        const { parent, child } = await parentWithFlaggedChild();
-        const body = await publicBody("/listings");
-        expect(body).toContain("Solo Widget");
-        // Its own standalone CTA is present; the add-on note is NOT shown.
-        expect(body).toContain(`href="/ticket/${child.slug}"`);
-        expect(body).not.toContain("Available as an add-on to another booking");
-        // The parent keeps its own Book link too.
-        expect(body).toContain(`href="/ticket/${parent.slug}"`);
-      });
-    });
-
     describe("/order gallery", () => {
       test("offers a bookable_alone child as a selectable card", async () => {
         await enablePublicSite();
@@ -177,43 +139,7 @@ describeWithEnv(
       });
     });
 
-    describe("hidden-package concealment still wins", () => {
-      test("a hidden package member stays concealed even if bookable_alone", async () => {
-        // The hidden-member arm of the gate outranks the flag: a hidden package's
-        // member has no standalone page regardless of bookable_alone.
-        const group = await createTestGroup({
-          isPackage: true,
-          name: "Bundle",
-        });
-        // hide_package_listings isn't exposed by the create form helper, so set
-        // it directly — the concealment predicate reads this column.
-        await groups.table.update(group.id, {
-          hidePackageListings: true,
-          isPackage: true,
-        });
-        const member = await createTestListing({
-          bookableAlone: true,
-          groupId: group.id,
-          name: "Concealed Member",
-        });
-        expect(await ticketPageStatus(member.slug)).toBe(404);
-      });
-    });
-
     describe("flag transitions on listing save (no orphaned add-on)", () => {
-      test("clearing bookable_alone on a child is allowed when nothing is orphaned", async () => {
-        // The false-transition guard runs but finds no child-scoped add-on to
-        // orphan, so the save succeeds and the flag flips off (the child's
-        // /ticket page then 404s again).
-        const { child } = await parentWithFlaggedChild();
-        expect(await ticketPageStatus(child.slug)).toBe(200);
-        await updateTestListing(child.id, { bookableAlone: false });
-        expect((await listingsTable.findById(child.id))!.bookable_alone).toBe(
-          false,
-        );
-        expect(await ticketPageStatus(child.slug)).toBe(404);
-      });
-
       test("clearing bookable_alone on a NON-child listing is a no-op guard", async () => {
         // The flag is inert for a listing with no parents, so clearing it never
         // runs the reachability guard — the save just succeeds.
@@ -225,18 +151,6 @@ describeWithEnv(
         expect((await listingsTable.findById(solo.id))!.bookable_alone).toBe(
           false,
         );
-      });
-
-      test("setting bookable_alone true on a child opens its page", async () => {
-        // The reverse transition never runs the orphan guard (adding a page only
-        // ADDS reachability), so it always succeeds and the page opens.
-        const { child } = await makeParent({
-          children: [{ name: "Later Solo" }],
-          parent: { name: "Picker" },
-        });
-        expect(await ticketPageStatus(child.slug)).toBe(404);
-        await updateTestListing(child.id, { bookableAlone: true });
-        expect(await ticketPageStatus(child.slug)).toBe(200);
       });
     });
   },

--- a/test/scripts/specs/catalog.test.ts
+++ b/test/scripts/specs/catalog.test.ts
@@ -16,6 +16,7 @@ describe("Cucumber story catalog", () => {
       "attendees.merging-duplicate-bookings",
       "attendees.no-quantity-tickets",
       "attendees.removing-one-part-of-an-order",
+      "bookings.add-ons-sold-on-their-own",
       "bookings.adding-a-booking-by-hand",
       "bookings.backup-and-restore",
       "bookings.book-through-the-site",

--- a/test/specs/steps/add-ons.ts
+++ b/test/specs/steps/add-ons.ts
@@ -4,6 +4,7 @@ import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import {
   bookingLinkFor,
+  bookingPageFor,
   everythingForSale,
   expectCustomerCannotOpen,
   expectCustomerCanOpen,
@@ -99,6 +100,20 @@ Then(
     expect(
       forSalePage(this).containsText("as an add-on to another booking"),
     ).toBe(false);
+  },
+);
+
+Then(
+  "the {word} is still offered when booking the {word}",
+  async function (
+    this: TicketsWorld,
+    addOn: string,
+    mainThing: string,
+  ): Promise<void> {
+    // Selling it on its own must not take it off the page of the thing it goes
+    // with — that is where most people will meet it.
+    const page = await bookingPageFor(this, mainThing);
+    expect(page.pageText).toContain(addOn);
   },
 );
 

--- a/test/specs/steps/add-ons.ts
+++ b/test/specs/steps/add-ons.ts
@@ -1,0 +1,112 @@
+// jscpd:ignore-start
+
+import { Given, Then, When } from "@cucumber/cucumber";
+import { expect } from "@std/expect";
+import {
+  bookingLinkFor,
+  everythingForSale,
+  expectCustomerCannotOpen,
+  expectCustomerCanOpen,
+  sellHiddenBundle,
+  sellOnItsOwn,
+  sellWithAddOn,
+} from "#test/specs/support/add-ons.ts";
+import {
+  requiredWorldValue,
+  type TicketsWorld,
+} from "#test/specs/support/world.ts";
+import type { TestBrowser } from "#test-utils/test-browser.ts";
+
+// jscpd:ignore-end
+
+/** The page of everything for sale, as the customer last saw it. */
+const forSalePage = (world: TicketsWorld): TestBrowser =>
+  requiredWorldValue(world.customerBrowser, "the page the customer saw");
+
+Given(
+  "a {word} sold with a {word} that can also be bought on its own",
+  function (this: TicketsWorld, mainThing: string, addOn: string) {
+    return sellWithAddOn(this, mainThing, addOn, true);
+  },
+);
+
+Given(
+  "a {word} sold with a {word} that is only an add-on",
+  function (this: TicketsWorld, mainThing: string, addOn: string) {
+    return sellWithAddOn(this, mainThing, addOn, false);
+  },
+);
+
+Given(
+  "a hidden {word} whose {word} could be bought on its own",
+  function (this: TicketsWorld, bundle: string, part: string) {
+    return sellHiddenBundle(this, bundle, part);
+  },
+);
+
+When(
+  "the organiser starts selling the {word} on its own",
+  async function (this: TicketsWorld, name: string): Promise<void> {
+    await sellOnItsOwn(this, name, true);
+  },
+);
+
+When(
+  "the organiser stops selling the {word} on its own",
+  async function (this: TicketsWorld, name: string): Promise<void> {
+    await sellOnItsOwn(this, name, false);
+  },
+);
+
+When(
+  "a customer looks at everything for sale",
+  async function (this: TicketsWorld): Promise<void> {
+    this.customerBrowser = await everythingForSale();
+  },
+);
+
+Then(
+  "a customer can open the {word}'s own page",
+  function (this: TicketsWorld, name: string): Promise<void> {
+    return expectCustomerCanOpen(this, name);
+  },
+);
+
+Then(
+  "a customer cannot open the {word}'s own page",
+  function (this: TicketsWorld, name: string): Promise<void> {
+    return expectCustomerCannotOpen(this, name);
+  },
+);
+
+Then(
+  "the {word} is offered with a link to its own page",
+  function (this: TicketsWorld, name: string): void {
+    const page = forSalePage(this);
+    expect(page.pageText).toContain(name);
+    expect(page.links.map(({ href }) => href)).toContain(
+      bookingLinkFor(this, name),
+    );
+  },
+);
+
+Then(
+  "the {word} is not called an add-on there",
+  function (this: TicketsWorld, name: string): void {
+    // The note belongs to things that are only ever sold alongside something
+    // else, so it must not follow this one onto the page.
+    expect(forSalePage(this).pageText).toContain(name);
+    expect(
+      forSalePage(this).containsText("as an add-on to another booking"),
+    ).toBe(false);
+  },
+);
+
+Then(
+  "the {word} is still offered too",
+  function (this: TicketsWorld, name: string): void {
+    expect(forSalePage(this).links.map(({ href }) => href)).toContain(
+      bookingLinkFor(this, name),
+    );
+  },
+);

--- a/test/specs/support/add-ons.ts
+++ b/test/specs/support/add-ons.ts
@@ -1,0 +1,102 @@
+/**
+ * Things sold alongside something else, and the ones an organiser also sells on
+ * their own. A customer only ever meets these through the public pages, so
+ * every check here opens a page the way they would.
+ */
+
+import { expect } from "@std/expect";
+import { groups } from "#shared/db/groups.ts";
+import type { Listing } from "#shared/types.ts";
+import { rememberStayListing, stayListing } from "#test/specs/support/stays.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
+import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
+import {
+  createTestListing,
+  updateTestListing,
+} from "#test-utils/db-helpers/listings.ts";
+import { makeParent, ticketPageStatus } from "#test-utils/parents.ts";
+import { enablePublicSite } from "#test-utils/settings.ts";
+import { TestBrowser } from "#test-utils/test-browser.ts";
+
+/** Something sold with an add-on, which the organiser may or may not also sell
+ * on its own. Both are remembered by the names the story calls them. */
+export const sellWithAddOn = async (
+  world: TicketsWorld,
+  mainThing: string,
+  addOn: string,
+  onItsOwn: boolean,
+): Promise<void> => {
+  await enablePublicSite();
+  const { parent, children } = await makeParent({
+    children: [{ bookableAlone: onItsOwn, name: addOn }],
+    parent: { name: mainThing },
+  });
+  rememberStayListing(world, mainThing, parent);
+  rememberStayListing(world, addOn, children[0]!);
+};
+
+/** A bundle whose parts the organiser has chosen to keep hidden, holding one
+ * part that is nonetheless marked as sellable on its own. */
+export const sellHiddenBundle = async (
+  world: TicketsWorld,
+  bundle: string,
+  part: string,
+): Promise<void> => {
+  await enablePublicSite();
+  const group = await createTestGroup({ isPackage: true, name: bundle });
+  await groups.table.update(group.id, {
+    hidePackageListings: true,
+    isPackage: true,
+  });
+  rememberStayListing(
+    world,
+    part,
+    await createTestListing({
+      bookableAlone: true,
+      groupId: group.id,
+      name: part,
+    }),
+  );
+};
+
+/** The link a customer would follow to book something on its own. */
+export const bookingLinkFor = (world: TicketsWorld, name: string): string =>
+  `/ticket/${stayListing(world, name).slug}`;
+
+/** A customer opens something's own page and is shown it. Both halves matter:
+ * the page has to answer at all, and it has to be the page for this thing
+ * rather than some other one that also answered. */
+export const expectCustomerCanOpen = async (
+  world: TicketsWorld,
+  name: string,
+): Promise<void> => {
+  expect(await ticketPageStatus(stayListing(world, name).slug)).toBe(200);
+  const browser = new TestBrowser();
+  await browser.visit(bookingLinkFor(world, name));
+  expect(browser.pageText).toContain(name);
+};
+
+/** There is no page for this thing at all — the site's way of saying it is only
+ * ever sold with something else. */
+export const expectCustomerCannotOpen = async (
+  world: TicketsWorld,
+  name: string,
+): Promise<void> => {
+  expect(await ticketPageStatus(stayListing(world, name).slug)).toBe(404);
+};
+
+/** The organiser turns selling-on-its-own on or off, through the listing's own
+ * edit form. */
+export const sellOnItsOwn = async (
+  world: TicketsWorld,
+  name: string,
+  onItsOwn: boolean,
+): Promise<Listing> =>
+  updateTestListing(stayListing(world, name).id, { bookableAlone: onItsOwn });
+
+/** Everything the site currently offers for sale, as the customer sees it. */
+export const everythingForSale = async (): Promise<TestBrowser> => {
+  const browser = new TestBrowser();
+  await browser.visit("/listings");
+  return browser;
+};

--- a/test/specs/support/add-ons.ts
+++ b/test/specs/support/add-ons.ts
@@ -4,16 +4,21 @@
  * every check here opens a page the way they would.
  */
 
+/** The box on the edit form, and the value it carries when it is ticked. */
+const FIELD = "bookable_alone";
+const TICKED = "1";
+
 import { expect } from "@std/expect";
 import { groups } from "#shared/db/groups.ts";
-import type { Listing } from "#shared/types.ts";
+import { adminBrowser } from "#test/specs/support/browser.ts";
+import {
+  tickedCheckboxes,
+  whyValueCannotBeSent,
+} from "#test/specs/support/form-controls.ts";
 import { rememberStayListing, stayListing } from "#test/specs/support/stays.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
-import {
-  createTestListing,
-  updateTestListing,
-} from "#test-utils/db-helpers/listings.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { makeParent, ticketPageStatus } from "#test-utils/parents.ts";
 import { enablePublicSite } from "#test-utils/settings.ts";
 import { TestBrowser } from "#test-utils/test-browser.ts";
@@ -85,14 +90,39 @@ export const expectCustomerCannotOpen = async (
   expect(await ticketPageStatus(stayListing(world, name).slug)).toBe(404);
 };
 
-/** The organiser turns selling-on-its-own on or off, through the listing's own
- * edit form. */
+/** The organiser turns selling-on-its-own on or off, by ticking or unticking
+ * the box on the listing's own edit form. The box has to be there and be
+ * usable, so a page that stops offering it fails the story rather than the
+ * change being forced through underneath. */
 export const sellOnItsOwn = async (
   world: TicketsWorld,
   name: string,
   onItsOwn: boolean,
-): Promise<Listing> =>
-  updateTestListing(stayListing(world, name).id, { bookableAlone: onItsOwn });
+): Promise<void> => {
+  const browser = await adminBrowser(world);
+  await browser.visit(`/admin/listing/${stayListing(world, name).id}/edit`);
+  expect(whyValueCannotBeSent(browser.currentHtml, FIELD, TICKED)).toBeNull();
+  expect(tickedCheckboxes(browser.currentHtml, FIELD)).toEqual(
+    onItsOwn ? [] : [TICKED],
+  );
+  // Unticking a box sends nothing at all for it, which is what an empty list
+  // means here.
+  await browser.submitForm(
+    { [FIELD]: onItsOwn ? [TICKED] : [] },
+    "Save Changes",
+  );
+  expect(browser.containsText("Listing updated")).toBe(true);
+};
+
+/** Whether the Chair's own booking page still offers the Cover with it. */
+export const bookingPageFor = async (
+  world: TicketsWorld,
+  name: string,
+): Promise<TestBrowser> => {
+  const browser = new TestBrowser();
+  await browser.visit(bookingLinkFor(world, name));
+  return browser;
+};
 
 /** Everything the site currently offers for sale, as the customer sees it. */
 export const everythingForSale = async (): Promise<TestBrowser> => {

--- a/test/specs/support/add-ons.ts
+++ b/test/specs/support/add-ons.ts
@@ -4,16 +4,15 @@
  * every check here opens a page the way they would.
  */
 
-/** The box on the edit form, and the value it carries when it is ticked. */
+/** The box on the edit form. Its value is read off the page, not assumed. */
 const FIELD = "bookable_alone";
-const TICKED = "1";
 
 import { expect } from "@std/expect";
 import { groups } from "#shared/db/groups.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
 import {
+  checkboxValueOffered,
   tickedCheckboxes,
-  whyValueCannotBeSent,
 } from "#test/specs/support/form-controls.ts";
 import { rememberStayListing, stayListing } from "#test/specs/support/stays.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
@@ -101,14 +100,16 @@ export const sellOnItsOwn = async (
 ): Promise<void> => {
   const browser = await adminBrowser(world);
   await browser.visit(`/admin/listing/${stayListing(world, name).id}/edit`);
-  expect(whyValueCannotBeSent(browser.currentHtml, FIELD, TICKED)).toBeNull();
+  // Send whatever the page's own box sends, rather than a value this file
+  // believes in: a box rewritten to carry something else must fail the story.
+  const ticked = checkboxValueOffered(browser.currentHtml, FIELD);
   expect(tickedCheckboxes(browser.currentHtml, FIELD)).toEqual(
-    onItsOwn ? [] : [TICKED],
+    onItsOwn ? [] : [ticked],
   );
-  // Unticking a box sends nothing at all for it, which is what an empty list
-  // means here.
+  // Unticking a box sends nothing at all for it, which is what a real browser
+  // does.
   await browser.submitForm(
-    { [FIELD]: onItsOwn ? [TICKED] : [] },
+    { [FIELD]: onItsOwn ? [ticked] : [] },
     "Save Changes",
   );
   expect(browser.containsText("Listing updated")).toBe(true);

--- a/test/specs/support/form-controls.test.ts
+++ b/test/specs/support/form-controls.test.ts
@@ -8,6 +8,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  checkboxValueOffered,
   optionsOffered,
   tickedCheckboxes,
   whyValueCannotBeSent,
@@ -207,5 +208,32 @@ describe("the days a page has ticked", () => {
     expect(
       tickedCheckboxes(`${day("Monday")}${other}`, "bookable_days"),
     ).toEqual(["Monday"]);
+  });
+
+  describe("the value a page's own box sends", () => {
+    test("reads it off the box rather than assuming one", () => {
+      expect(
+        checkboxValueOffered(
+          '<input type="checkbox" name="bookable_alone" value="on">',
+          "bookable_alone",
+        ),
+      ).toBe("on");
+    });
+
+    test("ignores a box nobody could tick", () => {
+      const off =
+        '<input type="checkbox" name="bookable_alone" value="1" disabled>';
+      const usable =
+        '<input type="checkbox" name="bookable_alone" value="yes">';
+      expect(checkboxValueOffered(`${off}${usable}`, "bookable_alone")).toBe(
+        "yes",
+      );
+    });
+
+    test("throws when the page offers no such box", () => {
+      expect(() =>
+        checkboxValueOffered("<p>nothing</p>", "bookable_alone"),
+      ).toThrow("The page offers no bookable_alone box to tick");
+    });
   });
 });

--- a/test/specs/support/form-controls.ts
+++ b/test/specs/support/form-controls.ts
@@ -76,26 +76,46 @@ const whyNumberIsOutOfRange = (
   return null;
 };
 
-/** The values a page has already ticked for one field, counting only real
- * checkboxes a person could untick. A day carried by a hidden box instead is
- * left out, because nobody can untick that. */
-export const tickedCheckboxes = (html: string, field: string): string[] => {
-  const ticked: string[] = [];
+/** Every checkbox on the page for one field that a person could actually
+ * tick — a switched-off one is not one of them. Each is given as the value it
+ * would send and whether it is already ticked. */
+const usableCheckboxes = (
+  html: string,
+  field: string,
+): Array<{ ticked: boolean; value: string }> => {
+  const boxes: Array<{ ticked: boolean; value: string }> = [];
   for (const box of html.matchAll(/<input\s([^>]*)>/g)) {
     const tag = box[1]!;
     const value = attribute(tag, "value");
     if (
       tag.includes('type="checkbox"') &&
       tag.includes(`name="${field}"`) &&
-      tag.includes("checked") &&
       !tag.includes("disabled") &&
       value !== null
     ) {
-      ticked.push(value);
+      boxes.push({ ticked: tag.includes("checked"), value });
     }
   }
-  return ticked;
+  return boxes;
 };
+
+/** The value the page's own box for a field sends when ticked — what a person
+ * ticking it would send, rather than a value the caller believes in. Throws
+ * when the page offers no such box, so "the box is gone" and "the box sends
+ * something else" stay separate failures. */
+export const checkboxValueOffered = (html: string, field: string): string => {
+  const box = usableCheckboxes(html, field)[0];
+  if (!box) throw new Error(`The page offers no ${field} box to tick`);
+  return box.value;
+};
+
+/** The values a page has already ticked for one field, counting only real
+ * checkboxes a person could untick. A day carried by a hidden box instead is
+ * left out, because nobody can untick that. */
+export const tickedCheckboxes = (html: string, field: string): string[] =>
+  usableCheckboxes(html, field)
+    .filter(({ ticked }) => ticked)
+    .map(({ value }) => value);
 
 /**
  * Why a visitor could not send this value through the page's own control, or


### PR DESCRIPTION
## What changed

Some things are only sold alongside something else — a cover with a chair, a guide with a tour. An organiser can also mark one of those as something people may buy on its own, and it then gets its own page and its own place in the list while still being offered as an add-on where it belongs.

That rule had no story. It does now, covering what a customer actually meets:

- **Only an add-on marked for it has a page of its own.** An ordinary add-on has no page anyone could reach; marking it opens one.
- **An add-on sold on its own is listed like anything else** — in the list of what's for sale, with its own booking link, and *not* described as an add-on there, because in that context it isn't one. The thing it goes with is still offered too.
- **The organiser can open and close that page whenever they like.** Marking an ordinary add-on opens its page; unmarking it closes it again.
- **A hidden bundle keeps its parts hidden** whatever they are marked. An organiser can hide what a bundle is made of, and that choice comes first — a part marked as sellable on its own still has no page.

This is the first batch drawn from `test/integration/server/` rather than `test/e2e/`, since the multi-day area is largely migrated now.

## What stayed a direct test

The same flag has effects on surfaces a customer never visits directly: the RSS and calendar feeds, the JSON API's listing and availability endpoints, the admin multi-booking builder, and the share/QR affordances. Those are surface contracts rather than journeys, so they stay as direct tests — along with the structural rule that a group whose only members are flagged add-ons still isn't advertised as live.

## Checks

`deno task precommit` passes in full — typecheck, lint, duplication at 0%, the whole test suite, and 100% line and branch coverage. All 78 Cucumber scenarios (509 steps) pass. No production code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga3qdj1PzXyZTcjmXZRqz7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add-ons marked for independent sale can have their own customer-facing booking page and booking link.
  * Independently sellable add-ons appear in the general “for sale” listing without being labelled as add-ons.
  * Organisers can open or close an add-on’s standalone page by changing its sale setting.
  * Hidden bundle components remain unavailable, even when independently sellable.

* **Tests**
  * Added coverage for standalone add-on pages, listings, visibility, and booking navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->