### PR TITLE
Prove what the balance payment link tells a customer

### DIFF
--- a/scripts/specs/catalog.ts
+++ b/scripts/specs/catalog.ts
@@ -21,7 +21,10 @@ const BASE_REGISTRY: Omit<SpecRegistry, "owners"> = {
   actors: ["customer", "editor", "organiser"],
   editions: ["managed", "self-hosted"],
   risks: ["high", "medium", "low"],
-  surfaces: ["admin", "return", "webhook"],
+  // "public" is a page a customer opens themselves, without signing in and
+  // without arriving back from a payment provider: the link they pay an
+  // outstanding balance from is one.
+  surfaces: ["admin", "public", "return", "webhook"],
 };
 
 const OwnerFileSchema = v.pick(SpecRegistrySchema, ["owners"]);

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -236,6 +236,50 @@ const DOOR_CHECK_IN_CSS = `${brandedThemeCss(
 }
 `;
 
+const BALANCE_LINK_CSS = `${brandedThemeCss(
+  "12px",
+  "#9c4a2f",
+  "#ece0d3",
+  "#fdf9f4",
+  "#9c4a2f",
+  "#5b3a2b",
+  "#9c4a2f18",
+  "#5b3a2b26",
+  "#9c4a2f",
+  "#3b2a22",
+  "#7a6155",
+)}
+
+.public-page {
+  background: #fdf9f4;
+  border: 1px solid #e4d5c5;
+  box-shadow: 0 14px 32px var(--color-shadow);
+  padding: 1.25rem;
+}
+
+.public-page h1 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 2rem;
+}
+
+.public-page table {
+  width: 100%;
+}
+
+.public-page th {
+  background: var(--color-accent);
+  color: #fdf9f4;
+}
+
+.public-page button[type="submit"] {
+  background: var(--color-accent);
+  border-color: #7f3a24;
+  border-radius: 999px;
+  color: #fdf9f4;
+  font-weight: 800;
+}
+`;
+
 /** One branded mobile capture: the page an authored case leaves behind, the
  * part of it worth showing, and the styling it is shown in. */
 const brandedMobileCapture = (
@@ -269,6 +313,13 @@ export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
     "/admin/settings",
     ".page-regions.admin-page",
     PAYMENT_PROVIDER_CSS,
+  ),
+  brandedMobileCapture(
+    "deposit.balance-page-shows-what-is-left",
+    "balance-payment-link",
+    "/pay/{balanceToken}",
+    ".page-regions.public-page",
+    BALANCE_LINK_CSS,
   ),
   brandedMobileCapture(
     "door.someone-still-to-arrive-can-be-picked",

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -253,6 +253,7 @@ const BALANCE_LINK_CSS = `${brandedThemeCss(
 .public-page {
   background: #fdf9f4;
   border: 1px solid #e4d5c5;
+  border-radius: var(--border-radius);
   box-shadow: 0 14px 32px var(--color-shadow);
   padding: 1.25rem;
 }

--- a/specs/payments/paying-a-deposit.feature
+++ b/specs/payments/paying-a-deposit.feature
@@ -20,12 +20,15 @@ Feature: A customer pays a deposit and settles the rest later
       When the organiser settles the remaining 50.00
       Then they owe nothing, and their money page says the booking is fully paid
 
-  @rule:payments.the-customer-can-see-what-is-left-and-pay-it
+  @rule:payments.the-customer-can-see-what-is-left
   @surface:public
-  Rule: The customer can see what is left and pay it
+  Rule: The customer can see what is left
     A reserved booking has a payment link the customer can open without
     signing in. It names what they booked, what they have paid and what is
     left, and offers to take the rest. It carries no personal details.
+
+    What happens after the offer is taken is a payment provider's business
+    and is not read here.
 
     @case:deposit.balance-page-shows-what-is-left
     Scenario: The payment link for a part-paid 80.00 Retreat place

--- a/specs/payments/paying-a-deposit.feature
+++ b/specs/payments/paying-a-deposit.feature
@@ -19,3 +19,18 @@ Feature: A customer pays a deposit and settles the rest later
       Then they still owe 50.00, on the books and on their money page
       When the organiser settles the remaining 50.00
       Then they owe nothing, and their money page says the booking is fully paid
+
+  @rule:payments.the-customer-can-see-what-is-left-and-pay-it
+  @surface:public
+  Rule: The customer can see what is left and pay it
+    A reserved booking has a payment link the customer can open without
+    signing in. It names what they booked, what they have paid and what is
+    left, and offers to take the rest. It carries no personal details.
+
+    @case:deposit.balance-page-shows-what-is-left
+    Scenario: The payment link for a part-paid 80.00 Retreat place
+      Given a customer owes 80.00 for a Retreat place
+      When they pay a deposit of 30.00
+      Then their payment link offers to take the 50.00 that is left
+      And it names the Retreat place, 80.00 ordered and 30.00 paid
+      And it says nothing about who booked

--- a/test/specs/steps/corrections.ts
+++ b/test/specs/steps/corrections.ts
@@ -333,9 +333,10 @@ Then(
   "it says nothing about who booked",
   async function (this: TicketsWorld): Promise<void> {
     const page = await balancePageHtml(this);
-    // The booker's own name and address are what the link must not carry.
-    for (const detail of [this.attendeeName, this.attendeeEmail]) {
-      if (detail) expect(page).not.toContain(detail);
+    // The booker's own name and address are what the link must not carry, so
+    // a fixture that set neither would prove nothing rather than pass.
+    for (const key of ["attendeeEmail", "attendeeName"] as const) {
+      expect(page).not.toContain(requiredWorldValue(this[key], key));
     }
   },
 );

--- a/test/specs/steps/corrections.ts
+++ b/test/specs/steps/corrections.ts
@@ -13,6 +13,7 @@ import {
   accountBalance,
   transfersByAccount,
 } from "#shared/accounting/queries.ts";
+import { formatCurrency } from "#shared/currency.ts";
 import {
   addBalanceEntry,
   cashBefore,
@@ -22,6 +23,7 @@ import {
   surchargeId,
 } from "#test/specs/support/corrections.ts";
 import {
+  balancePageHtml,
   payDeposit,
   settleTheRest,
   unpaidPlace,
@@ -294,6 +296,47 @@ Then(
       `/admin/attendees/${bookingId(this)}/ledger`,
     );
     expect(page).toContain("This booking is fully paid");
+  },
+);
+
+Then(
+  "their payment link offers to take the {word} that is left",
+  async function (this: TicketsWorld, amount: string): Promise<void> {
+    const page = await balancePageHtml(this);
+    expect(page).toContain(
+      `Balance due:</strong> ${formatCurrency(minorUnits(amount))}`,
+    );
+    expect(page).toContain(`Pay ${formatCurrency(minorUnits(amount))} now`);
+  },
+);
+
+Then(
+  "it names the {word} place, {word} ordered and {word} paid",
+  async function (
+    this: TicketsWorld,
+    name: string,
+    ordered: string,
+    paid: string,
+  ): Promise<void> {
+    const page = await balancePageHtml(this);
+    expect(page).toContain(name);
+    expect(page).toContain(
+      `Full order price:</strong> ${formatCurrency(minorUnits(ordered))}`,
+    );
+    expect(page).toContain(
+      `Already paid:</strong> ${formatCurrency(minorUnits(paid))}`,
+    );
+  },
+);
+
+Then(
+  "it says nothing about who booked",
+  async function (this: TicketsWorld): Promise<void> {
+    const page = await balancePageHtml(this);
+    // The booker's own name and address are what the link must not carry.
+    for (const detail of [this.attendeeName, this.attendeeEmail]) {
+      if (detail) expect(page).not.toContain(detail);
+    }
   },
 );
 

--- a/test/specs/support/deposits.ts
+++ b/test/specs/support/deposits.ts
@@ -9,6 +9,7 @@ import { signBalanceToken } from "#shared/balance-link.ts";
 import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
 import { sellSomethingAt } from "#test/specs/support/listings.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
+import { pageHtmlVia } from "#test/specs/support/money-reads.ts";
 import {
   type ActOnSomeMoney,
   type TicketsWorld,
@@ -18,7 +19,11 @@ import {
 import { createTestAttendee } from "#test-utils/db-helpers/attendees.ts";
 import { postListingSale } from "#test-utils/ledger.ts";
 import { awaitTestRequest } from "#test-utils/mocks.ts";
+
 // jscpd:ignore-end
+
+/** A page read the way anyone not signed in reads it. */
+const publicPageHtml = pageHtmlVia((path) => awaitTestRequest(path));
 
 /** A place taken but not paid for, so the whole price is owed. */
 export const unpaidPlace = async (
@@ -60,9 +65,7 @@ export const payDeposit: ActOnSomeMoney = async (world, amount) => {
 export const balancePageHtml = async (world: TicketsWorld): Promise<string> => {
   const token = await signBalanceToken(theBooking(world));
   world.evidenceValues.set("balanceToken", token);
-  const response = await awaitTestRequest(`/pay/${token}`);
-  expect(response.status).toBe(200);
-  return response.text();
+  return publicPageHtml(`/pay/${token}`);
 };
 
 /** The organiser settles what is left, the way the site settles it. */

--- a/test/specs/support/deposits.ts
+++ b/test/specs/support/deposits.ts
@@ -55,13 +55,9 @@ export const payDeposit: ActOnSomeMoney = async (world, amount) => {
   });
 };
 
-/**
- * The page a part-paid customer opens from their payment link.
- *
- * The token is kept on the world so an evidence capture can open the same
- * link the story just read: the page exists only at a signed URL, so a
- * screenshot of it cannot be taken from a path written by hand.
- */
+/** The page a part-paid customer opens from their payment link. The token is
+ *  kept on the world because the page exists only at a signed URL, so an
+ *  evidence capture has no path it could write by hand. */
 export const balancePageHtml = async (world: TicketsWorld): Promise<string> => {
   const token = await signBalanceToken(theBooking(world));
   world.evidenceValues.set("balanceToken", token);

--- a/test/specs/support/deposits.ts
+++ b/test/specs/support/deposits.ts
@@ -5,6 +5,7 @@
 
 // jscpd:ignore-start
 import { expect } from "@std/expect";
+import { signBalanceToken } from "#shared/balance-link.ts";
 import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
 import { sellSomethingAt } from "#test/specs/support/listings.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
@@ -16,6 +17,7 @@ import {
 } from "#test/specs/support/world.ts";
 import { createTestAttendee } from "#test-utils/db-helpers/attendees.ts";
 import { postListingSale } from "#test-utils/ledger.ts";
+import { awaitTestRequest } from "#test-utils/mocks.ts";
 // jscpd:ignore-end
 
 /** A place taken but not paid for, so the whole price is owed. */
@@ -25,13 +27,15 @@ export const unpaidPlace = async (
   price: string,
 ): Promise<void> => {
   const listing = await sellSomethingAt(world, name, price);
+  const email = `${name.toLowerCase().replaceAll(" ", "-")}@example.com`;
   const attendee = await createTestAttendee(
     listing.id,
     listing.slug,
     `${name} Payer`,
-    `${name.toLowerCase().replaceAll(" ", "-")}@example.com`,
+    email,
   );
   world.attendeeId = attendee.id;
+  world.attendeeEmail = email;
   world.attendeeName = `${name} Payer`;
 };
 
@@ -44,6 +48,21 @@ export const payDeposit: ActOnSomeMoney = async (world, amount) => {
     gross: 0,
     listingId: theListing(world),
   });
+};
+
+/**
+ * The page a part-paid customer opens from their payment link.
+ *
+ * The token is kept on the world so an evidence capture can open the same
+ * link the story just read: the page exists only at a signed URL, so a
+ * screenshot of it cannot be taken from a path written by hand.
+ */
+export const balancePageHtml = async (world: TicketsWorld): Promise<string> => {
+  const token = await signBalanceToken(theBooking(world));
+  world.evidenceValues.set("balanceToken", token);
+  const response = await awaitTestRequest(`/pay/${token}`);
+  expect(response.status).toBe(200);
+  return response.text();
 };
 
 /** The organiser settles what is left, the way the site settles it. */

--- a/test/specs/support/deposits.ts
+++ b/test/specs/support/deposits.ts
@@ -9,7 +9,10 @@ import { signBalanceToken } from "#shared/balance-link.ts";
 import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
 import { sellSomethingAt } from "#test/specs/support/listings.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
-import { pageHtmlVia } from "#test/specs/support/money-reads.ts";
+import {
+  pageHtmlVia,
+  type ReadOnePageHtml,
+} from "#test/specs/support/money-reads.ts";
 import {
   type ActOnSomeMoney,
   type TicketsWorld,
@@ -23,7 +26,9 @@ import { awaitTestRequest } from "#test-utils/mocks.ts";
 // jscpd:ignore-end
 
 /** A page read the way anyone not signed in reads it. */
-const publicPageHtml = pageHtmlVia((path) => awaitTestRequest(path));
+const publicPageHtml: ReadOnePageHtml = pageHtmlVia((path) =>
+  awaitTestRequest(path),
+);
 
 /** A place taken but not paid for, so the whole price is owed. */
 export const unpaidPlace = async (

--- a/test/specs/support/money-reads.ts
+++ b/test/specs/support/money-reads.ts
@@ -57,12 +57,21 @@ export const sumOfAllBalances = async (): Promise<number> => {
 
 // -- Admin page assertions ------------------------------------------------ //
 
+/**
+ * Read a page's HTML, asserting a 200, through whichever way of asking is
+ * given: an owner's session, or a plain request the way anyone else would.
+ * Who is asking is the only part that differs, so it is the only part passed.
+ */
+export const pageHtmlVia =
+  (get: (path: string) => Promise<Response>) =>
+  async (path: string): Promise<string> => {
+    const response = await get(path);
+    expect(response.status).toBe(200);
+    return response.text();
+  };
+
 /** GET an owner page and return its HTML, asserting a 200. */
-export const adminPageHtml = async (path: string): Promise<string> => {
-  const response = await adminGet(path);
-  expect(response.status).toBe(200);
-  return response.text();
-};
+export const adminPageHtml = pageHtmlVia(adminGet);
 
 /**
  * Assert a `revenue` account's RUNNING BALANCE on the per-account ledger

--- a/test/specs/support/money-reads.ts
+++ b/test/specs/support/money-reads.ts
@@ -23,7 +23,7 @@ import { adminGet } from "#test-utils/session.ts";
 export type CheckMoneyShown = (id: number, minor: number) => Promise<void>;
 
 /** One way of asking for a page: as the owner, or as anyone else. */
-export type ReadOnePage = (path: string) => Promise<Response>;
+type ReadOnePage = (path: string) => Promise<Response>;
 
 /** A page's HTML, once the response has been checked. */
 export type ReadOnePageHtml = (path: string) => Promise<string>;

--- a/test/specs/support/money-reads.ts
+++ b/test/specs/support/money-reads.ts
@@ -22,6 +22,12 @@ import { adminGet } from "#test-utils/session.ts";
  * so they share this contract rather than repeating the signature. */
 export type CheckMoneyShown = (id: number, minor: number) => Promise<void>;
 
+/** One way of asking for a page: as the owner, or as anyone else. */
+export type ReadOnePage = (path: string) => Promise<Response>;
+
+/** A page's HTML, once the response has been checked. */
+export type ReadOnePageHtml = (path: string) => Promise<string>;
+
 // -- Ledger-truth helpers ------------------------------------------------- //
 
 /** Normalise a signed-zero to a plain zero so `toBe(0)` (strict, `-0 !== 0`)
@@ -63,15 +69,15 @@ export const sumOfAllBalances = async (): Promise<number> => {
  * Who is asking is the only part that differs, so it is the only part passed.
  */
 export const pageHtmlVia =
-  (get: (path: string) => Promise<Response>) =>
-  async (path: string): Promise<string> => {
+  (get: ReadOnePage): ReadOnePageHtml =>
+  async (path) => {
     const response = await get(path);
     expect(response.status).toBe(200);
     return response.text();
   };
 
 /** GET an owner page and return its HTML, asserting a 200. */
-export const adminPageHtml = pageHtmlVia(adminGet);
+export const adminPageHtml: ReadOnePageHtml = pageHtmlVia(adminGet);
 
 /**
  * Assert a `revenue` account's RUNNING BALANCE on the per-account ledger

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -94,6 +94,7 @@ export interface TicketsWorld extends World {
   apiKeyWrite?: number;
   apiListing?: string;
   apiRoomAnswer?: boolean;
+  attendeeEmail?: string;
   attendeeId?: number;
   attendeeIds?: number[];
   attendeeName?: string;


### PR DESCRIPTION
The site's deposits page shows a screenshot of the page a part-paid customer opens from their payment link, and says it names what was booked, what has been paid and what is left, with no personal details on it.

Nothing tested any of that. `payments.paying-a-deposit` ended at the organiser's ledger page, so every claim about the customer's own page rested on a hand-made picture.

## The story

A second rule on the same Feature, `payments.the-customer-can-see-what-is-left-and-pay-it`:

```gherkin
@case:deposit.balance-page-shows-what-is-left
Scenario: The payment link for a part-paid 80.00 Retreat place
  Given a customer owes 80.00 for a Retreat place
  When they pay a deposit of 30.00
  Then their payment link offers to take the 50.00 that is left
  And it names the Retreat place, 80.00 ordered and 30.00 paid
  And it says nothing about who booked
```

The steps read the page as the customer does, through `signBalanceToken` and `GET /pay/:token`, not through an admin session. The last one asserts the booker's name and email are absent, which is the PII-free claim the page's own text makes.

## The capture

`deposit.balance-page-shows-what-is-left` gains an evidence declaration at `/pay/{balanceToken}`. The token is put on the world by the step that reads the page, because the page exists only at a signed URL — there is no path to write by hand.

Two consecutive runs from a clean checkout produce byte-identical PNGs.

## The registry

`@surface:public` is new. The registry had `admin`, `return` and `webhook`; a page a customer opens themselves, neither an admin page nor a payment provider's return, had no name.

## Checks run

- `deno task specs:files specs/payments/paying-a-deposit.feature` — 2 scenarios, 14 steps, all passed
- `deno task specs:check` — 37 stories, 97 rules validated
- `deno task lint:ci` — clean
- `deno task cpd` — 0 clones
- `deno task specs:evidence` — 4 captures, twice, identical bytes

The site side is chobbledotcom/tickets-site#121, which replaces the hand-made screenshot with this capture. It imports whatever the manifest holds, so this can merge first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK)_