### PR TITLE
Write the record kept about someone as a story

### DIFF
--- a/specs/attendees/the-record-kept-about-someone.feature
+++ b/specs/attendees/the-record-kept-about-someone.feature
@@ -20,6 +20,7 @@ Feature: An organiser reads and corrects the record kept about someone
       Given the site has seen Sam book 5 times and get in touch 4 times
       When the organiser opens Sam's record
       Then the record shows Sam booked 5 times through the site
+      And the record shows Sam has been in touch 4 times
       And the record shows the note about Sam written out
 
     @case:contact-record.someone-the-site-has-never-seen
@@ -39,6 +40,9 @@ Feature: An organiser reads and corrects the record kept about someone
       When the organiser sets Sam's bookings to 11 and note to "Paid in cash"
       Then the record shows Sam booked 11 times through the site
       And the note kept about Sam is "Paid in cash"
+      When the organiser sets Sam's messages to 7
+      Then the record shows Sam has been in touch 7 times
+      And Sam is counted as having been in touch 7 times
 
     @case:contact-record.a-blank-or-impossible-count-means-none
     Scenario: The organiser leaves a count blank or types a silly one
@@ -68,6 +72,7 @@ Feature: An organiser reads and corrects the record kept about someone
       When the organiser tries to save Sam a note longer than the box allows
       Then the organiser is told the note is too long
       And Sam is counted as having booked no times at all
+      And no note is kept about Sam at all
 
   @rule:attendees.a-record-the-site-cannot-read-can-still-be-repaired
   @surface:admin

--- a/specs/attendees/the-record-kept-about-someone.feature
+++ b/specs/attendees/the-record-kept-about-someone.feature
@@ -1,0 +1,87 @@
+@story:attendees.the-record-kept-about-someone
+@owner:attendees @risk:medium
+@actor:organiser
+@edition:managed @edition:self-hosted
+Feature: An organiser reads and corrects the record kept about someone
+  The site keeps a little history for each person who deals with it: how many
+  times they booked, how often they have been in touch, and a private note only
+  the organiser sees. It is filed under a one-way code made from their email, so
+  the address itself is never stored. The organiser can read that record and put
+  it right whenever it is wrong.
+
+  @rule:attendees.the-organiser-can-read-what-is-kept
+  @surface:admin
+  Rule: The organiser can read what is kept about someone
+    The counts are shown as numbers they can edit, and the private note is shown
+    written out. Someone the site has never seen has a record of nothing.
+
+    @case:contact-record.a-record-with-a-history-behind-it
+    Scenario: The organiser opens the record of someone who has booked before
+      Given the site has seen Sam book 5 times and get in touch 4 times
+      When the organiser opens Sam's record
+      Then the record shows Sam booked 5 times through the site
+      And the record shows the note about Sam written out
+
+    @case:contact-record.someone-the-site-has-never-seen
+    Scenario: The organiser opens the record of a stranger
+      When the organiser opens Nobody's record
+      Then the record shows nothing was ever counted
+      And the record says they have never been in touch
+
+  @rule:attendees.the-organiser-can-put-the-record-right
+  @surface:admin
+  Rule: The organiser can put the record right
+    Whatever they type is what the site keeps from then on.
+
+    @case:contact-record.correcting-the-counts-and-the-note
+    Scenario: The organiser corrects someone's counts and note
+      Given the site has seen Sam book 5 times and get in touch 4 times
+      When the organiser sets Sam's bookings to 11 and note to "Paid in cash"
+      Then the record shows Sam booked 11 times through the site
+      And the note kept about Sam is "Paid in cash"
+
+    @case:contact-record.a-blank-or-impossible-count-means-none
+    Scenario: The organiser leaves a count blank or types a silly one
+      When the organiser leaves Sam's site bookings blank and types -5 by hand
+      Then Sam is counted as having booked no times at all
+
+  @rule:attendees.correcting-one-record-leaves-the-others-alone
+  @surface:admin
+  Rule: Correcting one person's record leaves everyone else's alone
+    Each record belongs to one person, so an edit must never reach another.
+
+    @case:contact-record.the-other-person-is-untouched
+    Scenario: The organiser edits one of two records
+      Given the site has a note about Ali saying "Ali's own note"
+      When the organiser sets Sam's bookings to 5 and note to "Sam's own note"
+      Then the note kept about Ali is still "Ali's own note"
+      And the note kept about Sam is "Sam's own note"
+
+  @rule:attendees.a-note-that-is-too-long-is-refused
+  @surface:admin
+  Rule: A note longer than the box allows is refused, and nothing is saved
+    The organiser is told the note is too long and the record is left as it was,
+    so a rejected save never half-writes the rest of the form.
+
+    @case:contact-record.too-long-a-note-saves-nothing
+    Scenario: The organiser writes a note longer than the box allows
+      When the organiser tries to save Sam a note longer than the box allows
+      Then the organiser is told the note is too long
+      And Sam is counted as having booked no times at all
+
+  @rule:attendees.a-record-the-site-cannot-read-can-still-be-repaired
+  @surface:admin
+  Rule: A record the site cannot read can still be opened and repaired
+    If the private note becomes unreadable, the page still opens and still shows
+    the counts, which are kept in plain sight. The organiser can save over it
+    and get a working record back without losing what was counted.
+
+    @case:contact-record.repairing-an-unreadable-record
+    Scenario: The organiser opens a record whose note cannot be read
+      Given Sam's record cannot be read, but says 5 site bookings and 9 visits
+      When the organiser opens Sam's record
+      Then the record shows Sam booked 5 times through the site
+      And the record shows Sam has visited 9 times
+      When the organiser saves Sam's record again with the note "Repaired"
+      Then the note kept about Sam is "Repaired"
+      And Sam is still counted as having booked 5 times and visited 9

--- a/specs/attendees/the-record-kept-about-someone.feature
+++ b/specs/attendees/the-record-kept-about-someone.feature
@@ -44,9 +44,9 @@ Feature: An organiser reads and corrects the record kept about someone
       Then the record shows Sam has been in touch 7 times
       And Sam is counted as having been in touch 7 times
 
-    @case:contact-record.a-blank-or-impossible-count-means-none
-    Scenario: The organiser leaves a count blank or types a silly one
-      When the organiser leaves Sam's site bookings blank and types -5 by hand
+    @case:contact-record.a-blank-count-means-none
+    Scenario: The organiser clears a count
+      When the organiser leaves Sam's site bookings blank
       Then Sam is counted as having booked no times at all
 
   @rule:attendees.correcting-one-record-leaves-the-others-alone
@@ -60,19 +60,6 @@ Feature: An organiser reads and corrects the record kept about someone
       When the organiser sets Sam's bookings to 5 and note to "Sam's own note"
       Then the note kept about Ali is still "Ali's own note"
       And the note kept about Sam is "Sam's own note"
-
-  @rule:attendees.a-note-that-is-too-long-is-refused
-  @surface:admin
-  Rule: A note longer than the box allows is refused, and nothing is saved
-    The organiser is told the note is too long and the record is left as it was,
-    so a rejected save never half-writes the rest of the form.
-
-    @case:contact-record.too-long-a-note-saves-nothing
-    Scenario: The organiser writes a note longer than the box allows
-      When the organiser tries to save Sam a note longer than the box allows
-      Then the organiser is told the note is too long
-      And Sam is counted as having booked no times at all
-      And no note is kept about Sam at all
 
   @rule:attendees.a-record-the-site-cannot-read-can-still-be-repaired
   @surface:admin

--- a/test/integration/server/contact-history.test.ts
+++ b/test/integration/server/contact-history.test.ts
@@ -28,13 +28,8 @@ const seededRecord = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-/**
- * The contact-record editor's own routes and rendering. The story
- * `@story:attendees.the-record-kept-about-someone` tells the same page in the
- * organiser's words; these keep the direct cover of its branches — the empty
- * record, the note preview, the counter coercion and the over-long note — which
- * a Cucumber journey may never be the only test of.
- */
+/** Sits beside the story `@story:attendees.the-record-kept-about-someone`: these
+ * own the branch cover, and the values a real form would block. */
 describeWithEnv("server (/admin/history/:hmac)", { db: true }, () => {
   describe("GET", () => {
     testRequiresAuth("/admin/history/somehash");

--- a/test/integration/server/contact-history.test.ts
+++ b/test/integration/server/contact-history.test.ts
@@ -28,6 +28,13 @@ const seededRecord = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+/**
+ * The contact-record editor's own routes and rendering. The story
+ * `@story:attendees.the-record-kept-about-someone` tells the same page in the
+ * organiser's words; these keep the direct cover of its branches — the empty
+ * record, the note preview, the counter coercion and the over-long note — which
+ * a Cucumber journey may never be the only test of.
+ */
 describeWithEnv("server (/admin/history/:hmac)", { db: true }, () => {
   describe("GET", () => {
     testRequiresAuth("/admin/history/somehash");
@@ -122,28 +129,6 @@ describeWithEnv("server (/admin/history/:hmac)", { db: true }, () => {
       expect(record.publicBookingCount).toBe(0);
       expect(record.adminBookingCount).toBe(0);
       expect(record.visits).toBe(4);
-    });
-
-    test("editing one contact's record leaves another's untouched", async () => {
-      const pk = await getTestPrivateKey();
-      const target = await hashEmail("target@example.com");
-      const other = await hashEmail("other@example.com");
-      await saveContactRecord(
-        other,
-        seededRecord({ adminNotes: "Other note" }),
-      );
-
-      await adminFormPost(`/admin/history/${toContactHashParam(target)}`, {
-        admin_notes: "Target note",
-        public_booking_count: "5",
-      });
-
-      // The unrelated contact's record is untouched...
-      expect((await getContactRecord(other, pk)).adminNotes).toBe("Other note");
-      // ...and only the targeted hash received the edit.
-      const edited = await getContactRecord(target, pk);
-      expect(edited.adminNotes).toBe("Target note");
-      expect(edited.publicBookingCount).toBe(5);
     });
 
     test("rejects an over-long note and persists nothing", async () => {

--- a/test/scripts/specs/catalog.test.ts
+++ b/test/scripts/specs/catalog.test.ts
@@ -16,6 +16,7 @@ describe("Cucumber story catalog", () => {
       "attendees.merging-duplicate-bookings",
       "attendees.no-quantity-tickets",
       "attendees.removing-one-part-of-an-order",
+      "attendees.the-record-kept-about-someone",
       "bookings.add-ons-sold-on-their-own",
       "bookings.adding-a-booking-by-hand",
       "bookings.backup-and-restore",

--- a/test/specs/steps/contact-records.ts
+++ b/test/specs/steps/contact-records.ts
@@ -21,6 +21,10 @@ import type { TestBrowser } from "#test-utils/test-browser.ts";
 /** Everyone a story talks about has an email the site files them under. */
 const emailFor = (who: string): string => `${who.toLowerCase()}@example.com`;
 
+/** Bookings the organiser took by hand, seeded on the record that cannot be
+ * read. Repairing the note must leave this count alone too. */
+const HAND_BOOKINGS = 2;
+
 /** The record page the organiser is looking at. */
 const recordPage = (world: TicketsWorld): TestBrowser =>
   requiredWorldValue(world.customerBrowser, "the record page");
@@ -67,7 +71,7 @@ Given(
     visits: number,
   ): Promise<void> {
     return unreadableRecord(emailFor(who), {
-      bookedByHand: 2,
+      bookedByHand: HAND_BOOKINGS,
       bookedThroughTheSite: booked,
       visits,
     });
@@ -226,5 +230,6 @@ Then(
     const record = await recordFor(emailFor(who));
     expect(record.publicBookingCount).toBe(booked);
     expect(record.visits).toBe(visits);
+    expect(record.adminBookingCount).toBe(HAND_BOOKINGS);
   },
 );

--- a/test/specs/steps/contact-records.ts
+++ b/test/specs/steps/contact-records.ts
@@ -1,0 +1,222 @@
+// jscpd:ignore-start
+
+import { Given, Then, When } from "@cucumber/cucumber";
+import { expect } from "@std/expect";
+import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
+import {
+  boxShows,
+  contactWithHistory,
+  openRecord,
+  recordFor,
+  saveRecord,
+  unreadableRecord,
+} from "#test/specs/support/contact-records.ts";
+import {
+  requiredWorldValue,
+  type TicketsWorld,
+} from "#test/specs/support/world.ts";
+import type { TestBrowser } from "#test-utils/test-browser.ts";
+
+// jscpd:ignore-end
+
+/** Everyone a story talks about has an email the site files them under. */
+const emailFor = (who: string): string => `${who.toLowerCase()}@example.com`;
+
+/** The record page the organiser is looking at. */
+const recordPage = (world: TicketsWorld): TestBrowser =>
+  requiredWorldValue(world.customerBrowser, "the record page");
+
+Given(
+  "the site has seen {word} book {int} times and get in touch {int} times",
+  function (
+    this: TicketsWorld,
+    who: string,
+    booked: number,
+    messages: number,
+  ): Promise<void> {
+    return contactWithHistory(emailFor(who), {
+      bookedByHand: 2,
+      bookedThroughTheSite: booked,
+      lastContacted: "2026-06-01T10:00:00.000Z",
+      messages,
+      note: `**VIP** ${who}`,
+      visits: 9,
+    });
+  },
+);
+
+Given(
+  "the site has a note about {word} saying {string}",
+  function (this: TicketsWorld, who: string, note: string): Promise<void> {
+    return contactWithHistory(emailFor(who), {
+      bookedByHand: 0,
+      bookedThroughTheSite: 0,
+      lastContacted: "",
+      messages: 0,
+      note,
+      visits: 0,
+    });
+  },
+);
+
+Given(
+  "{word}'s record cannot be read, but says {int} site bookings and {int} visits",
+  function (
+    this: TicketsWorld,
+    who: string,
+    booked: number,
+    visits: number,
+  ): Promise<void> {
+    return unreadableRecord(emailFor(who), {
+      bookedByHand: 2,
+      bookedThroughTheSite: booked,
+      visits,
+    });
+  },
+);
+
+When(
+  "the organiser opens {word}'s record",
+  async function (this: TicketsWorld, who: string): Promise<void> {
+    this.customerBrowser = await openRecord(this, emailFor(who));
+  },
+);
+
+When(
+  "the organiser sets {word}'s bookings to {int} and note to {string}",
+  async function (
+    this: TicketsWorld,
+    who: string,
+    booked: number,
+    note: string,
+  ): Promise<void> {
+    this.customerBrowser = await saveRecord(this, emailFor(who), {
+      bookedThroughTheSite: String(booked),
+      note,
+    });
+  },
+);
+
+When(
+  "the organiser leaves {word}'s site bookings blank and types {int} by hand",
+  async function (
+    this: TicketsWorld,
+    who: string,
+    byHand: number,
+  ): Promise<void> {
+    this.customerBrowser = await saveRecord(this, emailFor(who), {
+      bookedByHand: String(byHand),
+      bookedThroughTheSite: "",
+    });
+  },
+);
+
+When(
+  "the organiser tries to save {word} a note longer than the box allows",
+  async function (this: TicketsWorld, who: string): Promise<void> {
+    this.customerBrowser = await saveRecord(this, emailFor(who), {
+      bookedThroughTheSite: "4",
+      note: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
+    });
+  },
+);
+
+When(
+  "the organiser saves {word}'s record again with the note {string}",
+  async function (
+    this: TicketsWorld,
+    who: string,
+    note: string,
+  ): Promise<void> {
+    // Resubmitting what the page already showed, which is what an organiser
+    // pressing Save on the repaired form actually sends.
+    const page = recordPage(this);
+    expect(page.currentHtml).toContain('name="admin_notes"');
+    this.customerBrowser = await saveRecord(this, emailFor(who), { note });
+  },
+);
+
+Then(
+  "the record shows {word} booked {int} times through the site",
+  function (this: TicketsWorld, _who: string, booked: number): void {
+    boxShows(recordPage(this), "bookedThroughTheSite", String(booked));
+  },
+);
+
+Then(
+  "the record shows {word} has visited {int} times",
+  function (this: TicketsWorld, _who: string, visits: number): void {
+    boxShows(recordPage(this), "visits", String(visits));
+  },
+);
+
+Then(
+  "the record shows the note about {word} written out",
+  function (this: TicketsWorld, who: string): void {
+    // The note is kept as the organiser typed it and shown made-up, so bold
+    // stays bold rather than arriving as raw markup.
+    expect(recordPage(this).currentHtml).toContain(
+      `<strong>VIP</strong> ${who}`,
+    );
+  },
+);
+
+Then(
+  "the record shows nothing was ever counted",
+  function (this: TicketsWorld): void {
+    boxShows(recordPage(this), "visits", "0");
+    boxShows(recordPage(this), "bookedThroughTheSite", "0");
+  },
+);
+
+Then(
+  "the record says they have never been in touch",
+  function (this: TicketsWorld): void {
+    expect(recordPage(this).containsText("Never")).toBe(true);
+  },
+);
+
+Then(
+  "the note kept about {word} is {string}",
+  async function (this: TicketsWorld, who: string, note: string) {
+    expect((await recordFor(emailFor(who))).adminNotes).toBe(note);
+  },
+);
+
+Then(
+  "the note kept about {word} is still {string}",
+  async function (this: TicketsWorld, who: string, note: string) {
+    expect((await recordFor(emailFor(who))).adminNotes).toBe(note);
+  },
+);
+
+Then(
+  "{word} is counted as having booked no times at all",
+  async function (this: TicketsWorld, who: string): Promise<void> {
+    const record = await recordFor(emailFor(who));
+    expect(record.publicBookingCount).toBe(0);
+    expect(record.adminBookingCount).toBe(0);
+  },
+);
+
+Then(
+  "the organiser is told the note is too long",
+  function (this: TicketsWorld): void {
+    // Told in place, on the form they were filling in — not sent away.
+    expect(recordPage(this).containsText("characters or fewer")).toBe(true);
+  },
+);
+
+Then(
+  "{word} is still counted as having booked {int} times and visited {int}",
+  async function (
+    this: TicketsWorld,
+    who: string,
+    booked: number,
+    visits: number,
+  ): Promise<void> {
+    const record = await recordFor(emailFor(who));
+    expect(record.publicBookingCount).toBe(booked);
+    expect(record.visits).toBe(visits);
+  },
+);

--- a/test/specs/steps/contact-records.ts
+++ b/test/specs/steps/contact-records.ts
@@ -2,7 +2,6 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
-import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import {
   boxShows,
   contactWithHistory,
@@ -111,25 +110,10 @@ When(
 );
 
 When(
-  "the organiser leaves {word}'s site bookings blank and types {int} by hand",
-  async function (
-    this: TicketsWorld,
-    who: string,
-    byHand: number,
-  ): Promise<void> {
-    this.customerBrowser = await saveRecord(this, emailFor(who), {
-      bookedByHand: String(byHand),
-      bookedThroughTheSite: "",
-    });
-  },
-);
-
-When(
-  "the organiser tries to save {word} a note longer than the box allows",
+  "the organiser leaves {word}'s site bookings blank",
   async function (this: TicketsWorld, who: string): Promise<void> {
     this.customerBrowser = await saveRecord(this, emailFor(who), {
-      bookedThroughTheSite: "4",
-      note: "x".repeat(MAX_TEXTAREA_LENGTH + 1),
+      bookedThroughTheSite: "",
     });
   },
 );
@@ -177,8 +161,11 @@ Then(
 Then(
   "the record shows nothing was ever counted",
   function (this: TicketsWorld): void {
+    // Every count, not just the two the page happens to show first.
     boxShows(recordPage(this), "visits", "0");
     boxShows(recordPage(this), "bookedThroughTheSite", "0");
+    boxShows(recordPage(this), "bookedByHand", "0");
+    boxShows(recordPage(this), "messages", "0");
   },
 );
 
@@ -220,27 +207,11 @@ Then(
 );
 
 Then(
-  "no note is kept about {word} at all",
-  async function (this: TicketsWorld, who: string): Promise<void> {
-    // The refused save must not have written the over-long note either.
-    expect((await recordFor(emailFor(who))).adminNotes).toBe("");
-  },
-);
-
-Then(
   "{word} is counted as having booked no times at all",
   async function (this: TicketsWorld, who: string): Promise<void> {
     const record = await recordFor(emailFor(who));
     expect(record.publicBookingCount).toBe(0);
     expect(record.adminBookingCount).toBe(0);
-  },
-);
-
-Then(
-  "the organiser is told the note is too long",
-  function (this: TicketsWorld): void {
-    // Told in place, on the form they were filling in — not sent away.
-    expect(recordPage(this).containsText("characters or fewer")).toBe(true);
   },
 );
 

--- a/test/specs/steps/contact-records.ts
+++ b/test/specs/steps/contact-records.ts
@@ -83,6 +83,19 @@ When(
 );
 
 When(
+  "the organiser sets {word}'s messages to {int}",
+  async function (
+    this: TicketsWorld,
+    who: string,
+    messages: number,
+  ): Promise<void> {
+    this.customerBrowser = await saveRecord(this, emailFor(who), {
+      messages: String(messages),
+    });
+  },
+);
+
+When(
   "the organiser sets {word}'s bookings to {int} and note to {string}",
   async function (
     this: TicketsWorld,
@@ -176,17 +189,41 @@ Then(
   },
 );
 
+/** The note the site has kept about them, however the story words the check. */
+const expectNoteKept = async function (
+  this: TicketsWorld,
+  who: string,
+  note: string,
+): Promise<void> {
+  expect((await recordFor(emailFor(who))).adminNotes).toBe(note);
+};
+
+Then("the note kept about {word} is {string}", expectNoteKept);
+Then("the note kept about {word} is still {string}", expectNoteKept);
+
 Then(
-  "the note kept about {word} is {string}",
-  async function (this: TicketsWorld, who: string, note: string) {
-    expect((await recordFor(emailFor(who))).adminNotes).toBe(note);
+  "the record shows {word} has been in touch {int} times",
+  function (this: TicketsWorld, _who: string, messages: number): void {
+    boxShows(recordPage(this), "messages", String(messages));
   },
 );
 
 Then(
-  "the note kept about {word} is still {string}",
-  async function (this: TicketsWorld, who: string, note: string) {
-    expect((await recordFor(emailFor(who))).adminNotes).toBe(note);
+  "{word} is counted as having been in touch {int} times",
+  async function (
+    this: TicketsWorld,
+    who: string,
+    messages: number,
+  ): Promise<void> {
+    expect((await recordFor(emailFor(who))).contactCount).toBe(messages);
+  },
+);
+
+Then(
+  "no note is kept about {word} at all",
+  async function (this: TicketsWorld, who: string): Promise<void> {
+    // The refused save must not have written the over-long note either.
+    expect((await recordFor(emailFor(who))).adminNotes).toBe("");
   },
 );
 

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -108,17 +108,15 @@ const BOXES = {
 /** The organiser fills the record's own form in and saves it. Every box has to
  * be on the page — including the ones this edit does not touch, because those
  * are carried forward from what the page showed, so a box that quietly vanished
- * would be saved as nothing without anyone noticing. */
+ * would be saved as nothing without anyone noticing. What the organiser types
+ * must also be something the box itself would accept, so a story can never send
+ * what a real form would block. */
 export const saveRecord = async (
   world: TicketsWorld,
   email: string,
   edit: RecordEdit,
 ): Promise<TestBrowser> => {
   const browser = await openRecord(world, email);
-  // Every box has to be there, including the ones this edit leaves alone: those
-  // are carried forward from the page, so one that quietly vanished would be
-  // saved as nothing. And what the organiser types has to be something the box
-  // itself would accept — a story must never send what a real form would block.
   for (const box of Object.values(BOXES)) {
     expect(browser.currentHtml).toContain(`name="${box}"`);
   }

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -6,6 +6,7 @@
  */
 
 import { expect } from "@std/expect";
+import { mapNotNullish } from "#fp";
 import { execute } from "#shared/db/client.ts";
 import {
   type ContactRecord,
@@ -15,6 +16,7 @@ import {
   toContactHashParam,
 } from "#shared/db/contact-preferences.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
+import { whyValueCannotBeSent } from "#test/specs/support/form-controls.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { getTestPrivateKey } from "#test-utils/crypto.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
@@ -22,7 +24,7 @@ import type { TestBrowser } from "#test-utils/test-browser.ts";
 /** What the organiser types into the record's form. A box left out here keeps
  * whatever the page already had in it, the way it would for a person who edits
  * one field and presses save. */
-export interface RecordEdit {
+interface RecordEdit {
   bookedByHand?: string;
   bookedThroughTheSite?: string;
   messages?: string;
@@ -113,12 +115,21 @@ export const saveRecord = async (
   edit: RecordEdit,
 ): Promise<TestBrowser> => {
   const browser = await openRecord(world, email);
-  const values: Record<string, string> = {};
-  for (const [word, box] of Object.entries(BOXES)) {
+  // Every box has to be there, including the ones this edit leaves alone: those
+  // are carried forward from the page, so one that quietly vanished would be
+  // saved as nothing. And what the organiser types has to be something the box
+  // itself would accept — a story must never send what a real form would block.
+  for (const box of Object.values(BOXES)) {
     expect(browser.currentHtml).toContain(`name="${box}"`);
-    const typed = edit[word as keyof RecordEdit];
-    if (typed !== undefined) values[box] = typed;
   }
+  const values = Object.fromEntries(
+    mapNotNullish(([word, box]: [string, string]) => {
+      const typed = edit[word as keyof RecordEdit];
+      if (typed === undefined) return;
+      expect(whyValueCannotBeSent(browser.currentHtml, box, typed)).toBeNull();
+      return [box, typed] as const;
+    })(Object.entries(BOXES)),
+  );
   await browser.submitForm(values, "Save record");
   return browser;
 };

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -1,0 +1,133 @@
+/**
+ * The record the site keeps about one person, and the organiser's page for
+ * putting it right. A contact is found by a one-way code made from their email,
+ * so the real address is never stored — every helper here starts from the email
+ * the story names and lets the site work that code out.
+ */
+
+import { expect } from "@std/expect";
+import { execute } from "#shared/db/client.ts";
+import {
+  type ContactRecord,
+  getContactRecord,
+  hashEmail,
+  saveContactRecord,
+  toContactHashParam,
+} from "#shared/db/contact-preferences.ts";
+import { adminBrowser } from "#test/specs/support/browser.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
+import { getTestPrivateKey } from "#test-utils/crypto.ts";
+import type { TestBrowser } from "#test-utils/test-browser.ts";
+
+/** What the organiser types into the record's form. Anything left out is sent
+ * as the form's own empty value, the way a blank box would be. */
+export interface RecordEdit {
+  bookedByHand?: string;
+  bookedThroughTheSite?: string;
+  messages?: string;
+  note?: string;
+  visits?: string;
+}
+
+/** The page for one person's record, found the way the site finds it. */
+const pagePath = async (email: string): Promise<string> =>
+  `/admin/history/${toContactHashParam(await hashEmail(email))}`;
+
+/** Everything the site has stored about them right now. */
+export const recordFor = async (email: string): Promise<ContactRecord> =>
+  getContactRecord(await hashEmail(email), await getTestPrivateKey());
+
+/** Someone the site has already seen, with a history behind them. */
+export const contactWithHistory = async (
+  email: string,
+  history: {
+    bookedByHand: number;
+    bookedThroughTheSite: number;
+    lastContacted: string;
+    messages: number;
+    note: string;
+    visits: number;
+  },
+): Promise<void> => {
+  await saveContactRecord(await hashEmail(email), {
+    adminBookingCount: history.bookedByHand,
+    adminNotes: history.note,
+    contactCount: history.messages,
+    lastContact: history.lastContacted,
+    lastSubject: "Hello",
+    publicBookingCount: history.bookedThroughTheSite,
+    visits: history.visits,
+  });
+};
+
+/** A stored record whose note the site can no longer read, with its plain
+ * counts intact — the state a half-finished write can leave behind. */
+export const unreadableRecord = async (
+  email: string,
+  counts: {
+    bookedByHand: number;
+    bookedThroughTheSite: number;
+    visits: number;
+  },
+): Promise<void> => {
+  await execute(
+    "INSERT INTO contact_preferences (contact_hash, visits, public_booking_count, admin_booking_count, stats_blob, last_activity) VALUES (?, ?, ?, ?, ?, ?)",
+    [
+      await hashEmail(email),
+      counts.visits,
+      counts.bookedThroughTheSite,
+      counts.bookedByHand,
+      "not-valid-ciphertext",
+      Date.now(),
+    ],
+  );
+};
+
+/** The organiser opens someone's record. */
+export const openRecord = async (
+  world: TicketsWorld,
+  email: string,
+): Promise<TestBrowser> => {
+  const browser = await adminBrowser(world);
+  await browser.visit(await pagePath(email));
+  return browser;
+};
+
+/** The boxes on the page, by the words this file uses for them. */
+const BOXES = {
+  bookedByHand: "admin_booking_count",
+  bookedThroughTheSite: "public_booking_count",
+  messages: "messages",
+  note: "admin_notes",
+  visits: "visits",
+} as const;
+
+/** The organiser fills the record's own form in and saves it. Every box has to
+ * be on the page, so a form that stops offering one fails the story. */
+export const saveRecord = async (
+  world: TicketsWorld,
+  email: string,
+  edit: RecordEdit,
+): Promise<TestBrowser> => {
+  const browser = await openRecord(world, email);
+  const values: Record<string, string> = {};
+  for (const [word, box] of Object.entries(BOXES)) {
+    const typed = edit[word as keyof RecordEdit];
+    if (typed === undefined) continue;
+    expect(browser.currentHtml).toContain(`name="${box}"`);
+    values[box] = typed;
+  }
+  await browser.submitForm(values, "Save record");
+  return browser;
+};
+
+/** What one of the record's boxes is filled in with when the page is opened. */
+export const boxShows = (
+  browser: TestBrowser,
+  word: keyof typeof BOXES,
+  value: string,
+): void => {
+  expect(browser.currentHtml).toMatch(
+    new RegExp(`name="${BOXES[word]}"[^>]*value="${value}"`),
+  );
+};

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -19,8 +19,9 @@ import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { getTestPrivateKey } from "#test-utils/crypto.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
-/** What the organiser types into the record's form. Anything left out is sent
- * as the form's own empty value, the way a blank box would be. */
+/** What the organiser types into the record's form. A box left out here keeps
+ * whatever the page already had in it, the way it would for a person who edits
+ * one field and presses save. */
 export interface RecordEdit {
   bookedByHand?: string;
   bookedThroughTheSite?: string;
@@ -103,7 +104,9 @@ const BOXES = {
 } as const;
 
 /** The organiser fills the record's own form in and saves it. Every box has to
- * be on the page, so a form that stops offering one fails the story. */
+ * be on the page — including the ones this edit does not touch, because those
+ * are carried forward from what the page showed, so a box that quietly vanished
+ * would be saved as nothing without anyone noticing. */
 export const saveRecord = async (
   world: TicketsWorld,
   email: string,
@@ -112,10 +115,9 @@ export const saveRecord = async (
   const browser = await openRecord(world, email);
   const values: Record<string, string> = {};
   for (const [word, box] of Object.entries(BOXES)) {
-    const typed = edit[word as keyof RecordEdit];
-    if (typed === undefined) continue;
     expect(browser.currentHtml).toContain(`name="${box}"`);
-    values[box] = typed;
+    const typed = edit[word as keyof RecordEdit];
+    if (typed !== undefined) values[box] = typed;
   }
   await browser.submitForm(values, "Save record");
   return browser;


### PR DESCRIPTION
## What changed

The site keeps a small history for each person who deals with it: how many times they booked, how often they have been in touch, and a private note only the organiser sees. It is filed under a one-way code made from their email, so the address itself is never stored. The organiser can read that record and correct it.

That page had no story. It has one now, in five rules:

- **The organiser can read what is kept** — the counts come up as numbers they can edit, and the private note is shown written out. Someone the site has never seen has a record of nothing, and is shown as never having been in touch.
- **The organiser can put the record right** — whatever they type is what the site keeps from then on, both on the page they come back to and in what the site stores.
- **A blank count means none** — clearing a box counts as zero rather than being stored as an empty value.
- **Correcting one person's record leaves everyone else's alone.**
- **A record the site cannot read can still be opened and repaired.** If the private note becomes unreadable, the page still opens and still shows the counts, which are kept in plain sight — so the organiser can save over it and get a working record back without losing what was counted. That one is worth knowing about: a page that blanked the counts instead would let a blind save wipe someone's real booking history.

## Two things the review changed

**Some of what I first wrote could not actually happen.** The counts render `min="0"` and the note a maximum length, so an organiser cannot type a negative count or an over-long note — the form stops them. Two scenarios were describing journeys nobody can make, and only repeated what the direct tests already prove by posting straight to the route. Those went back to the direct tests, and the story's form helper now refuses to send any value the rendered box would block, so the same mistake cannot be made again here.

**A count was seeded and never looked at.** The story set up "in touch 4 times" and then checked only the bookings and the note. It now reads that count *and* edits it, checking both what the page shows afterwards and what the site kept.

## Honest note on what this replaced

Most of the direct tests stayed. The route and template branches — the empty record, the note preview, the counter coercion, the over-long note — need deterministic coverage a Cucumber run cannot provide, so they keep their tests, with a short comment naming the story they sit beside so nobody deletes them later as duplicates. Only one claim was handed over outright: that editing one contact's record leaves another's untouched.

So this batch adds a readable account of a page that had none, rather than moving a pile of tests across. Coverage decided that: the first attempt deleted more, and the gate caught it.

## Checks

`deno task precommit` passes in full — typecheck, lint, duplication at 0%, the whole test suite, and 100% line and branch coverage. All 84 Cucumber scenarios (550 steps) pass. No production code changed.