### PR TITLE
Run the equivalent-mutant audit in its own copy of the checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -975,7 +975,11 @@ counts that lint failure as killed before tests run. Use
 `deno task mutation:audit-equivalents` to check the whole equivalent list with
 lint and type-check only; pass `--write` to remove entries those static gates
 now kill. The audit never runs tests and refuses to rewrite stale or malformed
-entries.
+entries. Like `deno task mutation`, it works in a copy of the checkout under
+`.mutation-runs/`, so the live source files are never left mutated and a commit
+made while it runs cannot pick up a mutant. With `--write`, the pruned
+`equivalent-mutants.txt` is copied back when the run ends — unless that file was
+edited meanwhile, which fails the run instead of overwriting the edit.
 
 Before it runs the mapped tests, the runner puts every mutant through two cheap
 **static gates**, ordered cheapest-first: a per-file Biome **lint** and then a

--- a/TODO.md
+++ b/TODO.md
@@ -1738,3 +1738,26 @@ and then lets go of it before use can be gazumped. The install tests are the
 ones that noticed, because they are the ones that assert a failure. Worth
 looking at whether ports should be handed out so that no two tests in a run can
 ever receive the same one.
+
+## The gap between a mutation child ending and its supervisor taking the lock
+
+*Raised by Codex on [PR #1976](https://github.com/chobbledotcom/tickets/pull/1976),
+about `scripts/mutation/isolation.ts` and `scripts/mutation/isolation-cleanup.ts`.*
+
+A run's copy is protected by its lock, held by the child while it works and by
+the supervisor afterwards. Between the child ending and the supervisor taking
+the lock, nobody holds it. A mutation command starting in that moment sees a
+record that says "running" with a process that has gone, and — once the run is
+older than the startup grace — may delete the run's folder.
+
+Today that costs a run its copy-back: the read fails, the run is reported as
+failed, and the work has to be run again. It is loud, not silent, and it needs
+a second mutation command to start inside a window of a few milliseconds.
+
+The fix is to stop judging a run's liveness by the child alone. If the record
+also carried the supervisor's process id, a run would count as live for as long
+as the supervisor is up, closing the gap. That means changing what
+`runProcessIsUp` and `activeByRecord` in `isolation-cleanup.ts` consider alive,
+and thinking again about the startup grace, which exists because a process id
+can be given to somebody else after the original has gone. Start at
+`RUN_STARTUP_GRACE_MS` in `isolation-state.ts` and the comment above it.

--- a/scripts/audit-equivalent-mutants.ts
+++ b/scripts/audit-equivalent-mutants.ts
@@ -68,7 +68,8 @@ if (import.meta.main) {
       ? await runSnapshotChild(() => runAudit(options))
       : await runInSnapshot({
           args: Deno.args,
-          copyBack: [EQUIVALENT_MUTANTS_PATH],
+          // Only a --write audit rewrites the list, so only it keeps a file.
+          copyBack: options.write ? [EQUIVALENT_MUTANTS_PATH] : [],
           entryScript: "scripts/audit-equivalent-mutants.ts",
         }),
   );

--- a/scripts/audit-equivalent-mutants.ts
+++ b/scripts/audit-equivalent-mutants.ts
@@ -1,7 +1,15 @@
 #!/usr/bin/env -S deno run --allow-all
 
 import { auditEquivalentMutants } from "#scripts/mutation/equivalent-audit.ts";
-import { EQUIVALENT_MUTANTS_FILE } from "#scripts/mutation/ignore.ts";
+import {
+  EQUIVALENT_MUTANTS_FILE,
+  EQUIVALENT_MUTANTS_PATH,
+} from "#scripts/mutation/ignore.ts";
+import { runInSnapshot } from "#scripts/mutation/isolation.ts";
+import {
+  isSnapshotChild,
+  runSnapshotChild,
+} from "#scripts/mutation/snapshot-child.ts";
 import { projectRoot } from "#scripts/project-root.ts";
 import {
   offTerminationSignals,
@@ -25,8 +33,8 @@ const parseOptions = (args: string[]): { write: boolean } => {
   throw new Error(`Unknown arguments: ${args.join(" ")}\n\n${usage}`);
 };
 
-if (import.meta.main) {
-  const options = parseOptions(Deno.args);
+/** Audit inside this checkout, which the snapshot child owns outright. */
+const runAudit = async (options: { write: boolean }): Promise<number> => {
   const controller = new AbortController();
   const onSignal = (): void => controller.abort();
   onTerminationSignals(onSignal);
@@ -49,5 +57,19 @@ if (import.meta.main) {
   for (const line of [...result.killedByLint, ...result.killedByTypeCheck]) {
     console.log(`  ${line}`);
   }
-  if (!options.write && result.retained !== result.checked) Deno.exit(1);
+  return !options.write && result.retained !== result.checked ? 1 : 0;
+};
+
+if (import.meta.main) {
+  // Parsed here too, so a bad flag or --help answers without copying anything.
+  const options = parseOptions(Deno.args);
+  Deno.exit(
+    isSnapshotChild()
+      ? await runSnapshotChild(() => runAudit(options))
+      : await runInSnapshot({
+          args: Deno.args,
+          copyBack: [EQUIVALENT_MUTANTS_PATH],
+          entryScript: "scripts/audit-equivalent-mutants.ts",
+        }),
+  );
 }

--- a/scripts/mutation.ts
+++ b/scripts/mutation.ts
@@ -20,13 +20,10 @@
 import { globToRegExp, join, normalize, SEPARATOR } from "@std/path";
 import { DEFAULT_TIMEOUT, parseArgs } from "./mutation/args.ts";
 import { runIsolatedMutationCommand } from "./mutation/isolation.ts";
-import { withMutationRunLock } from "./mutation/isolation-lock.ts";
 import {
-  MUTATION_RUN_ID_ENV,
-  MUTATION_RUN_ROOT_ENV,
-  MUTATION_SNAPSHOT_CHILD_ENV,
-  MUTATION_WORK_ROOT_ENV,
-} from "./mutation/isolation-state.ts";
+  isSnapshotChild,
+  runSnapshotChild,
+} from "./mutation/snapshot-child.ts";
 
 const USAGE = `Usage:
   deno task mutation <source-glob> <test-glob> [options]
@@ -139,23 +136,9 @@ const main = async (): Promise<void> => {
   Deno.exit(code);
 };
 
-const mutationRunRootFromEnv = (): string | null => {
-  const id = Deno.env.get(MUTATION_RUN_ID_ENV);
-  const runRoot = Deno.env.get(MUTATION_RUN_ROOT_ENV);
-  const workRoot = Deno.env.get(MUTATION_WORK_ROOT_ENV);
-  return id && runRoot && workRoot ? runRoot : null;
-};
-
-const runSnapshotChild = async (): Promise<void> => {
-  const runRoot = mutationRunRootFromEnv();
-  return runRoot === null
-    ? await main()
-    : await withMutationRunLock(runRoot, main);
-};
-
 if (import.meta.main) {
-  if (Deno.env.get(MUTATION_SNAPSHOT_CHILD_ENV) === "1") {
-    await runSnapshotChild();
+  if (isSnapshotChild()) {
+    await runSnapshotChild(main);
   } else {
     Deno.exit(await runIsolatedMutationCommand(Deno.args));
   }

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -979,7 +979,7 @@ scripts/process.ts:60:17  0 → 1   # the promise body runs straight away and ov
 scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it and replacing it store the same timer id
 
 # Isolated mutation runs: the exit code before any path has set one.
-scripts/mutation/isolation.ts:167:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
+scripts/mutation/isolation.ts:170:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
 src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -979,7 +979,7 @@ scripts/process.ts:60:17  0 → 1   # the promise body runs straight away and ov
 scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it and replacing it store the same timer id
 
 # Isolated mutation runs: the exit code before any path has set one.
-scripts/mutation/isolation.ts:187:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
+scripts/mutation/isolation.ts:167:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
 src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -979,7 +979,7 @@ scripts/process.ts:60:17  0 → 1   # the promise body runs straight away and ov
 scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it and replacing it store the same timer id
 
 # Isolated mutation runs: the exit code before any path has set one.
-scripts/mutation/isolation.ts:127:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
+scripts/mutation/isolation.ts:187:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
 src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -979,7 +979,7 @@ scripts/process.ts:60:17  0 → 1   # the promise body runs straight away and ov
 scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it and replacing it store the same timer id
 
 # Isolated mutation runs: the exit code before any path has set one.
-scripts/mutation/isolation.ts:175:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
+scripts/mutation/isolation.ts:188:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
 src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -979,7 +979,7 @@ scripts/process.ts:60:17  0 → 1   # the promise body runs straight away and ov
 scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it and replacing it store the same timer id
 
 # Isolated mutation runs: the exit code before any path has set one.
-scripts/mutation/isolation.ts:170:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
+scripts/mutation/isolation.ts:172:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
 src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -979,7 +979,7 @@ scripts/process.ts:60:17  0 → 1   # the promise body runs straight away and ov
 scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it and replacing it store the same timer id
 
 # Isolated mutation runs: the exit code before any path has set one.
-scripts/mutation/isolation.ts:172:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
+scripts/mutation/isolation.ts:175:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
 src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the

--- a/scripts/mutation/ignore.ts
+++ b/scripts/mutation/ignore.ts
@@ -29,6 +29,10 @@ export const EQUIVALENT_MUTANTS_FILE = new URL(
   import.meta.url,
 );
 
+/** The same file, as a path from the top of the checkout. */
+export const EQUIVALENT_MUTANTS_PATH =
+  "scripts/mutation/equivalent-mutants.txt";
+
 /** Canonical key for a mutant at a project-relative path. */
 export const mutantKeyForPath = (relPath: string, mutant: Mutant): string =>
   `${relPath}:${mutant.line}:${mutant.column} ${mutant.operator}→${mutant.newOperator}`;

--- a/scripts/mutation/isolation-lock.ts
+++ b/scripts/mutation/isolation-lock.ts
@@ -10,7 +10,11 @@
 import { withFileLock, withFileLockOrNull } from "#scripts/lock-file.ts";
 import { statOrNull } from "#scripts/not-found.ts";
 import { denoExitCode } from "./child-process.ts";
-import { type MutationRunRecord, runLockPath } from "./isolation-state.ts";
+import {
+  copyBackLockPath,
+  type MutationRunRecord,
+  runLockPath,
+} from "./isolation-state.ts";
 
 const LOCK_HELD_EXIT_CODE = 124;
 const LOCK_FREE_EXIT_CODE = 0;
@@ -88,3 +92,13 @@ export const withMutationRunLock = <Result>(
   runRootPath: string,
   run: () => Promise<Result>,
 ): Promise<Result> => withFileLock(runLockPath({ root: runRootPath }), run);
+
+/**
+ * Hold the checkout's copy-back lock. Every run brings its kept files back
+ * through this one lock, so two runs finishing together cannot both read the
+ * checkout, agree it is unchanged, and then write over each other.
+ */
+export const withCopyBackLock = <Result>(
+  root: string,
+  run: () => Promise<Result>,
+): Promise<Result> => withFileLock(copyBackLockPath(root), run);

--- a/scripts/mutation/isolation-lock.ts
+++ b/scripts/mutation/isolation-lock.ts
@@ -87,18 +87,27 @@ export const withRunLockOrNull = <Result>(
 ): Promise<Result | null> =>
   withFileLockOrNull(runLockPath(record), timeoutMs, run);
 
-/** Hold a run's own lock, for as long as the run needs it. */
-export const withMutationRunLock = <Result>(
-  runRootPath: string,
+/** Holds the lock named by `Key` while the body runs. */
+export type LockHolder<Key> = <Result>(
+  key: Key,
   run: () => Promise<Result>,
-): Promise<Result> => withFileLock(runLockPath({ root: runRootPath }), run);
+) => Promise<Result>;
+
+/** A lock named by where it lives: say how to find it, get its holder. */
+const lockHolder =
+  <Key>(pathOf: (key: Key) => string): LockHolder<Key> =>
+  (key, run) =>
+    withFileLock(pathOf(key), run);
+
+/** Hold a run's own lock, for as long as the run needs it. */
+export const withMutationRunLock: LockHolder<string> = lockHolder(
+  (runRootPath: string) => runLockPath({ root: runRootPath }),
+);
 
 /**
  * Hold the checkout's copy-back lock. Every run brings its kept files back
  * through this one lock, so two runs finishing together cannot both read the
  * checkout, agree it is unchanged, and then write over each other.
  */
-export const withCopyBackLock = <Result>(
-  root: string,
-  run: () => Promise<Result>,
-): Promise<Result> => withFileLock(copyBackLockPath(root), run);
+export const withCopyBackLock: LockHolder<string> =
+  lockHolder(copyBackLockPath);

--- a/scripts/mutation/isolation-state.ts
+++ b/scripts/mutation/isolation-state.ts
@@ -14,6 +14,7 @@ export const MUTATION_WORK_DIR = "work";
 export const MUTATION_RECORD_FILE = "run.json";
 const MUTATION_RUN_ID_PREFIX = "mutation-";
 export const MUTATION_RUN_LOCK_FILE = "run.lock";
+const MUTATION_COPY_BACK_LOCK_FILE = "copy-back.lock";
 export const MUTATION_SNAPSHOT_CHILD_ENV = "TICKETS_MUTATION_SNAPSHOT_CHILD";
 export const MUTATION_RUN_ID_ENV = "TICKETS_MUTATION_RUN_ID";
 export const MUTATION_RUN_ROOT_ENV = "TICKETS_MUTATION_RUN_ROOT";
@@ -205,6 +206,10 @@ export const recordPath = runChildPath(MUTATION_RECORD_FILE);
 
 export const runLockPath = (record: Pick<MutationRunRecord, "root">): string =>
   join(record.root, MUTATION_RUN_LOCK_FILE);
+
+/** One lock for the whole checkout, shared by every run bringing files back. */
+export const copyBackLockPath = (root = projectRoot): string =>
+  join(runsRoot(root), MUTATION_COPY_BACK_LOCK_FILE);
 
 export const newRunRecord = (
   id: string,

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -125,24 +125,27 @@ const settleRecord = (
   interrupted ? markInterrupted(record) : markFinished(record, code);
 
 /** Record the child's result, then bring back what the run means to keep. */
-const finishChild = async (
+const finishChild = (
   record: MutationRunRecord,
   interrupted: boolean,
   code: number,
   root: string,
   copyBack: CopyBackFile[],
-): Promise<{ exitCode: number; record: MutationRunRecord }> => {
-  const settled = settleRecord(record, interrupted, code);
-  // Under the lock, so a clear-up elsewhere cannot take the folder while this
-  // last write lands in it.
-  await withMutationRunLock(settled.root, () => writeRunRecord(settled));
-  if (interrupted) return { exitCode: 130, record: settled };
-  const failedToKeep =
-    copyBack.length === 0
-      ? 0
-      : await bringFilesBack(root, settled.workRoot, copyBack);
-  return { exitCode: failedToKeep || code, record: settled };
-};
+): Promise<{ exitCode: number; record: MutationRunRecord }> =>
+  // All under the lock, so a clear-up elsewhere can neither take the copy
+  // before its kept files are read nor take the folder while the last record
+  // write lands in it.
+  withMutationRunLock(record.root, async () => {
+    const failedToKeep =
+      interrupted || copyBack.length === 0
+        ? 0
+        : await bringFilesBack(root, record.workRoot, copyBack);
+    // A run that could not keep its files failed, whatever the child said.
+    const exitCode = interrupted ? 130 : failedToKeep || code;
+    const settled = settleRecord(record, interrupted, exitCode);
+    await writeRunRecord(settled);
+    return { exitCode, record: settled };
+  });
 
 export const runInSnapshot = async (
   run: SnapshotRun,

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -124,6 +124,23 @@ const settleRecord = (
 ): MutationRunRecord =>
   interrupted ? markInterrupted(record) : markFinished(record, code);
 
+/**
+ * Bring the run's kept files back, one run at a time across the checkout. The
+ * question is asked again inside the lock: waiting for it is a moment long
+ * enough to be interrupted, and an interrupted run keeps nothing.
+ */
+const keepFiles = (
+  wasInterrupted: () => boolean,
+  root: string,
+  workRoot: string,
+  copyBack: CopyBackFile[],
+): Promise<number> =>
+  withCopyBackLock(root, () =>
+    wasInterrupted()
+      ? Promise.resolve(0)
+      : bringFilesBack(root, workRoot, copyBack),
+  );
+
 /** Record the child's result, then bring back what the run means to keep. */
 const finishChild = (
   record: MutationRunRecord,
@@ -136,14 +153,10 @@ const finishChild = (
   // before its kept files are read nor take the folder while the last record
   // write lands in it.
   withMutationRunLock(record.root, async () => {
-    // Asked again here: waiting for the lock is a moment long enough for the
-    // operator to interrupt, and an interrupted run keeps nothing.
     const failedToKeep =
       wasInterrupted() || copyBack.length === 0
         ? 0
-        : await withCopyBackLock(root, () =>
-            bringFilesBack(root, record.workRoot, copyBack),
-          );
+        : await keepFiles(wasInterrupted, root, record.workRoot, copyBack);
     const interrupted = wasInterrupted();
     // A run that could not keep its files failed, whatever the child said.
     const exitCode = interrupted ? 130 : failedToKeep || code;

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -26,7 +26,7 @@ import {
   removeWorkSnapshot,
   reportRemoveFailure,
 } from "./isolation-cleanup.ts";
-import { withMutationRunLock } from "./isolation-lock.ts";
+import { withCopyBackLock, withMutationRunLock } from "./isolation-lock.ts";
 import { readRunRecords, writeRunRecord } from "./isolation-records.ts";
 import {
   copyMutationSnapshot,
@@ -139,7 +139,9 @@ const finishChild = (
     const failedToKeep =
       interrupted || copyBack.length === 0
         ? 0
-        : await bringFilesBack(root, record.workRoot, copyBack);
+        : await withCopyBackLock(root, () =>
+            bringFilesBack(root, record.workRoot, copyBack),
+          );
     // A run that could not keep its files failed, whatever the child said.
     const exitCode = interrupted ? 130 : failedToKeep || code;
     const settled = settleRecord(record, interrupted, exitCode);

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -127,7 +127,7 @@ const settleRecord = (
 /** Record the child's result, then bring back what the run means to keep. */
 const finishChild = (
   record: MutationRunRecord,
-  interrupted: boolean,
+  wasInterrupted: () => boolean,
   code: number,
   root: string,
   copyBack: CopyBackFile[],
@@ -136,12 +136,15 @@ const finishChild = (
   // before its kept files are read nor take the folder while the last record
   // write lands in it.
   withMutationRunLock(record.root, async () => {
+    // Asked again here: waiting for the lock is a moment long enough for the
+    // operator to interrupt, and an interrupted run keeps nothing.
     const failedToKeep =
-      interrupted || copyBack.length === 0
+      wasInterrupted() || copyBack.length === 0
         ? 0
         : await withCopyBackLock(root, () =>
             bringFilesBack(root, record.workRoot, copyBack),
           );
+    const interrupted = wasInterrupted();
     // A run that could not keep its files failed, whatever the child said.
     const exitCode = interrupted ? 130 : failedToKeep || code;
     const settled = settleRecord(record, interrupted, exitCode);
@@ -201,7 +204,7 @@ export const runInSnapshot = async (
       const status = await child.status;
       const finished = await finishChild(
         record,
-        interrupted,
+        () => interrupted,
         status.code,
         root,
         copyBack,

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -47,9 +47,25 @@ import {
   type SnapshotArgsFn,
   selectedRuns,
 } from "./isolation-state.ts";
+import {
+  type CopyBackFile,
+  copyBackFiles,
+  readCopyBackFiles,
+} from "./snapshot-copy-back.ts";
 
 /** Runs a mutation command from its argv and returns a process exit code. */
 type MutationCommandRunner = (args: string[], root?: string) => Promise<number>;
+
+/** What a run does inside its copy of the checkout. */
+export interface SnapshotRun {
+  args: string[];
+  /** Paths, relative to the checkout, to bring back when the run finishes. */
+  copyBack?: string[];
+  /** The script the child runs, relative to the checkout. */
+  entryScript: string;
+}
+
+const MUTATION_ENTRY_SCRIPT = "scripts/mutation.ts";
 
 const signalRun = async (
   record: MutationRunRecord,
@@ -78,12 +94,14 @@ const childEnv = (
     [MUTATION_WORK_ROOT_ENV]: snapshotRoot,
   });
 
-const childArgs: SnapshotArgsFn = (root, snapshotRoot, args) => [
-  "run",
-  "-A",
-  "scripts/mutation.ts",
-  ...rewriteMutationArgs(root, snapshotRoot, args),
-];
+const childArgs =
+  (entryScript: string): SnapshotArgsFn =>
+  (root, snapshotRoot, args) => [
+    "run",
+    "-A",
+    entryScript,
+    ...rewriteMutationArgs(root, snapshotRoot, args),
+  ];
 
 const forceStopChild = (child: Deno.ChildProcess | null): never => {
   if (child) stopProcessNow(child);
@@ -106,10 +124,52 @@ const settleRecord = (
 ): MutationRunRecord =>
   interrupted ? markInterrupted(record) : markFinished(record, code);
 
-export const runMutationInSnapshot: MutationCommandRunner = async (
-  args,
+/**
+ * Bring the run's kept files back out of its copy. A file someone else edited
+ * meanwhile fails the run rather than overwriting their work.
+ */
+const bringFilesBack = async (
+  root: string,
+  workRoot: string,
+  files: CopyBackFile[],
+): Promise<number> => {
+  try {
+    for (const file of await copyBackFiles(root, workRoot, files)) {
+      console.log(`Updated ${file}`);
+    }
+    return 0;
+  } catch (error) {
+    console.error(errorMessage(error));
+    return 1;
+  }
+};
+
+/** Record the child's result, then bring back what the run means to keep. */
+const finishChild = async (
+  record: MutationRunRecord,
+  interrupted: boolean,
+  code: number,
+  root: string,
+  copyBack: CopyBackFile[],
+): Promise<{ exitCode: number; record: MutationRunRecord }> => {
+  const settled = settleRecord(record, interrupted, code);
+  // Under the lock, so a clear-up elsewhere cannot take the folder while this
+  // last write lands in it.
+  await withMutationRunLock(settled.root, () => writeRunRecord(settled));
+  if (interrupted) return { exitCode: 130, record: settled };
+  const failedToKeep =
+    copyBack.length === 0
+      ? 0
+      : await bringFilesBack(root, settled.workRoot, copyBack);
+  return { exitCode: failedToKeep || code, record: settled };
+};
+
+export const runInSnapshot = async (
+  run: SnapshotRun,
   root = projectRoot,
-) => {
+): Promise<number> => {
+  const { args } = run;
+  const copyBack = await readCopyBackFiles(root, run.copyBack ?? []);
   await removeInactiveRuns(root);
   const id = createRunId();
   let record = newRunRecord(id, args, root);
@@ -140,7 +200,7 @@ export const runMutationInSnapshot: MutationCommandRunner = async (
         return null;
       }
       const spawned = new Deno.Command(Deno.execPath(), {
-        args: childArgs(root, record.workRoot, args),
+        args: childArgs(run.entryScript)(root, record.workRoot, args),
         cwd: record.workRoot,
         env: childEnv(id, record.root, record.workRoot),
         ...INHERIT_STDIO,
@@ -154,11 +214,15 @@ export const runMutationInSnapshot: MutationCommandRunner = async (
 
     if (child !== null) {
       const status = await child.status;
-      record = settleRecord(record, interrupted, status.code);
-      // Under the lock, so a clear-up elsewhere cannot take the folder while
-      // this last write lands in it.
-      await withMutationRunLock(record.root, () => writeRunRecord(record));
-      exitCode = interrupted ? 130 : status.code;
+      const finished = await finishChild(
+        record,
+        interrupted,
+        status.code,
+        root,
+        copyBack,
+      );
+      record = finished.record;
+      exitCode = finished.exitCode;
     }
   } catch (error) {
     if (child !== null) await stopProcess(child, 250);
@@ -175,6 +239,11 @@ export const runMutationInSnapshot: MutationCommandRunner = async (
   await removeWorkSnapshot(record);
   return exitCode;
 };
+
+export const runMutationInSnapshot: MutationCommandRunner = (
+  args,
+  root = projectRoot,
+) => runInSnapshot({ args, entryScript: MUTATION_ENTRY_SCRIPT }, root);
 
 const listRuns = async (root = projectRoot): Promise<number> => {
   const records = await readRunRecords(root);

--- a/scripts/mutation/isolation.ts
+++ b/scripts/mutation/isolation.ts
@@ -48,8 +48,8 @@ import {
   selectedRuns,
 } from "./isolation-state.ts";
 import {
+  bringFilesBack,
   type CopyBackFile,
-  copyBackFiles,
   readCopyBackFiles,
 } from "./snapshot-copy-back.ts";
 
@@ -123,26 +123,6 @@ const settleRecord = (
   code: number,
 ): MutationRunRecord =>
   interrupted ? markInterrupted(record) : markFinished(record, code);
-
-/**
- * Bring the run's kept files back out of its copy. A file someone else edited
- * meanwhile fails the run rather than overwriting their work.
- */
-const bringFilesBack = async (
-  root: string,
-  workRoot: string,
-  files: CopyBackFile[],
-): Promise<number> => {
-  try {
-    for (const file of await copyBackFiles(root, workRoot, files)) {
-      console.log(`Updated ${file}`);
-    }
-    return 0;
-  } catch (error) {
-    console.error(errorMessage(error));
-    return 1;
-  }
-};
 
 /** Record the child's result, then bring back what the run means to keep. */
 const finishChild = async (

--- a/scripts/mutation/snapshot-child.ts
+++ b/scripts/mutation/snapshot-child.ts
@@ -5,6 +5,8 @@
  * so a script can tell whether it is the outer command or the copy's worker.
  */
 
+import { resolve } from "@std/path";
+import { projectRoot } from "#scripts/project-root.ts";
 import { withMutationRunLock } from "./isolation-lock.ts";
 import {
   MUTATION_RUN_ID_ENV,
@@ -34,7 +36,15 @@ const runValue = (name: string): string => {
 const runRootFromEnv = (): string => {
   runValue(MUTATION_RUN_ID_ENV);
   const runRoot = runValue(MUTATION_RUN_ROOT_ENV);
-  runValue(MUTATION_WORK_ROOT_ENV);
+  const workRoot = resolve(runValue(MUTATION_WORK_ROOT_ENV));
+  // The copy it says it is in must be the one it is running from. Anything
+  // else means these values belong to another run, and the work would land in
+  // whatever checkout this script was started from — the live one, most likely.
+  if (workRoot !== resolve(projectRoot)) {
+    throw new Error(
+      `A snapshot child says it works in ${workRoot}, but it is running in ${resolve(projectRoot)}.`,
+    );
+  }
   return runRoot;
 };
 

--- a/scripts/mutation/snapshot-child.ts
+++ b/scripts/mutation/snapshot-child.ts
@@ -16,19 +16,29 @@ import {
 export const isSnapshotChild = (): boolean =>
   Deno.env.get(MUTATION_SNAPSHOT_CHILD_ENV) === "1";
 
-const runRootFromEnv = (): string | null => {
-  const id = Deno.env.get(MUTATION_RUN_ID_ENV);
-  const runRoot = Deno.env.get(MUTATION_RUN_ROOT_ENV);
-  const workRoot = Deno.env.get(MUTATION_WORK_ROOT_ENV);
-  return id && runRoot && workRoot ? runRoot : null;
+/**
+ * Where this child's run lives. Saying it is a child and then leaving out
+ * which run it belongs to is a broken setup, not a run to carry on with: the
+ * work would go ahead in whatever checkout it was started from, unlocked.
+ */
+const runValue = (name: string): string => {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(
+      `${MUTATION_SNAPSHOT_CHILD_ENV} is set, but ${name} is not. A snapshot child cannot run without its own run to work in.`,
+    );
+  }
+  return value;
+};
+
+const runRootFromEnv = (): string => {
+  runValue(MUTATION_RUN_ID_ENV);
+  const runRoot = runValue(MUTATION_RUN_ROOT_ENV);
+  runValue(MUTATION_WORK_ROOT_ENV);
+  return runRoot;
 };
 
 /** Do the run's work, holding its lock so a clear-up cannot take the copy. */
-export const runSnapshotChild = async <Result>(
+export const runSnapshotChild = <Result>(
   body: () => Promise<Result>,
-): Promise<Result> => {
-  const runRoot = runRootFromEnv();
-  return runRoot === null
-    ? await body()
-    : await withMutationRunLock(runRoot, body);
-};
+): Promise<Result> => withMutationRunLock(runRootFromEnv(), body);

--- a/scripts/mutation/snapshot-child.ts
+++ b/scripts/mutation/snapshot-child.ts
@@ -1,0 +1,34 @@
+/**
+ * The side of a snapshot run that runs inside the copied checkout.
+ *
+ * The supervisor in isolation.ts sets these variables when it starts a child,
+ * so a script can tell whether it is the outer command or the copy's worker.
+ */
+
+import { withMutationRunLock } from "./isolation-lock.ts";
+import {
+  MUTATION_RUN_ID_ENV,
+  MUTATION_RUN_ROOT_ENV,
+  MUTATION_SNAPSHOT_CHILD_ENV,
+  MUTATION_WORK_ROOT_ENV,
+} from "./isolation-state.ts";
+
+export const isSnapshotChild = (): boolean =>
+  Deno.env.get(MUTATION_SNAPSHOT_CHILD_ENV) === "1";
+
+const runRootFromEnv = (): string | null => {
+  const id = Deno.env.get(MUTATION_RUN_ID_ENV);
+  const runRoot = Deno.env.get(MUTATION_RUN_ROOT_ENV);
+  const workRoot = Deno.env.get(MUTATION_WORK_ROOT_ENV);
+  return id && runRoot && workRoot ? runRoot : null;
+};
+
+/** Do the run's work, holding its lock so a clear-up cannot take the copy. */
+export const runSnapshotChild = async <Result>(
+  body: () => Promise<Result>,
+): Promise<Result> => {
+  const runRoot = runRootFromEnv();
+  return runRoot === null
+    ? await body()
+    : await withMutationRunLock(runRoot, body);
+};

--- a/scripts/mutation/snapshot-copy-back.ts
+++ b/scripts/mutation/snapshot-copy-back.ts
@@ -7,6 +7,7 @@
  */
 
 import { join } from "@std/path";
+import { errorMessage } from "#shared/error-message.ts";
 
 /** One file to bring back, and what it held when the run started. */
 export interface CopyBackFile {
@@ -27,26 +28,41 @@ export const readCopyBackFiles = (
   );
 
 /**
- * Copy each changed file out of the snapshot, and return the ones that moved.
- * A file someone else edited during the run is left alone: the run's version
- * was built from the older text, so writing it would undo their edit.
+ * Copy one file out of the snapshot, and say whether it moved. A file someone
+ * else edited during the run stops the copy: the run's version was built from
+ * the older text, so writing it would undo their edit.
  */
-export const copyBackFiles = async (
+const copyOneBack = async (
+  root: string,
+  workRoot: string,
+  { before, file }: CopyBackFile,
+): Promise<boolean> => {
+  if ((await Deno.readTextFile(join(root, file))) !== before) {
+    throw new Error(
+      `${file} changed while the isolated run was going, so its result was left behind. Re-run it on an unchanged checkout.`,
+    );
+  }
+  const after = await Deno.readTextFile(join(workRoot, file));
+  if (after === before) return false;
+  await Deno.writeTextFile(join(root, file), after);
+  return true;
+};
+
+/** Bring every kept file back, and report a failure as an exit code. */
+export const bringFilesBack = async (
   root: string,
   workRoot: string,
   files: CopyBackFile[],
-): Promise<string[]> => {
-  const copied: string[] = [];
-  for (const { before, file } of files) {
-    if ((await Deno.readTextFile(join(root, file))) !== before) {
-      throw new Error(
-        `${file} changed while the isolated run was going, so its result was left behind. Re-run it on an unchanged checkout.`,
-      );
+): Promise<number> => {
+  try {
+    for (const entry of files) {
+      if (await copyOneBack(root, workRoot, entry)) {
+        console.log(`Updated ${entry.file}`);
+      }
     }
-    const after = await Deno.readTextFile(join(workRoot, file));
-    if (after === before) continue;
-    await Deno.writeTextFile(join(root, file), after);
-    copied.push(file);
+    return 0;
+  } catch (error) {
+    console.error(errorMessage(error));
+    return 1;
   }
-  return copied;
 };

--- a/scripts/mutation/snapshot-copy-back.ts
+++ b/scripts/mutation/snapshot-copy-back.ts
@@ -1,0 +1,52 @@
+/**
+ * Bringing a snapshot run's file edits back to the live checkout.
+ *
+ * A run works inside a copy of the checkout, so anything it means to keep —
+ * such as a pruned equivalent-mutant list — has to be carried back out before
+ * the copy is deleted.
+ */
+
+import { join } from "@std/path";
+
+/** One file to bring back, and what it held when the run started. */
+export interface CopyBackFile {
+  before: string;
+  file: string;
+}
+
+/** Read what each file holds now, so a later change can be spotted. */
+export const readCopyBackFiles = (
+  root: string,
+  files: string[],
+): Promise<CopyBackFile[]> =>
+  Promise.all(
+    files.map(async (file) => ({
+      before: await Deno.readTextFile(join(root, file)),
+      file,
+    })),
+  );
+
+/**
+ * Copy each changed file out of the snapshot, and return the ones that moved.
+ * A file someone else edited during the run is left alone: the run's version
+ * was built from the older text, so writing it would undo their edit.
+ */
+export const copyBackFiles = async (
+  root: string,
+  workRoot: string,
+  files: CopyBackFile[],
+): Promise<string[]> => {
+  const copied: string[] = [];
+  for (const { before, file } of files) {
+    if ((await Deno.readTextFile(join(root, file))) !== before) {
+      throw new Error(
+        `${file} changed while the isolated run was going, so its result was left behind. Re-run it on an unchanged checkout.`,
+      );
+    }
+    const after = await Deno.readTextFile(join(workRoot, file));
+    if (after === before) continue;
+    await Deno.writeTextFile(join(root, file), after);
+    copied.push(file);
+  }
+  return copied;
+};

--- a/test/scripts/mutation/isolation-helpers.ts
+++ b/test/scripts/mutation/isolation-helpers.ts
@@ -66,10 +66,16 @@ export const writeMovedRunRecord = async (
   return { id, oldRunRoot, record };
 };
 
-export const writeFakeMutationScript = async (
+export const writeFakeScript = async (
   root: string,
+  name: string,
   body: string,
 ): Promise<void> => {
   await Deno.mkdir(join(root, "scripts"), { recursive: true });
-  await Deno.writeTextFile(join(root, "scripts", "mutation.ts"), body);
+  await Deno.writeTextFile(join(root, "scripts", name), body);
 };
+
+export const writeFakeMutationScript = (
+  root: string,
+  body: string,
+): Promise<void> => writeFakeScript(root, "mutation.ts", body);

--- a/test/scripts/mutation/isolation-helpers.ts
+++ b/test/scripts/mutation/isolation-helpers.ts
@@ -79,21 +79,3 @@ export const writeFakeMutationScript = (
   root: string,
   body: string,
 ): Promise<void> => writeFakeScript(root, "mutation.ts", body);
-
-/**
- * Run `body` with coverage collection kept out of the child's environment. A
- * child that records coverage names files inside the copy, which is deleted
- * when the run ends, and the coverage report cannot then read them back.
- */
-export const withoutChildCoverage = async <Result>(
-  body: () => Promise<Result>,
-): Promise<Result> => {
-  const dir = Deno.env.get("DENO_COVERAGE_DIR");
-  if (dir === undefined) return await body();
-  Deno.env.delete("DENO_COVERAGE_DIR");
-  try {
-    return await body();
-  } finally {
-    Deno.env.set("DENO_COVERAGE_DIR", dir);
-  }
-};

--- a/test/scripts/mutation/isolation-helpers.ts
+++ b/test/scripts/mutation/isolation-helpers.ts
@@ -79,3 +79,21 @@ export const writeFakeMutationScript = (
   root: string,
   body: string,
 ): Promise<void> => writeFakeScript(root, "mutation.ts", body);
+
+/**
+ * Run `body` with coverage collection kept out of the child's environment. A
+ * child that records coverage names files inside the copy, which is deleted
+ * when the run ends, and the coverage report cannot then read them back.
+ */
+export const withoutChildCoverage = async <Result>(
+  body: () => Promise<Result>,
+): Promise<Result> => {
+  const dir = Deno.env.get("DENO_COVERAGE_DIR");
+  if (dir === undefined) return await body();
+  Deno.env.delete("DENO_COVERAGE_DIR");
+  try {
+    return await body();
+  } finally {
+    Deno.env.set("DENO_COVERAGE_DIR", dir);
+  }
+};

--- a/test/scripts/mutation/isolation-lock.test.ts
+++ b/test/scripts/mutation/isolation-lock.test.ts
@@ -4,10 +4,14 @@ import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import {
   runLockIsHeld,
+  withCopyBackLock,
   withMutationRunLock,
   withRunLockOrNull,
 } from "#scripts/mutation/isolation-lock.ts";
-import { MUTATION_RUN_LOCK_FILE } from "#scripts/mutation/isolation-state.ts";
+import {
+  copyBackLockPath,
+  MUTATION_RUN_LOCK_FILE,
+} from "#scripts/mutation/isolation-state.ts";
 import { withTempDir } from "#test/scripts/mutation/isolation-helpers.ts";
 import { pathExists } from "#test-utils/files.ts";
 
@@ -201,6 +205,38 @@ describe("the lock that keeps two runs out of one folder", () => {
       });
 
       await expect(runLockIsHeld(record)).rejects.toThrow("Could not tell");
+    });
+  });
+});
+
+describe("the lock that keeps two runs out of one copy-back", () => {
+  test("keeps a second run out until the first has brought its files back", async () => {
+    await withTempDir(async (root) => {
+      const order: string[] = [];
+      const firstInside = Promise.withResolvers<void>();
+      const releaseFirst = Promise.withResolvers<void>();
+
+      const first = withCopyBackLock(root, async () => {
+        order.push("first in");
+        firstInside.resolve();
+        await releaseFirst.promise;
+        order.push("first out");
+      });
+      await firstInside.promise;
+
+      const second = withCopyBackLock(root, () => {
+        order.push("second in");
+        return Promise.resolve();
+      });
+      await pause(LONG_ENOUGH_TO_BE_LET_IN_MS);
+
+      expect(order).toEqual(["first in"]);
+
+      releaseFirst.resolve();
+      await Promise.all([first, second]);
+
+      expect(order).toEqual(["first in", "first out", "second in"]);
+      expect(await pathExists(copyBackLockPath(root))).toBe(true);
     });
   });
 });

--- a/test/scripts/mutation/isolation-lock.test.ts
+++ b/test/scripts/mutation/isolation-lock.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import type { LockHolder } from "#scripts/mutation/isolation-lock.ts";
 import {
   runLockIsHeld,
   withCopyBackLock,
@@ -44,6 +45,38 @@ const statSaying = (
   );
 };
 
+/**
+ * Send two bodies through the same lock, and report the order they got in:
+ * once while the first is still inside, and once after both are done.
+ */
+const orderThroughLock = async (
+  hold: LockHolder<string>,
+  key: string,
+): Promise<{ afterwards: string[]; whileHeld: string[] }> => {
+  const order: string[] = [];
+  const firstInside = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+
+  const first = hold(key, async () => {
+    order.push("first in");
+    firstInside.resolve();
+    await releaseFirst.promise;
+    order.push("first out");
+  });
+  await firstInside.promise;
+
+  const second = hold(key, () => {
+    order.push("second in");
+    return Promise.resolve();
+  });
+  await pause(LONG_ENOUGH_TO_BE_LET_IN_MS);
+  const whileHeld = [...order];
+
+  releaseFirst.resolve();
+  await Promise.all([first, second]);
+  return { afterwards: order, whileHeld };
+};
+
 describe("the lock that keeps two runs out of one folder", () => {
   test("puts a run's lock inside the folder it was given", async () => {
     await withTempDir(async (root) => {
@@ -62,30 +95,11 @@ describe("the lock that keeps two runs out of one folder", () => {
   test("keeps a second run out until the first one is done", async () => {
     await withTempDir(async (root) => {
       const runFolder = join(root, ".mutation-runs", "mutation-shared");
-      const order: string[] = [];
-      const firstInside = Promise.withResolvers<void>();
-      const releaseFirst = Promise.withResolvers<void>();
 
-      const first = withMutationRunLock(runFolder, async () => {
-        order.push("first in");
-        firstInside.resolve();
-        await releaseFirst.promise;
-        order.push("first out");
-      });
-      await firstInside.promise;
+      const order = await orderThroughLock(withMutationRunLock, runFolder);
 
-      const second = withMutationRunLock(runFolder, () => {
-        order.push("second in");
-        return Promise.resolve();
-      });
-      await pause(LONG_ENOUGH_TO_BE_LET_IN_MS);
-
-      expect(order).toEqual(["first in"]);
-
-      releaseFirst.resolve();
-      await Promise.all([first, second]);
-
-      expect(order).toEqual(["first in", "first out", "second in"]);
+      expect(order.whileHeld).toEqual(["first in"]);
+      expect(order.afterwards).toEqual(["first in", "first out", "second in"]);
     });
   });
 
@@ -212,30 +226,10 @@ describe("the lock that keeps two runs out of one folder", () => {
 describe("the lock that keeps two runs out of one copy-back", () => {
   test("keeps a second run out until the first has brought its files back", async () => {
     await withTempDir(async (root) => {
-      const order: string[] = [];
-      const firstInside = Promise.withResolvers<void>();
-      const releaseFirst = Promise.withResolvers<void>();
+      const order = await orderThroughLock(withCopyBackLock, root);
 
-      const first = withCopyBackLock(root, async () => {
-        order.push("first in");
-        firstInside.resolve();
-        await releaseFirst.promise;
-        order.push("first out");
-      });
-      await firstInside.promise;
-
-      const second = withCopyBackLock(root, () => {
-        order.push("second in");
-        return Promise.resolve();
-      });
-      await pause(LONG_ENOUGH_TO_BE_LET_IN_MS);
-
-      expect(order).toEqual(["first in"]);
-
-      releaseFirst.resolve();
-      await Promise.all([first, second]);
-
-      expect(order).toEqual(["first in", "first out", "second in"]);
+      expect(order.whileHeld).toEqual(["first in"]);
+      expect(order.afterwards).toEqual(["first in", "first out", "second in"]);
       expect(await pathExists(copyBackLockPath(root))).toBe(true);
     });
   });

--- a/test/scripts/mutation/isolation/copy-back.test.ts
+++ b/test/scripts/mutation/isolation/copy-back.test.ts
@@ -4,7 +4,6 @@ import { describe, it as test } from "@std/testing/bdd";
 import { runInSnapshot } from "#scripts/mutation/isolation.ts";
 import {
   captureConsole,
-  withoutChildCoverage,
   withTempDir,
   writeFakeScript,
 } from "#test/scripts/mutation/isolation-helpers.ts";
@@ -16,15 +15,16 @@ const KEPT = "scripts/kept.txt";
 const runKeeper = async (
   root: string,
   body: string,
+  code = 0,
 ): Promise<{ errors: string[]; logs: string[]; result: number }> => {
-  await writeFakeScript(root, ENTRY, body);
+  // Ending with an exit keeps the child from writing coverage for files that
+  // are deleted with the copy, which the coverage report cannot then read.
+  await writeFakeScript(root, ENTRY, `${body}Deno.exit(${code});\n`);
   await Deno.writeTextFile(join(root, KEPT), "first\nsecond\n");
   return await captureConsole(() =>
-    withoutChildCoverage(() =>
-      runInSnapshot(
-        { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
-        root,
-      ),
+    runInSnapshot(
+      { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
+      root,
     ),
   );
 };
@@ -44,7 +44,7 @@ describe("keeping a snapshot run's file edits", () => {
 
   test("keeps the edit even when the run itself reports a failure", async () => {
     await withTempDir(async (root) => {
-      const run = await runKeeper(root, `${REWRITE_KEPT}Deno.exit(3);\n`);
+      const run = await runKeeper(root, REWRITE_KEPT, 3);
 
       expect(run.result).toBe(3);
       expect(await Deno.readTextFile(join(root, KEPT))).toBe("first\n");

--- a/test/scripts/mutation/isolation/copy-back.test.ts
+++ b/test/scripts/mutation/isolation/copy-back.test.ts
@@ -4,6 +4,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { runInSnapshot } from "#scripts/mutation/isolation.ts";
 import {
   captureConsole,
+  withoutChildCoverage,
   withTempDir,
   writeFakeScript,
 } from "#test/scripts/mutation/isolation-helpers.ts";
@@ -19,9 +20,11 @@ const runKeeper = async (
   await writeFakeScript(root, ENTRY, body);
   await Deno.writeTextFile(join(root, KEPT), "first\nsecond\n");
   return await captureConsole(() =>
-    runInSnapshot(
-      { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
-      root,
+    withoutChildCoverage(() =>
+      runInSnapshot(
+        { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
+        root,
+      ),
     ),
   );
 };

--- a/test/scripts/mutation/isolation/copy-back.test.ts
+++ b/test/scripts/mutation/isolation/copy-back.test.ts
@@ -7,6 +7,7 @@ import {
   withTempDir,
   writeFakeScript,
 } from "#test/scripts/mutation/isolation-helpers.ts";
+import { readOnlyRunRecord } from "./helpers.ts";
 
 const ENTRY = "keeper.ts";
 const KEPT = "scripts/kept.txt";
@@ -66,6 +67,10 @@ ${REWRITE_KEPT}`;
       expect(await Deno.readTextFile(join(root, KEPT))).toBe(
         "changed by hand\n",
       );
+      // The child exited cleanly, but the run did not do what it was for.
+      const record = await readOnlyRunRecord(root);
+      expect(record.status).toBe("failed");
+      expect(record.exitCode).toBe(1);
     });
   });
 

--- a/test/scripts/mutation/isolation/copy-back.test.ts
+++ b/test/scripts/mutation/isolation/copy-back.test.ts
@@ -1,0 +1,78 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { runInSnapshot } from "#scripts/mutation/isolation.ts";
+import {
+  captureConsole,
+  withTempDir,
+  writeFakeScript,
+} from "#test/scripts/mutation/isolation-helpers.ts";
+
+const ENTRY = "keeper.ts";
+const KEPT = "scripts/kept.txt";
+
+/** Start a run whose child rewrites the kept file inside its own copy. */
+const runKeeper = async (
+  root: string,
+  body: string,
+): Promise<{ errors: string[]; logs: string[]; result: number }> => {
+  await writeFakeScript(root, ENTRY, body);
+  await Deno.writeTextFile(join(root, KEPT), "first\nsecond\n");
+  return await captureConsole(() =>
+    runInSnapshot(
+      { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
+      root,
+    ),
+  );
+};
+
+const REWRITE_KEPT = `await Deno.writeTextFile("${KEPT}", "first\\n");\n`;
+
+describe("keeping a snapshot run's file edits", () => {
+  test("copies the run's version into the checkout and says so", async () => {
+    await withTempDir(async (root) => {
+      const run = await runKeeper(root, REWRITE_KEPT);
+
+      expect(run.result).toBe(0);
+      expect(run.logs).toContain(`Updated ${KEPT}`);
+      expect(await Deno.readTextFile(join(root, KEPT))).toBe("first\n");
+    });
+  });
+
+  test("keeps the edit even when the run itself reports a failure", async () => {
+    await withTempDir(async (root) => {
+      const run = await runKeeper(root, `${REWRITE_KEPT}Deno.exit(3);\n`);
+
+      expect(run.result).toBe(3);
+      expect(await Deno.readTextFile(join(root, KEPT))).toBe("first\n");
+    });
+  });
+
+  test("fails without overwriting an edit made while the run was going", async () => {
+    await withTempDir(async (root) => {
+      const changeItMidRun = `
+await Deno.writeTextFile("${join(root, KEPT)}", "changed by hand\\n");
+${REWRITE_KEPT}`;
+
+      const run = await runKeeper(root, changeItMidRun);
+
+      expect(run.result).toBe(1);
+      expect(run.errors.join("\n")).toContain(
+        `${KEPT} changed while the isolated run was going`,
+      );
+      expect(await Deno.readTextFile(join(root, KEPT))).toBe(
+        "changed by hand\n",
+      );
+    });
+  });
+
+  test("leaves the checkout alone when the run changed nothing", async () => {
+    await withTempDir(async (root) => {
+      const run = await runKeeper(root, "");
+
+      expect(run.result).toBe(0);
+      expect(run.logs.some((line) => line.startsWith("Updated "))).toBe(false);
+      expect(await Deno.readTextFile(join(root, KEPT))).toBe("first\nsecond\n");
+    });
+  });
+});

--- a/test/scripts/mutation/isolation/copy-back.test.ts
+++ b/test/scripts/mutation/isolation/copy-back.test.ts
@@ -2,7 +2,10 @@ import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { runInSnapshot } from "#scripts/mutation/isolation.ts";
-import { withMutationRunLock } from "#scripts/mutation/isolation-lock.ts";
+import {
+  withCopyBackLock,
+  withMutationRunLock,
+} from "#scripts/mutation/isolation-lock.ts";
 import {
   captureConsole,
   withTempDir,
@@ -15,6 +18,12 @@ import {
   waitForRunningRecord,
   withCapturedStopChild,
 } from "./helpers.ts";
+
+/** Long enough for a waiting run to actually reach the lock it waits on. */
+const LONG_ENOUGH_TO_BE_WAITING_MS = 30;
+
+const pause = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 const ENTRY = "keeper.ts";
 const KEPT = "scripts/kept.txt";
@@ -92,41 +101,74 @@ ${REWRITE_KEPT}`;
   });
 });
 
+/** Each lock a finishing run waits for, and how a test can hold it first. */
+const FINISHING_LOCKS: {
+  hold: (
+    root: string,
+    runRoot: string,
+    body: () => Promise<void>,
+  ) => Promise<void>;
+  name: string;
+}[] = [
+  {
+    hold: (_root, runRoot, body) => withMutationRunLock(runRoot, body),
+    name: "the run's own lock",
+  },
+  {
+    hold: (root, _runRoot, body) => withCopyBackLock(root, body),
+    name: "the copy-back lock",
+  },
+];
+
 describe("interrupting a run as it finishes", () => {
-  test("keeps nothing when the signal arrives while the lock is waited for", async () => {
-    await withTempDir(async (root) => {
-      await writeFakeScript(root, ENTRY, "Deno.exit(0);\n");
-      await Deno.writeTextFile(join(root, KEPT), "first\nsecond\n");
-      const child = controlledChild(42_431, () => {});
-      using _command = stubCommand(child.child);
+  for (const lock of FINISHING_LOCKS) {
+    test(`keeps nothing when the signal arrives while waiting for ${lock.name}`, async () => {
+      await withTempDir(async (root) => {
+        await writeFakeScript(root, ENTRY, "Deno.exit(0);\n");
+        await Deno.writeTextFile(join(root, KEPT), "first\nsecond\n");
+        const child = controlledChild(42_431, () => {});
+        using _command = stubCommand(child.child);
 
-      await withCapturedStopChild(async (getStopChild) => {
-        const run = captureConsole(() =>
-          runInSnapshot(
-            { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
-            root,
-          ),
-        );
-        const started = await waitForRunningRecord(root);
+        await withCapturedStopChild(async (getStopChild) => {
+          const run = captureConsole(() =>
+            runInSnapshot(
+              { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
+              root,
+            ),
+          );
+          const started = await waitForRunningRecord(root);
 
-        // Held here, so the run waits for it and the signal lands in that wait.
-        const released = Promise.withResolvers<void>();
-        const holding = withMutationRunLock(
-          started.root,
-          () => released.promise,
-        );
-        child.finish({ code: 0, signal: null, success: true });
-        getStopChild()?.();
-        released.resolve();
-        await holding;
+          // Held here, so the run waits for it and the signal lands in that
+          // wait. The copy is given something worth keeping, so a run that
+          // carried on regardless would be caught writing it out.
+          const released = Promise.withResolvers<void>();
+          const taken = Promise.withResolvers<void>();
+          const holding = lock.hold(root, started.root, async () => {
+            await Deno.writeTextFile(
+              join(started.workRoot, KEPT),
+              "kept from the copy\n",
+            );
+            taken.resolve();
+            await released.promise;
+          });
+          // Only once it is really held does the run have to wait for it.
+          await taken.promise;
+          child.finish({ code: 0, signal: null, success: true });
+          // The signal has to land while the run is inside that wait, not
+          // before it gets there.
+          await pause(LONG_ENOUGH_TO_BE_WAITING_MS);
+          getStopChild()?.();
+          released.resolve();
+          await holding;
 
-        expect((await run).result).toBe(130);
-        const finished = await readOnlyRunRecord(root);
-        expect(finished.status).toBe("interrupted");
-        expect(await Deno.readTextFile(join(root, KEPT))).toBe(
-          "first\nsecond\n",
-        );
+          expect((await run).result).toBe(130);
+          const finished = await readOnlyRunRecord(root);
+          expect(finished.status).toBe("interrupted");
+          expect(await Deno.readTextFile(join(root, KEPT))).toBe(
+            "first\nsecond\n",
+          );
+        });
       });
     });
-  });
+  }
 });

--- a/test/scripts/mutation/isolation/copy-back.test.ts
+++ b/test/scripts/mutation/isolation/copy-back.test.ts
@@ -2,12 +2,19 @@ import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { runInSnapshot } from "#scripts/mutation/isolation.ts";
+import { withMutationRunLock } from "#scripts/mutation/isolation-lock.ts";
 import {
   captureConsole,
   withTempDir,
   writeFakeScript,
 } from "#test/scripts/mutation/isolation-helpers.ts";
-import { readOnlyRunRecord } from "./helpers.ts";
+import {
+  controlledChild,
+  readOnlyRunRecord,
+  stubCommand,
+  waitForRunningRecord,
+  withCapturedStopChild,
+} from "./helpers.ts";
 
 const ENTRY = "keeper.ts";
 const KEPT = "scripts/kept.txt";
@@ -81,6 +88,45 @@ ${REWRITE_KEPT}`;
       expect(run.result).toBe(0);
       expect(run.logs.some((line) => line.startsWith("Updated "))).toBe(false);
       expect(await Deno.readTextFile(join(root, KEPT))).toBe("first\nsecond\n");
+    });
+  });
+});
+
+describe("interrupting a run as it finishes", () => {
+  test("keeps nothing when the signal arrives while the lock is waited for", async () => {
+    await withTempDir(async (root) => {
+      await writeFakeScript(root, ENTRY, "Deno.exit(0);\n");
+      await Deno.writeTextFile(join(root, KEPT), "first\nsecond\n");
+      const child = controlledChild(42_431, () => {});
+      using _command = stubCommand(child.child);
+
+      await withCapturedStopChild(async (getStopChild) => {
+        const run = captureConsole(() =>
+          runInSnapshot(
+            { args: [], copyBack: [KEPT], entryScript: `scripts/${ENTRY}` },
+            root,
+          ),
+        );
+        const started = await waitForRunningRecord(root);
+
+        // Held here, so the run waits for it and the signal lands in that wait.
+        const released = Promise.withResolvers<void>();
+        const holding = withMutationRunLock(
+          started.root,
+          () => released.promise,
+        );
+        child.finish({ code: 0, signal: null, success: true });
+        getStopChild()?.();
+        released.resolve();
+        await holding;
+
+        expect((await run).result).toBe(130);
+        const finished = await readOnlyRunRecord(root);
+        expect(finished.status).toBe("interrupted");
+        expect(await Deno.readTextFile(join(root, KEPT))).toBe(
+          "first\nsecond\n",
+        );
+      });
     });
   });
 });

--- a/test/scripts/mutation/snapshot-child.test.ts
+++ b/test/scripts/mutation/snapshot-child.test.ts
@@ -53,17 +53,24 @@ describe("the worker inside a snapshot", () => {
     });
   });
 
-  test("works without a lock when it was not started by a run", async () => {
-    await withTempDir(async (runRoot) => {
+  test("refuses to work when it is not told which run it belongs to", async () => {
+    await withTempDir((runRoot) => {
       setRunVars(runRoot);
-      // A half-set environment is not a run, so no lock is taken.
+      Deno.env.set(MUTATION_SNAPSHOT_CHILD_ENV, "1");
       Deno.env.delete(MUTATION_WORK_ROOT_ENV);
+      let ranAnyway = false;
 
-      const result = await runSnapshotChild(() =>
-        pathExists(join(runRoot, MUTATION_RUN_LOCK_FILE)),
+      expect(() =>
+        runSnapshotChild(() => {
+          ranAnyway = true;
+          return Promise.resolve(0);
+        }),
+      ).toThrow(
+        `${MUTATION_SNAPSHOT_CHILD_ENV} is set, but ${MUTATION_WORK_ROOT_ENV} is not`,
       );
-
-      expect(result).toBe(false);
+      // Carrying on would mutate whatever checkout it was started from.
+      expect(ranAnyway).toBe(false);
+      return Promise.resolve();
     });
   });
 });

--- a/test/scripts/mutation/snapshot-child.test.ts
+++ b/test/scripts/mutation/snapshot-child.test.ts
@@ -12,6 +12,7 @@ import {
   isSnapshotChild,
   runSnapshotChild,
 } from "#scripts/mutation/snapshot-child.ts";
+import { projectRoot } from "#scripts/project-root.ts";
 import { pathExists, withTempDir } from "#test-utils/files.ts";
 
 const CHILD_VARS = [
@@ -25,10 +26,11 @@ const clearChildVars = (): void => {
   for (const name of CHILD_VARS) Deno.env.delete(name);
 };
 
+/** The run values a child started properly would see: it runs in its copy. */
 const setRunVars = (runRoot: string): void => {
   Deno.env.set(MUTATION_RUN_ID_ENV, "mutation-test");
   Deno.env.set(MUTATION_RUN_ROOT_ENV, runRoot);
-  Deno.env.set(MUTATION_WORK_ROOT_ENV, join(runRoot, "work"));
+  Deno.env.set(MUTATION_WORK_ROOT_ENV, projectRoot);
 };
 
 describe("the worker inside a snapshot", () => {
@@ -69,6 +71,26 @@ describe("the worker inside a snapshot", () => {
         `${MUTATION_SNAPSHOT_CHILD_ENV} is set, but ${MUTATION_WORK_ROOT_ENV} is not`,
       );
       // Carrying on would mutate whatever checkout it was started from.
+      expect(ranAnyway).toBe(false);
+      return Promise.resolve();
+    });
+  });
+
+  test("refuses to work when the copy it names is not the one it is in", async () => {
+    await withTempDir((runRoot) => {
+      setRunVars(runRoot);
+      Deno.env.set(MUTATION_SNAPSHOT_CHILD_ENV, "1");
+      // Values from another run: this one is not running in that copy.
+      Deno.env.set(MUTATION_WORK_ROOT_ENV, join(runRoot, "somebody-elses"));
+      let ranAnyway = false;
+
+      expect(() =>
+        runSnapshotChild(() => {
+          ranAnyway = true;
+          return Promise.resolve(0);
+        }),
+      ).toThrow("but it is running in");
+
       expect(ranAnyway).toBe(false);
       return Promise.resolve();
     });

--- a/test/scripts/mutation/snapshot-child.test.ts
+++ b/test/scripts/mutation/snapshot-child.test.ts
@@ -1,0 +1,69 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import {
+  MUTATION_RUN_ID_ENV,
+  MUTATION_RUN_LOCK_FILE,
+  MUTATION_RUN_ROOT_ENV,
+  MUTATION_SNAPSHOT_CHILD_ENV,
+  MUTATION_WORK_ROOT_ENV,
+} from "#scripts/mutation/isolation-state.ts";
+import {
+  isSnapshotChild,
+  runSnapshotChild,
+} from "#scripts/mutation/snapshot-child.ts";
+import { pathExists, withTempDir } from "#test-utils/files.ts";
+
+const CHILD_VARS = [
+  MUTATION_RUN_ID_ENV,
+  MUTATION_RUN_ROOT_ENV,
+  MUTATION_SNAPSHOT_CHILD_ENV,
+  MUTATION_WORK_ROOT_ENV,
+];
+
+const clearChildVars = (): void => {
+  for (const name of CHILD_VARS) Deno.env.delete(name);
+};
+
+const setRunVars = (runRoot: string): void => {
+  Deno.env.set(MUTATION_RUN_ID_ENV, "mutation-test");
+  Deno.env.set(MUTATION_RUN_ROOT_ENV, runRoot);
+  Deno.env.set(MUTATION_WORK_ROOT_ENV, join(runRoot, "work"));
+};
+
+describe("the worker inside a snapshot", () => {
+  afterEach(clearChildVars);
+
+  test("knows it is the copy's worker only when told so", () => {
+    clearChildVars();
+    expect(isSnapshotChild()).toBe(false);
+
+    Deno.env.set(MUTATION_SNAPSHOT_CHILD_ENV, "1");
+    expect(isSnapshotChild()).toBe(true);
+  });
+
+  test("holds the run's lock while it works", async () => {
+    await withTempDir(async (runRoot) => {
+      setRunVars(runRoot);
+      const lock = join(runRoot, MUTATION_RUN_LOCK_FILE);
+
+      const held = await runSnapshotChild(() => pathExists(lock));
+
+      expect(held).toBe(true);
+    });
+  });
+
+  test("works without a lock when it was not started by a run", async () => {
+    await withTempDir(async (runRoot) => {
+      setRunVars(runRoot);
+      // A half-set environment is not a run, so no lock is taken.
+      Deno.env.delete(MUTATION_WORK_ROOT_ENV);
+
+      const result = await runSnapshotChild(() =>
+        pathExists(join(runRoot, MUTATION_RUN_LOCK_FILE)),
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/test/scripts/mutation/snapshot-copy-back.test.ts
+++ b/test/scripts/mutation/snapshot-copy-back.test.ts
@@ -2,9 +2,10 @@ import { join } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
-  copyBackFiles,
+  bringFilesBack,
   readCopyBackFiles,
 } from "#scripts/mutation/snapshot-copy-back.ts";
+import { captureConsole } from "#test/scripts/mutation/isolation-helpers.ts";
 import { withTempDir } from "#test-utils/files.ts";
 
 const KEPT = "kept.txt";
@@ -28,26 +29,37 @@ const withCheckoutAndCopy = <Result>(
     { prefix: "snapshot-copy-back-" },
   );
 
+/** Note what the kept file holds, run `between`, then bring the file back. */
+const keepFile = async (
+  roots: { root: string; workRoot: string },
+  between: () => Promise<void> = () => Promise.resolve(),
+): ReturnType<typeof captureConsole<number>> => {
+  const files = await readCopyBackFiles(roots.root, [KEPT]);
+  await between();
+  return await captureConsole(() =>
+    bringFilesBack(roots.root, roots.workRoot, files),
+  );
+};
+
 describe("bringing files back out of a snapshot", () => {
   test("copies a file the run changed into the checkout", async () => {
     await withCheckoutAndCopy("one\ntwo\n", "one\n", async (roots) => {
-      const files = await readCopyBackFiles(roots.root, [KEPT]);
+      const run = await keepFile(roots);
 
-      const copied = await copyBackFiles(roots.root, roots.workRoot, files);
-
-      expect(copied).toEqual([KEPT]);
+      expect(run.result).toBe(0);
+      expect(run.logs).toEqual([`Updated ${KEPT}`]);
       expect(await Deno.readTextFile(join(roots.root, KEPT))).toBe("one\n");
     });
   });
 
   test("leaves a file the run did not change alone", async () => {
     await withCheckoutAndCopy("same\n", "same\n", async (roots) => {
-      const files = await readCopyBackFiles(roots.root, [KEPT]);
       const before = await Deno.stat(join(roots.root, KEPT));
 
-      const copied = await copyBackFiles(roots.root, roots.workRoot, files);
+      const run = await keepFile(roots);
 
-      expect(copied).toEqual([]);
+      expect(run.result).toBe(0);
+      expect(run.logs).toEqual([]);
       expect((await Deno.stat(join(roots.root, KEPT))).mtime).toEqual(
         before.mtime,
       );
@@ -56,12 +68,14 @@ describe("bringing files back out of a snapshot", () => {
 
   test("refuses to overwrite an edit made while the run was going", async () => {
     await withCheckoutAndCopy("one\ntwo\n", "one\n", async (roots) => {
-      const files = await readCopyBackFiles(roots.root, [KEPT]);
-      await Deno.writeTextFile(join(roots.root, KEPT), "one\ntwo\nthree\n");
+      const run = await keepFile(roots, () =>
+        Deno.writeTextFile(join(roots.root, KEPT), "one\ntwo\nthree\n"),
+      );
 
-      await expect(
-        copyBackFiles(roots.root, roots.workRoot, files),
-      ).rejects.toThrow(`${KEPT} changed while the isolated run was going`);
+      expect(run.result).toBe(1);
+      expect(run.errors.join("\n")).toContain(
+        `${KEPT} changed while the isolated run was going`,
+      );
       expect(await Deno.readTextFile(join(roots.root, KEPT))).toBe(
         "one\ntwo\nthree\n",
       );

--- a/test/scripts/mutation/snapshot-copy-back.test.ts
+++ b/test/scripts/mutation/snapshot-copy-back.test.ts
@@ -1,0 +1,76 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  copyBackFiles,
+  readCopyBackFiles,
+} from "#scripts/mutation/snapshot-copy-back.ts";
+import { withTempDir } from "#test-utils/files.ts";
+
+const KEPT = "kept.txt";
+
+/** A checkout holding `live`, and a copy of it holding `inWork`. */
+const withCheckoutAndCopy = <Result>(
+  live: string,
+  inWork: string,
+  run: (roots: { root: string; workRoot: string }) => Promise<Result>,
+): Promise<Result> =>
+  withTempDir(
+    async (dir) => {
+      const root = join(dir, "checkout");
+      const workRoot = join(dir, "work");
+      await Deno.mkdir(root);
+      await Deno.mkdir(workRoot);
+      await Deno.writeTextFile(join(root, KEPT), live);
+      await Deno.writeTextFile(join(workRoot, KEPT), inWork);
+      return await run({ root, workRoot });
+    },
+    { prefix: "snapshot-copy-back-" },
+  );
+
+describe("bringing files back out of a snapshot", () => {
+  test("copies a file the run changed into the checkout", async () => {
+    await withCheckoutAndCopy("one\ntwo\n", "one\n", async (roots) => {
+      const files = await readCopyBackFiles(roots.root, [KEPT]);
+
+      const copied = await copyBackFiles(roots.root, roots.workRoot, files);
+
+      expect(copied).toEqual([KEPT]);
+      expect(await Deno.readTextFile(join(roots.root, KEPT))).toBe("one\n");
+    });
+  });
+
+  test("leaves a file the run did not change alone", async () => {
+    await withCheckoutAndCopy("same\n", "same\n", async (roots) => {
+      const files = await readCopyBackFiles(roots.root, [KEPT]);
+      const before = await Deno.stat(join(roots.root, KEPT));
+
+      const copied = await copyBackFiles(roots.root, roots.workRoot, files);
+
+      expect(copied).toEqual([]);
+      expect((await Deno.stat(join(roots.root, KEPT))).mtime).toEqual(
+        before.mtime,
+      );
+    });
+  });
+
+  test("refuses to overwrite an edit made while the run was going", async () => {
+    await withCheckoutAndCopy("one\ntwo\n", "one\n", async (roots) => {
+      const files = await readCopyBackFiles(roots.root, [KEPT]);
+      await Deno.writeTextFile(join(roots.root, KEPT), "one\ntwo\nthree\n");
+
+      await expect(
+        copyBackFiles(roots.root, roots.workRoot, files),
+      ).rejects.toThrow(`${KEPT} changed while the isolated run was going`);
+      expect(await Deno.readTextFile(join(roots.root, KEPT))).toBe(
+        "one\ntwo\nthree\n",
+      );
+    });
+  });
+
+  test("reads nothing when no files are kept", async () => {
+    await withCheckoutAndCopy("one\n", "one\n", async (roots) => {
+      expect(await readCopyBackFiles(roots.root, [])).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What this changes

`deno task mutation:audit-equivalents` checks every recorded equivalent mutant to see whether lint or type-check now catches it. To do that it edits the real source files, one at a time, and puts each one back afterwards.

That meant anything else touching the files at the same moment — a commit, a build, another tool — could pick up a half-mutated file. It caught me out once while working on the previous change.

The audit now works the same way `deno task mutation` already does: it copies the checkout into `.mutation-runs/`, does all its editing in that copy, and deletes the copy when it finishes. The live files are never touched.

With `--write`, the trimmed list of equivalent mutants is copied back out of the copy when the run ends. A read-only audit keeps nothing, so it can never be affected. If someone edited that same file while a `--write` run was going, the run says so, leaves their edit alone, and is recorded as failed.

## Sharing one mechanism rather than writing a second

- Starting a run inside a copy of the checkout was already there for `deno task mutation`. It now takes the script to run and the files to bring back, so both commands go through one supervisor.
- The check for "am I the worker inside the copy?" moved into one small file both entry scripts use.
- Both locks — a run's own and the new copy-back one — now come from one holder, and both lock tests share one ordering check.

## Getting the finishing steps right

Review turned up several ways a run could go wrong as it ends. Each is fixed and covered by a test that fails without the fix:

- **The copy is read under the same lock as the final record write**, so a clear-up elsewhere cannot take it in between.
- **A run that could not keep its files is recorded as failed**, rather than inheriting the child's clean exit code and showing as `passed` in `deno task mutation --list`.
- **Copy-back goes through one lock for the whole checkout**, so two runs finishing together take their turns instead of both deciding the file is unchanged and writing over each other.
- **An interrupt is noticed while waiting for either lock.** A signal arriving in those moments now means the run keeps nothing and still reports 130.
- **A worker refuses to run unless it knows which run it belongs to, and proves it is in that copy.** Left-over or half-set values used to pass, and the work would have landed in whatever checkout the script was started from — the live one, most likely.

One known gap is left, written up in `TODO.md`: between the child ending and the supervisor taking the lock, nobody holds it, so a mutation command starting in that few-millisecond window can delete the run's folder. Closing it means judging a run's liveness by the supervisor rather than the child, which is wider than this change. It costs a run its copy-back, loudly and re-runnably, not silently.

## Result of running the audit

Run over the whole list with `--write`, on a clean checkout:

```
Checked 494 equivalent mutants.
Killed by lint: 0
Killed by type-check: 0
Still reaches tests: 494
```

Nothing needed removing — every recorded entry still gets past both static checks, so the list is accurate as it stands. Entries whose line numbers had drifted were re-anchored, and all 494 now resolve against freshly generated mutants.

## Testing

New tests cover bringing files back (copied when changed, left alone when not, refused when someone else edited meanwhile, recorded as failed when refused), interrupting a run while it waits for either lock, the copy-back lock keeping two runs apart, and the worker-inside-the-copy checks. `deno task precommit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdDZCWRXwjqsidfRJFarXC