### PR TITLE
Move the phone-index tests next to the code they test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1455,22 +1455,6 @@ re-conflict with the import-only changes that are the actual subject of the
 PR. The ~400-line target is guidance, and the cold-start PR's brief was
 explicitly about import-graph narrowing, not test reorganisation.
 
-## Split the sms-webhook test suite
-
-*Origin: Codex review on PR #1909 (independent test hardening).*
-
-`test/features/api/sms-webhook.test.ts` is 461 lines (the ~400-line target
-applies to test files too). It bundles three concerns that can stand alone:
-phone-index normalisation/unit tests (`describeWithEnv({ encryptionKey: true })`),
-attendee phone-index DB tests (`describeWithEnv({ db: true })`), and the webhook
-handler tests (`describeWithEnv({ db: true })`). The file was already 427 lines
-on main; the independent-test-hardening PR added 34 lines of new webhook coverage.
-Splitting now was deferred because the PR's brief was test hardening, not test
-reorganisation. Starting point: move the two phone-index describe blocks into
-`test/shared/sms/phone-index.test.ts`, keeping the `makeAttendee` /
-`storedPhoneIndex` helpers in whichever file needs them (or lift to `#test-utils`
-if both do). The webhook test file drops to ~380 lines.
-
 ## Mutation coverage of `src/features/api/folded-booking.ts` (direct tests)
 
 Direct tests at `test/features/api/folded-booking.test.ts` and

--- a/test/features/api/sms-webhook.test.ts
+++ b/test/features/api/sms-webhook.test.ts
@@ -2,29 +2,21 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
 import { handleRequest } from "#routes";
-import {
-  findAttendeeIdByPhoneIndex,
-  setAttendeePhoneIndexIfEmpty,
-} from "#shared/db/attendee-phone-index.ts";
-import { execute, queryOne } from "#shared/db/client.ts";
+import { setAttendeePhoneIndexIfEmpty } from "#shared/db/attendee-phone-index.ts";
+import { execute } from "#shared/db/client.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   getSmsMessageByProviderId,
   recordSmsMessage,
 } from "#shared/db/sms-messages.ts";
 import { encryptField } from "#shared/sms/e2e.ts";
-import {
-  computePhoneIndex,
-  normalizeForIndex,
-} from "#shared/sms/phone-index.ts";
+import { computePhoneIndex } from "#shared/sms/phone-index.ts";
 import {
   getAllActivityLog,
   getAttendeeActivityLog,
 } from "#test-utils/activity-log.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { createTestAttendeeDirect } from "#test-utils/db-helpers/attendees.ts";
-import { createTestListing } from "#test-utils/db-helpers/listings.ts";
-import { createServicingHold } from "#test-utils/servicing.ts";
+import { createTestAttendeeWithPhone } from "#test-utils/db-helpers/attendees.ts";
 
 const SECRET = "whsec-123";
 const PASS = "gateway-pass";
@@ -68,104 +60,6 @@ const postWebhook = async (
 };
 
 const configure = () => settings.update.smsGatewayWebhookSecret(SECRET);
-
-const makeAttendee = async () => {
-  const listing = await createTestListing({ maxAttendees: 100 });
-  const { attendee } = await createTestAttendeeDirect(
-    listing.id,
-    "Jane",
-    "jane@example.com",
-    1,
-    "+447700900123",
-  );
-  return attendee;
-};
-
-describeWithEnv("sms phone index", { encryptionKey: true }, () => {
-  test("normalizeForIndex keeps the last 9 digits", () => {
-    expect(normalizeForIndex("+44 7700 900123")).toBe("700900123");
-    expect(normalizeForIndex("07700900123")).toBe("700900123");
-    expect(normalizeForIndex("")).toBe("");
-  });
-
-  test("computePhoneIndex matches across formats and is empty for empty", async () => {
-    const a = await computePhoneIndex("+447700900123");
-    const b = await computePhoneIndex("07700 900123");
-    expect(a).toBe(b);
-    expect(await computePhoneIndex("")).toBe("");
-  });
-});
-
-describeWithEnv("db > attendee phone index", { db: true }, () => {
-  /** The raw stored phone_index column for one attendee row. */
-  const storedPhoneIndex = async (attendeeId: number): Promise<string> => {
-    const row = await queryOne<{ phone_index: string }>(
-      "SELECT phone_index FROM attendees WHERE id = ?",
-      [attendeeId],
-    );
-    return row!.phone_index;
-  };
-
-  test("setAttendeePhoneIndexIfEmpty fills an empty column, for that attendee only", async () => {
-    const attendee = await makeAttendee();
-    const listing = await createTestListing({ maxAttendees: 100 });
-    const { attendee: other } = await createTestAttendeeDirect(
-      listing.id,
-      "Other",
-      "other@example.com",
-    );
-    const idx = await computePhoneIndex("+447700900123");
-
-    await setAttendeePhoneIndexIfEmpty(attendee.id, idx);
-
-    expect(await storedPhoneIndex(attendee.id)).toBe(idx);
-    // The write is keyed on the id — the other attendee stays unset.
-    expect(await storedPhoneIndex(other.id)).toBe("");
-  });
-
-  test("setAttendeePhoneIndexIfEmpty never overwrites an existing index", async () => {
-    const attendee = await makeAttendee();
-    const idx = await computePhoneIndex("+447700900123");
-    await setAttendeePhoneIndexIfEmpty(attendee.id, idx);
-
-    await setAttendeePhoneIndexIfEmpty(
-      attendee.id,
-      await computePhoneIndex("+447700900456"),
-    );
-
-    expect(await storedPhoneIndex(attendee.id)).toBe(idx);
-  });
-
-  test("setAttendeePhoneIndexIfEmpty with an empty index leaves the row unset", async () => {
-    const attendee = await makeAttendee();
-
-    await setAttendeePhoneIndexIfEmpty(attendee.id, "");
-
-    expect(await storedPhoneIndex(attendee.id)).toBe("");
-  });
-
-  test("set is idempotent and lookup finds the attendee", async () => {
-    const attendee = await makeAttendee();
-    const idx = await computePhoneIndex("+447700900123");
-
-    await setAttendeePhoneIndexIfEmpty(attendee.id, "");
-    expect(await findAttendeeIdByPhoneIndex("")).toBeNull();
-
-    await setAttendeePhoneIndexIfEmpty(attendee.id, idx);
-    await setAttendeePhoneIndexIfEmpty(attendee.id, "different"); // ignored
-    expect(await findAttendeeIdByPhoneIndex(idx)).toBe(attendee.id);
-    expect(await findAttendeeIdByPhoneIndex("nope")).toBeNull();
-  });
-
-  test("lookup ignores servicing rows even if a phone index exists", async () => {
-    const service = await createServicingHold();
-    const idx = await computePhoneIndex("+447700900321");
-
-    await setAttendeePhoneIndexIfEmpty(service.id, idx);
-
-    expect(await findAttendeeIdByPhoneIndex(idx)).toBeNull();
-  });
-});
 
 describeWithEnv("api > sms webhook", { db: true }, () => {
   test("404 when the webhook secret is not configured", async () => {
@@ -269,7 +163,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
 
   test("cleanup preserves a provider-message row within retention and prunes an expired one", async () => {
     await configure();
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await recordSmsMessage({
       attendeeId: attendee.id,
       listingId: 1,
@@ -299,7 +193,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
 
   test("delivered logs against the attendee and clears the row", async () => {
     await configure();
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await recordSmsMessage({
       attendeeId: attendee.id,
       listingId: 1,
@@ -318,7 +212,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
 
   test("failed logs the reason against the attendee", async () => {
     await configure();
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await recordSmsMessage({
       attendeeId: attendee.id,
       listingId: 1,
@@ -335,7 +229,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
 
   test("delivered falls back to the `id` field when messageId is absent", async () => {
     await configure();
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await recordSmsMessage({
       attendeeId: attendee.id,
       listingId: 1,
@@ -369,7 +263,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
       ).status,
     ).toBe(200);
 
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await recordSmsMessage({
       attendeeId: attendee.id,
       listingId: 1,
@@ -399,7 +293,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
   test("received decrypts the reply and logs it against the attendee", async () => {
     await configure();
     await settings.update.smsGatewayPassphrase(PASS);
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await setAttendeePhoneIndexIfEmpty(
       attendee.id,
       await computePhoneIndex("+447700900123"),
@@ -443,7 +337,7 @@ describeWithEnv("api > sms webhook", { db: true }, () => {
 
   test("replayed delivered event remains idempotent", async () => {
     await configure();
-    const attendee = await makeAttendee();
+    const attendee = await createTestAttendeeWithPhone();
     await recordSmsMessage({
       attendeeId: attendee.id,
       listingId: 1,

--- a/test/shared/sms/phone-index.test.ts
+++ b/test/shared/sms/phone-index.test.ts
@@ -1,0 +1,103 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import {
+  findAttendeeIdByPhoneIndex,
+  setAttendeePhoneIndexIfEmpty,
+} from "#shared/db/attendee-phone-index.ts";
+import { queryOne } from "#shared/db/client.ts";
+import {
+  computePhoneIndex,
+  normalizeForIndex,
+} from "#shared/sms/phone-index.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import {
+  createTestAttendeeDirect,
+  createTestAttendeeWithPhone,
+} from "#test-utils/db-helpers/attendees.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { createServicingHold } from "#test-utils/servicing.ts";
+
+describeWithEnv("sms phone index", { encryptionKey: true }, () => {
+  test("normalizeForIndex keeps the last 9 digits", () => {
+    expect(normalizeForIndex("+44 7700 900123")).toBe("700900123");
+    expect(normalizeForIndex("07700900123")).toBe("700900123");
+    expect(normalizeForIndex("")).toBe("");
+  });
+
+  test("computePhoneIndex matches across formats and is empty for empty", async () => {
+    const a = await computePhoneIndex("+447700900123");
+    const b = await computePhoneIndex("07700 900123");
+    expect(a).toBe(b);
+    expect(await computePhoneIndex("")).toBe("");
+  });
+});
+
+describeWithEnv("db > attendee phone index", { db: true }, () => {
+  /** The raw stored phone_index column for one attendee row. */
+  const storedPhoneIndex = async (attendeeId: number): Promise<string> => {
+    const row = await queryOne<{ phone_index: string }>(
+      "SELECT phone_index FROM attendees WHERE id = ?",
+      [attendeeId],
+    );
+    return row!.phone_index;
+  };
+
+  test("setAttendeePhoneIndexIfEmpty fills an empty column, for that attendee only", async () => {
+    const attendee = await createTestAttendeeWithPhone();
+    const { attendee: other } = await createTestAttendeeDirect(
+      (await createTestListing({ maxAttendees: 100 })).id,
+      "Other",
+      "other@example.com",
+    );
+    const idx = await computePhoneIndex("+447700900123");
+
+    await setAttendeePhoneIndexIfEmpty(attendee.id, idx);
+
+    expect(await storedPhoneIndex(attendee.id)).toBe(idx);
+    // The write is keyed on the id — the other attendee stays unset.
+    expect(await storedPhoneIndex(other.id)).toBe("");
+  });
+
+  test("setAttendeePhoneIndexIfEmpty never overwrites an existing index", async () => {
+    const attendee = await createTestAttendeeWithPhone();
+    const idx = await computePhoneIndex("+447700900123");
+    await setAttendeePhoneIndexIfEmpty(attendee.id, idx);
+
+    await setAttendeePhoneIndexIfEmpty(
+      attendee.id,
+      await computePhoneIndex("+447700900456"),
+    );
+
+    expect(await storedPhoneIndex(attendee.id)).toBe(idx);
+  });
+
+  test("setAttendeePhoneIndexIfEmpty with an empty index leaves the row unset", async () => {
+    const attendee = await createTestAttendeeWithPhone();
+
+    await setAttendeePhoneIndexIfEmpty(attendee.id, "");
+
+    expect(await storedPhoneIndex(attendee.id)).toBe("");
+  });
+
+  test("set is idempotent and lookup finds the attendee", async () => {
+    const attendee = await createTestAttendeeWithPhone();
+    const idx = await computePhoneIndex("+447700900123");
+
+    await setAttendeePhoneIndexIfEmpty(attendee.id, "");
+    expect(await findAttendeeIdByPhoneIndex("")).toBeNull();
+
+    await setAttendeePhoneIndexIfEmpty(attendee.id, idx);
+    await setAttendeePhoneIndexIfEmpty(attendee.id, "different"); // ignored
+    expect(await findAttendeeIdByPhoneIndex(idx)).toBe(attendee.id);
+    expect(await findAttendeeIdByPhoneIndex("nope")).toBeNull();
+  });
+
+  test("lookup ignores servicing rows even if a phone index exists", async () => {
+    const service = await createServicingHold();
+    const idx = await computePhoneIndex("+447700900321");
+
+    await setAttendeePhoneIndexIfEmpty(service.id, idx);
+
+    expect(await findAttendeeIdByPhoneIndex(idx)).toBeNull();
+  });
+});

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -314,7 +314,6 @@ export const createTestAttendeeWithToken = async (
   return { attendee, listing, token };
 };
 
-/** A booked attendee carrying a phone number, for phone-lookup tests. */
 export const createTestAttendeeWithPhone = async (
   phone = "+447700900123",
 ): Promise<Attendee> => {

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -314,6 +314,20 @@ export const createTestAttendeeWithToken = async (
   return { attendee, listing, token };
 };
 
+/** A booked attendee carrying a phone number, for phone-lookup tests. */
+export const createTestAttendeeWithPhone = async (
+  phone = "+447700900123",
+): Promise<Attendee> => {
+  const { attendee } = await createTestAttendeeWithToken(
+    "Jane",
+    "jane@example.com",
+    { maxAttendees: 100 },
+    1,
+    phone,
+  );
+  return attendee;
+};
+
 /** Create a test attendee for "Alice" and fetch her ticket page body.
  *  Returns both the token (for further URL assertions) and the HTML body. */
 export const fetchAliceTicketPageBody = async (): Promise<{


### PR DESCRIPTION
The test file for text-message webhooks had grown to 478 lines and covered three separate things. Two of them were not about webhooks at all: turning a phone number into a lookup value, and saving and finding that value on a booking.

Those two groups now live in their own file, `test/shared/sms/phone-index.test.ts`, beside the code they check. The webhook file is down to 380 lines and only covers webhooks.

Both files need the same starting point — a booking with a phone number on it — so that setup is now a shared test helper, `createTestAttendeeWithPhone`, instead of being written out in each file.

No app code changes and no tests were added, removed, or weakened. All 33 tests across the two files pass, and the duplication check is clean.

The matching item is removed from `TODO.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mAQvERz1MNvZxNGwmdHw)_