### PR TITLE
Write checking people in at the door as a story

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1697,3 +1697,28 @@ Starting point: `strippedPageOrphanedAddOn` and
 `firstChildUnreachableAddOnForListings` in `src/shared/db/modifier-resolve.ts`,
 plus whichever direct test already covers the guard, for the shape of the
 fixture.
+
+---
+
+## Test the door's confirmation steps in the browser script
+
+*Origin: reviewer suggestion (Codex) on PR #1959.*
+
+`src/ui/client/scanner.js` is the only part of checking people in that nothing
+tests. It is the script that shows the organiser the question the door asked —
+"this ticket is for another listing, let them in anyway?" and "check this
+person's ID first" — and sends the second request carrying their answer.
+
+The story `attendees.checking-people-in-at-the-door` reads a ticket, gets the
+query back, and then sends the answer, which is the same pair of requests the
+script makes. What it cannot do is press the button: `TestBrowser` runs no
+JavaScript, so a broken confirmation prompt would leave the story green.
+
+That is a pre-existing gap — `scanner.js` had no test before this story either,
+and it is the only client script in `src/ui/client/` with none. Closing it needs
+a DOM test in the shape of `test/ui/client/order.test.ts`, which was too much
+scaffolding to add inside a test migration.
+
+Starting point: `src/ui/client/scanner.js`, the confirmation branches around its
+handling of `wrong_listing` and `verify_id`, and `test/ui/client/order.test.ts`
+for how a client script is driven without a real browser.

--- a/specs/attendees/checking-people-in-at-the-door.feature
+++ b/specs/attendees/checking-people-in-at-the-door.feature
@@ -77,7 +77,8 @@ Feature: An organiser checks people in at the door
     Scenario: The organiser lets in someone from another listing
       Given Alice has a ticket for the Ceilidh
       And the Quiz is running its own door
-      When the organiser reads Alice's ticket at the Quiz door and lets her in anyway
+      And the organiser reads Alice's ticket at the Quiz door
+      When the organiser lets Alice in at the Quiz door anyway
       Then the door lets Alice in
 
   @rule:attendees.a-listing-that-needs-id-holds-the-ticket-first
@@ -95,7 +96,8 @@ Feature: An organiser checks people in at the door
     @case:door.the-id-is-checked
     Scenario: The organiser checks the ID and lets them in
       Given Alice has a ticket for the Ceilidh, which needs ID checked
-      When the organiser reads Alice's ticket at the Ceilidh door having checked her ID
+      And the organiser reads Alice's ticket at the Ceilidh door
+      When the organiser confirms Alice's ID at the Ceilidh door
       Then the door lets Alice in
 
   @rule:attendees.the-door-only-offers-people-who-are-not-in-yet

--- a/specs/attendees/checking-people-in-at-the-door.feature
+++ b/specs/attendees/checking-people-in-at-the-door.feature
@@ -1,0 +1,123 @@
+@story:attendees.checking-people-in-at-the-door
+@owner:attendees @risk:high
+@actor:organiser
+@edition:managed @edition:self-hosted
+Feature: An organiser checks people in at the door
+  On the day, the organiser stands at the door with the listing's scanner open
+  and reads each person's ticket. The site tells them who is in front of them,
+  how many places that ticket covers, and whether to let them through. It also
+  keeps the people already inside off the list, so nobody is counted twice.
+
+  @rule:attendees.a-ticket-for-this-listing-lets-them-in
+  @surface:admin
+  Rule: A ticket for this listing lets the person in
+    The organiser is told the name on the ticket and how many places it covers,
+    so they know how many people to wave through.
+
+    @case:door.the-first-look-at-a-ticket
+    Scenario: The organiser reads a ticket for the listing they are running
+      Given Alice has a ticket for the Ceilidh
+      When the organiser reads Alice's ticket at the Ceilidh door
+      Then the door lets Alice in
+      And the door says the ticket covers 1 place
+
+    @case:door.a-ticket-for-a-group
+    Scenario: The organiser reads a ticket that covers several people
+      Given Bruno has a ticket for 4 places at the Ceilidh
+      When the organiser reads Bruno's ticket at the Ceilidh door
+      Then the door lets Bruno in
+      And the door says the ticket covers 4 places
+
+    @case:door.the-day-is-written-down
+    Scenario: The listing's own record of the day shows the check-in
+      Given Alice has a ticket for the Ceilidh
+      When the organiser reads Alice's ticket at the Ceilidh door
+      Then the Ceilidh's record of the day says Alice was checked in
+
+  @rule:attendees.a-ticket-already-used-says-so
+  @surface:admin
+  Rule: A ticket already used says so
+    Reading the same ticket twice does not quietly let someone in again. The
+    organiser is told it has been used, and still sees whose it is.
+
+    @case:door.reading-the-same-ticket-twice
+    Scenario: The organiser reads a ticket that has already been used
+      Given Alice has a ticket for the Ceilidh
+      And the organiser reads Alice's ticket at the Ceilidh door
+      When the organiser reads Alice's ticket at the Ceilidh door
+      Then the door says Alice is already in
+
+  @rule:attendees.a-refunded-ticket-does-not-let-them-in
+  @surface:admin
+  Rule: A ticket that has been refunded does not let them in
+    Once the money is back with the customer, the ticket stops working — but
+    the organiser is told whose it is, so they can talk to the right person.
+
+    @case:door.a-refunded-ticket-is-turned-away
+    Scenario: The organiser reads a ticket that was refunded
+      Given Alice has a ticket for the Ceilidh
+      And Alice's Ceilidh ticket has been refunded
+      When the organiser reads Alice's ticket at the Ceilidh door
+      Then the door says Alice was refunded
+
+  @rule:attendees.a-ticket-for-another-listing-is-queried-not-refused
+  @surface:admin
+  Rule: A ticket for another listing is queried, not simply refused
+    The door names the listing the ticket is really for, so the organiser can
+    see what has happened. It is their call: they can still let the person in.
+
+    @case:door.the-wrong-door
+    Scenario: The organiser reads a ticket belonging to another listing
+      Given Alice has a ticket for the Ceilidh
+      And the Quiz is running its own door
+      When the organiser reads Alice's ticket at the Quiz door
+      Then the door says Alice belongs to the Ceilidh
+
+    @case:door.letting-them-in-anyway
+    Scenario: The organiser lets in someone from another listing
+      Given Alice has a ticket for the Ceilidh
+      And the Quiz is running its own door
+      When the organiser reads Alice's ticket at the Quiz door and lets her in anyway
+      Then the door lets Alice in
+
+  @rule:attendees.a-listing-that-needs-id-holds-the-ticket-first
+  @surface:admin
+  Rule: A listing whose tickets cannot be passed on asks for ID first
+    Where a ticket cannot be given to someone else, the door holds it until the
+    organiser says they have seen the person's ID.
+
+    @case:door.the-door-asks-for-id
+    Scenario: The organiser reads a ticket that cannot be passed on
+      Given Alice has a ticket for the Ceilidh, which needs ID checked
+      When the organiser reads Alice's ticket at the Ceilidh door
+      Then the door asks the organiser to check Alice's ID
+
+    @case:door.the-id-is-checked
+    Scenario: The organiser checks the ID and lets them in
+      Given Alice has a ticket for the Ceilidh, which needs ID checked
+      When the organiser reads Alice's ticket at the Ceilidh door having checked her ID
+      Then the door lets Alice in
+
+  @rule:attendees.the-door-only-offers-people-who-are-not-in-yet
+  @surface:admin
+  Rule: Looking someone up by hand only offers people who are not in yet
+    When a ticket cannot be read, the organiser can pick the person from a list.
+    That list holds only the people still to arrive, so nobody is let in twice
+    and a refunded ticket cannot be waved through by hand.
+
+    @case:door.someone-still-to-arrive-can-be-picked
+    Scenario: The organiser looks for someone who has not arrived
+      Given Alice has a ticket for the Ceilidh
+      Then the Ceilidh door offers Alice by name
+
+    @case:door.someone-already-in-is-not-offered
+    Scenario: The organiser looks for someone already inside
+      Given Alice has a ticket for the Ceilidh
+      And the organiser reads Alice's ticket at the Ceilidh door
+      Then the Ceilidh door does not offer Alice
+
+    @case:door.a-refunded-person-is-not-offered
+    Scenario: The organiser looks for someone whose money was given back
+      Given Alice has a ticket for the Ceilidh
+      And Alice's Ceilidh ticket has been refunded
+      Then the Ceilidh door does not offer Alice

--- a/test/integration/server/scanner.test.ts
+++ b/test/integration/server/scanner.test.ts
@@ -2,6 +2,9 @@
  * Tests for the QR scanner admin feature
  * GET /admin/listing/:id/scanner - Scanner page
  * POST /admin/listing/:id/scan - JSON check-in API
+ *
+ * Sits beside the story `@story:attendees.checking-people-in-at-the-door`:
+ * these own the branch cover, and the requests only a crafted POST can make.
  */
 
 import { expect } from "@std/expect";
@@ -297,52 +300,6 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       expect(body).toContain('role="combobox"');
     });
 
-    test("datalist includes unchecked-in attendees", async () => {
-      const { listing, token } = await createTestAttendeeWithToken(
-        "Alice Unchecked",
-        "alice-uc@test.com",
-      );
-      const body = await getScannerBody(listing.id);
-      expect(body).toContain(token);
-      expect(body).toContain("Alice Unchecked");
-    });
-
-    test("datalist excludes checked-in attendees", async () => {
-      const { listing, token, session } = await setupScanTest(
-        "Bob Checked",
-        "bob-checked@test.com",
-      );
-      // Check in the attendee
-      await handleRequest(
-        mockScanRequest(
-          listing.id,
-          { token },
-          session.cookie,
-          session.csrfToken,
-        ),
-      );
-      const body = await getScannerBody(listing.id);
-      expect(body).not.toContain(token);
-    });
-
-    test("datalist excludes refunded attendees", async () => {
-      const { getAttendeesByTokens } = await import(
-        "#shared/db/attendees/tokens.ts"
-      );
-      const { postAttendeeRefund } = await import("#test-utils/ledger.ts");
-      const { listing, token } = await createTestAttendeeWithToken(
-        "Carol Refunded",
-        "carol-ref@test.com",
-      );
-      const attendees = await getAttendeesByTokens([token]);
-      await postAttendeeRefund({
-        attendeeId: attendees[0]!.id,
-        listingId: listing.id,
-      });
-      const body = await getScannerBody(listing.id);
-      expect(body).not.toContain(token);
-    });
-
     test("datalist shows attendee quantity", async () => {
       const { listing } = await createTestAttendeeWithToken(
         "Dave Multi",
@@ -365,31 +322,35 @@ describeWithEnv("QR Scanner", { db: true }, () => {
   });
 
   describe("POST /admin/listing/:id/scan", () => {
-    test("checks in attendee from same listing", async () => {
-      const { response } = await setupAndScan("Alice", "alice@test.com");
-      await assertJson(Promise.resolve(response), 200, (result) => {
-        expect(result.status).toBe("checked_in");
-        expect(result.name).toBe("Alice");
-        expect(result.quantity).toBe(1);
-      });
+    test("returns Unknown listing when attendee's listing is deleted", async () => {
+      const { token } = await createTestAttendeeWithToken(
+        "Frank",
+        "frank@test.com",
+      );
+      const listingB = await createTestListing({ maxAttendees: 10 });
+
+      // Point attendee at a non-existent listing to simulate orphan
+      const { getDb } = await orphanAttendee(token);
+      await getDb().execute({ args: [], sql: "PRAGMA foreign_keys = ON" });
+
+      // Scan from listing B - attendee's listing_id still points to deleted listing A
+      const result = await crossListingScanAndGetJson(listingB.id, { token });
+      expect(result.status).toBe("wrong_listing");
+      expect(result.listingName).toBe("Unknown listing");
     });
 
-    test("returns already_checked_in for checked-in attendee", async () => {
-      const { listing, token, session } = await setupAndScan(
-        "Bob",
-        "bob@test.com",
+    test("returns wrong_listing for attendee from different listing", async () => {
+      const { listing: listingA, token } = await createTestAttendeeWithToken(
+        "Carol",
+        "carol@test.com",
       );
+      const listingB = await createTestListing({ maxAttendees: 10 });
 
-      // Second scan - already checked in
-      const result = await scanAndGetJson(
-        listing.id,
-        { token },
-        session.cookie,
-        session.csrfToken,
-      );
-      expect(result.status).toBe("already_checked_in");
-      expect(result.name).toBe("Bob");
-      expect(result.quantity).toBe(1);
+      // Scan token from listing A while on listing B's scanner
+      const result = await crossListingScanAndGetJson(listingB.id, { token });
+      expect(result.status).toBe("wrong_listing");
+      expect(result.name).toBe("Carol");
+      expect(result.listingName).toBe(listingA.name);
     });
 
     test("returns refunded status for refunded attendee", async () => {
@@ -418,51 +379,36 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       expect(result.name).toBe("Refund");
     });
 
-    test("returns wrong_listing for attendee from different listing", async () => {
-      const { listing: listingA, token } = await createTestAttendeeWithToken(
-        "Carol",
-        "carol@test.com",
+    test("returns already_checked_in for checked-in attendee", async () => {
+      const { listing, token, session } = await setupAndScan(
+        "Bob",
+        "bob@test.com",
       );
-      const listingB = await createTestListing({ maxAttendees: 10 });
 
-      // Scan token from listing A while on listing B's scanner
-      const result = await crossListingScanAndGetJson(listingB.id, { token });
-      expect(result.status).toBe("wrong_listing");
-      expect(result.name).toBe("Carol");
-      expect(result.listingName).toBe(listingA.name);
+      // Second scan - already checked in
+      const result = await scanAndGetJson(
+        listing.id,
+        { token },
+        session.cookie,
+        session.csrfToken,
+      );
+      expect(result.status).toBe("already_checked_in");
+      expect(result.name).toBe("Bob");
+      expect(result.quantity).toBe(1);
     });
 
-    test("checks in cross-listing attendee with force flag", async () => {
-      const { token } = await createTestAttendeeWithToken(
-        "Dave",
-        "dave@test.com",
+    test("returns verify_id for non-transferable listing without id_verified", async () => {
+      const { response } = await setupAndScan(
+        "Alice",
+        "alice@test.com",
+        {},
+        { nonTransferable: true },
       );
-      const listingB = await createTestListing({ maxAttendees: 10 });
-
-      // Force check-in from listing B's scanner
-      const result = await crossListingScanAndGetJson(listingB.id, {
-        force: true,
-        token,
+      await assertJson(Promise.resolve(response), 200, (result) => {
+        expect(result.status).toBe("verify_id");
+        expect(result.name).toBe("Alice");
+        expect(result.quantity).toBe(1);
       });
-      expect(result.status).toBe("checked_in");
-      expect(result.name).toBe("Dave");
-    });
-
-    test("returns Unknown listing when attendee's listing is deleted", async () => {
-      const { token } = await createTestAttendeeWithToken(
-        "Frank",
-        "frank@test.com",
-      );
-      const listingB = await createTestListing({ maxAttendees: 10 });
-
-      // Point attendee at a non-existent listing to simulate orphan
-      const { getDb } = await orphanAttendee(token);
-      await getDb().execute({ args: [], sql: "PRAGMA foreign_keys = ON" });
-
-      // Scan from listing B - attendee's listing_id still points to deleted listing A
-      const result = await crossListingScanAndGetJson(listingB.id, { token });
-      expect(result.status).toBe("wrong_listing");
-      expect(result.listingName).toBe("Unknown listing");
     });
 
     test("returns not_found for invalid token", async () => {
@@ -567,41 +513,6 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       });
     });
 
-    test("returns verify_id for non-transferable listing without id_verified", async () => {
-      const { response } = await setupAndScan(
-        "Alice",
-        "alice@test.com",
-        {},
-        { nonTransferable: true },
-      );
-      await assertJson(Promise.resolve(response), 200, (result) => {
-        expect(result.status).toBe("verify_id");
-        expect(result.name).toBe("Alice");
-        expect(result.quantity).toBe(1);
-      });
-    });
-
-    test("checks in non-transferable attendee with id_verified flag", async () => {
-      const { response } = await setupAndScan(
-        "Bob",
-        "bob@test.com",
-        { id_verified: true },
-        { nonTransferable: true },
-      );
-      await assertJson(Promise.resolve(response), 200, (result) => {
-        expect(result.status).toBe("checked_in");
-        expect(result.name).toBe("Bob");
-      });
-    });
-
-    test("checks in transferable listing without id_verified", async () => {
-      const { response } = await setupAndScan("Carol", "carol@test.com");
-      await assertJson(Promise.resolve(response), 200, (result) => {
-        expect(result.status).toBe("checked_in");
-        expect(result.name).toBe("Carol");
-      });
-    });
-
     test("force check-in with deleted listing returns not_found", async () => {
       const { token } = await createTestAttendeeWithToken(
         "Eve",
@@ -624,18 +535,6 @@ describeWithEnv("QR Scanner", { db: true }, () => {
       });
 
       await getDb().execute({ args: [], sql: "PRAGMA foreign_keys = ON" });
-    });
-
-    test("logs activity when checking in via scanner", async () => {
-      const { listing, session } = await setupAndScan("Eve", "eve@test.com");
-
-      // Check activity log (now the listing entity page's Activity tab)
-      const logResponse = await awaitTestRequest(
-        `/admin/listing/${listing.id}/activity`,
-        { cookie: session.cookie },
-      );
-      const logBody = await logResponse.text();
-      expect(logBody).toContain("checked in via scanner for 'Test Listing 1'");
     });
   });
 

--- a/test/scripts/specs/catalog.test.ts
+++ b/test/scripts/specs/catalog.test.ts
@@ -11,6 +11,7 @@ const FEATURE_PATH = "specs/payments/capacity-after-payment.feature";
 describe("Cucumber story catalog", () => {
   test("reads every story from the repository catalog", async () => {
     expect((await readSpecCatalog()).stories.map(({ id }) => id)).toEqual([
+      "attendees.checking-people-in-at-the-door",
       "attendees.downloading-the-attendee-list",
       "attendees.editing-and-moving",
       "attendees.merging-duplicate-bookings",

--- a/test/specs/steps/door.ts
+++ b/test/specs/steps/door.ts
@@ -1,0 +1,200 @@
+// jscpd:ignore-start
+
+import { Given, Then, When } from "@cucumber/cucumber";
+import { expect } from "@std/expect";
+import {
+  dayLog,
+  doorPageHtml,
+  otherListing,
+  peopleOfferedAtDoor,
+  personWithTicket,
+  refundTicket,
+  showTicketAtDoor,
+  ticketOf,
+} from "#test/specs/support/door.ts";
+import {
+  requiredWorldValue,
+  type TicketsWorld,
+} from "#test/specs/support/world.ts";
+
+// jscpd:ignore-end
+
+/** What the door said about the last person the organiser looked at. */
+const lastAnswer = (world: TicketsWorld) =>
+  requiredWorldValue(world.doorAnswer, "the door's answer");
+
+Given(
+  "{word} has a ticket for the {word}",
+  function (this: TicketsWorld, who: string, listing: string): Promise<void> {
+    return personWithTicket(this, who, listing);
+  },
+);
+
+Given(
+  "{word} has a ticket for {int} places at the {word}",
+  function (
+    this: TicketsWorld,
+    who: string,
+    places: number,
+    listing: string,
+  ): Promise<void> {
+    return personWithTicket(this, who, listing, { places });
+  },
+);
+
+Given(
+  "{word} has a ticket for the {word}, which needs ID checked",
+  function (this: TicketsWorld, who: string, listing: string): Promise<void> {
+    return personWithTicket(this, who, listing, { needsIdChecked: true });
+  },
+);
+
+Given(
+  "the {word} is running its own door",
+  function (this: TicketsWorld, listing: string): Promise<void> {
+    return otherListing(this, listing);
+  },
+);
+
+Given(
+  "{word}'s {word} ticket has been refunded",
+  function (this: TicketsWorld, who: string, listing: string): Promise<void> {
+    return refundTicket(this, who, listing);
+  },
+);
+
+/** The organiser reads one person's ticket at one listing's door, with whatever
+ * they decided to do about a ticket the door queried. */
+const readTicket = async function (
+  this: TicketsWorld,
+  who: string,
+  listing: string,
+  choices: { confirmedTheirId?: boolean; letInAnyway?: boolean } = {},
+): Promise<void> {
+  this.doorAnswer = await showTicketAtDoor(
+    this,
+    listing,
+    ticketOf(this, who),
+    choices,
+  );
+};
+
+// Cucumber matches an expression whatever keyword the story used, so the
+// "Given the organiser reads …" set-up lines run this same definition.
+When(
+  "the organiser reads {word}'s ticket at the {word} door",
+  function (this: TicketsWorld, who: string, listing: string): Promise<void> {
+    return readTicket.call(this, who, listing);
+  },
+);
+
+When(
+  "the organiser reads {word}'s ticket at the {word} door and lets her in anyway",
+  function (this: TicketsWorld, who: string, listing: string): Promise<void> {
+    return readTicket.call(this, who, listing, { letInAnyway: true });
+  },
+);
+
+When(
+  "the organiser reads {word}'s ticket at the {word} door having checked her ID",
+  function (this: TicketsWorld, who: string, listing: string): Promise<void> {
+    return readTicket.call(this, who, listing, { confirmedTheirId: true });
+  },
+);
+
+Then(
+  "the door lets {word} in",
+  function (this: TicketsWorld, who: string): void {
+    const answer = lastAnswer(this);
+    expect(answer.status).toBe("checked_in");
+    expect(answer.name).toBe(who);
+  },
+);
+
+Then(
+  "the door says {word} is already in",
+  function (this: TicketsWorld, who: string): void {
+    const answer = lastAnswer(this);
+    expect(answer.status).toBe("already_checked_in");
+    expect(answer.name).toBe(who);
+  },
+);
+
+Then(
+  "the door says {word} was refunded",
+  function (this: TicketsWorld, who: string): void {
+    const answer = lastAnswer(this);
+    expect(answer.status).toBe("refunded");
+    expect(answer.name).toBe(who);
+  },
+);
+
+Then(
+  "the door says {word} belongs to the {word}",
+  function (this: TicketsWorld, who: string, listing: string): void {
+    const answer = lastAnswer(this);
+    expect(answer.status).toBe("wrong_listing");
+    expect(answer.name).toBe(who);
+    expect(answer.listingName).toBe(listing);
+  },
+);
+
+Then(
+  "the door asks the organiser to check {word}'s ID",
+  function (this: TicketsWorld, who: string): void {
+    const answer = lastAnswer(this);
+    expect(answer.status).toBe("verify_id");
+    expect(answer.name).toBe(who);
+  },
+);
+
+Then(
+  "the door says the ticket covers {int} place(s)",
+  function (this: TicketsWorld, places: number): void {
+    expect(lastAnswer(this).quantity).toBe(places);
+  },
+);
+
+Then(
+  "the {word}'s record of the day says {word} was checked in",
+  async function (
+    this: TicketsWorld,
+    listing: string,
+    who: string,
+  ): Promise<void> {
+    const written = await dayLog(this, listing);
+    expect(written).toContain(who);
+    expect(written).toContain(`checked in via scanner for '${listing}'`);
+  },
+);
+
+Then(
+  "the {word} door offers {word} by name",
+  async function (
+    this: TicketsWorld,
+    listing: string,
+    who: string,
+  ): Promise<void> {
+    expect(await peopleOfferedAtDoor(this, listing)).toEqual([
+      { name: who, ticket: ticketOf(this, who) },
+    ]);
+  },
+);
+
+Then(
+  "the {word} door does not offer {word}",
+  async function (
+    this: TicketsWorld,
+    listing: string,
+    who: string,
+  ): Promise<void> {
+    expect(
+      (await peopleOfferedAtDoor(this, listing)).map(({ name }) => name),
+    ).not.toContain(who);
+    // Their ticket code must be off the page altogether, not merely out of the
+    // list — anything left behind is a code the door would still take.
+    expect(await doorPageHtml(this, listing)).not.toContain(
+      ticketOf(this, who),
+    );
+  },
+);

--- a/test/specs/steps/door.ts
+++ b/test/specs/steps/door.ts
@@ -88,17 +88,36 @@ When(
   },
 );
 
+/** The organiser answers the question the door just asked them. The door has to
+ * have asked it: sending an answer to a question that was never put is not
+ * something the organiser could do, and would hide a door that stopped
+ * querying. */
+const answerTheDoor = async function (
+  this: TicketsWorld,
+  who: string,
+  listing: string,
+  asked: string,
+  choices: { confirmedTheirId?: boolean; letInAnyway?: boolean },
+): Promise<void> {
+  expect(lastAnswer(this).status).toBe(asked);
+  await readTicket.call(this, who, listing, choices);
+};
+
 When(
-  "the organiser reads {word}'s ticket at the {word} door and lets her in anyway",
+  "the organiser lets {word} in at the {word} door anyway",
   function (this: TicketsWorld, who: string, listing: string): Promise<void> {
-    return readTicket.call(this, who, listing, { letInAnyway: true });
+    return answerTheDoor.call(this, who, listing, "wrong_listing", {
+      letInAnyway: true,
+    });
   },
 );
 
 When(
-  "the organiser reads {word}'s ticket at the {word} door having checked her ID",
+  "the organiser confirms {word}'s ID at the {word} door",
   function (this: TicketsWorld, who: string, listing: string): Promise<void> {
-    return readTicket.call(this, who, listing, { confirmedTheirId: true });
+    return answerTheDoor.call(this, who, listing, "verify_id", {
+      confirmedTheirId: true,
+    });
   },
 );
 

--- a/test/specs/support/door.ts
+++ b/test/specs/support/door.ts
@@ -1,0 +1,184 @@
+/**
+ * Checking people in at the door. The organiser works from the listing's
+ * scanner page: it reads a ticket code and asks the site whether that person
+ * may come in. Every check here goes through that page — the page is opened
+ * first, and the code it carries for the request is the one the page itself
+ * supplies, so a scanner page that stopped working would fail the story rather
+ * than being stepped around.
+ */
+
+import { expect } from "@std/expect";
+import { getAttendeesByTokens } from "#shared/db/attendees/tokens.ts";
+import { adminBrowser } from "#test/specs/support/browser.ts";
+import { rememberStayListing, stayListing } from "#test/specs/support/stays.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
+import { createTestAttendeeWithToken } from "#test-utils/db-helpers/attendees.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { postAttendeeRefund } from "#test-utils/ledger.ts";
+import type { TestBrowser } from "#test-utils/test-browser.ts";
+
+/** What the site says about one person at the door. */
+export interface DoorAnswer {
+  listingName?: string;
+  name?: string;
+  quantity?: number;
+  status: string;
+}
+
+/** A page belonging to one of the story's listings. */
+const listingPath = (
+  world: TicketsWorld,
+  listing: string,
+  page: string,
+): string => `/admin/listing/${stayListing(world, listing).id}/${page}`;
+
+/** Someone with a ticket for one of the story's listings. Both the listing and
+ * the ticket are kept under the names the story uses for them. */
+export const personWithTicket = async (
+  world: TicketsWorld,
+  who: string,
+  listing: string,
+  options: { needsIdChecked?: boolean; places?: number } = {},
+): Promise<void> => {
+  const { listing: created, token } = await createTestAttendeeWithToken(
+    who,
+    `${who.toLowerCase()}@example.com`,
+    { name: listing, nonTransferable: options.needsIdChecked ?? false },
+    options.places ?? 1,
+  );
+  rememberStayListing(world, listing, created);
+  world.doorTickets ??= new Map();
+  world.doorTickets.set(who, token);
+};
+
+/** Another listing running its own door, with nobody booked on it yet. */
+export const otherListing = async (
+  world: TicketsWorld,
+  listing: string,
+): Promise<void> => {
+  rememberStayListing(
+    world,
+    listing,
+    await createTestListing({ maxAttendees: 10, name: listing }),
+  );
+};
+
+/** The ticket code the story gave this person. */
+export const ticketOf = (world: TicketsWorld, who: string): string => {
+  const token = world.doorTickets?.get(who);
+  if (!token) throw new Error(`${who} was never given a ticket`);
+  return token;
+};
+
+/** Their money is given back, so the ticket should no longer let them in. */
+export const refundTicket = async (
+  world: TicketsWorld,
+  who: string,
+  listing: string,
+): Promise<void> => {
+  const [attendee] = await getAttendeesByTokens([ticketOf(world, who)]);
+  if (!attendee) throw new Error(`${who}'s ticket is not on any booking`);
+  await postAttendeeRefund({
+    attendeeId: attendee.id,
+    listingId: stayListing(world, listing).id,
+  });
+};
+
+/** The one-use code the scanner page carries for its own requests. Reading it
+ * off the page is what the page's own script does, so a page that stopped
+ * supplying it fails the story here rather than the story inventing one. */
+const codeOnPage = (browser: TestBrowser): string => {
+  const found = browser.currentHtml.match(
+    /<meta[^>]*name="csrf-token"[^>]*content="([^"]*)"/,
+  );
+  if (!found?.[1]) throw new Error("The scanner page carries no code to send");
+  return found[1];
+};
+
+/** The organiser opens a listing's door. */
+export const openDoor = async (
+  world: TicketsWorld,
+  listing: string,
+): Promise<TestBrowser> => {
+  const browser = await adminBrowser(world);
+  await browser.visit(listingPath(world, listing, "scanner"));
+  return browser;
+};
+
+/** The organiser holds a ticket up to a listing's door and is told what to do
+ * with the person in front of them. Letting someone in who belongs to another
+ * listing is a deliberate second press, so it is asked for rather than assumed.
+ */
+export const showTicketAtDoor = async (
+  world: TicketsWorld,
+  listing: string,
+  ticket: string,
+  choices: { confirmedTheirId?: boolean; letInAnyway?: boolean } = {},
+): Promise<DoorAnswer> => {
+  const browser = await openDoor(world, listing);
+  const { handleRequest } = await import("#routes");
+  const cookies = [...browser.debugCookies()]
+    .map(([name, value]) => `${name}=${value}`)
+    .join("; ");
+  const response = await handleRequest(
+    new Request(`http://localhost${listingPath(world, listing, "scan")}`, {
+      body: JSON.stringify({
+        token: ticket,
+        ...(choices.letInAnyway === undefined
+          ? {}
+          : { force: choices.letInAnyway }),
+        ...(choices.confirmedTheirId === undefined
+          ? {}
+          : { id_verified: choices.confirmedTheirId }),
+      }),
+      headers: {
+        "content-type": "application/json",
+        cookie: cookies,
+        host: "localhost",
+        "x-csrf-token": codeOnPage(browser),
+      },
+      method: "POST",
+    }),
+  );
+  expect(response.status).toBe(200);
+  return (await response.json()) as DoorAnswer;
+};
+
+/** The whole door page, for checks about what is not on it at all. */
+export const doorPageHtml = async (
+  world: TicketsWorld,
+  listing: string,
+): Promise<string> => (await openDoor(world, listing)).currentHtml;
+
+/** The people the door offers when the organiser looks someone up by hand
+ * instead of reading their ticket. Each one is read from the row the organiser
+ * would click, so a name shown anywhere else on the page does not count as
+ * being offered. */
+export const peopleOfferedAtDoor = async (
+  world: TicketsWorld,
+  listing: string,
+): Promise<Array<{ name: string; ticket: string }>> => {
+  const html = await doorPageHtml(world, listing);
+  return [...html.matchAll(/<div[^>]*role="option"[^>]*>/g)].map(([row]) => ({
+    name: readOf(row, "name"),
+    ticket: readOf(row, "token"),
+  }));
+};
+
+/** One thing the door records about a person it is offering. A row missing it
+ * is a broken page, not an empty answer. */
+const readOf = (row: string, what: string): string => {
+  const found = row.match(new RegExp(`data-${what}="([^"]*)"`));
+  if (!found?.[1]) throw new Error(`A row at the door has no ${what}`);
+  return found[1];
+};
+
+/** What the listing's own record of the day says happened. */
+export const dayLog = async (
+  world: TicketsWorld,
+  listing: string,
+): Promise<string> => {
+  const browser = await adminBrowser(world);
+  await browser.visit(listingPath(world, listing, "activity"));
+  return browser.pageText;
+};

--- a/test/specs/support/door.ts
+++ b/test/specs/support/door.ts
@@ -96,7 +96,7 @@ const codeOnPage = (browser: TestBrowser): string => {
 };
 
 /** The organiser opens a listing's door. */
-export const openDoor = async (
+const openDoor = async (
   world: TicketsWorld,
   listing: string,
 ): Promise<TestBrowser> => {

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -2,6 +2,7 @@ import type { World } from "@cucumber/cucumber";
 import { type CleanupTask, runCleanups } from "#scripts/cleanup.ts";
 import type { Listing } from "#shared/types.ts";
 import type { ApiAnswer } from "#test/specs/support/booking-api.ts";
+import type { DoorAnswer } from "#test/specs/support/door.ts";
 import type { BookingAttempt } from "#test/specs/support/public-booking.ts";
 import type {
   JourneyCatalogSpec,
@@ -28,6 +29,8 @@ export interface TicketsWorld extends World {
   customerBrowser?: TestBrowser;
   daysOffered?: Map<string, string[]>;
   daysOfferedLastLook?: string;
+  doorAnswer?: DoorAnswer;
+  doorTickets?: Map<string, string>;
   duplicateId?: number;
   duplicateToken?: string;
   evidenceValues: Map<string, string>;


### PR DESCRIPTION
## What changed

On the day, the organiser stands at the door with the listing's scanner open and reads each person's ticket. That whole job had no story. It has one now, in six rules and twelve scenarios:

- **A ticket for this listing lets the person in** — and says who they are and how many places the ticket covers, so the organiser knows how many people to wave through. The listing's own record of the day notes the check-in.
- **A ticket already used says so** — reading the same one twice does not quietly let someone in again, and the organiser still sees whose it is.
- **A refunded ticket does not let them in** — but it still names the person, so the organiser can talk to the right one.
- **A ticket for another listing is queried, not simply refused** — the door names the listing it is really for, and it stays the organiser's call: they can let the person in anyway.
- **A listing whose tickets cannot be passed on asks for ID first** — the door holds the ticket until the organiser says they have seen it.
- **Looking someone up by hand only offers people who are not in yet** — so nobody is let in twice, and a refunded ticket cannot be waved through by hand.

## How the story works the door

Everything goes through the scanner page. The story opens that page first and takes the one-use code for its request off the page itself — which is exactly what the page's own script does. A scanner page that stopped opening, or stopped carrying that code, fails the story rather than being stepped around.

The two rules where the door asks a question are told as two steps, because that is how the organiser lives them: read the ticket, get "this is for another listing" or "check their ID" back, and only then answer. The answering step fails unless the door really did ask — so a door that stopped querying and quietly let people through would fail the story rather than pass it.

Two smaller things the same rule bought: when the story says the door "does not offer" someone, it checks both that they are gone from the list the organiser clicks *and* that their ticket code is off the page altogether — a code left lying about is a code the door would still take. And a row at the door with no name or no code is treated as a broken page, not as an empty answer.

## Honest note on what this replaced

Eleven direct tests handed their journeys over. Four came straight back: refused, already in, ID needed, and the wrong-listing name are the only cover of those branches in the check-in code, and a Cucumber run does not feed the coverage gate. The first attempt deleted all eleven and the gate caught it, which is how those four were picked. They keep their tests, with a short comment naming the story they sit beside so nobody deletes them later as duplicates.

Everything else in that file stays untouched — the crafted requests a browser cannot make (no login, a bad one-use code, malformed JSON, a missing code), the extended code window the scanner needs because the page stays open all day, and the page-level checks.

## One thing this cannot reach

The browser script that shows the organiser the door's question and sends their answer, `src/ui/client/scanner.js`, is still untested — the test browser runs no JavaScript. That is a gap this change neither creates nor widens: it is the one script in `src/ui/client/` that has never had a test. It is written up in `TODO.md` with the branches to cover and the existing client test to copy.

## Checks

`deno task precommit` passes in full — typecheck, lint, duplication at 0%, the whole test suite, and 100% line and branch coverage. All 96 Cucumber scenarios (615 steps) pass. No production code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga3qdj1PzXyZTcjmXZRqz7)_