### PR TITLE
Test how stripe-mock is fetched and installed, and fix two faults it uncovered

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1701,32 +1701,3 @@ Starting point: `src/ui/client/scanner.js`, the confirmation branches around its
 handling of `wrong_listing` and `verify_id`, and `test/ui/client/order.test.ts`
 for how a client script is driven without a real browser.
 
-## Finish the mutation tests for the stripe-mock install
-
-*Origin: the chunk that took `scripts/stripe-mock/install.ts` from 67.2% to
-83.3%.*
-
-Nineteen mutants survive, in three small clusters:
-
-- **The lock refresh timer.** `startInstallLockRefresh` re-writes the lock every
-  second while an install runs, so another waiting install can tell the lock is
-  still being looked after. Nothing checks that it keeps doing so, or that it
-  stops when the install ends.
-- **Reading a lock record.** `parseInstallLockRecord` copes with an older
-  one-line format and with a lock whose contents are unreadable, falling back to
-  the file's own modified time. Neither fallback is checked.
-- **The platform tables.** The `darwin` and `arm64` entries are never read on a
-  Linux machine, so pinning them needs a test that pretends to be a Mac
-  (`Deno.build` stubbed) rather than one that runs on one.
-
-The waiting itself is now covered — see `test/scripts/stripe-mock/install/
-waiting.test.ts`, which holds the lock from another owner and counts how many
-times ours tries to take it. That counting approach is the one to copy for the
-refresh timer: put a counted stand-in in front of the thing being waited on and
-assert how many times it happened, rather than how long it took.
-
-Starting point: the lock functions in `scripts/stripe-mock/install.ts` —
-`startInstallLockRefresh`, `acquireInstallLock`, `readInstallLockRecord` and
-`removeStaleInstallLock` — and
-`deno task mutation scripts/stripe-mock/install.ts
-'test/scripts/stripe-mock/install/*.test.ts' --harness`.

--- a/TODO.md
+++ b/TODO.md
@@ -1700,3 +1700,34 @@ scaffolding to add inside a test migration.
 Starting point: `src/ui/client/scanner.js`, the confirmation branches around its
 handling of `wrong_listing` and `verify_id`, and `test/ui/client/order.test.ts`
 for how a client script is driven without a real browser.
+
+## Finish the mutation tests for the stripe-mock install
+
+*Origin: the chunk that took `scripts/stripe-mock/install.ts` from 67.2% to
+79.8%.*
+
+What is left is one cluster: the lock that stops two installs racing each
+other. Twenty-three mutants survive, all in the same few functions —
+`startInstallLockRefresh`, `acquireInstallLock`, `readInstallLockRecord`, and
+the waiting they do between tries. They are the fiddliest part of the file to
+test because every one of them is about *timing*: how often the lock is
+touched, how long a stale lock is tolerated, whether a timer is cleared.
+
+The tests that already exist drive these paths through real waits, which is
+why the numbers themselves are not pinned down. The way in is likely the one
+that worked for stripe-mock's own starter in #1960: put a counted stand-in
+in front of the thing being waited on, then assert how many times it happened
+rather than how long it took.
+
+Two specific ones worth knowing about:
+
+- `INSTALL_LOCK_RETRY_MS` and `INSTALL_LOCK_TIMEOUT_MS` can both be set to
+  zero without a test noticing, which would turn "wait a minute for the other
+  install" into "give up at once".
+- The `darwin` and `arm64` entries in the platform tables are never read on a
+  Linux machine, so they need a test that pretends to be a Mac
+  (`Deno.build.os` stubbed) rather than one that runs on one.
+
+Starting point: `scripts/stripe-mock/install.ts` lines 90-210, and
+`deno task mutation scripts/stripe-mock/install.ts
+'test/scripts/stripe-mock/install.test.ts' --harness`.

--- a/TODO.md
+++ b/TODO.md
@@ -1725,6 +1725,8 @@ times ours tries to take it. That counting approach is the one to copy for the
 refresh timer: put a counted stand-in in front of the thing being waited on and
 assert how many times it happened, rather than how long it took.
 
-Starting point: `scripts/stripe-mock/install.ts` lines 90-210, and
+Starting point: the lock functions in `scripts/stripe-mock/install.ts` —
+`startInstallLockRefresh`, `acquireInstallLock`, `readInstallLockRecord` and
+`removeStaleInstallLock` — and
 `deno task mutation scripts/stripe-mock/install.ts
 'test/scripts/stripe-mock/install/*.test.ts' --harness`.

--- a/TODO.md
+++ b/TODO.md
@@ -1704,30 +1704,27 @@ for how a client script is driven without a real browser.
 ## Finish the mutation tests for the stripe-mock install
 
 *Origin: the chunk that took `scripts/stripe-mock/install.ts` from 67.2% to
-79.8%.*
+83.3%.*
 
-What is left is one cluster: the lock that stops two installs racing each
-other. Twenty-three mutants survive, all in the same few functions —
-`startInstallLockRefresh`, `acquireInstallLock`, `readInstallLockRecord`, and
-the waiting they do between tries. They are the fiddliest part of the file to
-test because every one of them is about *timing*: how often the lock is
-touched, how long a stale lock is tolerated, whether a timer is cleared.
+Nineteen mutants survive, in three small clusters:
 
-The tests that already exist drive these paths through real waits, which is
-why the numbers themselves are not pinned down. The way in is likely the one
-that worked for stripe-mock's own starter in #1960: put a counted stand-in
-in front of the thing being waited on, then assert how many times it happened
-rather than how long it took.
+- **The lock refresh timer.** `startInstallLockRefresh` re-writes the lock every
+  second while an install runs, so another waiting install can tell the lock is
+  still being looked after. Nothing checks that it keeps doing so, or that it
+  stops when the install ends.
+- **Reading a lock record.** `parseInstallLockRecord` copes with an older
+  one-line format and with a lock whose contents are unreadable, falling back to
+  the file's own modified time. Neither fallback is checked.
+- **The platform tables.** The `darwin` and `arm64` entries are never read on a
+  Linux machine, so pinning them needs a test that pretends to be a Mac
+  (`Deno.build` stubbed) rather than one that runs on one.
 
-Two specific ones worth knowing about:
-
-- `INSTALL_LOCK_RETRY_MS` and `INSTALL_LOCK_TIMEOUT_MS` can both be set to
-  zero without a test noticing, which would turn "wait a minute for the other
-  install" into "give up at once".
-- The `darwin` and `arm64` entries in the platform tables are never read on a
-  Linux machine, so they need a test that pretends to be a Mac
-  (`Deno.build.os` stubbed) rather than one that runs on one.
+The waiting itself is now covered — see `test/scripts/stripe-mock/install/
+waiting.test.ts`, which holds the lock from another owner and counts how many
+times ours tries to take it. That counting approach is the one to copy for the
+refresh timer: put a counted stand-in in front of the thing being waited on and
+assert how many times it happened, rather than how long it took.
 
 Starting point: `scripts/stripe-mock/install.ts` lines 90-210, and
 `deno task mutation scripts/stripe-mock/install.ts
-'test/scripts/stripe-mock/install.test.ts' --harness`.
+'test/scripts/stripe-mock/install/*.test.ts' --harness`.

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -79,6 +79,7 @@ const defaultCommands: StripeMockCommands = {
 
 const textDecoder = new TextDecoder();
 
+/** What stripe-mock calls this machine, which is not always what Deno calls it. */
 const getPlatform = (): string => platformMap[Deno.build.os] ?? "linux";
 
 const getArch = (): string => archMap[Deno.build.arch] ?? "amd64";
@@ -119,13 +120,18 @@ export const installLockPath = (paths: StripeMockPaths): string =>
 const installLockGuardPath = (lockPath: string): string =>
   `${lockPath}${INSTALL_LOCK_GUARD_SUFFIX}`;
 
-const installLockSettings = (
-  options: StripeMockInstallOptions,
-): InstallLockSettings => ({
-  retryMs: options.installLockRetryMs ?? INSTALL_LOCK_RETRY_MS,
-  staleMs: options.installLockStaleMs ?? INSTALL_LOCK_STALE_MS,
-  timeoutMs: options.installLockTimeoutMs ?? INSTALL_LOCK_TIMEOUT_MS,
-  touchMs: options.installLockTouchMs ?? INSTALL_LOCK_TOUCH_MS,
+const installLockSettings = ({
+  // Only a missing setting takes the standard value, so an explicit one —
+  // including a deliberate zero — is always kept.
+  installLockRetryMs: retryMs = INSTALL_LOCK_RETRY_MS,
+  installLockStaleMs: staleMs = INSTALL_LOCK_STALE_MS,
+  installLockTimeoutMs: timeoutMs = INSTALL_LOCK_TIMEOUT_MS,
+  installLockTouchMs: touchMs = INSTALL_LOCK_TOUCH_MS,
+}: StripeMockInstallOptions): InstallLockSettings => ({
+  retryMs,
+  staleMs,
+  timeoutMs,
+  touchMs,
 });
 
 const formatInstallLockRecord = (owner: string): string =>
@@ -349,7 +355,7 @@ const installStripeMock = async (
 export const downloadStripeMock = async (
   options: StripeMockInstallOptions,
 ): Promise<void> => {
-  const paths = options.paths ?? defaultStripeMockPaths;
+  const { paths = defaultStripeMockPaths } = options;
   if (await stripeMockBinaryExists(paths)) return;
 
   await withInstallLock(paths, options, async () => {

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -179,8 +179,9 @@ const startInstallLockRefresh = (
   return async (): Promise<void> => {
     stopped = true;
     clearTimeout(timeout);
+    // A refresh already under way finishes without booking another, because
+    // scheduling checks the flag above.
     await latestRefresh;
-    clearTimeout(timeout);
   };
 };
 

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -138,7 +138,8 @@ const formatInstallLockRecord = (owner: string): string =>
   `${owner}\n${Date.now()}`;
 
 const parseInstallLockRecord = (text: string): InstallLockRecord => {
-  const [first = "", second] = text.split("\n");
+  // Splitting always yields at least one part, so first is always a string.
+  const [first, second] = text.split("\n") as [string, string?];
   const writtenAt = Number(second ?? first);
   return second === undefined ? { writtenAt } : { owner: first, writtenAt };
 };

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -95,12 +95,7 @@ const runCommand = async (
   message: string,
 ): Promise<Deno.CommandOutput> => {
   const output = await command.output();
-  let stderr = "";
-  try {
-    stderr = textDecoder.decode(output.stderr).trim();
-  } catch {
-    stderr = "";
-  }
+  const stderr = textDecoder.decode(output.stderr).trim();
   if (!output.success)
     throw new Error(stderr ? `${message}: ${stderr}` : message);
   return output;

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -19,9 +19,6 @@ const INSTALL_LOCK_GUARD_SUFFIX = ".guard";
 const BIN_DIR = join(projectRoot, ".bin");
 const STRIPE_MOCK_PATH = join(BIN_DIR, "stripe-mock");
 
-const platformMap: Record<string, string> = { darwin: "darwin" };
-const archMap: Record<string, string> = { aarch64: "arm64" };
-
 export type StripeMockPaths = {
   binDir: string;
   binaryPath: string;
@@ -79,10 +76,16 @@ const defaultCommands: StripeMockCommands = {
 
 const textDecoder = new TextDecoder();
 
-/** What stripe-mock calls this machine, which is not always what Deno calls it. */
-const getPlatform = (): string => platformMap[Deno.build.os] ?? "linux";
+/**
+ * What stripe-mock calls this machine in its release names, which is not always
+ * what Deno calls it. Everything that is not a Mac is named as Linux, and every
+ * processor that is not 64-bit ARM is named as amd64.
+ */
+const getPlatform = (): string =>
+  Deno.build.os === "darwin" ? "darwin" : "linux";
 
-const getArch = (): string => archMap[Deno.build.arch] ?? "amd64";
+const getArch = (): string =>
+  Deno.build.arch === "aarch64" ? "arm64" : "amd64";
 
 const stripeMockDownloadUrl = (): string =>
   `https://github.com/stripe/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_${getPlatform()}_${getArch()}.tar.gz`;

--- a/scripts/stripe-mock/install.ts
+++ b/scripts/stripe-mock/install.ts
@@ -327,7 +327,7 @@ const installStripeMock = async (
     await runCommand(
       new Deno.Command(commands.tar, {
         args: ["-xzf", tarPath, "-C", tempDir],
-        stderr: "null",
+        stderr: "piped",
         stdout: "null",
       }),
       "Failed to extract stripe-mock",
@@ -336,7 +336,7 @@ const installStripeMock = async (
     await runCommand(
       new Deno.Command(commands.chmod, {
         args: ["+x", tempBinaryPath],
-        stderr: "null",
+        stderr: "piped",
         stdout: "null",
       }),
       "Failed to make stripe-mock executable",

--- a/test/scripts/stripe-mock/fixtures.ts
+++ b/test/scripts/stripe-mock/fixtures.ts
@@ -159,6 +159,7 @@ export const startFailureMessage = async (
 export const runsToCompletion = async (
   source: string,
   timeoutMs = 20_000,
+  env: Record<string, string> = {},
 ): Promise<boolean> => {
   const scriptPath = await Deno.makeTempFile({ suffix: ".ts" });
   await Deno.writeTextFile(scriptPath, source);
@@ -174,7 +175,7 @@ export const runsToCompletion = async (
         join(projectRoot, "deno.json"),
         scriptPath,
       ],
-      env: { DENO_COVERAGE_DIR: coverageDir },
+      env: { ...env, DENO_COVERAGE_DIR: coverageDir },
       // Whatever it leaves running is killed once the time is up, so a script
       // that cannot finish on its own comes back as a failure rather than
       // hanging the suite.

--- a/test/scripts/stripe-mock/install.test.ts
+++ b/test/scripts/stripe-mock/install.test.ts
@@ -1,7 +1,12 @@
 import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { installLockPath } from "#scripts/stripe-mock/install.ts";
+import { relativeToProject } from "#scripts/path.ts";
+import {
+  defaultStripeMockPaths,
+  downloadStripeMock,
+  installLockPath,
+} from "#scripts/stripe-mock/install.ts";
 import {
   createFakeArchive,
   expectStartFails,
@@ -97,6 +102,13 @@ const expectDownloadWithLockCleanup = async (
     paths,
   });
 };
+
+/** What stripe-mock calls the machine this test is running on. */
+const expectedPlatform = (): string =>
+  Deno.build.os === "darwin" ? "darwin" : "linux";
+
+const expectedArch = (): string =>
+  Deno.build.arch === "aarch64" ? "arm64" : "amd64";
 
 describe("stripe-mock install", () => {
   test("downloads a missing binary before trying to start it", async () => {
@@ -441,5 +453,106 @@ describe("stripe-mock install", () => {
         },
       );
     });
+  });
+});
+
+describe("what stripe-mock is fetched with", () => {
+  test("asks curl for the pinned release for this machine, quietly", async () => {
+    const fakeArchive = await createFakeArchive();
+    try {
+      await withTempStripeMockPaths(async (paths) => {
+        const argsPath = join(paths.binDir, "curl-args");
+        await withFakeCurl(
+          `printf '%s\n' "$@" > ${JSON.stringify(argsPath)}; cat ${JSON.stringify(
+            fakeArchive.archivePath,
+          )}`,
+          async (curl) => {
+            await downloadStripeMock({ commands: { curl }, paths });
+          },
+        );
+
+        const args = (await Deno.readTextFile(argsPath)).trim().split("\n");
+        const url = args.find((arg) => arg.startsWith("https://"));
+
+        // Quiet, following redirects, and writing the archive to our own hands.
+        expect(args).toContain("-sL");
+        expect(args).toContain("-o");
+        expect(args).toContain("-");
+        // The version is pinned on purpose. Changing it here means changing
+        // it in install.ts and in the note about it in AGENTS.md.
+        const version = "0.188.0";
+        expect(url).toBe(
+          `https://github.com/stripe/stripe-mock/releases/download/v${version}/stripe-mock_${version}_${expectedPlatform()}_${expectedArch()}.tar.gz`,
+        );
+      });
+    } finally {
+      await fakeArchive.cleanup();
+    }
+  });
+
+  test("keeps the binary in the project's own bin folder", () => {
+    expect(relativeToProject(defaultStripeMockPaths.binDir)).toBe(".bin");
+    expect(relativeToProject(defaultStripeMockPaths.binaryPath)).toBe(
+      ".bin/stripe-mock",
+    );
+  });
+});
+
+describe("when a step of the install goes wrong", () => {
+  test("says which step failed when the archive cannot be opened", async () => {
+    await withTempStripeMockPaths(async (paths) => {
+      await withFakeCurl("echo not-an-archive", async (curl) => {
+        await expect(
+          downloadStripeMock({ commands: { curl, tar: "false" }, paths }),
+        ).rejects.toThrow("Failed to extract stripe-mock");
+      });
+    });
+  });
+
+  test("says which step failed when the binary cannot be made runnable", async () => {
+    const fakeArchive = await createFakeArchive();
+    try {
+      await withTempStripeMockPaths(async (paths) => {
+        await withFakeCurl(
+          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+          async (curl) => {
+            await expect(
+              downloadStripeMock({
+                commands: { chmod: "false", curl },
+                paths,
+              }),
+            ).rejects.toThrow("Failed to make stripe-mock executable");
+          },
+        );
+      });
+    } finally {
+      await fakeArchive.cleanup();
+    }
+  });
+
+  test("makes the bin folder before reaching for the lock in it", async () => {
+    const fakeArchive = await createFakeArchive();
+    try {
+      const parent = await Deno.makeTempDir();
+      // Nothing has made this folder yet, so the lock has nowhere to live.
+      const paths = {
+        binaryPath: join(parent, "bin", "stripe-mock"),
+        binDir: join(parent, "bin"),
+      };
+      try {
+        await withFakeCurl(
+          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+          async (curl) => {
+            await downloadStripeMock({ commands: { curl }, paths });
+          },
+        );
+
+        expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+      } finally {
+        await Deno.remove(parent, { recursive: true });
+      }
+    } finally {
+      await fakeArchive.cleanup();
+    }
   });
 });

--- a/test/scripts/stripe-mock/install/cleanup.test.ts
+++ b/test/scripts/stripe-mock/install/cleanup.test.ts
@@ -100,11 +100,8 @@ describe("cleaning up after an install", () => {
   });
 
   test("stops the lock refresh without scheduling another write when the install fails mid-refresh", async () => {
-    // Regression: scheduleNextRefresh (line 157) checks `if (stopped) return;`
-    // — the branch where a lock refresh write is still in-flight when the
-    // install fails and stopRefreshingLock is called. Without coverage, a
-    // mutation to that guard (e.g. `if (!stopped) return;`) would silently
-    // schedule an extra refresh write after the lock is released.
+    // A refresh still being written when the install fails must not book
+    // another one, or the lock keeps being touched after it is released.
     await withTempStripeMockPaths(async (paths) => {
       const proceedPath = join(paths.binDir, "proceed");
       await withSecondLockRefreshHeld(

--- a/test/scripts/stripe-mock/install/cleanup.test.ts
+++ b/test/scripts/stripe-mock/install/cleanup.test.ts
@@ -1,0 +1,138 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { installLockPath } from "#scripts/stripe-mock/install.ts";
+import {
+  createFakeArchive,
+  expectStartFails,
+  withFakeCurl,
+  withInstallLockRemoveFailure,
+  withLockReadFailure,
+  withSecondLockRefreshHeld,
+  withTempStripeMockPaths,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+import { expectDownloadWithLockCleanup } from "./lock-fixture.ts";
+
+describe("cleaning up after an install", () => {
+  test("ignores a missing install lock during cleanup", async () => {
+    const fakeArchive = await createFakeArchive();
+
+    try {
+      await withTempStripeMockPaths(async (paths) => {
+        const lockPath = installLockPath(paths);
+        await withInstallLockRemoveFailure(
+          lockPath,
+          new Deno.errors.NotFound(),
+          async () => {
+            await withFakeCurl(
+              `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+              (curl) => expectDownloadWithLockCleanup(paths, curl),
+            );
+          },
+        );
+
+        expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+      });
+    } finally {
+      await fakeArchive.cleanup();
+    }
+  });
+
+  test("throws when install lock cleanup fails", async () => {
+    const fakeArchive = await createFakeArchive();
+
+    try {
+      await withTempStripeMockPaths(async (paths) => {
+        const lockPath = installLockPath(paths);
+        await withInstallLockRemoveFailure(
+          lockPath,
+          new Error("install lock cleanup failed"),
+          async () => {
+            await withFakeCurl(
+              `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+              async (curl) => {
+                await expectStartFails(
+                  { commands: { curl }, paths },
+                  "install lock cleanup failed",
+                );
+              },
+            );
+          },
+        );
+      });
+    } finally {
+      await fakeArchive.cleanup();
+    }
+  });
+
+  test("keeps a replacement install lock during cleanup", async () => {
+    await withTempStripeMockPaths(async (paths) => {
+      const lockPath = installLockPath(paths);
+      const replacementOwner = crypto.randomUUID();
+      await withFakeCurl(
+        [
+          `cat > ${JSON.stringify(lockPath)} <<'EOF'`,
+          replacementOwner,
+          String(Date.now()),
+          "EOF",
+          "exit 7",
+        ].join("\n"),
+        async (curl) => {
+          await expectStartFails(
+            { commands: { curl }, paths },
+            "Failed to download stripe-mock",
+          );
+        },
+      );
+
+      expect(await Deno.readTextFile(lockPath)).toContain(replacementOwner);
+    });
+  });
+
+  test("throws when the install lock stale check fails", async () => {
+    await withTempStripeMockPaths(async (paths) => {
+      const lockPath = installLockPath(paths);
+      await Deno.writeTextFile(lockPath, String(Date.now()));
+      await withLockReadFailure(lockPath, async () => {
+        await expectStartFails({ paths }, "stale check failed");
+      });
+    });
+  });
+
+  test("stops the lock refresh without scheduling another write when the install fails mid-refresh", async () => {
+    // Regression: scheduleNextRefresh (line 157) checks `if (stopped) return;`
+    // — the branch where a lock refresh write is still in-flight when the
+    // install fails and stopRefreshingLock is called. Without coverage, a
+    // mutation to that guard (e.g. `if (!stopped) return;`) would silently
+    // schedule an extra refresh write after the lock is released.
+    await withTempStripeMockPaths(async (paths) => {
+      const proceedPath = join(paths.binDir, "proceed");
+      await withSecondLockRefreshHeld(
+        installLockPath(paths),
+        async (lockWrite) => {
+          await withFakeCurl(
+            `while [ ! -f ${JSON.stringify(proceedPath)} ]; do sleep 0.01; done; exit 7`,
+            async (curl) => {
+              const started = expectStartFails(
+                { commands: { curl }, installLockTouchMs: 1, paths },
+                "Failed to download stripe-mock",
+              );
+              // Wait for the 3rd lock refresh write to be intercepted and
+              // paused — at that point the install body is still running
+              // (curl is spinning on the proceed file).
+              await lockWrite.waitForWrite();
+              // Let curl fail now — the install body throws and
+              // stopRefreshingLock sets stopped=true while the 3rd write
+              // is still in-flight.
+              await Deno.writeTextFile(proceedPath, "");
+              // Releasing the paused write lets scheduleNextRefresh run with
+              // stopped=true — it returns early instead of scheduling another.
+              lockWrite.releaseWrite();
+              await started;
+            },
+          );
+        },
+      );
+    });
+  });
+});

--- a/test/scripts/stripe-mock/install/download.test.ts
+++ b/test/scripts/stripe-mock/install/download.test.ts
@@ -8,9 +8,13 @@ import {
 } from "#scripts/stripe-mock/install.ts";
 import {
   createFakeArchive,
+  fakeCommand,
   withFakeCurl,
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
+
+const withFakeTar = fakeCommand("tar");
+const withFakeChmod = fakeCommand("chmod");
 
 /** Make the code believe it is running on a different machine. */
 const pretendMachineIs = ({
@@ -150,9 +154,18 @@ describe("when a step of the install goes wrong", () => {
   test("says which step failed when the archive cannot be opened", async () => {
     await withTempStripeMockPaths(async (paths) => {
       await withFakeCurl("echo not-an-archive", async (curl) => {
-        await expect(
-          downloadStripeMock({ commands: { curl, tar: "false" }, paths }),
-        ).rejects.toThrow("Failed to extract stripe-mock");
+        await withFakeTar(
+          'echo "not in gzip format" >&2; exit 1',
+          async (tar) => {
+            // The reason comes from tar itself, so it only reaches the reader if
+            // what tar said was kept rather than thrown away.
+            await expect(
+              downloadStripeMock({ commands: { curl, tar }, paths }),
+            ).rejects.toThrow(
+              "Failed to extract stripe-mock: not in gzip format",
+            );
+          },
+        );
       });
     });
   });
@@ -164,12 +177,16 @@ describe("when a step of the install goes wrong", () => {
         await withFakeCurl(
           `cat ${JSON.stringify(fakeArchive.archivePath)}`,
           async (curl) => {
-            await expect(
-              downloadStripeMock({
-                commands: { chmod: "false", curl },
-                paths,
-              }),
-            ).rejects.toThrow("Failed to make stripe-mock executable");
+            await withFakeChmod(
+              'echo "operation not permitted" >&2; exit 1',
+              async (chmod) => {
+                await expect(
+                  downloadStripeMock({ commands: { chmod, curl }, paths }),
+                ).rejects.toThrow(
+                  "Failed to make stripe-mock executable: operation not permitted",
+                );
+              },
+            );
           },
         );
       });

--- a/test/scripts/stripe-mock/install/download.test.ts
+++ b/test/scripts/stripe-mock/install/download.test.ts
@@ -6,6 +6,7 @@ import {
   defaultStripeMockPaths,
   downloadStripeMock,
 } from "#scripts/stripe-mock/install.ts";
+import { runsToCompletion } from "#test/scripts/stripe-mock/fixtures.ts";
 import {
   createFakeArchive,
   fakeCommand,
@@ -128,23 +129,34 @@ describe("what stripe-mock is fetched with", () => {
 
   test("fetches with curl when no other command is named", async () => {
     const fakeArchive = await createFakeArchive();
-    const realPath = Deno.env.get("PATH") ?? "";
     try {
       await withFakeCurl(
         `cat ${JSON.stringify(fakeArchive.archivePath)}`,
         async (curl) => {
-          // The stand-in is called curl, so it is only found if the installer
-          // asks for curl by that name.
-          Deno.env.set("PATH", `${dirname(curl)}:${realPath}`);
           await withTempStripeMockPaths(async (paths) => {
-            await downloadStripeMock({ paths });
+            // The stand-in is called curl, so it is only found if the
+            // installer asks for curl by that name. It runs in a process of
+            // its own, because a changed path here would reach every test
+            // sharing this one.
+            const installed = await runsToCompletion(
+              [
+                'import { downloadStripeMock } from "#scripts/stripe-mock/install.ts";',
+                `await downloadStripeMock({ paths: ${JSON.stringify(paths)} });`,
+                `await Deno.stat(${JSON.stringify(paths.binaryPath)});`,
+              ].join("\n"),
+              20_000,
+              {
+                DENO_DIR: Deno.env.get("DENO_DIR") ?? "",
+                HOME: Deno.env.get("HOME") ?? "",
+                PATH: `${dirname(curl)}:${Deno.env.get("PATH") ?? ""}`,
+              },
+            );
 
-            expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+            expect(installed).toBe(true);
           });
         },
       );
     } finally {
-      Deno.env.set("PATH", realPath);
       await fakeArchive.cleanup();
     }
   });

--- a/test/scripts/stripe-mock/install/download.test.ts
+++ b/test/scripts/stripe-mock/install/download.test.ts
@@ -1,0 +1,138 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { relativeToProject } from "#scripts/path.ts";
+import {
+  defaultStripeMockPaths,
+  downloadStripeMock,
+} from "#scripts/stripe-mock/install.ts";
+import {
+  createFakeArchive,
+  withFakeCurl,
+  withTempStripeMockPaths,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+
+/** What stripe-mock calls the machine this test is running on. */
+const expectedPlatform = (): string =>
+  Deno.build.os === "darwin" ? "darwin" : "linux";
+
+const expectedArch = (): string =>
+  Deno.build.arch === "aarch64" ? "arm64" : "amd64";
+
+/** Run a download with a curl that records what it was asked for. */
+const curlArgsFor = async (): Promise<string[]> => {
+  const fakeArchive = await createFakeArchive();
+  let args: string[] = [];
+  try {
+    await withTempStripeMockPaths(async (paths) => {
+      const argsPath = join(paths.binDir, "curl-args");
+      await withFakeCurl(
+        [
+          `printf '%s\n' "$@" > ${JSON.stringify(argsPath)}`,
+          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        ].join("; "),
+        async (curl) => {
+          await downloadStripeMock({ commands: { curl }, paths });
+        },
+      );
+      args = (await Deno.readTextFile(argsPath)).trim().split("\n");
+    });
+  } finally {
+    await fakeArchive.cleanup();
+  }
+  return args;
+};
+
+describe("what stripe-mock is fetched with", () => {
+  test("asks for the pinned release built for this machine", async () => {
+    const url = (await curlArgsFor()).find((arg) => arg.startsWith("https://"));
+
+    // The version is pinned on purpose. Changing it here means changing it in
+    // install.ts and in the note about it in AGENTS.md.
+    const version = "0.188.0";
+    expect(url).toBe(
+      `https://github.com/stripe/stripe-mock/releases/download/v${version}/stripe-mock_${version}_${expectedPlatform()}_${expectedArch()}.tar.gz`,
+    );
+  });
+
+  test("asks curl to work quietly, follow redirects, and hand the file back", async () => {
+    const args = await curlArgsFor();
+
+    expect(args).toContain("-sL");
+    expect(args).toContain("-o");
+    expect(args).toContain("-");
+  });
+
+  test("puts the binary where everything else looks for it", async () => {
+    // Nothing is downloaded: the real binary is already where it belongs, and
+    // finding it there is what stops a second fetch.
+    const fetched: string[] = [];
+    await withFakeCurl('echo "should not run" >&2; exit 1', async (curl) => {
+      fetched.push(curl);
+      await downloadStripeMock({ commands: { curl } });
+    });
+
+    expect((await Deno.stat(defaultStripeMockPaths.binaryPath)).isFile).toBe(
+      true,
+    );
+    expect(relativeToProject(defaultStripeMockPaths.binaryPath)).toBe(
+      ".bin/stripe-mock",
+    );
+  });
+});
+
+describe("when a step of the install goes wrong", () => {
+  test("says which step failed when the archive cannot be opened", async () => {
+    await withTempStripeMockPaths(async (paths) => {
+      await withFakeCurl("echo not-an-archive", async (curl) => {
+        await expect(
+          downloadStripeMock({ commands: { curl, tar: "false" }, paths }),
+        ).rejects.toThrow("Failed to extract stripe-mock");
+      });
+    });
+  });
+
+  test("says which step failed when the binary cannot be made runnable", async () => {
+    const fakeArchive = await createFakeArchive();
+    try {
+      await withTempStripeMockPaths(async (paths) => {
+        await withFakeCurl(
+          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+          async (curl) => {
+            await expect(
+              downloadStripeMock({
+                commands: { chmod: "false", curl },
+                paths,
+              }),
+            ).rejects.toThrow("Failed to make stripe-mock executable");
+          },
+        );
+      });
+    } finally {
+      await fakeArchive.cleanup();
+    }
+  });
+
+  test("makes the bin folder before reaching for the lock in it", async () => {
+    const fakeArchive = await createFakeArchive();
+    const parent = await Deno.makeTempDir();
+    try {
+      // Nothing has made this folder yet, so the lock has nowhere to live.
+      const paths = {
+        binaryPath: join(parent, "bin", "stripe-mock"),
+        binDir: join(parent, "bin"),
+      };
+      await withFakeCurl(
+        `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        async (curl) => {
+          await downloadStripeMock({ commands: { curl }, paths });
+        },
+      );
+
+      expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+    } finally {
+      await Deno.remove(parent, { recursive: true });
+      await fakeArchive.cleanup();
+    }
+  });
+});

--- a/test/scripts/stripe-mock/install/download.test.ts
+++ b/test/scripts/stripe-mock/install/download.test.ts
@@ -12,6 +12,26 @@ import {
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
 
+/** Make the code believe it is running on a different machine. */
+const pretendMachineIs = ({
+  arch,
+  os,
+}: {
+  arch: string;
+  os: string;
+}): Disposable => {
+  const real = Deno.build;
+  Object.defineProperty(Deno, "build", {
+    configurable: true,
+    value: { ...real, arch, os },
+  });
+  return {
+    [Symbol.dispose]: () => {
+      Object.defineProperty(Deno, "build", { configurable: true, value: real });
+    },
+  };
+};
+
 /** What stripe-mock calls the machine this test is running on. */
 const expectedPlatform = (): string =>
   Deno.build.os === "darwin" ? "darwin" : "linux";
@@ -20,7 +40,13 @@ const expectedArch = (): string =>
   Deno.build.arch === "aarch64" ? "arm64" : "amd64";
 
 /** Run a download with a curl that records what it was asked for. */
-const curlArgsFor = async (): Promise<string[]> => {
+const curlArgsFor = async (build?: {
+  arch: string;
+  os: string;
+}): Promise<string[]> => {
+  using _build = build
+    ? pretendMachineIs(build)
+    : { [Symbol.dispose]: () => {} };
   const fakeArchive = await createFakeArchive();
   let args: string[] = [];
   try {
@@ -53,6 +79,22 @@ describe("what stripe-mock is fetched with", () => {
     expect(url).toBe(
       `https://github.com/stripe/stripe-mock/releases/download/v${version}/stripe-mock_${version}_${expectedPlatform()}_${expectedArch()}.tar.gz`,
     );
+  });
+
+  test("names the release for a Mac on Apple silicon", async () => {
+    const url = (await curlArgsFor({ arch: "aarch64", os: "darwin" })).find(
+      (arg) => arg.startsWith("https://"),
+    );
+
+    expect(url).toContain("_darwin_arm64.tar.gz");
+  });
+
+  test("names the release for an ordinary Linux machine", async () => {
+    const url = (await curlArgsFor({ arch: "x86_64", os: "linux" })).find(
+      (arg) => arg.startsWith("https://"),
+    );
+
+    expect(url).toContain("_linux_amd64.tar.gz");
   });
 
   test("asks curl to work quietly, follow redirects, and hand the file back", async () => {

--- a/test/scripts/stripe-mock/install/download.test.ts
+++ b/test/scripts/stripe-mock/install/download.test.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { relativeToProject } from "#scripts/path.ts";
@@ -120,6 +120,29 @@ describe("what stripe-mock is fetched with", () => {
     expect(relativeToProject(defaultStripeMockPaths.binaryPath)).toBe(
       ".bin/stripe-mock",
     );
+  });
+
+  test("fetches with curl when no other command is named", async () => {
+    const fakeArchive = await createFakeArchive();
+    const realPath = Deno.env.get("PATH") ?? "";
+    try {
+      await withFakeCurl(
+        `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        async (curl) => {
+          // The stand-in is called curl, so it is only found if the installer
+          // asks for curl by that name.
+          Deno.env.set("PATH", `${dirname(curl)}:${realPath}`);
+          await withTempStripeMockPaths(async (paths) => {
+            await downloadStripeMock({ paths });
+
+            expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+          });
+        },
+      );
+    } finally {
+      Deno.env.set("PATH", realPath);
+      await fakeArchive.cleanup();
+    }
   });
 });
 

--- a/test/scripts/stripe-mock/install/lock-fixture.ts
+++ b/test/scripts/stripe-mock/install/lock-fixture.ts
@@ -15,9 +15,9 @@ import {
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
 
-export const oldDate = (): Date => new Date(Date.now() - 1_000);
+const oldDate = (): Date => new Date(Date.now() - 1_000);
 
-export const makeLockFileOld = async (lockPath: string): Promise<void> => {
+const makeLockFileOld = async (lockPath: string): Promise<void> => {
   const date = oldDate();
   await Deno.utime(lockPath, date, date);
 };
@@ -54,7 +54,7 @@ export const expectStaleLockRemoved = async (
   }
 };
 
-export const releaseLockAfterWritingBinary = async (
+const releaseLockAfterWritingBinary = async (
   paths: TestStripeMockPaths,
   releaseLock: () => Promise<void>,
 ): Promise<void> => {

--- a/test/scripts/stripe-mock/install/lock-fixture.ts
+++ b/test/scripts/stripe-mock/install/lock-fixture.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared setup for the install-lock suites: ageing a lock file, standing in for
+ * another install that finishes partway through, and the common expectations.
+ */
+
+import { expect } from "@std/expect";
+import { installLockPath } from "#scripts/stripe-mock/install.ts";
+import {
+  createFakeArchive,
+  expectStripeMockFails,
+  makeExecutable,
+  type TestStripeMockPaths,
+  wait,
+  withFakeCurl,
+  withTempStripeMockPaths,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+
+export const oldDate = (): Date => new Date(Date.now() - 1_000);
+
+export const makeLockFileOld = async (lockPath: string): Promise<void> => {
+  const date = oldDate();
+  await Deno.utime(lockPath, date, date);
+};
+
+export const expectStaleLockRemoved = async (
+  lockText: string,
+): Promise<void> => {
+  const fakeArchive = await createFakeArchive();
+
+  try {
+    await withTempStripeMockPaths(async (paths) => {
+      const lockPath = installLockPath(paths);
+      await Deno.writeTextFile(lockPath, lockText);
+      await makeLockFileOld(lockPath);
+      await withFakeCurl(
+        `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        async (curl) => {
+          await expectStripeMockFails({
+            budgetMs: 30,
+            commands: { curl },
+            delayMs: 10,
+            installLockRetryMs: 1,
+            installLockStaleMs: 1,
+            paths,
+          });
+        },
+      );
+
+      await expect(Deno.stat(lockPath)).rejects.toThrow();
+      expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+    });
+  } finally {
+    await fakeArchive.cleanup();
+  }
+};
+
+export const releaseLockAfterWritingBinary = async (
+  paths: TestStripeMockPaths,
+  releaseLock: () => Promise<void>,
+): Promise<void> => {
+  const pendingBinaryPath = `${paths.binaryPath}.pending`;
+  await wait(30);
+  await Deno.writeTextFile(pendingBinaryPath, "#!/bin/sh\nexit 0\n");
+  await makeExecutable(pendingBinaryPath);
+  await Deno.rename(pendingBinaryPath, paths.binaryPath);
+  await releaseLock();
+};
+
+export const withBinaryReleasedAfterDelay = async (
+  paths: TestStripeMockPaths,
+  releaseLock: () => Promise<void>,
+  body: (releaseLock: () => Promise<void>) => Promise<void>,
+): Promise<void> => {
+  const releasing = releaseLockAfterWritingBinary(paths, releaseLock);
+
+  try {
+    await body(releaseLock);
+  } finally {
+    await releasing;
+  }
+};
+
+export const expectDownloadWithLockCleanup = async (
+  paths: TestStripeMockPaths,
+  curl: string,
+): Promise<void> => {
+  await expectStripeMockFails({
+    budgetMs: 30,
+    commands: { curl },
+    delayMs: 10,
+    paths,
+  });
+};

--- a/test/scripts/stripe-mock/install/locking.test.ts
+++ b/test/scripts/stripe-mock/install/locking.test.ts
@@ -6,97 +6,23 @@ import {
   createFakeArchive,
   expectStartFails,
   expectStripeMockFails,
-  makeExecutable,
-  type TestStripeMockPaths,
   wait,
   waitForFile,
   waitForNoInstallTempDir,
   withFakeCurl,
   withInstallLockHeld,
   withInstallLockOpenFailure,
-  withInstallLockRemoveFailure,
   withInstallLockWriteFailure,
-  withLockReadFailure,
   withLockRemovedDuringRead,
   withSecondLockRefreshHeld,
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
 import { tempDir } from "#test-utils/files.ts";
-
-const oldDate = (): Date => new Date(Date.now() - 1_000);
-
-const makeLockFileOld = async (lockPath: string): Promise<void> => {
-  const date = oldDate();
-  await Deno.utime(lockPath, date, date);
-};
-
-const expectStaleLockRemoved = async (lockText: string): Promise<void> => {
-  const fakeArchive = await createFakeArchive();
-
-  try {
-    await withTempStripeMockPaths(async (paths) => {
-      const lockPath = installLockPath(paths);
-      await Deno.writeTextFile(lockPath, lockText);
-      await makeLockFileOld(lockPath);
-      await withFakeCurl(
-        `cat ${JSON.stringify(fakeArchive.archivePath)}`,
-        async (curl) => {
-          await expectStripeMockFails({
-            budgetMs: 30,
-            commands: { curl },
-            delayMs: 10,
-            installLockRetryMs: 1,
-            installLockStaleMs: 1,
-            paths,
-          });
-        },
-      );
-
-      await expect(Deno.stat(lockPath)).rejects.toThrow();
-      expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
-    });
-  } finally {
-    await fakeArchive.cleanup();
-  }
-};
-
-const releaseLockAfterWritingBinary = async (
-  paths: TestStripeMockPaths,
-  releaseLock: () => Promise<void>,
-): Promise<void> => {
-  const pendingBinaryPath = `${paths.binaryPath}.pending`;
-  await wait(30);
-  await Deno.writeTextFile(pendingBinaryPath, "#!/bin/sh\nexit 0\n");
-  await makeExecutable(pendingBinaryPath);
-  await Deno.rename(pendingBinaryPath, paths.binaryPath);
-  await releaseLock();
-};
-
-const withBinaryReleasedAfterDelay = async (
-  paths: TestStripeMockPaths,
-  releaseLock: () => Promise<void>,
-  body: (releaseLock: () => Promise<void>) => Promise<void>,
-): Promise<void> => {
-  const releasing = releaseLockAfterWritingBinary(paths, releaseLock);
-
-  try {
-    await body(releaseLock);
-  } finally {
-    await releasing;
-  }
-};
-
-const expectDownloadWithLockCleanup = async (
-  paths: TestStripeMockPaths,
-  curl: string,
-): Promise<void> => {
-  await expectStripeMockFails({
-    budgetMs: 30,
-    commands: { curl },
-    delayMs: 10,
-    paths,
-  });
-};
+import {
+  expectDownloadWithLockCleanup,
+  expectStaleLockRemoved,
+  withBinaryReleasedAfterDelay,
+} from "./lock-fixture.ts";
 
 describe("stripe-mock install", () => {
   test("downloads a missing binary before trying to start it", async () => {
@@ -319,127 +245,5 @@ describe("stripe-mock install", () => {
     } finally {
       await fakeArchive.cleanup();
     }
-  });
-
-  test("ignores a missing install lock during cleanup", async () => {
-    const fakeArchive = await createFakeArchive();
-
-    try {
-      await withTempStripeMockPaths(async (paths) => {
-        const lockPath = installLockPath(paths);
-        await withInstallLockRemoveFailure(
-          lockPath,
-          new Deno.errors.NotFound(),
-          async () => {
-            await withFakeCurl(
-              `cat ${JSON.stringify(fakeArchive.archivePath)}`,
-              (curl) => expectDownloadWithLockCleanup(paths, curl),
-            );
-          },
-        );
-
-        expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
-      });
-    } finally {
-      await fakeArchive.cleanup();
-    }
-  });
-
-  test("throws when install lock cleanup fails", async () => {
-    const fakeArchive = await createFakeArchive();
-
-    try {
-      await withTempStripeMockPaths(async (paths) => {
-        const lockPath = installLockPath(paths);
-        await withInstallLockRemoveFailure(
-          lockPath,
-          new Error("install lock cleanup failed"),
-          async () => {
-            await withFakeCurl(
-              `cat ${JSON.stringify(fakeArchive.archivePath)}`,
-              async (curl) => {
-                await expectStartFails(
-                  { commands: { curl }, paths },
-                  "install lock cleanup failed",
-                );
-              },
-            );
-          },
-        );
-      });
-    } finally {
-      await fakeArchive.cleanup();
-    }
-  });
-
-  test("keeps a replacement install lock during cleanup", async () => {
-    await withTempStripeMockPaths(async (paths) => {
-      const lockPath = installLockPath(paths);
-      const replacementOwner = crypto.randomUUID();
-      await withFakeCurl(
-        [
-          `cat > ${JSON.stringify(lockPath)} <<'EOF'`,
-          replacementOwner,
-          String(Date.now()),
-          "EOF",
-          "exit 7",
-        ].join("\n"),
-        async (curl) => {
-          await expectStartFails(
-            { commands: { curl }, paths },
-            "Failed to download stripe-mock",
-          );
-        },
-      );
-
-      expect(await Deno.readTextFile(lockPath)).toContain(replacementOwner);
-    });
-  });
-
-  test("throws when the install lock stale check fails", async () => {
-    await withTempStripeMockPaths(async (paths) => {
-      const lockPath = installLockPath(paths);
-      await Deno.writeTextFile(lockPath, String(Date.now()));
-      await withLockReadFailure(lockPath, async () => {
-        await expectStartFails({ paths }, "stale check failed");
-      });
-    });
-  });
-
-  test("stops the lock refresh without scheduling another write when the install fails mid-refresh", async () => {
-    // Regression: scheduleNextRefresh (line 157) checks `if (stopped) return;`
-    // — the branch where a lock refresh write is still in-flight when the
-    // install fails and stopRefreshingLock is called. Without coverage, a
-    // mutation to that guard (e.g. `if (!stopped) return;`) would silently
-    // schedule an extra refresh write after the lock is released.
-    await withTempStripeMockPaths(async (paths) => {
-      const proceedPath = join(paths.binDir, "proceed");
-      await withSecondLockRefreshHeld(
-        installLockPath(paths),
-        async (lockWrite) => {
-          await withFakeCurl(
-            `while [ ! -f ${JSON.stringify(proceedPath)} ]; do sleep 0.01; done; exit 7`,
-            async (curl) => {
-              const started = expectStartFails(
-                { commands: { curl }, installLockTouchMs: 1, paths },
-                "Failed to download stripe-mock",
-              );
-              // Wait for the 3rd lock refresh write to be intercepted and
-              // paused — at that point the install body is still running
-              // (curl is spinning on the proceed file).
-              await lockWrite.waitForWrite();
-              // Let curl fail now — the install body throws and
-              // stopRefreshingLock sets stopped=true while the 3rd write
-              // is still in-flight.
-              await Deno.writeTextFile(proceedPath, "");
-              // Releasing the paused write lets scheduleNextRefresh run with
-              // stopped=true — it returns early instead of scheduling another.
-              lockWrite.releaseWrite();
-              await started;
-            },
-          );
-        },
-      );
-    });
   });
 });

--- a/test/scripts/stripe-mock/install/locking.test.ts
+++ b/test/scripts/stripe-mock/install/locking.test.ts
@@ -1,12 +1,7 @@
 import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { relativeToProject } from "#scripts/path.ts";
-import {
-  defaultStripeMockPaths,
-  downloadStripeMock,
-  installLockPath,
-} from "#scripts/stripe-mock/install.ts";
+import { installLockPath } from "#scripts/stripe-mock/install.ts";
 import {
   createFakeArchive,
   expectStartFails,
@@ -453,106 +448,5 @@ describe("stripe-mock install", () => {
         },
       );
     });
-  });
-});
-
-describe("what stripe-mock is fetched with", () => {
-  test("asks curl for the pinned release for this machine, quietly", async () => {
-    const fakeArchive = await createFakeArchive();
-    try {
-      await withTempStripeMockPaths(async (paths) => {
-        const argsPath = join(paths.binDir, "curl-args");
-        await withFakeCurl(
-          `printf '%s\n' "$@" > ${JSON.stringify(argsPath)}; cat ${JSON.stringify(
-            fakeArchive.archivePath,
-          )}`,
-          async (curl) => {
-            await downloadStripeMock({ commands: { curl }, paths });
-          },
-        );
-
-        const args = (await Deno.readTextFile(argsPath)).trim().split("\n");
-        const url = args.find((arg) => arg.startsWith("https://"));
-
-        // Quiet, following redirects, and writing the archive to our own hands.
-        expect(args).toContain("-sL");
-        expect(args).toContain("-o");
-        expect(args).toContain("-");
-        // The version is pinned on purpose. Changing it here means changing
-        // it in install.ts and in the note about it in AGENTS.md.
-        const version = "0.188.0";
-        expect(url).toBe(
-          `https://github.com/stripe/stripe-mock/releases/download/v${version}/stripe-mock_${version}_${expectedPlatform()}_${expectedArch()}.tar.gz`,
-        );
-      });
-    } finally {
-      await fakeArchive.cleanup();
-    }
-  });
-
-  test("keeps the binary in the project's own bin folder", () => {
-    expect(relativeToProject(defaultStripeMockPaths.binDir)).toBe(".bin");
-    expect(relativeToProject(defaultStripeMockPaths.binaryPath)).toBe(
-      ".bin/stripe-mock",
-    );
-  });
-});
-
-describe("when a step of the install goes wrong", () => {
-  test("says which step failed when the archive cannot be opened", async () => {
-    await withTempStripeMockPaths(async (paths) => {
-      await withFakeCurl("echo not-an-archive", async (curl) => {
-        await expect(
-          downloadStripeMock({ commands: { curl, tar: "false" }, paths }),
-        ).rejects.toThrow("Failed to extract stripe-mock");
-      });
-    });
-  });
-
-  test("says which step failed when the binary cannot be made runnable", async () => {
-    const fakeArchive = await createFakeArchive();
-    try {
-      await withTempStripeMockPaths(async (paths) => {
-        await withFakeCurl(
-          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
-          async (curl) => {
-            await expect(
-              downloadStripeMock({
-                commands: { chmod: "false", curl },
-                paths,
-              }),
-            ).rejects.toThrow("Failed to make stripe-mock executable");
-          },
-        );
-      });
-    } finally {
-      await fakeArchive.cleanup();
-    }
-  });
-
-  test("makes the bin folder before reaching for the lock in it", async () => {
-    const fakeArchive = await createFakeArchive();
-    try {
-      const parent = await Deno.makeTempDir();
-      // Nothing has made this folder yet, so the lock has nowhere to live.
-      const paths = {
-        binaryPath: join(parent, "bin", "stripe-mock"),
-        binDir: join(parent, "bin"),
-      };
-      try {
-        await withFakeCurl(
-          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
-          async (curl) => {
-            await downloadStripeMock({ commands: { curl }, paths });
-          },
-        );
-
-        expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
-      } finally {
-        await Deno.remove(parent, { recursive: true });
-      }
-    } finally {
-      await fakeArchive.cleanup();
-    }
   });
 });

--- a/test/scripts/stripe-mock/install/locking.test.ts
+++ b/test/scripts/stripe-mock/install/locking.test.ts
@@ -98,13 +98,6 @@ const expectDownloadWithLockCleanup = async (
   });
 };
 
-/** What stripe-mock calls the machine this test is running on. */
-const expectedPlatform = (): string =>
-  Deno.build.os === "darwin" ? "darwin" : "linux";
-
-const expectedArch = (): string =>
-  Deno.build.arch === "aarch64" ? "arm64" : "amd64";
-
 describe("stripe-mock install", () => {
   test("downloads a missing binary before trying to start it", async () => {
     using gate = tempDir();

--- a/test/scripts/stripe-mock/install/locking.test.ts
+++ b/test/scripts/stripe-mock/install/locking.test.ts
@@ -150,7 +150,9 @@ describe("stripe-mock install", () => {
         await expectStartFails(
           {
             installLockRetryMs: 1,
-            installLockTimeoutMs: 1,
+            // Long enough that giving up means the time waited was really
+            // measured, rather than any reading of the clock being past it.
+            installLockTimeoutMs: 100,
             paths,
           },
           "Timed out waiting for stripe-mock install lock",

--- a/test/scripts/stripe-mock/install/locking.test.ts
+++ b/test/scripts/stripe-mock/install/locking.test.ts
@@ -234,6 +234,9 @@ describe("stripe-mock install", () => {
                 commands: { curl },
                 delayMs: 10,
                 installLockRetryMs: 1,
+                // No time to try again: a lock that vanished counts as gone
+                // straight away, or this install never gets to run.
+                installLockTimeoutMs: 0,
                 paths,
               });
             },

--- a/test/scripts/stripe-mock/install/refreshing.test.ts
+++ b/test/scripts/stripe-mock/install/refreshing.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
@@ -12,8 +13,8 @@ import {
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
 
-/** How long the install is made to take, so the lock is held for a while. */
-const INSTALL_TAKES_MS = 120;
+/** How many times the lock must be re-written before the install may finish. */
+const REFRESHES_WANTED = 3;
 const TOUCH_EVERY_MS = 20;
 
 type Touches = { afterFinishing: number; whileInstalling: number };
@@ -29,6 +30,7 @@ const touchesAround = async (touchMs: number): Promise<Touches> => {
   try {
     await withTempStripeMockPaths(async (paths) => {
       const lockPath = installLockPath(paths);
+      const proceedPath = join(paths.binDir, "proceed");
       const writeTextFile = Deno.writeTextFile;
       using _write = stub(Deno, "writeTextFile", ((
         path: string | URL,
@@ -38,12 +40,20 @@ const touchesAround = async (touchMs: number): Promise<Touches> => {
         if (String(path) === lockPath) {
           if (finished) counts.afterFinishing += 1;
           else counts.whileInstalling += 1;
+          // The download is held until the lock has been kept alive often
+          // enough, so the install can never finish first.
+          if (counts.whileInstalling > REFRESHES_WANTED) {
+            void writeTextFile(proceedPath, "");
+          }
         }
         return writeTextFile(path, data, options);
       }) as typeof Deno.writeTextFile);
 
       await withFakeCurl(
-        `sleep ${INSTALL_TAKES_MS / 1000}; cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        [
+          `while [ ! -f ${JSON.stringify(proceedPath)} ]; do sleep 0.01; done`,
+          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        ].join("\n"),
         async (curl) => {
           await downloadStripeMock({
             commands: { curl },
@@ -55,7 +65,7 @@ const touchesAround = async (touchMs: number): Promise<Touches> => {
       finished = true;
 
       // Long enough for several more refreshes, if any were still coming.
-      await wait(INSTALL_TAKES_MS);
+      await wait(TOUCH_EVERY_MS * 4);
     });
   } finally {
     await fakeArchive.cleanup();
@@ -69,7 +79,7 @@ describe("keeping hold of the install lock", () => {
 
     // Written once to claim it, then again every so often. Without the
     // repeats, another install would think this one had died.
-    expect(touches.whileInstalling).toBeGreaterThan(2);
+    expect(touches.whileInstalling).toBeGreaterThan(REFRESHES_WANTED);
   });
 
   test("stops saying so once the install is done", async () => {

--- a/test/scripts/stripe-mock/install/refreshing.test.ts
+++ b/test/scripts/stripe-mock/install/refreshing.test.ts
@@ -1,0 +1,80 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import {
+  downloadStripeMock,
+  installLockPath,
+} from "#scripts/stripe-mock/install.ts";
+import {
+  createFakeArchive,
+  wait,
+  withFakeCurl,
+  withTempStripeMockPaths,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+
+/** How long the install is made to take, so the lock is held for a while. */
+const INSTALL_TAKES_MS = 120;
+const TOUCH_EVERY_MS = 20;
+
+type Touches = { afterFinishing: number; whileInstalling: number };
+
+/**
+ * Run an install that takes its time, counting how often the lock is written
+ * to while it runs and how often it is written to afterwards.
+ */
+const touchesAround = async (touchMs: number): Promise<Touches> => {
+  const fakeArchive = await createFakeArchive();
+  const counts: Touches = { afterFinishing: 0, whileInstalling: 0 };
+  let finished = false;
+  try {
+    await withTempStripeMockPaths(async (paths) => {
+      const lockPath = installLockPath(paths);
+      const writeTextFile = Deno.writeTextFile;
+      using _write = stub(Deno, "writeTextFile", ((
+        path: string | URL,
+        data: string | ReadableStream<string>,
+        options?: Deno.WriteFileOptions,
+      ) => {
+        if (String(path) === lockPath) {
+          if (finished) counts.afterFinishing += 1;
+          else counts.whileInstalling += 1;
+        }
+        return writeTextFile(path, data, options);
+      }) as typeof Deno.writeTextFile);
+
+      await withFakeCurl(
+        `sleep ${INSTALL_TAKES_MS / 1000}; cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        async (curl) => {
+          await downloadStripeMock({
+            commands: { curl },
+            installLockTouchMs: touchMs,
+            paths,
+          });
+        },
+      );
+      finished = true;
+
+      // Long enough for several more refreshes, if any were still coming.
+      await wait(INSTALL_TAKES_MS);
+    });
+  } finally {
+    await fakeArchive.cleanup();
+  }
+  return counts;
+};
+
+describe("keeping hold of the install lock", () => {
+  test("keeps saying the lock is in use while the install runs", async () => {
+    const touches = await touchesAround(TOUCH_EVERY_MS);
+
+    // Written once to claim it, then again every so often. Without the
+    // repeats, another install would think this one had died.
+    expect(touches.whileInstalling).toBeGreaterThan(2);
+  });
+
+  test("stops saying so once the install is done", async () => {
+    const touches = await touchesAround(TOUCH_EVERY_MS);
+
+    expect(touches.afterFinishing).toBe(0);
+  });
+});

--- a/test/scripts/stripe-mock/install/stale-locks.test.ts
+++ b/test/scripts/stripe-mock/install/stale-locks.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  downloadStripeMock,
+  installLockPath,
+} from "#scripts/stripe-mock/install.ts";
+import {
+  createFakeArchive,
+  withFakeCurl,
+  withTempStripeMockPaths,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+
+/** Long ago, so any sane staleness rule counts it as abandoned. */
+const LONG_AGO = new Date(Date.now() - 60 * 60 * 1000);
+
+/**
+ * Leave a lock behind with the given contents, then try to install. Gives back
+ * whether the install got past it, without waiting long if it did not.
+ */
+const installsPast = async (
+  lockText: string,
+  age: Date = LONG_AGO,
+): Promise<boolean> => {
+  const fakeArchive = await createFakeArchive();
+  let installed = false;
+  try {
+    await withTempStripeMockPaths(async (paths) => {
+      const lockPath = installLockPath(paths);
+      await Deno.writeTextFile(lockPath, lockText);
+      await Deno.utime(lockPath, age, age);
+
+      await withFakeCurl(
+        `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+        async (curl) => {
+          try {
+            await downloadStripeMock({
+              commands: { curl },
+              installLockRetryMs: 1,
+              installLockTimeoutMs: 200,
+              paths,
+            });
+            installed = true;
+          } catch {
+            // Gave up waiting: the lock was treated as still in use.
+            installed = false;
+          }
+        },
+      );
+    });
+  } finally {
+    await fakeArchive.cleanup();
+  }
+  return installed;
+};
+
+describe("a lock left behind by an install that never finished", () => {
+  test("is taken over once it is old enough", async () => {
+    expect(await installsPast(`someone-else\n${LONG_AGO.getTime()}`)).toBe(
+      true,
+    );
+  });
+
+  test("is taken over when it says a time from the very start of the clock", async () => {
+    // A time of 1 is a real time, however unlikely: 1970 is long ago enough.
+    expect(await installsPast("someone-else\n1")).toBe(true);
+  });
+
+  test("is judged by the file's own age when it says no time at all", async () => {
+    expect(await installsPast("someone-else\nnot-a-time")).toBe(true);
+  });
+
+  test("is judged by the file's own age when it is from an older install", async () => {
+    // Older installs wrote the time alone, with nobody's name against it.
+    expect(await installsPast(String(LONG_AGO.getTime()))).toBe(true);
+  });
+
+  test("is left alone while it is still fresh", async () => {
+    expect(await installsPast(`someone-else\n${Date.now()}`, new Date())).toBe(
+      false,
+    );
+  });
+});

--- a/test/scripts/stripe-mock/install/stale-locks.test.ts
+++ b/test/scripts/stripe-mock/install/stale-locks.test.ts
@@ -42,8 +42,17 @@ const installsPast = async (
               paths,
             });
             installed = true;
-          } catch {
-            // Gave up waiting: the lock was treated as still in use.
+          } catch (error) {
+            // Only giving up on the wait means the lock was left alone.
+            // Anything else is a fault, and must not read as one.
+            if (
+              !(error instanceof Error) ||
+              !error.message.includes(
+                "Timed out waiting for stripe-mock install lock",
+              )
+            ) {
+              throw error;
+            }
             installed = false;
           }
         },

--- a/test/scripts/stripe-mock/install/stale-locks.test.ts
+++ b/test/scripts/stripe-mock/install/stale-locks.test.ts
@@ -36,7 +36,9 @@ const installsPast = async (
             await downloadStripeMock({
               commands: { curl },
               installLockRetryMs: 1,
-              installLockTimeoutMs: 200,
+              // No time to try again, so an abandoned lock has to be taken
+              // over on the very first look for this install to happen at all.
+              installLockTimeoutMs: 0,
               paths,
             });
             installed = true;

--- a/test/scripts/stripe-mock/install/stale-locks.test.ts
+++ b/test/scripts/stripe-mock/install/stale-locks.test.ts
@@ -61,8 +61,9 @@ describe("a lock left behind by an install that never finished", () => {
   });
 
   test("is taken over when it says a time from the very start of the clock", async () => {
-    // A time of 1 is a real time, however unlikely: 1970 is long ago enough.
-    expect(await installsPast("someone-else\n1")).toBe(true);
+    // The file itself was touched a moment ago, so only reading the time it
+    // claims — 1970, however unlikely — can tell that it is abandoned.
+    expect(await installsPast("someone-else\n1", new Date())).toBe(true);
   });
 
   test("is judged by the file's own age when it says no time at all", async () => {
@@ -72,6 +73,14 @@ describe("a lock left behind by an install that never finished", () => {
   test("is judged by the file's own age when it is from an older install", async () => {
     // Older installs wrote the time alone, with nobody's name against it.
     expect(await installsPast(String(LONG_AGO.getTime()))).toBe(true);
+  });
+
+  test("is judged by the file's age when its time has nothing after it", async () => {
+    // A time with a newline after it and nothing else is not a record we ever
+    // write, so the file's own age decides — and this file is new.
+    expect(await installsPast(`${LONG_AGO.getTime()}\n`, new Date())).toBe(
+      false,
+    );
   });
 
   test("is left alone while it is still fresh", async () => {

--- a/test/scripts/stripe-mock/install/waiting.test.ts
+++ b/test/scripts/stripe-mock/install/waiting.test.ts
@@ -1,0 +1,89 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import {
+  downloadStripeMock,
+  installLockPath,
+} from "#scripts/stripe-mock/install.ts";
+import {
+  createFakeArchive,
+  type TestStripeMockPaths,
+  wait,
+  withFakeCurl,
+  withInstallLockHeld,
+  withTempStripeMockPaths,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+
+/** How long the other install keeps hold of the lock before letting go. */
+const HELD_FOR_MS = 250;
+
+type Tries = { count: number };
+
+/**
+ * Run an install while somebody else holds the lock for a moment, and report
+ * how many times ours tried to take it before it got in.
+ */
+const triesWhileWaiting = async (
+  body: (context: {
+    paths: TestStripeMockPaths;
+    tries: Tries;
+  }) => Promise<void>,
+): Promise<void> => {
+  const fakeArchive = await createFakeArchive();
+  try {
+    await withTempStripeMockPaths(async (paths) => {
+      const lockPath = installLockPath(paths);
+      const tries: Tries = { count: 0 };
+      const open = Deno.open;
+      using _open = stub(Deno, "open", ((
+        path: string | URL,
+        options?: Deno.OpenOptions,
+      ) => {
+        if (String(path) === lockPath && options?.createNew) tries.count += 1;
+        return open(path, options);
+      }) as typeof Deno.open);
+
+      await withInstallLockHeld(paths, async (releaseLock) => {
+        const letGo = wait(HELD_FOR_MS).then(releaseLock);
+        await withFakeCurl(
+          `cat ${JSON.stringify(fakeArchive.archivePath)}`,
+          async (curl) => {
+            await downloadStripeMock({ commands: { curl }, paths });
+          },
+        );
+        await letGo;
+      });
+
+      await body({ paths, tries });
+    });
+  } finally {
+    await fakeArchive.cleanup();
+  }
+};
+
+describe("waiting for another install to finish", () => {
+  test("waits for the lock rather than giving up at once", async () => {
+    await triesWhileWaiting(async ({ paths }) => {
+      // Getting the binary at all means it outlasted the other install.
+      expect((await Deno.stat(paths.binaryPath)).isFile).toBe(true);
+    });
+  });
+
+  test("pauses between tries instead of asking as fast as it can", async () => {
+    await triesWhileWaiting(({ tries }) => {
+      // A quarter of a second of waiting, fifty milliseconds apart, is a
+      // handful of tries. With no pause it would be many thousands.
+      expect(tries.count).toBeLessThan(50);
+      return Promise.resolve();
+    });
+  });
+
+  test("leaves a lock that is still being looked after alone", async () => {
+    await triesWhileWaiting(({ tries }) => {
+      // It never treated the other install's fresh lock as abandoned, so it
+      // had to try more than once.
+      expect(tries.count).toBeGreaterThan(1);
+      return Promise.resolve();
+    });
+  });
+});

--- a/test/scripts/stripe-mock/install/waiting.test.ts
+++ b/test/scripts/stripe-mock/install/waiting.test.ts
@@ -14,8 +14,12 @@ import {
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
 
-/** How long the other install keeps hold of the lock before letting go. */
-const HELD_FOR_MS = 250;
+/**
+ * How long the other install keeps hold of the lock before letting go. Long
+ * enough for a few tries at the standard fifty-millisecond pause, and short
+ * enough that a mutation run repeating it stays quick.
+ */
+const HELD_FOR_MS = 120;
 
 type Tries = { count: number };
 

--- a/test/scripts/stripe-mock/install/waiting.test.ts
+++ b/test/scripts/stripe-mock/install/waiting.test.ts
@@ -44,7 +44,10 @@ const triesWhileWaiting = async (
       }) as typeof Deno.open);
 
       await withInstallLockHeld(paths, async (releaseLock) => {
-        const letGo = wait(HELD_FOR_MS).then(releaseLock);
+        const letGo = (async () => {
+          await wait(HELD_FOR_MS);
+          await releaseLock();
+        })();
         await withFakeCurl(
           `cat ${JSON.stringify(fakeArchive.archivePath)}`,
           async (curl) => {

--- a/test/test-utils/stripe-mock/helpers.ts
+++ b/test/test-utils/stripe-mock/helpers.ts
@@ -390,13 +390,16 @@ export const writeTermIgnoringMock = async (
   await makeExecutable(paths.binaryPath);
 };
 
+/** Runs a body with a stand-in command of the given name in place. */
+export type WithFakeCommand = (
+  script: string,
+  body: (path: string) => Promise<void>,
+) => Promise<void>;
+
 /** Stand in for a command the installer runs, with a script of our own. */
 export const fakeCommand =
-  (name: string) =>
-  async (
-    script: string,
-    body: (path: string) => Promise<void>,
-  ): Promise<void> =>
+  (name: string): WithFakeCommand =>
+  async (script, body) =>
     await withTempDir(async (dir) => {
       const fake = `${dir}/${name}`;
       await Deno.writeTextFile(fake, `#!/bin/sh\n${script}\n`);
@@ -404,4 +407,4 @@ export const fakeCommand =
       await body(fake);
     });
 
-export const withFakeCurl = fakeCommand("curl");
+export const withFakeCurl: WithFakeCommand = fakeCommand("curl");

--- a/test/test-utils/stripe-mock/helpers.ts
+++ b/test/test-utils/stripe-mock/helpers.ts
@@ -390,13 +390,18 @@ export const writeTermIgnoringMock = async (
   await makeExecutable(paths.binaryPath);
 };
 
-export const withFakeCurl = async (
-  script: string,
-  body: (curlPath: string) => Promise<void>,
-): Promise<void> =>
-  await withTempDir(async (dir) => {
-    const fakeCurl = `${dir}/curl`;
-    await Deno.writeTextFile(fakeCurl, `#!/bin/sh\n${script}\n`);
-    await makeExecutable(fakeCurl);
-    await body(fakeCurl);
-  });
+/** Stand in for a command the installer runs, with a script of our own. */
+export const fakeCommand =
+  (name: string) =>
+  async (
+    script: string,
+    body: (path: string) => Promise<void>,
+  ): Promise<void> =>
+    await withTempDir(async (dir) => {
+      const fake = `${dir}/${name}`;
+      await Deno.writeTextFile(fake, `#!/bin/sh\n${script}\n`);
+      await makeExecutable(fake);
+      await body(fake);
+    });
+
+export const withFakeCurl = fakeCommand("curl");


### PR DESCRIPTION
Tests only run once the `stripe-mock` binary is on the machine, and the code that fetches it had very little testing of its own. This adds that testing, and fixes two real faults it turned up.

## What was wrong

**Two of the three install steps could not report why they failed.** Unpacking the archive and marking the file runnable were both run with their error output thrown away, so when either failed the message said only which step it was. They now keep that output, so the reason comes through.

**The lock had a line that could never do anything.** While an install runs it keeps a lock file so a second install waits instead of fighting over the same folder. The code that stops the lock being kept cancelled its timer twice; the second cancel could never have anything to cancel, so it has gone.

## What is now checked

- The address it downloads from, including the pinned version and the right name for a Mac, for Apple silicon, and for an ordinary Linux machine.
- That it fetches with `curl` when nothing else is named.
- That each failing step says what went wrong.
- That the lock is claimed, kept fresh while the install runs, and stops being kept once it ends.
- That a lock left behind by an install that died is taken over, whether it is judged by what it says or by the file's own age, and that a lock still in use is left alone.
- That an install waiting on someone else's lock gives up after the time it was given.

## Why the numbers moved

Every one of the 112 changes the mutation tester can make to `scripts/stripe-mock/install.ts` is now caught, up from about two thirds before. The note in `TODO.md` about finishing this work is gone, because it is finished.