### PR TITLE
Say where each evidence story was authored

### DIFF
--- a/scripts/specs/evidence/manifest.ts
+++ b/scripts/specs/evidence/manifest.ts
@@ -224,7 +224,7 @@ export const buildEvidenceBundle = async (
   const manifest = v.parse(EvidenceManifestSchema, {
     app: { commit: input.commit, repository: EVIDENCE_REPOSITORY },
     captures,
-    schemaVersion: 1,
+    schemaVersion: 2,
   });
   return { assets, manifest };
 };

--- a/scripts/specs/evidence/resolve.ts
+++ b/scripts/specs/evidence/resolve.ts
@@ -14,11 +14,17 @@ interface StableNamedItem {
   name: string;
 }
 
+/** A story also carries the Feature file it was authored in, so anything
+ * quoting the story can link to its source without guessing the path. */
+interface StableStoryItem extends StableNamedItem {
+  uri: string;
+}
+
 export interface ResolvedEvidenceScenario {
   case: { id: string; name: string };
   rule: StableNamedItem;
   steps: Array<{ keyword: string; text: string }>;
-  story: StableNamedItem;
+  story: StableStoryItem;
 }
 
 interface AstIndex {
@@ -108,6 +114,11 @@ const stableItem = (item: SpecRule | SpecStory): StableNamedItem => ({
   name: item.name,
 });
 
+const stableStory = (story: SpecStory): StableStoryItem => ({
+  ...stableItem(story),
+  uri: story.uri,
+});
+
 const resolvedSteps = (
   pickle: Pickle,
   steps: Map<string, Step>,
@@ -144,6 +155,6 @@ export const resolveEvidenceScenario = (
     case: { id: match.caseId, name: pickle.name },
     rule: stableItem(match.rule),
     steps: resolvedSteps(pickle, index.steps),
-    story: stableItem(match.story),
+    story: stableStory(match.story),
   };
 };

--- a/scripts/specs/evidence/schema.ts
+++ b/scripts/specs/evidence/schema.ts
@@ -69,10 +69,20 @@ const NamedEvidenceItemSchema = v.strictObject({
   ...EvidenceItemSchema.entries,
 });
 
-/** Where the story lives, so a reader of the manifest can open it. */
+/**
+ * Where the story lives, so a reader of the manifest can open it. Feature
+ * discovery accepts any path under specs/ ending in .feature, so this checks
+ * the shape rather than the alphabet: a valid filename with a space or an
+ * accent must not stop the evidence run.
+ */
 const FeatureUriSchema = v.pipe(
   TrimmedNonEmptyTextSchema,
-  v.regex(/^specs\/[\w./-]+\.feature$/, "Invalid Feature uri"),
+  v.startsWith("specs/", "Feature uri must be under specs/"),
+  v.endsWith(".feature", "Feature uri must be a .feature file"),
+  v.check(
+    (uri) => !uri.split("/").includes("..") && !uri.includes("\\"),
+    "Feature uri must be a safe relative path",
+  ),
 );
 
 const EvidenceStorySchema = v.strictObject({

--- a/scripts/specs/evidence/schema.ts
+++ b/scripts/specs/evidence/schema.ts
@@ -69,6 +69,17 @@ const NamedEvidenceItemSchema = v.strictObject({
   ...EvidenceItemSchema.entries,
 });
 
+/** Where the story lives, so a reader of the manifest can open it. */
+const FeatureUriSchema = v.pipe(
+  TrimmedNonEmptyTextSchema,
+  v.regex(/^specs\/[\w./-]+\.feature$/, "Invalid Feature uri"),
+);
+
+const EvidenceStorySchema = v.strictObject({
+  uri: FeatureUriSchema,
+  ...NamedEvidenceItemSchema.entries,
+});
+
 const EvidenceViewportSchema = v.strictObject({
   deviceScaleFactor: v.pipe(v.number(), v.minValue(1)),
   height: PositiveIntegerSchema,
@@ -118,7 +129,7 @@ const EvidenceCaptureSchema = v.strictObject({
     ),
     v.minLength(1),
   ),
-  story: NamedEvidenceItemSchema,
+  story: EvidenceStorySchema,
 });
 
 const EvidenceCapturesSchema = v.pipe(
@@ -143,7 +154,7 @@ export const EvidenceManifestSchema = v.strictObject({
     repository: v.literal(EVIDENCE_REPOSITORY),
   }),
   captures: EvidenceCapturesSchema,
-  schemaVersion: v.literal(1),
+  schemaVersion: v.literal(2),
 });
 
 export type EvidenceManifest = v.InferOutput<typeof EvidenceManifestSchema>;

--- a/test/scripts/specs/evidence-fixture.ts
+++ b/test/scripts/specs/evidence-fixture.ts
@@ -24,6 +24,7 @@ export const PLAIN_EVIDENCE_SCENARIO = {
       "Customers get a clear result when the last place is taken during payment.",
     id: "payments.capacity-after-payment",
     name: "Paid booking capacity",
+    uri: "specs/payments/capacity.feature",
   },
 } as const;
 

--- a/test/scripts/specs/evidence-manifest.test.ts
+++ b/test/scripts/specs/evidence-manifest.test.ts
@@ -200,7 +200,7 @@ describe("Cucumber evidence manifest", () => {
           presentation: "canonical",
         },
       ],
-      schemaVersion: 1,
+      schemaVersion: 2,
     });
     expect(JSON.stringify(first.manifest)).not.toMatch(
       /started-case|test-case|timestamp/,

--- a/test/scripts/specs/evidence-schema.test.ts
+++ b/test/scripts/specs/evidence-schema.test.ts
@@ -102,17 +102,18 @@ describe("Cucumber evidence schema", () => {
             description: "Customers can pay.",
             id: "payments.story",
             name: "Customer payment",
+            uri: "specs/payments/customer-payment.feature",
           },
         },
       ],
-      schemaVersion: 1,
+      schemaVersion: 2,
     };
 
     expect(v.parse(EvidenceManifestSchema, manifest)).toEqual(manifest);
     expect(
       v.safeParse(EvidenceManifestSchema, {
         ...manifest,
-        schemaVersion: 2,
+        schemaVersion: 3,
       }).success,
     ).toBe(false);
     expect(
@@ -121,6 +122,22 @@ describe("Cucumber evidence schema", () => {
         app: { ...manifest.app, commit: "short" },
       }).success,
     ).toBe(false);
+    // A story says where it was authored, so anything quoting it can link to
+    // the Feature without guessing the path.
+    for (const uri of [undefined, "payments/customer-payment.feature", "specs/x.md"]) {
+      expect(
+        v.safeParse(EvidenceManifestSchema, {
+          ...manifest,
+          captures: [
+            {
+              ...manifest.captures[0],
+              story: { ...manifest.captures[0].story, uri },
+            },
+          ],
+        }).success,
+        String(uri),
+      ).toBe(false);
+    }
 
     const capture = requireValue(
       manifest.captures[0],

--- a/test/scripts/specs/evidence-schema.test.ts
+++ b/test/scripts/specs/evidence-schema.test.ts
@@ -124,7 +124,11 @@ describe("Cucumber evidence schema", () => {
     ).toBe(false);
     // A story says where it was authored, so anything quoting it can link to
     // the Feature without guessing the path.
-    for (const uri of [undefined, "payments/customer-payment.feature", "specs/x.md"]) {
+    for (const uri of [
+      undefined,
+      "payments/customer-payment.feature",
+      "specs/x.md",
+    ]) {
       expect(
         v.safeParse(EvidenceManifestSchema, {
           ...manifest,

--- a/test/scripts/specs/evidence-schema.test.ts
+++ b/test/scripts/specs/evidence-schema.test.ts
@@ -124,24 +124,41 @@ describe("Cucumber evidence schema", () => {
     ).toBe(false);
     // A story says where it was authored, so anything quoting it can link to
     // the Feature without guessing the path.
+    const storyCapture = requireValue(
+      manifest.captures[0],
+      "Manifest capture is missing",
+    );
     for (const uri of [
       undefined,
       "payments/customer-payment.feature",
       "specs/x.md",
+      "specs/../secrets.feature",
     ]) {
       expect(
         v.safeParse(EvidenceManifestSchema, {
           ...manifest,
           captures: [
-            {
-              ...manifest.captures[0],
-              story: { ...manifest.captures[0].story, uri },
-            },
+            { ...storyCapture, story: { ...storyCapture.story, uri } },
           ],
         }).success,
         String(uri),
       ).toBe(false);
     }
+    // A valid filename is not required to be ASCII.
+    expect(
+      v.safeParse(EvidenceManifestSchema, {
+        ...manifest,
+        captures: [
+          {
+            ...storyCapture,
+            story: {
+              ...storyCapture.story,
+              uri: "specs/payments/capacité aux portes.feature",
+            },
+          },
+        ],
+      }).success,
+    ).toBe(true);
 
     const capture = requireValue(
       manifest.captures[0],


### PR DESCRIPTION
The site prints a `(src)` link beside every evidence screenshot, pointing at the Feature the capture came from. It writes that link by hand in `_data/ticket_evidence_map.json`, so renaming a `.feature` file leaves a dead link that no check on either side can catch.

## What changes

- A story in the manifest carries `uri`, the Feature path the catalog already knows (`specs/<owner>/<name>.feature`). `resolveEvidenceScenario` reads it from `SpecStory`.
- The manifest contract is versioned and this adds a required field, so `schemaVersion` becomes `2`.

Nothing else in the app reads the manifest; it exists for the site.

## Why not derive it site-side

The convention almost holds — `servicing.hold-and-cost` lives in `specs/servicing/hold-and-cost.feature` — but `payments.provider-choice` lives in `specs/payments/payment-provider-choice.feature`. Any derivation is a guess, which is how the site ended up hand-writing the path.

## Checks run

- `deno task lint:ci` — clean
- `deno task cpd` — 0 clones
- `deno task test:files test/scripts/specs/` — 137 passed
- `deno task specs:evidence` — 3 captures, manifest emits `schemaVersion: 2` with `story.uri`

The schema test now also rejects a story with a missing `uri`, a path outside `specs/`, and a non-`.feature` path.

## Coordination

The site validates the manifest strictly and currently expects `schemaVersion: 1`, so its import will refuse a v2 artifact until chobbledotcom/tickets-site#119 merges. That PR is open and ready. If the site's daily import fires in the gap it fails loudly with a schema message and recovers on the next run — no bad data can land, because the refusal happens before anything is written.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK)_