### PR TITLE
Capture door check-in evidence from its Cucumber case

### DIFF
--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -236,32 +236,45 @@ const DOOR_CHECK_IN_CSS = `${brandedThemeCss(
 }
 `;
 
+/** One branded mobile capture: the page an authored case leaves behind, the
+ * part of it worth showing, and the styling it is shown in. */
+const brandedMobileCapture = (
+  caseId: string,
+  id: string,
+  path: string,
+  element: string,
+  css: string,
+): EvidenceCaptureDeclaration =>
+  v.parse(EvidenceCaptureDeclarationSchema, {
+    caseId,
+    css,
+    element,
+    id,
+    path,
+    presentation: "branded",
+    profiles: ["mobile"],
+  });
+
 export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
-  v.parse(EvidenceCaptureDeclarationSchema, {
-    caseId: "servicing.hold-on-dashboard",
-    css: SERVICING_STUDIO_CSS,
-    element: "#servicing-form",
-    id: "servicing-studio-floor-hold",
-    path: "/admin/servicing/{servicingEventId}",
-    presentation: "branded",
-    profiles: ["mobile"],
-  }),
-  v.parse(EvidenceCaptureDeclarationSchema, {
-    caseId: "payments.select-saved-stripe",
-    css: PAYMENT_PROVIDER_CSS,
-    element: ".page-regions.admin-page",
-    id: "payment-provider-choice",
-    path: "/admin/settings",
-    presentation: "branded",
-    profiles: ["mobile"],
-  }),
-  v.parse(EvidenceCaptureDeclarationSchema, {
-    caseId: "door.someone-still-to-arrive-can-be-picked",
-    css: DOOR_CHECK_IN_CSS,
-    element: "article:has(#manual-checkin)",
-    id: "qr-code-check-in",
-    path: "/admin/listing/{doorListingId}/scanner",
-    presentation: "branded",
-    profiles: ["mobile"],
-  }),
+  brandedMobileCapture(
+    "servicing.hold-on-dashboard",
+    "servicing-studio-floor-hold",
+    "/admin/servicing/{servicingEventId}",
+    "#servicing-form",
+    SERVICING_STUDIO_CSS,
+  ),
+  brandedMobileCapture(
+    "payments.select-saved-stripe",
+    "payment-provider-choice",
+    "/admin/settings",
+    ".page-regions.admin-page",
+    PAYMENT_PROVIDER_CSS,
+  ),
+  brandedMobileCapture(
+    "door.someone-still-to-arrive-can-be-picked",
+    "qr-code-check-in",
+    "/admin/listing/{doorListingId}/scanner",
+    "article:has(#manual-checkin)",
+    DOOR_CHECK_IN_CSS,
+  ),
 ];

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -152,6 +152,90 @@ const PAYMENT_PROVIDER_CSS = `${brandedThemeCss(
 }
 `;
 
+const DOOR_CHECK_IN_CSS = `${brandedThemeCss(
+  "8px",
+  "#164e63",
+  "#071525",
+  "#10283c",
+  "#67e8f9",
+  "#22d3ee",
+  "#22d3ee1f",
+  "#02081780",
+  "#22d3ee",
+  "#e6f7fb",
+  "#9bb7c5",
+)}
+
+#manual-checkin {
+  background: #0b1d2e;
+  border: 1px solid #25758b;
+  border-radius: 8px;
+  box-shadow: 0 12px 28px var(--color-shadow);
+  padding: 1rem;
+}
+
+#manual-checkin label {
+  color: #bdeff7;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+#manual-checkin input[type="text"] {
+  background: #071525;
+  border: 1px solid #2f7188;
+  border-radius: 6px;
+  color: var(--color-text);
+}
+
+/* The page's own script opens the list of people still to arrive once the
+ * organiser starts typing. A capture is a plain page load, so show the list
+ * the scenario proves is offered. */
+/* The search box's placeholder is drawn by the input's own text layer, which
+ * rasterises differently from run to run and would change the captured bytes
+ * without changing what the page says. The label above the box already says
+ * what the box is for, so the capture leaves it empty. */
+#manual-checkin input::placeholder {
+  color: transparent;
+}
+
+#ticket-options.hidden {
+  display: block;
+}
+
+#ticket-options {
+  margin-top: 0.5rem;
+  position: static;
+}
+
+#ticket-options [role="option"] {
+  background: #0d3a42;
+  border: 1px solid #22566d;
+  border-radius: 6px;
+  color: #cffafe;
+  /* Each row's own text carries the ticket token, which is new every run and
+   * would change the captured bytes. Show the row's name and place count
+   * instead, both read from the row the organiser would click. */
+  font-size: 0;
+  padding: 0.5rem;
+}
+
+#ticket-options [role="option"]::before {
+  content: attr(data-name) " (" attr(data-quantity) ")";
+  font-size: 1rem;
+}
+
+#manual-checkin button[type="submit"] {
+  background: var(--color-accent);
+  border-color: #2f7188;
+  border-radius: 6px;
+  color: #e6f7fb;
+  font-weight: 800;
+  width: 100%;
+}
+`;
+
 export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
   v.parse(EvidenceCaptureDeclarationSchema, {
     caseId: "servicing.hold-on-dashboard",
@@ -168,6 +252,15 @@ export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
     element: ".page-regions.admin-page",
     id: "payment-provider-choice",
     path: "/admin/settings",
+    presentation: "branded",
+    profiles: ["mobile"],
+  }),
+  v.parse(EvidenceCaptureDeclarationSchema, {
+    caseId: "door.someone-still-to-arrive-can-be-picked",
+    css: DOOR_CHECK_IN_CSS,
+    element: "article:has(#manual-checkin)",
+    id: "qr-code-check-in",
+    path: "/admin/listing/{doorListingId}/scanner",
     presentation: "branded",
     profiles: ["mobile"],
   }),

--- a/test/specs/support/door.ts
+++ b/test/specs/support/door.ts
@@ -47,6 +47,8 @@ export const personWithTicket = async (
     options.places ?? 1,
   );
   rememberStayListing(world, listing, created);
+  // The door this person belongs to, so a screenshot capture can open it.
+  world.evidenceValues.set("doorListingId", String(created.id));
   world.doorTickets ??= new Map();
   world.doorTickets.set(who, token);
 };


### PR DESCRIPTION
The site's QR check-in screenshot (`/images/screenshots/qr-code-check-in.png`) is currently taken by a site-owned script in `chobbledotcom/tickets-site` that drives a throwaway app itself. Nothing ties that image to a passing spec. This declares it as screenshot evidence instead, so it is produced by a Cucumber case and can only change while that case still passes.

## What this adds

- A third entry in `EVIDENCE_CAPTURES`, `qr-code-check-in`, for `@case:door.someone-still-to-arrive-can-be-picked` (`specs/attendees/checking-people-in-at-the-door.feature`). It opens `/admin/listing/{doorListingId}/scanner` and captures `article:has(#manual-checkin)` — the door offering the people still to arrive.
- `personWithTicket` records the door's listing id in `evidenceValues`, which is how the capture path resolves.

## Determinism

The capture is byte-stable across repeated `deno task specs:evidence` runs, which matters because the site commits the imported bytes and locks their SHA-256. Two things had to be handled:

- Each row's own text carries the ticket token, which is new every run. The CSS shows `data-name` and `data-quantity` from the row the organiser would click instead.
- The search box's placeholder is drawn by the input's own text layer and rasterises differently from run to run. The label above the box already says what the box is for, so the capture leaves the placeholder invisible.

Confirmed by six consecutive capture runs producing the same SHA-256.

## Checks run

- `deno task lint:ci` — clean
- `deno task specs:check` — 33 stories, 80 rules
- `deno task specs:files specs/attendees/checking-people-in-at-the-door.feature` — 12 scenarios, 67 steps
- `deno task test:files test/scripts/specs/` — 137 passed
- `deno task specs:evidence` — 3 scenarios, 3 captures written

## Follow-up

The site-side change (mapping, page reference, deleting the site-owned scenario script) is a separate PR on `chobbledotcom/tickets-site`, and needs this merged first so the scheduled evidence import finds the capture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK)_