### PR TITLE
Make the admin API example match the real responses

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -819,16 +819,6 @@ they were left out of that PR's scope.
   from "draft empty". Not a dedup regression: the ordering is byte-identical to
   before the PR.
 
-- **Tautological admin-API example test**
-  (`test/shared/admin-api-example.test.ts`: `toAdminListing output matches the
-  documented example`). `ADMIN_API_EXAMPLE_ADMIN_LISTING` is defined as
-  `toAdminListing(API_EXAMPLE_LISTING)` and the test compares
-  `toAdminListing(API_EXAMPLE_LISTING)` against it — both sides derive from the
-  same call, so the assertion cannot catch a `toAdminListing` shape regression.
-  Fix: author an independent `AdminListing` fixture (or assert against an
-  admin-listing schema). Pre-existing — the base had the same tautology via the
-  now-removed `ADMIN_API_EXAMPLE_LISTING` alias.
-
 - **Bulk-group-duplicate form loses inputs on a failed POST**
   (`src/ui/templates/admin/bulk-actions.tsx` `adminDuplicateGroupPage`). On a
   validation error the form re-renders with defaults (`${group.name} (copy)`,

--- a/src/features/admin/api.ts
+++ b/src/features/admin/api.ts
@@ -311,7 +311,7 @@ const handleToggleActive = (
     // A deactivation that would orphan a child-scoped add-on is rejected with
     // the same 400 + error the HTML deactivate route gives.
     if ("error" in result) return apiErrorResponse(result.error);
-    return jsonResponse({ listing: toAdminListing(result.updated) });
+    return jsonResponse({ listing: await toApiListing(result.updated) });
   });
 
 /** Strip slug_index from listing row, producing the admin API shape */
@@ -459,6 +459,15 @@ const hydrateListingGroupIds = async (
     group_ids: listingGroups.idsFor(groupIdsByListing, row.id),
   }))(rows);
 };
+
+/** One listing as every admin endpoint answers with it: the stored fields plus
+ * the ids of the groups it is in. */
+const toApiListing = async (
+  row: ListingWithCount,
+): Promise<Record<string, unknown>> => ({
+  ...toAdminListing(row),
+  ...(await hydrateListingGroupIds([row])).get(row.id),
+});
 
 const listingApiRoutes = defineCrudApi<
   Listing,

--- a/src/shared/admin-api-example.ts
+++ b/src/shared/admin-api-example.ts
@@ -33,9 +33,11 @@ import {
 } from "#shared/api-example.ts";
 import type { AdminListing } from "#shared/types.ts";
 
-/** The example AdminListing, produced by toAdminListing */
-export const ADMIN_API_EXAMPLE_ADMIN_LISTING: AdminListing =
-  toAdminListing(API_EXAMPLE_LISTING);
+/** The example listing exactly as the admin endpoints answer with it: the
+ * stored fields, plus the ids of the groups it is in. The example is in none. */
+export const ADMIN_API_EXAMPLE_ADMIN_LISTING: AdminListing & {
+  group_ids: number[];
+} = { ...toAdminListing(API_EXAMPLE_LISTING), group_ids: [] };
 
 /** Example create request body */
 const ADMIN_API_CREATE_BODY = {

--- a/test/integration/server/admin-api/listings/groups.test.ts
+++ b/test/integration/server/admin-api/listings/groups.test.ts
@@ -84,6 +84,37 @@ describeWithEnv("Admin API - Listings", { db: true }, () => {
       expect(inList.group_ids).toEqual([group.id]);
     });
 
+    test("deactivating and reactivating answer with group_ids too", async () => {
+      const group = await createTestGroup({ name: "Toggle Group" });
+      const created = await assertJson(
+        apiRequest("/api/admin/listings", {
+          body: {
+            group_ids: [group.id],
+            max_attendees: 10,
+            name: "Toggle Listing",
+          },
+          method: "POST",
+        }),
+        201,
+      );
+
+      const deactivated = await assertJson(
+        apiRequest(`/api/admin/listings/${created.listing.id}/deactivate`, {
+          method: "POST",
+        }),
+        200,
+      );
+      expect(deactivated.listing.group_ids).toEqual([group.id]);
+
+      const reactivated = await assertJson(
+        apiRequest(`/api/admin/listings/${created.listing.id}/reactivate`, {
+          method: "POST",
+        }),
+        200,
+      );
+      expect(reactivated.listing.group_ids).toEqual([group.id]);
+    });
+
     test("list batch-hydrates group_ids, including an empty array for ungrouped", async () => {
       const group = await createTestGroup({ name: "Batch Group" });
       const grouped = await assertJson(

--- a/test/shared/admin-api-example.test.ts
+++ b/test/shared/admin-api-example.test.ts
@@ -28,6 +28,30 @@ describe("admin API example", () => {
     ).not.toThrow();
   });
 
+  test("an internal field leaking into a response is refused", () => {
+    expect(() =>
+      v.parse(AdminListingSchema, {
+        ...ADMIN_API_EXAMPLE_ADMIN_LISTING,
+        slug_index: "leaked",
+      }),
+    ).toThrow();
+  });
+
+  test("a missing field is refused", () => {
+    const { name: _, ...withoutName } = ADMIN_API_EXAMPLE_ADMIN_LISTING;
+
+    expect(() => v.parse(AdminListingSchema, withoutName)).toThrow();
+  });
+
+  test("a field of the wrong type is refused", () => {
+    expect(() =>
+      v.parse(AdminListingSchema, {
+        ...ADMIN_API_EXAMPLE_ADMIN_LISTING,
+        id: "1",
+      }),
+    ).toThrow();
+  });
+
   test("the conversion drops the internal slug index", () => {
     expect(toAdminListing(API_EXAMPLE_LISTING)).not.toHaveProperty(
       "slug_index",

--- a/test/shared/admin-api-example.test.ts
+++ b/test/shared/admin-api-example.test.ts
@@ -63,6 +63,10 @@ describe("admin API example", () => {
 
     expect(toAdminListing(API_EXAMPLE_LISTING)).toEqual(expected);
   });
+
+  test("the documented example says which groups the listing is in", () => {
+    expect(ADMIN_API_EXAMPLE_ADMIN_LISTING.group_ids).toEqual([]);
+  });
 });
 
 describe("endpoint docs", () => {
@@ -94,7 +98,7 @@ describe("endpoint docs", () => {
     ).not.toThrow();
   });
 
-  test("admin listing list response uses AdminListing shape", () => {
+  test("the admin listing list also shows the groups a listing is in", () => {
     const listEndpoint = ADMIN_API_ENDPOINTS.find(
       (e: EndpointDoc) =>
         e.method === "GET" && e.path === "/api/admin/listings",

--- a/test/shared/admin-api-example.test.ts
+++ b/test/shared/admin-api-example.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests that the admin API examples match the real toAdminListing() output.
- * If the shape changes, this test fails and forces an update to
- * src/shared/admin-api-example.ts (and thus the API docs page).
+ * The admin API docs page publishes an example listing. These tests check it
+ * against a hand-written shape, so a change to the real conversion cannot
+ * quietly take the documented example with it.
  */
 
 import { expect } from "@std/expect";
@@ -16,19 +16,28 @@ import {
   PUBLIC_API_ENDPOINTS,
 } from "#shared/admin-api-example.ts";
 import { API_EXAMPLE_LISTING } from "#shared/api-example.ts";
-import { PublicListingSchema } from "#test-utils/api-schemas.ts";
+import {
+  AdminListingSchema,
+  PublicListingSchema,
+} from "#test-utils/api-schemas.ts";
 
 describe("admin API example", () => {
-  test("toAdminListing output matches the documented example", () => {
-    const result = toAdminListing(API_EXAMPLE_LISTING);
-    expect(result).toEqual(ADMIN_API_EXAMPLE_ADMIN_LISTING);
+  test("the documented example has every admin listing field", () => {
+    expect(() =>
+      v.parse(AdminListingSchema, ADMIN_API_EXAMPLE_ADMIN_LISTING),
+    ).not.toThrow();
   });
 
-  test("example has all AdminListing keys", () => {
-    const result = toAdminListing(API_EXAMPLE_LISTING);
-    const resultKeys = Object.keys(result).sort();
-    const exampleKeys = Object.keys(ADMIN_API_EXAMPLE_ADMIN_LISTING).sort();
-    expect(exampleKeys).toEqual(resultKeys);
+  test("the conversion drops the internal slug index", () => {
+    expect(toAdminListing(API_EXAMPLE_LISTING)).not.toHaveProperty(
+      "slug_index",
+    );
+  });
+
+  test("the conversion keeps every other listing field as it was", () => {
+    const { slug_index: _, ...expected } = API_EXAMPLE_LISTING;
+
+    expect(toAdminListing(API_EXAMPLE_LISTING)).toEqual(expected);
   });
 });
 
@@ -67,10 +76,7 @@ describe("endpoint docs", () => {
         e.method === "GET" && e.path === "/api/admin/listings",
     )!;
     const parsed = JSON.parse(listEndpoint.response);
-    const realAdminListing = toAdminListing(API_EXAMPLE_LISTING);
-    const realKeys = Object.keys(realAdminListing).sort();
-    const exampleKeys = Object.keys(parsed.listings[0]).sort();
-    expect(exampleKeys).toEqual(realKeys);
+    expect(() => v.parse(AdminListingSchema, parsed.listings[0])).not.toThrow();
   });
 
   test("every endpoint has a description", () => {

--- a/test/test-utils/api-schemas.ts
+++ b/test/test-utils/api-schemas.ts
@@ -37,3 +37,72 @@ export const PublicListingSchema = v.strictObject({
   availableDates: v.optional(v.array(v.string())),
   dayPrices: v.optional(v.record(v.string(), v.number())),
 });
+
+/**
+ * Shape of a listing as returned by the admin JSON API (mirrors the production
+ * `AdminListing` type). Written out by hand rather than derived from
+ * `toAdminListing`, so it can catch a change that both the function and its
+ * documented example would make together. `strictObject` rejects any
+ * unexpected key, which is what keeps the internal `slug_index` out of every
+ * admin response.
+ */
+export const AdminListingSchema = v.strictObject({
+  ...v.entriesFromList(
+    [
+      "attachment_name",
+      "attachment_url",
+      "created",
+      "date",
+      "description",
+      "fields",
+      "image_alt_text",
+      "image_thumb_url",
+      "image_url",
+      "listing_type",
+      "location",
+      "name",
+      "slug",
+      "thank_you_url",
+      "webhook_url",
+    ],
+    v.string(),
+  ),
+  ...v.entriesFromList(
+    [
+      "attendee_count",
+      "cost",
+      "duration_days",
+      "id",
+      "income",
+      "initial_site_months",
+      "max_attendees",
+      "max_price",
+      "max_quantity",
+      "maximum_days_after",
+      "minimum_days_before",
+      "months_per_unit",
+      "profit",
+      "tickets_count",
+      "unit_price",
+    ],
+    v.number(),
+  ),
+  ...v.entriesFromList(
+    [
+      "active",
+      "assign_built_site",
+      "bookable_alone",
+      "can_pay_more",
+      "customisable_days",
+      "hidden",
+      "non_transferable",
+      "purchase_only",
+      "use_defaults",
+      "uses_logistics",
+    ],
+    v.boolean(),
+  ),
+  bookable_days: v.array(v.string()),
+  closes_at: v.nullable(v.string()),
+  day_prices: v.record(v.string(), v.number()),
+});

--- a/test/test-utils/api-schemas.ts
+++ b/test/test-utils/api-schemas.ts
@@ -105,4 +105,6 @@ export const AdminListingSchema = v.strictObject({
   bookable_days: v.array(v.string()),
   closes_at: v.nullable(v.string()),
   day_prices: v.record(v.string(), v.number()),
+  /** The groups the listing is in, added to every admin response. */
+  group_ids: v.array(v.number()),
 });


### PR DESCRIPTION
The admin API documentation page shows an example listing so people can see what a response looks like. A test was meant to keep that example honest, but it could never fail — and once it could, it found that the example was wrong.

**The test could not fail.** The example is built by running the real conversion on a sample listing. The test ran that same conversion again and compared the two results. Both sides were the same thing, so if the conversion ever started returning the wrong shape, the example would change to match it and the test would still pass. A second test compared the two field lists — the same problem — and the check on the documented list response did it a third time.

Now the example is checked against a field list written out by hand. It names every field, its type, and nothing else, so a missing field, a wrong type, or an extra internal field all fail. Three tests prove that, using the exact cases that matter: the internal lookup key leaking into a response, a field going missing, and a field of the wrong type.

**What the honest test found.** Every listing the admin API returns also says which groups the listing is in, and the documented example never mentioned it. So anyone reading the docs saw a response missing a real field.

Fixing that turned up a bigger version of the same problem: deactivating or reactivating a listing answered *without* the groups, while every other endpoint included them. A client that toggled a listing got a different shape back than when it read the same listing a moment earlier. All six endpoints now build their answer the same way, so the shape is the same everywhere, and a test covers the two that were different.

Clears the "Tautological admin-API example test" entry in `TODO.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mAQvERz1MNvZxNGwmdHw)_