### PR TITLE
Make the order gallery test say what its waiting time means

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1455,20 +1455,6 @@ re-conflict with the import-only changes that are the actual subject of the
 PR. The ~400-line target is guidance, and the cold-start PR's brief was
 explicitly about import-graph narrowing, not test reorganisation.
 
-## Export REFRESH_DELAY_MS for test reuse
-
-*Origin: CodeRabbit review on PR #1909 (independent test hardening).*
-
-`src/ui/client/admin/order-gallery.ts` declares `const REFRESH_DELAY_MS = 200`
-privately. The debounce-timing test in `test/ui/client/admin/order-gallery.test.ts`
-hard-codes `199` and `1` to assert the exact 200 ms boundary. Importing the
-production constant (`REFRESH_DELAY_MS - 1` then `1`) would keep the test aligned
-if the delay changes. This requires exporting `REFRESH_DELAY_MS` from the
-production module — a small production change that was out of scope for the
-test-only PR. Starting point: add `export` to the `const REFRESH_DELAY_MS`
-declaration, then replace the hard-coded `199` in the "waits for the debounce
-delay" test with `REFRESH_DELAY_MS - 1`.
-
 ## Split the sms-webhook test suite
 
 *Origin: Codex review on PR #1909 (independent test hardening).*

--- a/src/ui/client/admin/order-gallery.ts
+++ b/src/ui/client/admin/order-gallery.ts
@@ -15,7 +15,7 @@ import { stringEntries } from "#shared/string-entries.ts";
  * messages can honour the earliest choice.
  */
 
-export const REFRESH_DELAY_MS = 200;
+const REFRESH_DELAY_MS = 200;
 
 /** Build the availability query from the form (checkboxes, date, order). */
 const availabilityQuery = (form: HTMLFormElement): URLSearchParams =>

--- a/src/ui/client/admin/order-gallery.ts
+++ b/src/ui/client/admin/order-gallery.ts
@@ -15,7 +15,7 @@ import { stringEntries } from "#shared/string-entries.ts";
  * messages can honour the earliest choice.
  */
 
-const REFRESH_DELAY_MS = 200;
+export const REFRESH_DELAY_MS = 200;
 
 /** Build the availability query from the form (checkboxes, date, order). */
 const availabilityQuery = (form: HTMLFormElement): URLSearchParams =>

--- a/test/ui/client/admin/order-gallery.test.ts
+++ b/test/ui/client/admin/order-gallery.test.ts
@@ -9,7 +9,10 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import { initOrderGallery } from "#src/ui/client/admin/order-gallery.ts";
+import {
+  initOrderGallery,
+  REFRESH_DELAY_MS,
+} from "#src/ui/client/admin/order-gallery.ts";
 import {
   createDomInstaller,
   createGlobalStash,
@@ -211,7 +214,7 @@ describe("initOrderGallery", () => {
   test("waits for the debounce delay before checking availability", async () => {
     const page = harness();
     page.tick("select_package_7", true);
-    await clock.time!.tickAsync(199);
+    await clock.time!.tickAsync(REFRESH_DELAY_MS - 1);
     expect(page.requests).toHaveLength(0);
 
     await clock.time!.tickAsync(1);

--- a/test/ui/client/admin/order-gallery.test.ts
+++ b/test/ui/client/admin/order-gallery.test.ts
@@ -9,10 +9,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
-import {
-  initOrderGallery,
-  REFRESH_DELAY_MS,
-} from "#src/ui/client/admin/order-gallery.ts";
+import { initOrderGallery } from "#src/ui/client/admin/order-gallery.ts";
 import {
   createDomInstaller,
   createGlobalStash,
@@ -23,6 +20,11 @@ type AvailabilityBody = {
   dateNeeded?: boolean;
   states?: Record<string, CardState>;
 };
+
+// The gallery must wait this long after a change before it asks what is still
+// available. Stated here on purpose: the test guards the 200 ms contract, so it
+// should fail if the production delay moves.
+const EXPECTED_REFRESH_DELAY_MS = 200;
 
 const GALLERY_HTML = `
   <form data-order-gallery>
@@ -214,7 +216,7 @@ describe("initOrderGallery", () => {
   test("waits for the debounce delay before checking availability", async () => {
     const page = harness();
     page.tick("select_package_7", true);
-    await clock.time!.tickAsync(REFRESH_DELAY_MS - 1);
+    await clock.time!.tickAsync(EXPECTED_REFRESH_DELAY_MS - 1);
     expect(page.requests).toHaveLength(0);
 
     await clock.time!.tickAsync(1);


### PR DESCRIPTION
The order gallery waits a moment after you tick cards before it checks what is still available. Its test used to spell that wait out as a bare `199` in the middle of a line, with nothing saying where the number came from.

The test now names the wait at the top of the file, with a note that it is stating the expected behaviour on purpose. Nothing about the app changes — this only makes the test easier to read and clearer about what it is protecting.

The TODO list asked for this to be done a different way: by sharing the value from the app code with the test. That turned out to break one of the project's own rules — app code must not export something only a test uses — and the project's checks caught it. So the shared-value idea is dropped and the TODO item is removed.

- `test/ui/client/admin/order-gallery.test.ts` names the 200 ms wait and uses it
- `TODO.md` loses the item that is no longer wanted
- `src/ui/client/admin/order-gallery.ts` is unchanged