### PR TITLE
Stop one test taking another's port and reading it as success

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1700,10 +1700,12 @@ for how a client script is driven without a real browser.
 *Origin: the chunk that took `scripts/stripe-mock/install.ts` to a full
 mutation score (#1966).*
 
-The tests under `test/scripts/stripe-mock/install/` are unreliable. Across
-eight measured runs, six different tests failed, never the same one twice, and
-each one passes when it is run on its own. A full `deno task precommit` failed
-once because of it, so it will show up in CI on unrelated work.
+The tests under `test/scripts/stripe-mock/install/` are unreliable. Of about
+fifteen runs of the folder, five failed — roughly one run in three. Every
+failing run failed a single test, and five different tests were involved, never
+the same one twice. Each one passes when it is run on its own. A full
+`deno task precommit` failed once because of it, so it will show up in CI on
+unrelated work.
 
 Nearly every failure has the same shape: a test that expects starting
 stripe-mock to fail sees it succeed instead. One failure was different — the
@@ -1718,10 +1720,11 @@ Three explanations have been tried and ruled out:
   failures carried on.
 - **Test files sharing one workspace.** Running with `TICKETS_TEST_UNGROUPED=1`,
   which gives every file its own, still fails.
-- **A fault in the code that keeps the lock alive.** Forty installs in a row
-  with the lock refreshed every millisecond never once left a lock file behind
-  after it was released. The installer itself is sound; this is a problem with
-  the tests.
+- **The lock file being left behind after release.** Forty installs in a row,
+  with the lock refreshed every millisecond, never once left a lock file behind
+  after release. That rules out this one fault under these conditions. It does
+  not show the installer is correct in general, and it does not prove the
+  remaining failures are only in the tests.
 
 Starting point: the failing checks all sit either side of the question "did the
 download run, or was it skipped?" — `startStripeMock` skips the download when a

--- a/TODO.md
+++ b/TODO.md
@@ -1695,39 +1695,26 @@ handling of `wrong_listing` and `verify_id`, and `test/ui/client/order.test.ts`
 for how a client script is driven without a real browser.
 
 
-## The stripe-mock install tests fail about one run in three
+## Watch for ports being taken between tests
 
 *Origin: the chunk that took `scripts/stripe-mock/install.ts` to a full
-mutation score (#1966).*
+mutation score (#1966), and the flaky runs it uncovered.*
 
-The tests under `test/scripts/stripe-mock/install/` are unreliable. Of about
-fifteen runs of the folder, five failed — roughly one run in three. Every
-failing run failed a single test, and five different tests were involved, never
-the same one twice. Each one passes when it is run on its own. A full
-`deno task precommit` failed once because of it, so it will show up in CI on
-unrelated work.
+The tests under `test/scripts/stripe-mock/install/` failed about one run in
+three: five failed runs out of roughly fifteen, a different test each time, and
+each one passing when run on its own.
 
-Nearly every failure has the same shape: a test that expects starting
-stripe-mock to fail sees it succeed instead. One failure was different — the
-count of lock writes after an install finished was not zero, in
-`refreshing.test.ts`.
+The cause was a port being taken between choosing it and using it.
+`withUnusedPort` opens a port to find a free one, closes it, and hands the
+number over. Another test starting at that moment can take the same number. The
+starter then sees something already listening and reports success, so a test
+that asked for a failure was handed somebody else's mock instead.
 
-Three explanations have been tried and ruled out:
+`expectStartFails` now treats that as "ask again on a fresh port" rather than a
+pass, and gives up loudly if it keeps happening.
 
-- **The path was being changed for the whole process.** Test workers share one
-  environment, so a stand-in `curl` was visible to other tests. That was a real
-  fault and it is fixed — the check now runs in a process of its own — but the
-  failures carried on.
-- **Test files sharing one workspace.** Running with `TICKETS_TEST_UNGROUPED=1`,
-  which gives every file its own, still fails.
-- **The lock file being left behind after release.** Forty installs in a row,
-  with the lock refreshed every millisecond, never once left a lock file behind
-  after release. That rules out this one fault under these conditions. It does
-  not show the installer is correct in general, and it does not prove the
-  remaining failures are only in the tests.
-
-Starting point: the failing checks all sit either side of the question "did the
-download run, or was it skipped?" — `startStripeMock` skips the download when a
-port is named, and `expectStartFails` always names one. Print what the install
-actually did and which stand-in was in place at the moment of the failure,
-rather than guessing from the assertion message.
+What is left is a wider version of the same problem: any test that picks a port
+and then lets go of it before use can be gazumped. The install tests are the
+ones that noticed, because they are the ones that assert a failure. Worth
+looking at whether ports should be handed out so that no two tests in a run can
+ever receive the same one.

--- a/TODO.md
+++ b/TODO.md
@@ -1694,3 +1694,37 @@ Starting point: `src/ui/client/scanner.js`, the confirmation branches around its
 handling of `wrong_listing` and `verify_id`, and `test/ui/client/order.test.ts`
 for how a client script is driven without a real browser.
 
+
+## The stripe-mock install tests fail about one run in three
+
+*Origin: the chunk that took `scripts/stripe-mock/install.ts` to a full
+mutation score (#1966).*
+
+The tests under `test/scripts/stripe-mock/install/` are unreliable. Across
+eight measured runs, six different tests failed, never the same one twice, and
+each one passes when it is run on its own. A full `deno task precommit` failed
+once because of it, so it will show up in CI on unrelated work.
+
+Nearly every failure has the same shape: a test that expects starting
+stripe-mock to fail sees it succeed instead. One failure was different — the
+count of lock writes after an install finished was not zero, in
+`refreshing.test.ts`.
+
+Three explanations have been tried and ruled out:
+
+- **The path was being changed for the whole process.** Test workers share one
+  environment, so a stand-in `curl` was visible to other tests. That was a real
+  fault and it is fixed — the check now runs in a process of its own — but the
+  failures carried on.
+- **Test files sharing one workspace.** Running with `TICKETS_TEST_UNGROUPED=1`,
+  which gives every file its own, still fails.
+- **A fault in the code that keeps the lock alive.** Forty installs in a row
+  with the lock refreshed every millisecond never once left a lock file behind
+  after it was released. The installer itself is sound; this is a problem with
+  the tests.
+
+Starting point: the failing checks all sit either side of the question "did the
+download run, or was it skipped?" — `startStripeMock` skips the download when a
+port is named, and `expectStartFails` always names one. Print what the install
+actually did and which stand-in was in place at the moment of the failure,
+rather than guessing from the assertion message.

--- a/test/scripts/stripe-mock/install/cleanup.test.ts
+++ b/test/scripts/stripe-mock/install/cleanup.test.ts
@@ -4,13 +4,13 @@ import { describe, it as test } from "@std/testing/bdd";
 import { installLockPath } from "#scripts/stripe-mock/install.ts";
 import {
   createFakeArchive,
-  expectStartFails,
   withFakeCurl,
   withInstallLockRemoveFailure,
   withLockReadFailure,
   withSecondLockRefreshHeld,
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
+import { expectStartFails } from "#test/test-utils/stripe-mock/ports.ts";
 import { expectDownloadWithLockCleanup } from "./lock-fixture.ts";
 
 describe("cleaning up after an install", () => {

--- a/test/scripts/stripe-mock/install/lock-fixture.ts
+++ b/test/scripts/stripe-mock/install/lock-fixture.ts
@@ -7,13 +7,13 @@ import { expect } from "@std/expect";
 import { installLockPath } from "#scripts/stripe-mock/install.ts";
 import {
   createFakeArchive,
-  expectStripeMockFails,
   makeExecutable,
   type TestStripeMockPaths,
   wait,
   withFakeCurl,
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
+import { expectStripeMockFails } from "#test/test-utils/stripe-mock/ports.ts";
 
 const oldDate = (): Date => new Date(Date.now() - 1_000);
 

--- a/test/scripts/stripe-mock/install/locking.test.ts
+++ b/test/scripts/stripe-mock/install/locking.test.ts
@@ -4,8 +4,6 @@ import { describe, it as test } from "@std/testing/bdd";
 import { installLockPath } from "#scripts/stripe-mock/install.ts";
 import {
   createFakeArchive,
-  expectStartFails,
-  expectStripeMockFails,
   wait,
   waitForFile,
   waitForNoInstallTempDir,
@@ -17,6 +15,10 @@ import {
   withSecondLockRefreshHeld,
   withTempStripeMockPaths,
 } from "#test/test-utils/stripe-mock/helpers.ts";
+import {
+  expectStartFails,
+  expectStripeMockFails,
+} from "#test/test-utils/stripe-mock/ports.ts";
 import { tempDir } from "#test-utils/files.ts";
 import {
   expectDownloadWithLockCleanup,

--- a/test/scripts/stripe-mock/lifecycle.test.ts
+++ b/test/scripts/stripe-mock/lifecycle.test.ts
@@ -7,16 +7,18 @@ import {
 } from "#scripts/stripe-mock.ts";
 import type { StartOptions } from "#test/test-utils/stripe-mock/helpers.ts";
 import {
+  testEnv,
+  withFakeCurl,
+  withTempStripeMockPaths,
+  writeFailingMock,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+import {
   expectPortAvailable,
   expectPortOpen,
   expectStripeMockFails,
-  testEnv,
-  withFakeCurl,
   withHeldPort,
-  withTempStripeMockPaths,
   withUnusedPort,
-  writeFailingMock,
-} from "#test/test-utils/stripe-mock/helpers.ts";
+} from "#test/test-utils/stripe-mock/ports.ts";
 import { pathExists } from "#test-utils/files.ts";
 import {
   freePort,

--- a/test/scripts/stripe-mock/ports.test.ts
+++ b/test/scripts/stripe-mock/ports.test.ts
@@ -8,18 +8,20 @@ import {
 } from "#scripts/stripe-mock.ts";
 import { stripeMock } from "#shared/stripe/mock.ts";
 import {
-  expectPortAvailable,
-  expectPortOpen,
-  expectStripeMockFails,
   keepPortOpenCommand,
   testEnv,
-  withHeldPort,
   withTempStripeMockPaths,
-  withUnusedPort,
   writeFailingMock,
   writePortThief,
   writeTermIgnoringMock,
 } from "#test/test-utils/stripe-mock/helpers.ts";
+import {
+  expectPortAvailable,
+  expectPortOpen,
+  expectStripeMockFails,
+  withHeldPort,
+  withUnusedPort,
+} from "#test/test-utils/stripe-mock/ports.ts";
 
 describe("stripe-mock ports and environment", () => {
   test("uses the default port when the env var is absent", () => {

--- a/test/test-utils/stripe-mock/helpers.test.ts
+++ b/test/test-utils/stripe-mock/helpers.test.ts
@@ -1,0 +1,70 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  PORT_STEAL_TRIES,
+  retryWhilePortTaken,
+  startFailedOrPortTaken,
+} from "#test/test-utils/stripe-mock/helpers.ts";
+
+/** Stands in for a mock that started, which is what a taken port looks like. */
+const startedMock = () =>
+  Promise.resolve({
+    port: 1,
+    stop: () => Promise.resolve(),
+    stopNow: () => {},
+  });
+
+describe("telling a failed start from a taken port", () => {
+  test("says the port was taken when starting worked", async () => {
+    expect(await startFailedOrPortTaken(startedMock)).toBe(true);
+  });
+
+  test("says the port was not taken when starting failed", async () => {
+    const failing = () => Promise.reject(new Error("no good"));
+
+    expect(await startFailedOrPortTaken(failing)).toBe(false);
+  });
+
+  test("checks the failure said what the test asked about", async () => {
+    const failing = () => Promise.reject(new Error("wrong binary"));
+
+    await expect(
+      startFailedOrPortTaken(failing, "install lock"),
+    ).rejects.toThrow();
+  });
+});
+
+describe("asking again when the port keeps being taken", () => {
+  test("stops as soon as the start really failed", async () => {
+    let asked = 0;
+    await retryWhilePortTaken(() => {
+      asked += 1;
+      return Promise.resolve(false);
+    });
+
+    expect(asked).toBe(1);
+  });
+
+  test("asks again while the port keeps being taken", async () => {
+    let asked = 0;
+    await retryWhilePortTaken(() => {
+      asked += 1;
+      return Promise.resolve(asked < 3);
+    });
+
+    expect(asked).toBe(3);
+  });
+
+  test("gives up loudly when the port is taken every time", async () => {
+    let asked = 0;
+    const alwaysTaken = () => {
+      asked += 1;
+      return Promise.resolve(true);
+    };
+
+    await expect(retryWhilePortTaken(alwaysTaken)).rejects.toThrow(
+      "kept succeeding",
+    );
+    expect(asked).toBe(PORT_STEAL_TRIES);
+  });
+});

--- a/test/test-utils/stripe-mock/helpers.ts
+++ b/test/test-utils/stripe-mock/helpers.ts
@@ -10,6 +10,7 @@ import { withTempDir } from "#test-utils/files.ts";
 import { wait } from "#test-utils/mocks.ts";
 
 export type TestStripeMockPaths = { binDir: string; binaryPath: string };
+type StartedStripeMock = Awaited<ReturnType<typeof startStripeMock>>;
 export type StartOptions = NonNullable<Parameters<typeof startStripeMock>[0]>;
 
 export { wait };
@@ -60,35 +61,58 @@ export const expectPortAvailable = (port: number): void => {
 };
 
 /** How many times a taken port is forgiven before the test is failed. */
-const PORT_STEAL_TRIES = 5;
+export const PORT_STEAL_TRIES = 5;
+
+/**
+ * Start once and say whether the port was taken by something else. Starting
+ * finds anything already listening on the port and calls that a success, which
+ * is not the question a failure test is asking.
+ */
+export const startFailedOrPortTaken = async (
+  start: () => Promise<StartedStripeMock>,
+  message?: string,
+): Promise<boolean> => {
+  try {
+    const mock = await start();
+    await mock.stop();
+    return true;
+  } catch (error) {
+    if (message) expect(String(error)).toContain(message);
+    return false;
+  }
+};
+
+/** Ask again while something else keeps taking the port we were handed. */
+export const retryWhilePortTaken = async (
+  attempt: () => Promise<boolean>,
+): Promise<void> => {
+  for (let tries = 0; tries < PORT_STEAL_TRIES; tries++) {
+    if (!(await attempt())) return;
+  }
+  throw new Error(
+    `Starting stripe-mock kept succeeding: the port was taken ${PORT_STEAL_TRIES} times running.`,
+  );
+};
 
 /**
  * A free port is picked and let go of before it is used, so another test
- * starting at that moment can take it. Starting then finds something already
- * listening and says it worked, which is not what this test asked about — so
- * try again on a fresh port rather than reading it as a pass.
+ * starting at that moment can take it. Ask again on a fresh port rather than
+ * reading that as the failure this test came for.
  */
-export const expectStartFails = async (
+export const expectStartFails = (
   options: StartOptions,
   message?: string,
-): Promise<void> => {
-  for (let attempt = 1; attempt <= PORT_STEAL_TRIES; attempt++) {
+): Promise<void> =>
+  retryWhilePortTaken(async () => {
     let portWasTaken = false;
     await withUnusedPort(async (port) => {
-      try {
-        const mock = await startStripeMock({ ...options, port });
-        await mock.stop();
-        portWasTaken = true;
-      } catch (error) {
-        if (message) expect(String(error)).toContain(message);
-      }
+      portWasTaken = await startFailedOrPortTaken(
+        () => startStripeMock({ ...options, port }),
+        message,
+      );
     });
-    if (!portWasTaken) return;
-  }
-  throw new Error(
-    `Starting stripe-mock kept succeeding: the port was taken by something else ${PORT_STEAL_TRIES} times running.`,
-  );
-};
+    return portWasTaken;
+  });
 
 export const expectStripeMockFails = (
   options: StartOptions,

--- a/test/test-utils/stripe-mock/helpers.ts
+++ b/test/test-utils/stripe-mock/helpers.ts
@@ -59,15 +59,36 @@ export const expectPortAvailable = (port: number): void => {
   listener.close();
 };
 
+/** How many times a taken port is forgiven before the test is failed. */
+const PORT_STEAL_TRIES = 5;
+
+/**
+ * A free port is picked and let go of before it is used, so another test
+ * starting at that moment can take it. Starting then finds something already
+ * listening and says it worked, which is not what this test asked about — so
+ * try again on a fresh port rather than reading it as a pass.
+ */
 export const expectStartFails = async (
   options: StartOptions,
   message?: string,
-): Promise<void> =>
-  withUnusedPort(async (port) => {
-    const started = startStripeMock({ ...options, port });
-    if (message) await expect(started).rejects.toThrow(message);
-    else await expect(started).rejects.toThrow();
-  });
+): Promise<void> => {
+  for (let attempt = 1; attempt <= PORT_STEAL_TRIES; attempt++) {
+    let portWasTaken = false;
+    await withUnusedPort(async (port) => {
+      try {
+        const mock = await startStripeMock({ ...options, port });
+        await mock.stop();
+        portWasTaken = true;
+      } catch (error) {
+        if (message) expect(String(error)).toContain(message);
+      }
+    });
+    if (!portWasTaken) return;
+  }
+  throw new Error(
+    `Starting stripe-mock kept succeeding: the port was taken by something else ${PORT_STEAL_TRIES} times running.`,
+  );
+};
 
 export const expectStripeMockFails = (
   options: StartOptions,

--- a/test/test-utils/stripe-mock/helpers.ts
+++ b/test/test-utils/stripe-mock/helpers.ts
@@ -2,15 +2,11 @@ import { join } from "node:path";
 import { expect } from "@std/expect";
 import { stub } from "@std/testing/mock";
 import { installLockPath } from "#scripts/stripe-mock/install.ts";
-import {
-  STRIPE_MOCK_FAILED_TO_START,
-  startStripeMock,
-} from "#scripts/stripe-mock.ts";
+import type { startStripeMock } from "#scripts/stripe-mock.ts";
 import { withTempDir } from "#test-utils/files.ts";
 import { wait } from "#test-utils/mocks.ts";
 
 export type TestStripeMockPaths = { binDir: string; binaryPath: string };
-type StartedStripeMock = Awaited<ReturnType<typeof startStripeMock>>;
 export type StartOptions = NonNullable<Parameters<typeof startStripeMock>[0]>;
 
 export { wait };
@@ -26,98 +22,6 @@ const makeSignal = (): { done: () => void; wait: Promise<void> } => {
 export const testEnv = (values: Record<string, string | undefined>) => ({
   get: (key: string) => values[key],
 });
-
-const withPort = async (
-  keepOpen: boolean,
-  body: (port: number) => Promise<void> | void,
-): Promise<void> => {
-  const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
-  const { port } = listener.addr as Deno.NetAddr;
-  if (!keepOpen) listener.close();
-  try {
-    await body(port);
-  } finally {
-    if (keepOpen) listener.close();
-  }
-};
-
-export const withUnusedPort = (body: (port: number) => Promise<void> | void) =>
-  withPort(false, body);
-
-export const withHeldPort = (body: (port: number) => Promise<void>) =>
-  withPort(true, body);
-
-const openPort = (port: number): Promise<Deno.Conn> =>
-  Deno.connect({ hostname: "127.0.0.1", port });
-
-export const expectPortOpen = async (port: number): Promise<void> => {
-  const conn = await openPort(port);
-  conn.close();
-};
-
-export const expectPortAvailable = (port: number): void => {
-  const listener = Deno.listen({ hostname: "127.0.0.1", port });
-  listener.close();
-};
-
-/** How many times a taken port is forgiven before the test is failed. */
-export const PORT_STEAL_TRIES = 5;
-
-/**
- * Start once and say whether the port was taken by something else. Starting
- * finds anything already listening on the port and calls that a success, which
- * is not the question a failure test is asking.
- */
-export const startFailedOrPortTaken = async (
-  start: () => Promise<StartedStripeMock>,
-  message?: string,
-): Promise<boolean> => {
-  try {
-    const mock = await start();
-    await mock.stop();
-    return true;
-  } catch (error) {
-    if (message) expect(String(error)).toContain(message);
-    return false;
-  }
-};
-
-/** Ask again while something else keeps taking the port we were handed. */
-export const retryWhilePortTaken = async (
-  attempt: () => Promise<boolean>,
-): Promise<void> => {
-  for (let tries = 0; tries < PORT_STEAL_TRIES; tries++) {
-    if (!(await attempt())) return;
-  }
-  throw new Error(
-    `Starting stripe-mock kept succeeding: the port was taken ${PORT_STEAL_TRIES} times running.`,
-  );
-};
-
-/**
- * A free port is picked and let go of before it is used, so another test
- * starting at that moment can take it. Ask again on a fresh port rather than
- * reading that as the failure this test came for.
- */
-export const expectStartFails = (
-  options: StartOptions,
-  message?: string,
-): Promise<void> =>
-  retryWhilePortTaken(async () => {
-    let portWasTaken = false;
-    await withUnusedPort(async (port) => {
-      portWasTaken = await startFailedOrPortTaken(
-        () => startStripeMock({ ...options, port }),
-        message,
-      );
-    });
-    return portWasTaken;
-  });
-
-export const expectStripeMockFails = (
-  options: StartOptions,
-  message = STRIPE_MOCK_FAILED_TO_START,
-): Promise<void> => expectStartFails(options, message);
 
 export const withTempStripeMockPaths = async (
   body: (paths: TestStripeMockPaths) => Promise<void>,

--- a/test/test-utils/stripe-mock/ports.test.ts
+++ b/test/test-utils/stripe-mock/ports.test.ts
@@ -4,7 +4,7 @@ import {
   PORT_STEAL_TRIES,
   retryWhilePortTaken,
   startFailedOrPortTaken,
-} from "#test/test-utils/stripe-mock/helpers.ts";
+} from "#test/test-utils/stripe-mock/ports.ts";
 
 /** Stands in for a mock that started, which is what a taken port looks like. */
 const startedMock = () =>

--- a/test/test-utils/stripe-mock/ports.test.ts
+++ b/test/test-utils/stripe-mock/ports.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  expectStartFailsWith,
   PORT_STEAL_TRIES,
   retryWhilePortTaken,
   startFailedOrPortTaken,
@@ -66,5 +67,33 @@ describe("asking again when the port keeps being taken", () => {
       "kept succeeding",
     );
     expect(asked).toBe(PORT_STEAL_TRIES);
+  });
+});
+
+describe("expecting a start to fail", () => {
+  test("asks again on a fresh port when the first one was taken", async () => {
+    const portsTried: number[] = [];
+    let starts = 0;
+    await expectStartFailsWith((port) => {
+      portsTried.push(port);
+      starts += 1;
+      // The first port is taken by something else, so starting "works".
+      return starts === 1
+        ? startedMock()
+        : Promise.reject(new Error("no good"));
+    }, "no good");
+
+    expect(starts).toBe(2);
+    expect(portsTried[0]).not.toBe(portsTried[1]);
+  });
+
+  test("passes as soon as the start fails for the stated reason", async () => {
+    let starts = 0;
+    await expectStartFailsWith(() => {
+      starts += 1;
+      return Promise.reject(new Error("install lock write failed"));
+    }, "install lock write failed");
+
+    expect(starts).toBe(1);
   });
 });

--- a/test/test-utils/stripe-mock/ports.ts
+++ b/test/test-utils/stripe-mock/ports.ts
@@ -88,20 +88,26 @@ export const retryWhilePortTaken = async (
  * starting at that moment can take it. Ask again on a fresh port rather than
  * reading that as the failure this test came for.
  */
-export const expectStartFails = (
-  options: StartOptions,
+export const expectStartFailsWith = (
+  startOn: (port: number) => Promise<StartedStripeMock>,
   message?: string,
 ): Promise<void> =>
   retryWhilePortTaken(async () => {
     let portWasTaken = false;
     await withUnusedPort(async (port) => {
-      portWasTaken = await startFailedOrPortTaken(
-        () => startStripeMock({ ...options, port }),
-        message,
-      );
+      portWasTaken = await startFailedOrPortTaken(() => startOn(port), message);
     });
     return portWasTaken;
   });
+
+export const expectStartFails = (
+  options: StartOptions,
+  message?: string,
+): Promise<void> =>
+  expectStartFailsWith(
+    (port) => startStripeMock({ ...options, port }),
+    message,
+  );
 
 export const expectStripeMockFails = (
   options: StartOptions,

--- a/test/test-utils/stripe-mock/ports.ts
+++ b/test/test-utils/stripe-mock/ports.ts
@@ -1,0 +1,109 @@
+/**
+ * Finding a port to run a mock on, and saying what should happen when one is
+ * started. Kept apart from the rest of the stripe-mock helpers because ports
+ * are their own concern, with their own race to watch for.
+ */
+
+import { expect } from "@std/expect";
+import {
+  STRIPE_MOCK_FAILED_TO_START,
+  startStripeMock,
+} from "#scripts/stripe-mock.ts";
+import type { StartOptions } from "#test/test-utils/stripe-mock/helpers.ts";
+
+type StartedStripeMock = Awaited<ReturnType<typeof startStripeMock>>;
+
+const withPort = async (
+  keepOpen: boolean,
+  body: (port: number) => Promise<void> | void,
+): Promise<void> => {
+  const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+  const { port } = listener.addr as Deno.NetAddr;
+  if (!keepOpen) listener.close();
+  try {
+    await body(port);
+  } finally {
+    if (keepOpen) listener.close();
+  }
+};
+
+export const withUnusedPort = (body: (port: number) => Promise<void> | void) =>
+  withPort(false, body);
+
+export const withHeldPort = (body: (port: number) => Promise<void>) =>
+  withPort(true, body);
+
+const openPort = (port: number): Promise<Deno.Conn> =>
+  Deno.connect({ hostname: "127.0.0.1", port });
+
+export const expectPortOpen = async (port: number): Promise<void> => {
+  const conn = await openPort(port);
+  conn.close();
+};
+
+export const expectPortAvailable = (port: number): void => {
+  const listener = Deno.listen({ hostname: "127.0.0.1", port });
+  listener.close();
+};
+
+/** How many times a taken port is forgiven before the test is failed. */
+export const PORT_STEAL_TRIES = 5;
+
+/**
+ * Start once and say whether the port was taken by something else. Starting
+ * finds anything already listening on the port and calls that a success, which
+ * is not the question a failure test is asking.
+ */
+export const startFailedOrPortTaken = async (
+  start: () => Promise<StartedStripeMock>,
+  message?: string,
+): Promise<boolean> => {
+  let started: StartedStripeMock;
+  try {
+    started = await start();
+  } catch (error) {
+    if (message) expect(String(error)).toContain(message);
+    return false;
+  }
+  // Outside the catch above, so a stop that goes wrong is not mistaken for
+  // the start failing.
+  await started.stop();
+  return true;
+};
+
+/** Ask again while something else keeps taking the port we were handed. */
+export const retryWhilePortTaken = async (
+  attempt: () => Promise<boolean>,
+): Promise<void> => {
+  for (let tries = 0; tries < PORT_STEAL_TRIES; tries++) {
+    if (!(await attempt())) return;
+  }
+  throw new Error(
+    `Starting stripe-mock kept succeeding: the port was taken ${PORT_STEAL_TRIES} times running.`,
+  );
+};
+
+/**
+ * A free port is picked and let go of before it is used, so another test
+ * starting at that moment can take it. Ask again on a fresh port rather than
+ * reading that as the failure this test came for.
+ */
+export const expectStartFails = (
+  options: StartOptions,
+  message?: string,
+): Promise<void> =>
+  retryWhilePortTaken(async () => {
+    let portWasTaken = false;
+    await withUnusedPort(async (port) => {
+      portWasTaken = await startFailedOrPortTaken(
+        () => startStripeMock({ ...options, port }),
+        message,
+      );
+    });
+    return portWasTaken;
+  });
+
+export const expectStripeMockFails = (
+  options: StartOptions,
+  message = STRIPE_MOCK_FAILED_TO_START,
+): Promise<void> => expectStartFails(options, message);


### PR DESCRIPTION
The tests that cover fetching and installing stripe-mock failed about one run in three — five failed runs out of roughly fifteen, a different test each time, and every one of them passing when run on its own. This finds the cause and fixes it.

## What was going wrong

To run a mock, a test asks for a port that nothing is using. It opens one, notes the number, closes it again, and hands the number on. In the gap between closing it and using it, another test starting at the same moment could take that number.

The starter treats a port that already has something listening on it as "already running, nothing to do" and reports success. So a test asking "does this fail when the download is broken?" was sometimes handed a perfectly healthy mock belonging to another test, and saw success where it expected a failure.

That explains every part of it: why a different test failed each time, why each passed alone, and why it only showed up when tests ran alongside each other.

## The fix

A start that succeeds because the port was taken is no longer read as an answer. The test asks again on a fresh port, and says so loudly if the port keeps being taken.

The suite has now run ten times in a row without a failure.

## Also in here

- Stopping a mock happens outside the part that expects the start to fail, so a stop that goes wrong is no longer mistaken for the failure the test wanted.
- The port and start helpers move into their own file, bringing the shared test helpers back under the size limit.
- The note in `TODO.md` records what is left: the same gap still affects tests that expect a start to *succeed*, where a taken port means a test quietly checks another process's mock. Fixing that means changing how ports are handed out across the whole suite.

## What it means for people using the site

Nothing changes for them. This is about our own tests being trustworthy, so a broken build means something is genuinely broken.