### PR TITLE
Put the check-in helper's comment back on the helper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1364,6 +1364,36 @@ a malformed response throws rather than being silently cast. Starting point:
 
 ---
 
+## Should the mutation gate pick fewer test files per source?
+
+*Origin: Codex review of PR #1981 (splitting three oversized test files into
+folders).*
+
+`ownsTest` in `scripts/mutation/test-map.ts` matches a source's mirror prefix
+*and everything under it*, so a source whose tests live in a folder selects
+every file in that folder, and `execution.ts` runs them with `--parallel` — one
+isolate each, for every mutant. Splitting a suite therefore turns one isolate
+per mutant into several. Codex's point is that this may cost more in repeated
+module-graph evaluation and setup than the single large file did.
+
+It may also cost less: each file is smaller, and they run in parallel. Nobody
+has measured it, and that measurement is the first job here — time
+`deno task mutation src/ui/templates/admin/questions.tsx` (which now selects six
+files) against the same run on the pre-split single file from git history.
+
+Only if the split shape is genuinely slower is there something to change, and
+then the options are to select more narrowly (map a mutant to the one file whose
+name matches the mutated export — fragile) or to generate a single entry file
+that imports the folder's suites so one isolate runs them all. Note the manual
+command is already narrow: you can name one file yourself, which is what the
+~400-line guidance in AGENTS.md is about.
+
+Starting point: `ownsTest` and `selectMutationTests` in
+`scripts/mutation/test-map.ts`, and the `--parallel` invocation in
+`scripts/mutation/execution.ts`.
+
+---
+
 ## Mutation coverage of `src/features/api/folded-booking.ts` (direct tests)
 
 Direct tests at `test/features/api/folded-booking.test.ts` and

--- a/TODO.md
+++ b/TODO.md
@@ -1377,9 +1377,17 @@ per mutant into several. Codex's point is that this may cost more in repeated
 module-graph evaluation and setup than the single large file did.
 
 It may also cost less: each file is smaller, and they run in parallel. Nobody
-has measured it, and that measurement is the first job here — time
-`deno task mutation src/ui/templates/admin/questions.tsx` (which now selects six
-files) against the same run on the pre-split single file from git history.
+has measured it, and that measurement is the first job here. The command needs
+both a source and a test glob, so the split shape times as:
+
+```bash
+deno task mutation src/ui/templates/admin/questions.tsx \
+  'test/ui/templates/admin/questions/*.test.ts' --harness
+```
+
+For the "before" number, run the same command in a checkout from before PR
+#1981 — that is where the single `test/ui/templates/admin/questions.test.ts`
+still exists — with that one file as the test glob.
 
 Only if the split shape is genuinely slower is there something to change, and
 then the options are to select more narrowly (map a mutant to the one file whose

--- a/test/ui/templates/checkin/helpers.ts
+++ b/test/ui/templates/checkin/helpers.ts
@@ -9,9 +9,9 @@ interface CheckinSession {
   csrfToken: string;
 }
 
-/** Create attendee + login, returning token + session for check-in tests */
 type ListingOverrides = Parameters<typeof createTestAttendeeWithToken>[2];
 
+/** Create attendee + login, returning token + session for check-in tests */
 export const setupCheckinTest = async (
   name: string,
   email: string,

--- a/test/ui/templates/checkin/helpers.ts
+++ b/test/ui/templates/checkin/helpers.ts
@@ -11,7 +11,7 @@ interface CheckinSession {
 
 type ListingOverrides = Parameters<typeof createTestAttendeeWithToken>[2];
 
-/** Create attendee + login, returning token + session for check-in tests */
+/** Create an attendee, returning its token plus the admin session to act as. */
 export const setupCheckinTest = async (
   name: string,
   email: string,


### PR DESCRIPTION
Two small follow-ups to #1981, which merged before these could go on it.

**The comment sat on the wrong thing.** While applying a review suggestion in #1981, a type was added between a comment and the function it describes, so the comment ended up explaining the type instead. Anyone hovering `setupCheckinTest` in an editor lost its explanation, and the type above claimed to create an attendee and log in. The type now sits above the comment, so the comment describes the helper again.

**A note for later.** A reviewer pointed out that when a test file is split into a folder, the mutation checker picks up every file in that folder for each change it tries, instead of the one file it used to run. That may make those runs slower, or it may not — the files are smaller and run side by side, and nobody has timed it. Changing how the checker picks files is a job in its own right, so it is written up in `TODO.md` with the measurement to do first.

No behaviour changes. `deno task precommit` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdDZCWRXwjqsidfRJFarXC)_