### PR TITLE
Tidy two repetitive test files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -506,25 +506,7 @@ documents the override. Confirm the suite's slow-test report
 (`SLOW_TEST_THRESHOLD_MS`) doesn't regress. Start points: `fast-expect.ts` for
 what it did and why, and grep `\.toContain(` under `test/` for the call sites.
 
-## Deferred CodeRabbit suggestions from PR #1736 (test-file mirror moves)
-
-PR #1736 relocated ~100 test files to their sources' mirror paths. CodeRabbit
-reviewed the moved content as if new and left two refactor suggestions that are
-valid but bigger than that PR's rename-only remit, so they're recorded here:
-
-- **`test/features/admin/settings-wallets.test.ts`** — the four
-  settings-validation tests ("requires Issuer ID", "requires Service Account
-  Email", "requires private key on initial setup", "rejects invalid PEM
-  private key") repeat the
-  same login → POST → flash-redirect scaffolding, differing only in the blanked
-  field and expected message. Fold them into one table-driven test, following
-  the "advanced redirect" cases in
-  `test/features/admin/settings-helpers/secret.test.ts`.
-- **`test/ui/client/admin/address-lookup/client.test.ts` +
-  `coords-diff.test.ts`** — both files define near-identical `formSpec` and
-  `one` selector helpers for the address-lookup DOM harness. Extract a shared
-  helper under `#test-utils` (or a sibling non-test file in the same folder)
-  and import it from both.
+---
 
 ## Code-quality detector & test-strengthening follow-ups (from PR #1729)
 

--- a/test/features/admin/settings-wallets.test.ts
+++ b/test/features/admin/settings-wallets.test.ts
@@ -30,100 +30,66 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
     method: "POST",
   });
 
-  test("requires Issuer ID", async () => {
-    const { cookie, csrfToken } = await loginAsAdmin();
-
-    const response = await handleRequest(
-      mockFormRequest(
-        "/admin/settings/google-wallet",
-        {
-          csrf_token: csrfToken,
-          google_wallet_issuer_id: "",
-          google_wallet_service_account_email:
-            "test@test.iam.gserviceaccount.com",
-          google_wallet_service_account_key:
-            generateGoogleTestCreds().serviceAccountKey,
-        },
-        cookie,
-      ),
-    );
-    await expectFlashRedirect(
-      "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
-      expect.stringContaining("Issuer ID is required"),
-      false,
-    )(response);
+  /** A valid Google Wallet form; each validation case blanks or breaks one
+   *  field so only that field's message can be the reason for the refusal. */
+  const validWalletForm = () => ({
+    google_wallet_issuer_id: "1234567890",
+    google_wallet_service_account_email: "test@test.iam.gserviceaccount.com",
+    google_wallet_service_account_key:
+      generateGoogleTestCreds().serviceAccountKey,
   });
 
-  test("requires Service Account Email", async () => {
-    const { cookie, csrfToken } = await loginAsAdmin();
+  const REFUSED_WALLET_FORMS: {
+    name: string;
+    field: keyof ReturnType<typeof validWalletForm>;
+    value: string;
+    message: string;
+  }[] = [
+    {
+      field: "google_wallet_issuer_id",
+      message: "Issuer ID is required",
+      name: "requires Issuer ID",
+      value: "",
+    },
+    {
+      field: "google_wallet_service_account_email",
+      message: "Service account email is required",
+      name: "requires Service Account Email",
+      value: "",
+    },
+    {
+      field: "google_wallet_service_account_key",
+      message: "Service account private key is required",
+      name: "requires private key on initial setup",
+      value: "",
+    },
+    {
+      field: "google_wallet_service_account_key",
+      message: "Service account private key is not a valid PEM private key",
+      name: "rejects invalid PEM private key",
+      value: "not a valid key",
+    },
+  ];
 
-    const response = await handleRequest(
-      mockFormRequest(
-        "/admin/settings/google-wallet",
-        {
-          csrf_token: csrfToken,
-          google_wallet_issuer_id: "1234567890",
-          google_wallet_service_account_email: "",
-          google_wallet_service_account_key:
-            generateGoogleTestCreds().serviceAccountKey,
-        },
-        cookie,
-      ),
-    );
-    await expectFlashRedirect(
-      "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
-      expect.stringContaining("Service account email is required"),
-      false,
-    )(response);
-  });
+  for (const { name, field, value, message } of REFUSED_WALLET_FORMS) {
+    test(name, async () => {
+      const { cookie, csrfToken } = await loginAsAdmin();
 
-  test("requires private key on initial setup", async () => {
-    const { cookie, csrfToken } = await loginAsAdmin();
+      const response = await handleRequest(
+        mockFormRequest(
+          "/admin/settings/google-wallet",
+          { ...validWalletForm(), [field]: value, csrf_token: csrfToken },
+          cookie,
+        ),
+      );
 
-    const response = await handleRequest(
-      mockFormRequest(
-        "/admin/settings/google-wallet",
-        {
-          csrf_token: csrfToken,
-          google_wallet_issuer_id: "1234567890",
-          google_wallet_service_account_email:
-            "test@test.iam.gserviceaccount.com",
-          google_wallet_service_account_key: "",
-        },
-        cookie,
-      ),
-    );
-    await expectFlashRedirect(
-      "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
-      expect.stringContaining("Service account private key is required"),
-      false,
-    )(response);
-  });
-
-  test("rejects invalid PEM private key", async () => {
-    const { cookie, csrfToken } = await loginAsAdmin();
-
-    const response = await handleRequest(
-      mockFormRequest(
-        "/admin/settings/google-wallet",
-        {
-          csrf_token: csrfToken,
-          google_wallet_issuer_id: "1234567890",
-          google_wallet_service_account_email:
-            "test@test.iam.gserviceaccount.com",
-          google_wallet_service_account_key: "not a valid key",
-        },
-        cookie,
-      ),
-    );
-    await expectFlashRedirect(
-      "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
-      expect.stringContaining(
-        "Service account private key is not a valid PEM private key",
-      ),
-      false,
-    )(response);
-  });
+      await expectFlashRedirect(
+        "/admin/settings-advanced?form=settings-google-wallet#settings-google-wallet",
+        expect.stringContaining(message),
+        false,
+      )(response);
+    });
+  }
 
   test("saves all settings successfully", async () => {
     const { cookie, csrfToken } = await loginAsAdmin();

--- a/test/features/admin/settings-wallets.test.ts
+++ b/test/features/admin/settings-wallets.test.ts
@@ -97,14 +97,7 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
     const response = await handleRequest(
       mockFormRequest(
         "/admin/settings/google-wallet",
-        {
-          csrf_token: csrfToken,
-          google_wallet_issuer_id: "1234567890",
-          google_wallet_service_account_email:
-            "test@test.iam.gserviceaccount.com",
-          google_wallet_service_account_key:
-            generateGoogleTestCreds().serviceAccountKey,
-        },
+        { ...validWalletForm(), csrf_token: csrfToken },
         cookie,
       ),
     );
@@ -115,9 +108,11 @@ describeWithEnv("POST /admin/settings/google-wallet", { db: true }, () => {
     )(response);
 
     expect(settings.googleWallet.hasConfig).toBe(true);
-    expect(settings.googleWallet.issuerId).toBe("1234567890");
+    expect(settings.googleWallet.issuerId).toBe(
+      validWalletForm().google_wallet_issuer_id,
+    );
     expect(settings.googleWallet.serviceAccountEmail).toBe(
-      "test@test.iam.gserviceaccount.com",
+      validWalletForm().google_wallet_service_account_email,
     );
   });
 

--- a/test/test-utils/address-lookup-dom.test.ts
+++ b/test/test-utils/address-lookup-dom.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { addressFormSpec, oneIn } from "#test-utils/address-lookup-dom.ts";
+import { installFakeDom, restoreDocument } from "#test-utils/fake-dom.ts";
+
+describe("address-lookup DOM fixtures", () => {
+  afterEach(() => {
+    restoreDocument();
+  });
+
+  test("the form holds the panel, the textarea, and anything extra", () => {
+    const [form] = installFakeDom([
+      addressFormSpec([{ name: "lat", tag: "input", type: "text" }]),
+    ]);
+    const one = oneIn(form!);
+
+    expect(one("[data-address-lookup]").tag).toBe("div");
+    expect(one("textarea").tag).toBe("textarea");
+    expect(one('[name="lat"]').tag).toBe("input");
+  });
+
+  test("looking up something the form does not have says which selector", () => {
+    const [form] = installFakeDom([addressFormSpec()]);
+
+    // A silent undefined would surface far from the missing element, so the
+    // lookup names what it could not find.
+    expect(() => oneIn(form!)('[name="lat"]')).toThrow(
+      'No [name="lat"] in the address-lookup form',
+    );
+  });
+});

--- a/test/test-utils/address-lookup-dom.ts
+++ b/test/test-utils/address-lookup-dom.ts
@@ -49,7 +49,7 @@ export const addressFormSpec = (extras: ElementSpec[] = []): ElementSpec => ({
 
 /** Look up one element inside the installed form, failing if it is missing. */
 export const oneIn =
-  (form: FakeElement) =>
+  (form: FakeElement): ((selector: string) => FakeElement) =>
   (selector: string): FakeElement => {
     const found = form.querySelector(selector);
     if (!found) throw new Error(`No ${selector} in the address-lookup form`);

--- a/test/test-utils/address-lookup-dom.ts
+++ b/test/test-utils/address-lookup-dom.ts
@@ -4,7 +4,7 @@
  * base client test and the coordinates/differences test.
  */
 
-import type { ElementSpec } from "#test-utils/fake-dom.ts";
+import type { ElementSpec, FakeElement } from "#test-utils/fake-dom.ts";
 
 /** The server-rendered address-lookup panel, as an element spec. */
 export const panelSpec = (): ElementSpec => ({
@@ -39,6 +39,22 @@ export const diffSpec = (): ElementSpec => ({
   hidden: true,
   tag: "output",
 });
+
+/** A form holding the lookup panel and the address textarea, plus whatever
+ *  else the page under test needs (the differences notice, pin inputs). */
+export const addressFormSpec = (extras: ElementSpec[] = []): ElementSpec => ({
+  children: [panelSpec(), { name: "address", tag: "textarea" }, ...extras],
+  tag: "form",
+});
+
+/** Look up one element inside the installed form, failing if it is missing. */
+export const oneIn =
+  (form: FakeElement) =>
+  (selector: string): FakeElement => {
+    const found = form.querySelector(selector);
+    if (!found) throw new Error(`No ${selector} in the address-lookup form`);
+    return found;
+  };
 
 /** Let an async search settle (fetch → json → DOM writes). */
 export const flushLookup = async (): Promise<void> => {

--- a/test/ui/client/admin/address-lookup/client.test.ts
+++ b/test/ui/client/admin/address-lookup/client.test.ts
@@ -9,7 +9,9 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { initAddressLookup } from "#src/ui/client/admin/address-lookup.ts";
 import {
+  addressFormSpec,
   flushLookup as flush,
+  oneIn,
   panelSpec,
 } from "#test-utils/address-lookup-dom.ts";
 import {
@@ -19,11 +21,6 @@ import {
   restoreDocument,
 } from "#test-utils/fake-dom.ts";
 import { stubFetch } from "#test-utils/fetch-stub.ts";
-
-const formSpec = (): ElementSpec => ({
-  children: [panelSpec(), { name: "address", tag: "textarea" }],
-  tag: "form",
-});
 
 type Parts = {
   form: FakeElement;
@@ -38,9 +35,9 @@ type Parts = {
 
 /** Install the DOM, run the enhancement, and hand back the pieces. */
 const setup = (): Parts => {
-  const [form] = installFakeDom([formSpec()]);
+  const [form] = installFakeDom([addressFormSpec()]);
   initAddressLookup();
-  const one = (selector: string) => form!.querySelector(selector)!;
+  const one = oneIn(form!);
   return {
     findButton: one("[data-address-find]"),
     form: form!,

--- a/test/ui/client/admin/address-lookup/coords-diff.test.ts
+++ b/test/ui/client/admin/address-lookup/coords-diff.test.ts
@@ -8,9 +8,10 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { initAddressLookup } from "#src/ui/client/admin/address-lookup.ts";
 import {
+  addressFormSpec,
   diffSpec,
   flushLookup as flush,
-  panelSpec,
+  oneIn,
 } from "#test-utils/address-lookup-dom.ts";
 import {
   type ElementSpec,
@@ -34,16 +35,12 @@ describe("address lookup fills the pin inputs", () => {
 
   /** A logistics-tab-shaped form: the panel, the textarea, the pin inputs
    * (optionally pre-filled with a saved pin), and the differences notice. */
-  const formSpec = (pin: [string, string] = ["", ""]): ElementSpec => ({
-    children: [
-      panelSpec(),
-      { name: "address", tag: "textarea" },
+  const formSpec = (pin: [string, string] = ["", ""]): ElementSpec =>
+    addressFormSpec([
       diffSpec(),
       { name: "lat", tag: "input", type: "text", value: pin[0] },
       { name: "lng", tag: "input", type: "text", value: pin[1] },
-    ],
-    tag: "form",
-  });
+    ]);
 
   /** Install the page, run a search, and choose the first result. `typed`
    * pre-fills the address textarea before searching. */
@@ -55,7 +52,7 @@ describe("address lookup fills the pin inputs", () => {
     using _fetch = stubFetch(new Response(JSON.stringify(body)));
     const [form] = installFakeDom([page]);
     initAddressLookup();
-    const one = (selector: string) => form!.querySelector(selector)!;
+    const one = oneIn(form!);
     one("textarea").value = typed;
     one("[data-address-search]").value = "SW1A 2AA";
     one("[data-address-find]").dispatch("click");
@@ -63,10 +60,16 @@ describe("address lookup fills the pin inputs", () => {
     const select = one("[data-address-results]");
     select.value = "10 Downing Street, LONDON";
     select.dispatch("change");
+    // The pin inputs are read lazily: a page without them is a real case, and
+    // only the tests that assert on the pin should insist it exists.
     return {
       form: form!,
-      lat: one('[name="lat"]'),
-      lng: one('[name="lng"]'),
+      get lat() {
+        return one('[name="lat"]');
+      },
+      get lng() {
+        return one('[name="lng"]');
+      },
     };
   };
 
@@ -113,10 +116,7 @@ describe("address lookup fills the pin inputs", () => {
   });
 
   test("a page without pin inputs still fills the textarea", async () => {
-    const { form } = await searchAndChoose(LOCATED, {
-      children: [panelSpec(), { name: "address", tag: "textarea" }],
-      tag: "form",
-    });
+    const { form } = await searchAndChoose(LOCATED, addressFormSpec());
     expect(form.querySelector("textarea")!.value).toBe(
       "10 Downing Street, LONDON",
     );


### PR DESCRIPTION
Two small clean-ups that were noted during an earlier review and written down for later. Both are test-only — nothing about how the site behaves changes.

**The Google Wallet settings tests.** Four tests checked that the form refuses to save when a field is missing or wrong. Each one repeated the same steps — log in, send the form, check the message — and differed only in which field was spoiled. They are now one list: a good form, plus the single field each case breaks, and the message the operator should see. Adding a fifth case is now one entry rather than another copy of the whole test.

**The address-lookup tests.** Two files each built their own copy of the same fake page and their own way of finding elements on it. Both now use shared versions from the fixtures file that already sat beside them.

While moving that element lookup, its behaviour changed for the better: it used to hand back nothing when an element was missing, which showed up as a confusing failure somewhere later. It now says which element it could not find. That immediately pointed at a test which reads the map pin boxes on a page that deliberately has none, so those boxes are now only read by the tests that actually check them.

The matching item is removed from `TODO.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mAQvERz1MNvZxNGwmdHw)_