### PR TITLE
Stop splitting a test file into a folder making mutation runs slower

### DIFF
--- a/scripts/mutation/execution.ts
+++ b/scripts/mutation/execution.ts
@@ -10,6 +10,7 @@ import { stripeMockEnv } from "#scripts/stripe-mock.ts";
 import { TEST_STATE_DIR_ENV } from "#test/test-utils/test-state-env.ts";
 import { batchTestFiles } from "./batch.ts";
 import { denoExitCode, envWith } from "./child-process.ts";
+import { planIsolateEntries } from "./isolate-entry.ts";
 import type { Status } from "./summary.ts";
 
 export type Outcome = "failed" | "passed" | "timed-out";
@@ -113,20 +114,25 @@ const runTestBatch: TestBatchRunner = async (batch, signal, env) => {
     stdout: "null",
   } as const;
   if (direct.length > 0) {
-    const code = await denoExitCode(
-      [
-        "test",
-        "--no-check",
-        "--allow-all",
-        "--parallel",
-        "--preload",
-        "./test/test-utils/preload.ts",
-        "--v8-flags=--expose-gc",
-        ...direct,
-      ],
-      options,
-    );
-    if (code !== 0) return code;
+    const entries = await planIsolateEntries(direct);
+    try {
+      const code = await denoExitCode(
+        [
+          "test",
+          "--no-check",
+          "--allow-all",
+          "--parallel",
+          "--preload",
+          "./test/test-utils/preload.ts",
+          "--v8-flags=--expose-gc",
+          ...entries.runArgs,
+        ],
+        options,
+      );
+      if (code !== 0) return code;
+    } finally {
+      await entries.cleanup();
+    }
   }
   return features.length === 0
     ? 0

--- a/scripts/mutation/isolate-entry.ts
+++ b/scripts/mutation/isolate-entry.ts
@@ -2,53 +2,33 @@
  * Run a mutant's direct test files through generated entry modules so they
  * share an isolate instead of getting one each.
  *
- * `deno test` gives every file its own isolate, and each isolate re-evaluates
- * the app module graph. A mutant re-runs its whole direct set, so that cost is
- * paid once per file per mutant: measured on the admin questions template,
- * six split files took ~824ms per run against ~530ms for the same tests in one
- * file, which over a 135-mutant sweep was ~29s of the run. Importing the files
- * from one entry module — the same trick `scripts/test-groups.ts` uses for the
- * full suite — brings the split shape back to ~547ms.
+ * `deno test` gives every test file its own isolate, and each isolate
+ * re-evaluates the app module graph. A mutant re-runs its whole direct set, so
+ * that cost is paid per file per mutant: measured on the admin questions
+ * template, six split files took ~824ms per run against ~530ms for the same
+ * tests in one file, which over a 135-mutant sweep was ~29s. Reusing the full
+ * suite's grouping — one entry module importing several test files — brings the
+ * split shape back to ~547ms, so splitting an oversized test file no longer
+ * costs anything at mutation time.
  *
- * Two limits shape the entries. Files with global (module-level) BDD hooks
- * cannot share an isolate at all, so they keep their own. And an isolate is
- * capped at `MAX_FILES_PER_ENTRY` files: one process holding many test files
- * strands file descriptors (see the header of `batch.ts`), and concentrating a
- * whole batch into a single isolate would push that further than the batching
- * already allows.
+ * Two limits shape the entries, both inherited from the mechanisms this builds
+ * on. Files with global (module-level) BDD hooks cannot share an isolate, so
+ * `planTestGroups` keeps them on their own. And an entry holds at most
+ * `MAX_FILES_PER_ENTRY` files: one process holding many test files strands file
+ * descriptors (see the header of `batch.ts`), and pulling a whole batch into a
+ * single isolate would push that past what the batching already allows.
  */
 
-import { isAbsolute, join, relative } from "node:path";
 import { projectRoot } from "#scripts/project-root.ts";
 import {
-  GROUPS_DIR,
-  mustRunAlone,
-  renderGroupEntry,
+  classifyRunAlone,
+  planTestGroups,
+  writeGroupEntries,
 } from "#scripts/test-groups.ts";
 
 /** Files one generated entry may import. Below `TEST_FILE_BATCH_SIZE` so an
  *  entry never holds more open files than a batch already does. */
 export const MAX_FILES_PER_ENTRY = 8;
-
-/** Split `paths` into runs of at most `size`, preserving order. */
-export const shardForEntries = (
-  paths: string[],
-  size = MAX_FILES_PER_ENTRY,
-): string[][] => {
-  const shards: string[][] = [];
-  for (let index = 0; index < paths.length; index += size) {
-    shards.push(paths.slice(index, index + size));
-  }
-  return shards;
-};
-
-/** Which files can share an isolate, and which must keep their own. */
-export const splitByIsolateSharing = (
-  files: { path: string; source: string }[],
-): { shareable: string[]; solo: string[] } => ({
-  shareable: files.filter((f) => !mustRunAlone(f.source)).map((f) => f.path),
-  solo: files.filter((f) => mustRunAlone(f.source)).map((f) => f.path),
-});
 
 export interface EntryPlan {
   /** Remove the generated entries. */
@@ -63,59 +43,34 @@ const passThrough = (paths: string[]): EntryPlan => ({
   runArgs: paths,
 });
 
-/** How an entry imports one of its members. Entries sit one level below the
- *  project root, and the paths handed in are absolute, so the specifier is the
- *  member's project-relative path with one level climbed out of the entries
- *  directory — which keeps the project's import map applying to it. */
-export const entryImport = (root: string, member: string): string =>
-  `../${relative(root, isAbsolute(member) ? member : join(root, member))}`;
+/** Entries per run of files, so no entry exceeds MAX_FILES_PER_ENTRY. */
+export const entryCountFor = (shareableFiles: number): number =>
+  Math.ceil(shareableFiles / MAX_FILES_PER_ENTRY);
 
 let entrySequence = 0;
 
-/**
- * Write one entry module per shard of shareable files and return what to run.
- * Entries import their members relative to the entries directory, so the
- * project's import map applies unchanged — which is what lets a mutated module
- * bind through its `#…` alias.
- */
+/** Plan and write the entry modules for one set of direct test files. */
 export const planIsolateEntries = async (
   paths: string[],
   root: string = projectRoot,
 ): Promise<EntryPlan> => {
   if (paths.length < 2) return passThrough(paths);
-  const files = await Promise.all(
-    paths.map(async (path) => ({
-      path,
-      source: await Deno.readTextFile(path),
-    })),
+  const files = await classifyRunAlone(paths);
+  const shareable = files.filter((file) => !file.runsAlone).length;
+  if (shareable < 2) return passThrough(paths);
+
+  const plan = planTestGroups(files, entryCountFor(shareable));
+  // Concurrent batch workers each write their own entries, so names carry a
+  // run-wide sequence number rather than only a per-call index.
+  const base = entrySequence;
+  entrySequence += plan.grouped.length;
+  const entries = await writeGroupEntries(
+    root,
+    plan.grouped,
+    (index) => `mutation-${base + index}.test.ts`,
   );
-  const { shareable, solo } = splitByIsolateSharing(files);
-  if (shareable.length < 2) return passThrough(paths);
-
-  const entriesDir = join(root, GROUPS_DIR);
-  await Deno.mkdir(entriesDir, { recursive: true });
-  const written: string[] = [];
-  for (const shard of shardForEntries(shareable)) {
-    const entry = join(entriesDir, `mutation-${entrySequence++}.test.ts`);
-    await Deno.writeTextFile(
-      entry,
-      renderGroupEntry(shard.map((member) => entryImport(root, member))),
-    );
-    written.push(entry);
-  }
   return {
-    cleanup: async () => {
-      for (const entry of written) {
-        await Deno.remove(entry).catch(rethrowUnlessGone);
-      }
-    },
-    runArgs: [...written, ...solo],
+    cleanup: entries.cleanup,
+    runArgs: [...entries.paths, ...plan.solo],
   };
-};
-
-/** A cleanup racing another cleanup (or a wiped run directory) may find the
- *  entry already gone; anything else is a real failure. */
-const rethrowUnlessGone = (error: unknown): void => {
-  if (error instanceof Deno.errors.NotFound) return;
-  throw error;
 };

--- a/scripts/mutation/isolate-entry.ts
+++ b/scripts/mutation/isolate-entry.ts
@@ -1,0 +1,121 @@
+/**
+ * Run a mutant's direct test files through generated entry modules so they
+ * share an isolate instead of getting one each.
+ *
+ * `deno test` gives every file its own isolate, and each isolate re-evaluates
+ * the app module graph. A mutant re-runs its whole direct set, so that cost is
+ * paid once per file per mutant: measured on the admin questions template,
+ * six split files took ~824ms per run against ~530ms for the same tests in one
+ * file, which over a 135-mutant sweep was ~29s of the run. Importing the files
+ * from one entry module — the same trick `scripts/test-groups.ts` uses for the
+ * full suite — brings the split shape back to ~547ms.
+ *
+ * Two limits shape the entries. Files with global (module-level) BDD hooks
+ * cannot share an isolate at all, so they keep their own. And an isolate is
+ * capped at `MAX_FILES_PER_ENTRY` files: one process holding many test files
+ * strands file descriptors (see the header of `batch.ts`), and concentrating a
+ * whole batch into a single isolate would push that further than the batching
+ * already allows.
+ */
+
+import { isAbsolute, join, relative } from "node:path";
+import { projectRoot } from "#scripts/project-root.ts";
+import {
+  GROUPS_DIR,
+  mustRunAlone,
+  renderGroupEntry,
+} from "#scripts/test-groups.ts";
+
+/** Files one generated entry may import. Below `TEST_FILE_BATCH_SIZE` so an
+ *  entry never holds more open files than a batch already does. */
+export const MAX_FILES_PER_ENTRY = 8;
+
+/** Split `paths` into runs of at most `size`, preserving order. */
+export const shardForEntries = (
+  paths: string[],
+  size = MAX_FILES_PER_ENTRY,
+): string[][] => {
+  const shards: string[][] = [];
+  for (let index = 0; index < paths.length; index += size) {
+    shards.push(paths.slice(index, index + size));
+  }
+  return shards;
+};
+
+/** Which files can share an isolate, and which must keep their own. */
+export const splitByIsolateSharing = (
+  files: { path: string; source: string }[],
+): { shareable: string[]; solo: string[] } => ({
+  shareable: files.filter((f) => !mustRunAlone(f.source)).map((f) => f.path),
+  solo: files.filter((f) => mustRunAlone(f.source)).map((f) => f.path),
+});
+
+export interface EntryPlan {
+  /** Remove the generated entries. */
+  cleanup: () => Promise<void>;
+  /** Paths to hand to `deno test`: generated entries plus solo files. */
+  runArgs: string[];
+}
+
+/** A single file is already one isolate, so it is handed through untouched. */
+const passThrough = (paths: string[]): EntryPlan => ({
+  cleanup: () => Promise.resolve(),
+  runArgs: paths,
+});
+
+/** How an entry imports one of its members. Entries sit one level below the
+ *  project root, and the paths handed in are absolute, so the specifier is the
+ *  member's project-relative path with one level climbed out of the entries
+ *  directory — which keeps the project's import map applying to it. */
+export const entryImport = (root: string, member: string): string =>
+  `../${relative(root, isAbsolute(member) ? member : join(root, member))}`;
+
+let entrySequence = 0;
+
+/**
+ * Write one entry module per shard of shareable files and return what to run.
+ * Entries import their members relative to the entries directory, so the
+ * project's import map applies unchanged — which is what lets a mutated module
+ * bind through its `#…` alias.
+ */
+export const planIsolateEntries = async (
+  paths: string[],
+  root: string = projectRoot,
+): Promise<EntryPlan> => {
+  if (paths.length < 2) return passThrough(paths);
+  const files = await Promise.all(
+    paths.map(async (path) => ({
+      path,
+      source: await Deno.readTextFile(path),
+    })),
+  );
+  const { shareable, solo } = splitByIsolateSharing(files);
+  if (shareable.length < 2) return passThrough(paths);
+
+  const entriesDir = join(root, GROUPS_DIR);
+  await Deno.mkdir(entriesDir, { recursive: true });
+  const written: string[] = [];
+  for (const shard of shardForEntries(shareable)) {
+    const entry = join(entriesDir, `mutation-${entrySequence++}.test.ts`);
+    await Deno.writeTextFile(
+      entry,
+      renderGroupEntry(shard.map((member) => entryImport(root, member))),
+    );
+    written.push(entry);
+  }
+  return {
+    cleanup: async () => {
+      for (const entry of written) {
+        await Deno.remove(entry).catch(rethrowUnlessGone);
+      }
+    },
+    runArgs: [...written, ...solo],
+  };
+};
+
+/** A cleanup racing another cleanup (or a wiped run directory) may find the
+ *  entry already gone; anything else is a real failure. */
+const rethrowUnlessGone = (error: unknown): void => {
+  if (error instanceof Deno.errors.NotFound) return;
+  throw error;
+};

--- a/scripts/test-groups.ts
+++ b/scripts/test-groups.ts
@@ -18,7 +18,7 @@
  * it a module-level `// test-groups: run-alone` comment.
  */
 
-import { join, relative } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import { rethrowUnlessNotFound } from "./not-found.ts";
 import { isSourcePath, isTestPath } from "./unit-tests-report-lib.ts";
 import { collectFiles } from "./walk-files.ts";
@@ -63,6 +63,17 @@ export type TestGroupPlan = {
   /** Files that keep their own isolate (global hooks or run-alone marker). */
   solo: string[];
 };
+
+/** Read each file once and pair it with whether it must run alone. */
+export const classifyRunAlone = (
+  paths: string[],
+): Promise<{ path: string; runsAlone: boolean }[]> =>
+  Promise.all(
+    paths.map(async (path) => ({
+      path,
+      runsAlone: mustRunAlone(await Deno.readTextFile(path)),
+    })),
+  );
 
 /** Split test files into isolate-sharing shards and solo files. Pure. */
 export const planTestGroups = (
@@ -118,6 +129,45 @@ export const rethrowUnlessLeftoverDir = (error: unknown): void => {
   throw error;
 };
 
+/** How an entry imports one of its members. Entries sit one level below the
+ *  project root, so the specifier climbs out of the entries directory to the
+ *  member's project-relative path — which keeps the project's import map
+ *  applying to it, and is what lets a mutated module bind through its alias. */
+export const groupEntryImport = (root: string, member: string): string =>
+  `../${relative(root, isAbsolute(member) ? member : join(root, member))}`;
+
+/**
+ * Write one entry module per shard into the entries directory, naming each by
+ * its index. Returns the entry paths to run and a cleanup that removes them.
+ */
+export const writeGroupEntries = async (
+  root: string,
+  shards: string[][],
+  nameFor: (index: number) => string,
+): Promise<{ cleanup: () => Promise<void>; paths: string[] }> => {
+  const entriesDir = join(root, GROUPS_DIR);
+  await Deno.mkdir(entriesDir, { recursive: true });
+  const paths: string[] = [];
+  for (const [index, members] of shards.entries()) {
+    const entry = join(entriesDir, nameFor(index));
+    await Deno.writeTextFile(
+      entry,
+      renderGroupEntry(members.map((member) => groupEntryImport(root, member))),
+    );
+    paths.push(entry);
+  }
+  return {
+    // Only an already-removed entry is expected; anything else must surface
+    // rather than leave generated files behind silently.
+    cleanup: async () => {
+      for (const entry of paths) {
+        await Deno.remove(entry).catch(rethrowUnlessNotFound);
+      }
+    },
+    paths,
+  };
+};
+
 export type WrittenTestGroups = {
   /** Paths to hand to `deno test`: group entries plus solo files. */
   runArgs: string[];
@@ -137,36 +187,20 @@ export const writeTestGroups = async (
   groupCount: number = defaultGroupCount(testWorkerCount()),
 ): Promise<WrittenTestGroups> => {
   const paths = await collectTestFiles(root);
-  const files = await Promise.all(
-    paths.map(async (path) => ({
-      path,
-      runsAlone: mustRunAlone(await Deno.readTextFile(path)),
-    })),
-  );
-  const plan = planTestGroups(files, groupCount);
+  const plan = planTestGroups(await classifyRunAlone(paths), groupCount);
 
-  const groupsDir = join(root, GROUPS_DIR);
-  await Deno.mkdir(groupsDir, { recursive: true });
-  const groupPaths: string[] = [];
-  for (const [index, members] of plan.grouped.entries()) {
-    const groupPath = join(groupsDir, `group-${index}.test.ts`);
-    await Deno.writeTextFile(
-      groupPath,
-      renderGroupEntry(members.map((member) => `../${relative(root, member)}`)),
-    );
-    groupPaths.push(groupPath);
-  }
+  const entries = await writeGroupEntries(
+    root,
+    plan.grouped,
+    (index) => `group-${index}.test.ts`,
+  );
 
   return {
     cleanup: async () => {
-      for (const groupPath of groupPaths) {
-        // Only an already-removed entry is expected; anything else must
-        // surface rather than leave generated files behind silently.
-        await Deno.remove(groupPath).catch(rethrowUnlessNotFound);
-      }
-      await Deno.remove(groupsDir).catch(rethrowUnlessLeftoverDir);
+      await entries.cleanup();
+      await Deno.remove(join(root, GROUPS_DIR)).catch(rethrowUnlessLeftoverDir);
     },
-    runArgs: [...groupPaths, ...plan.solo],
+    runArgs: [...entries.paths, ...plan.solo],
     testFiles: paths,
   };
 };

--- a/test/scripts/mutation/isolate-entry.test.ts
+++ b/test/scripts/mutation/isolate-entry.test.ts
@@ -2,11 +2,9 @@ import { basename } from "node:path";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
-  entryImport,
+  entryCountFor,
   MAX_FILES_PER_ENTRY,
   planIsolateEntries,
-  shardForEntries,
-  splitByIsolateSharing,
 } from "#scripts/mutation/isolate-entry.ts";
 import { GROUPS_DIR } from "#scripts/test-groups.ts";
 
@@ -29,61 +27,13 @@ const withFiles = async (
   return { paths, root };
 };
 
-describe("shardForEntries", () => {
-  test("keeps every path, in order, across shards", () => {
-    const paths = Array.from({ length: 5 }, (_, i) => `f${i}.ts`);
-    expect(shardForEntries(paths, 2)).toEqual([
-      ["f0.ts", "f1.ts"],
-      ["f2.ts", "f3.ts"],
-      ["f4.ts"],
-    ]);
+describe("entryCountFor", () => {
+  test("keeps one entry while the files fit in one isolate", () => {
+    expect(entryCountFor(MAX_FILES_PER_ENTRY)).toBe(1);
   });
 
-  test("caps a shard at MAX_FILES_PER_ENTRY by default", () => {
-    const paths = Array.from(
-      { length: MAX_FILES_PER_ENTRY + 1 },
-      (_, i) => `f${i}.ts`,
-    );
-    const shards = shardForEntries(paths);
-    expect(shards.map((shard) => shard.length)).toEqual([
-      MAX_FILES_PER_ENTRY,
-      1,
-    ]);
-  });
-
-  test("returns no shards for no paths", () => {
-    expect(shardForEntries([])).toEqual([]);
-  });
-});
-
-describe("entryImport", () => {
-  test("climbs out of the entries directory to a project-relative path", () => {
-    expect(entryImport("/repo", "/repo/test/a.test.ts")).toBe(
-      "../test/a.test.ts",
-    );
-  });
-
-  test("treats a relative member as already project-relative", () => {
-    expect(entryImport("/repo", "test/a.test.ts")).toBe("../test/a.test.ts");
-  });
-});
-
-describe("splitByIsolateSharing", () => {
-  test("sends a file with a global hook to its own isolate", () => {
-    expect(
-      splitByIsolateSharing([
-        { path: "a.test.ts", source: groupable },
-        { path: "b.test.ts", source: globalHook },
-      ]),
-    ).toEqual({ shareable: ["a.test.ts"], solo: ["b.test.ts"] });
-  });
-
-  test("honours the run-alone marker", () => {
-    expect(
-      splitByIsolateSharing([
-        { path: "a.test.ts", source: "// test-groups: run-alone\n" },
-      ]),
-    ).toEqual({ shareable: [], solo: ["a.test.ts"] });
+  test("adds an entry as soon as they do not fit", () => {
+    expect(entryCountFor(MAX_FILES_PER_ENTRY + 1)).toBe(2);
   });
 });
 
@@ -168,35 +118,47 @@ describe("planIsolateEntries", () => {
     const imported = imports.flatMap((body) =>
       [...body.matchAll(/import "\.\.\/(.+)";/g)].map((match) => match[1]),
     );
-    expect(imported).toEqual(paths.map((path) => basename(path)));
+    // Membership, not order: the files are dealt across entries, and what
+    // matters is that each one is run exactly once.
+    expect(imported.sort()).toEqual(paths.map((path) => basename(path)).sort());
 
     await plan.cleanup();
     await Deno.remove(root, { recursive: true });
   });
 
-  test("cleanup tolerates an entry that is already gone", async () => {
+  /** Plan two shareable files, disturb the first entry, then clean up —
+   *  returning the error cleanup threw, or null when it succeeded. */
+  const cleanupErrorAfter = async (
+    disturb: (entry: string) => Promise<void>,
+  ): Promise<unknown> => {
     const { paths, root } = await withFiles({
       "a.test.ts": groupable,
       "b.test.ts": groupable,
     });
     const plan = await planIsolateEntries(paths, root);
-    await Deno.remove(plan.runArgs[0]!);
-    await plan.cleanup();
-    await Deno.remove(root, { recursive: true });
+    await disturb(plan.runArgs[0]!);
+    try {
+      await plan.cleanup();
+      return null;
+    } catch (error) {
+      return error;
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  };
+
+  test("cleanup tolerates an entry that is already gone", async () => {
+    expect(await cleanupErrorAfter((entry) => Deno.remove(entry))).toBeNull();
   });
 
   test("cleanup surfaces a failure that is not a missing entry", async () => {
-    const { paths, root } = await withFiles({
-      "a.test.ts": groupable,
-      "b.test.ts": groupable,
-    });
-    const plan = await planIsolateEntries(paths, root);
     // A directory in place of the entry file fails removal for a different
     // reason, so cleanup must not swallow it.
-    await Deno.remove(plan.runArgs[0]!);
-    await Deno.mkdir(plan.runArgs[0]!);
-    await Deno.writeTextFile(`${plan.runArgs[0]!}/held.txt`, "x");
-    await expect(plan.cleanup()).rejects.toThrow();
-    await Deno.remove(root, { recursive: true });
+    const error = await cleanupErrorAfter(async (entry) => {
+      await Deno.remove(entry);
+      await Deno.mkdir(entry);
+      await Deno.writeTextFile(`${entry}/held.txt`, "x");
+    });
+    expect(error).toBeInstanceOf(Error);
   });
 });

--- a/test/scripts/mutation/isolate-entry.test.ts
+++ b/test/scripts/mutation/isolate-entry.test.ts
@@ -1,0 +1,202 @@
+import { basename } from "node:path";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  entryImport,
+  MAX_FILES_PER_ENTRY,
+  planIsolateEntries,
+  shardForEntries,
+  splitByIsolateSharing,
+} from "#scripts/mutation/isolate-entry.ts";
+import { GROUPS_DIR } from "#scripts/test-groups.ts";
+
+/** A test file body that can share an isolate: its hook sits inside a suite. */
+const groupable = 'describe("x", () => {\n  beforeAll(() => {});\n});\n';
+
+/** A test file body that cannot: the hook is registered at module level. */
+const globalHook = 'beforeAll(() => {});\ndescribe("x", () => {});\n';
+
+/** Build a throwaway project root holding the given test files. */
+const withFiles = async (
+  files: Record<string, string>,
+): Promise<{ paths: string[]; root: string }> => {
+  const root = await Deno.makeTempDir();
+  const paths: string[] = [];
+  for (const [name, body] of Object.entries(files)) {
+    await Deno.writeTextFile(`${root}/${name}`, body);
+    paths.push(`${root}/${name}`);
+  }
+  return { paths, root };
+};
+
+describe("shardForEntries", () => {
+  test("keeps every path, in order, across shards", () => {
+    const paths = Array.from({ length: 5 }, (_, i) => `f${i}.ts`);
+    expect(shardForEntries(paths, 2)).toEqual([
+      ["f0.ts", "f1.ts"],
+      ["f2.ts", "f3.ts"],
+      ["f4.ts"],
+    ]);
+  });
+
+  test("caps a shard at MAX_FILES_PER_ENTRY by default", () => {
+    const paths = Array.from(
+      { length: MAX_FILES_PER_ENTRY + 1 },
+      (_, i) => `f${i}.ts`,
+    );
+    const shards = shardForEntries(paths);
+    expect(shards.map((shard) => shard.length)).toEqual([
+      MAX_FILES_PER_ENTRY,
+      1,
+    ]);
+  });
+
+  test("returns no shards for no paths", () => {
+    expect(shardForEntries([])).toEqual([]);
+  });
+});
+
+describe("entryImport", () => {
+  test("climbs out of the entries directory to a project-relative path", () => {
+    expect(entryImport("/repo", "/repo/test/a.test.ts")).toBe(
+      "../test/a.test.ts",
+    );
+  });
+
+  test("treats a relative member as already project-relative", () => {
+    expect(entryImport("/repo", "test/a.test.ts")).toBe("../test/a.test.ts");
+  });
+});
+
+describe("splitByIsolateSharing", () => {
+  test("sends a file with a global hook to its own isolate", () => {
+    expect(
+      splitByIsolateSharing([
+        { path: "a.test.ts", source: groupable },
+        { path: "b.test.ts", source: globalHook },
+      ]),
+    ).toEqual({ shareable: ["a.test.ts"], solo: ["b.test.ts"] });
+  });
+
+  test("honours the run-alone marker", () => {
+    expect(
+      splitByIsolateSharing([
+        { path: "a.test.ts", source: "// test-groups: run-alone\n" },
+      ]),
+    ).toEqual({ shareable: [], solo: ["a.test.ts"] });
+  });
+});
+
+describe("planIsolateEntries", () => {
+  test("hands a single file through without writing an entry", async () => {
+    const { paths, root } = await withFiles({ "a.test.ts": groupable });
+    const plan = await planIsolateEntries(paths, root);
+    expect(plan.runArgs).toEqual(paths);
+    await plan.cleanup();
+    await expect(Deno.stat(`${root}/${GROUPS_DIR}`)).rejects.toThrow();
+    await Deno.remove(root, { recursive: true });
+  });
+
+  test("hands no files through without writing an entry", async () => {
+    const plan = await planIsolateEntries([]);
+    expect(plan.runArgs).toEqual([]);
+    await plan.cleanup();
+  });
+
+  test("replaces several shareable files with one entry that imports them", async () => {
+    const { paths, root } = await withFiles({
+      "a.test.ts": groupable,
+      "b.test.ts": groupable,
+    });
+    const plan = await planIsolateEntries(paths, root);
+
+    expect(plan.runArgs).toHaveLength(1);
+    const entry = plan.runArgs[0]!;
+    expect(entry.startsWith(`${root}/${GROUPS_DIR}/`)).toBe(true);
+    const body = await Deno.readTextFile(entry);
+    for (const path of paths) {
+      expect(body).toContain(`import "../${basename(path)}";`);
+    }
+
+    await plan.cleanup();
+    await expect(Deno.stat(entry)).rejects.toThrow(Deno.errors.NotFound);
+    await Deno.remove(root, { recursive: true });
+  });
+
+  test("runs a file with a global hook alongside the entry, not inside it", async () => {
+    const { paths, root } = await withFiles({
+      "a.test.ts": groupable,
+      "b.test.ts": groupable,
+      "c.test.ts": globalHook,
+    });
+    const plan = await planIsolateEntries(paths, root);
+
+    expect(plan.runArgs).toHaveLength(2);
+    expect(plan.runArgs.at(-1)).toBe(`${root}/c.test.ts`);
+    const body = await Deno.readTextFile(plan.runArgs[0]!);
+    expect(body).not.toContain("c.test.ts");
+
+    await plan.cleanup();
+    await Deno.remove(root, { recursive: true });
+  });
+
+  test("hands files through when only one of them can share an isolate", async () => {
+    const { paths, root } = await withFiles({
+      "a.test.ts": groupable,
+      "b.test.ts": globalHook,
+    });
+    const plan = await planIsolateEntries(paths, root);
+    expect(plan.runArgs).toEqual(paths);
+    await plan.cleanup();
+    await Deno.remove(root, { recursive: true });
+  });
+
+  test("splits more files than one entry may hold into several entries", async () => {
+    const bodies = Object.fromEntries(
+      Array.from({ length: MAX_FILES_PER_ENTRY + 2 }, (_, i) => [
+        `f${i}.test.ts`,
+        groupable,
+      ]),
+    );
+    const { paths, root } = await withFiles(bodies);
+    const plan = await planIsolateEntries(paths, root);
+
+    expect(plan.runArgs).toHaveLength(2);
+    const imports = await Promise.all(
+      plan.runArgs.map((entry) => Deno.readTextFile(entry)),
+    );
+    const imported = imports.flatMap((body) =>
+      [...body.matchAll(/import "\.\.\/(.+)";/g)].map((match) => match[1]),
+    );
+    expect(imported).toEqual(paths.map((path) => basename(path)));
+
+    await plan.cleanup();
+    await Deno.remove(root, { recursive: true });
+  });
+
+  test("cleanup tolerates an entry that is already gone", async () => {
+    const { paths, root } = await withFiles({
+      "a.test.ts": groupable,
+      "b.test.ts": groupable,
+    });
+    const plan = await planIsolateEntries(paths, root);
+    await Deno.remove(plan.runArgs[0]!);
+    await plan.cleanup();
+    await Deno.remove(root, { recursive: true });
+  });
+
+  test("cleanup surfaces a failure that is not a missing entry", async () => {
+    const { paths, root } = await withFiles({
+      "a.test.ts": groupable,
+      "b.test.ts": groupable,
+    });
+    const plan = await planIsolateEntries(paths, root);
+    // A directory in place of the entry file fails removal for a different
+    // reason, so cleanup must not swallow it.
+    await Deno.remove(plan.runArgs[0]!);
+    await Deno.mkdir(plan.runArgs[0]!);
+    await Deno.writeTextFile(`${plan.runArgs[0]!}/held.txt`, "x");
+    await expect(plan.cleanup()).rejects.toThrow();
+    await Deno.remove(root, { recursive: true });
+  });
+});

--- a/test/scripts/test-groups.test.ts
+++ b/test/scripts/test-groups.test.ts
@@ -5,6 +5,7 @@ import {
   collectTestFiles,
   defaultGroupCount,
   GROUPS_DIR,
+  groupEntryImport,
   mustRunAlone,
   planTestGroups,
   RUN_ALONE_MARKER,
@@ -254,6 +255,20 @@ describe("test-groups", () => {
 
     test("group count falls back to the machine's cores without DENO_JOBS", async () => {
       await expectOneGroupEntryWithEnv({ DENO_JOBS: undefined });
+    });
+  });
+
+  describe("groupEntryImport", () => {
+    test("climbs out of the entries directory to a project-relative path", () => {
+      expect(groupEntryImport("/repo", "/repo/test/a.test.ts")).toBe(
+        "../test/a.test.ts",
+      );
+    });
+
+    test("treats a member that is already project-relative as such", () => {
+      expect(groupEntryImport("/repo", "test/a.test.ts")).toBe(
+        "../test/a.test.ts",
+      );
     });
   });
 });


### PR DESCRIPTION
When we split an oversized test file into a folder of smaller ones, the mutation checker got slower. It runs a source file's tests once for every change it tries, and it was giving each test file its own worker — and every worker loads the whole app again before running a single check. Six small files therefore did that work six times where one big file did it once.

That was a real cost, so it is measured, not guessed. Timing the same source (the admin questions template, 135 changes tried) on this machine:

| tests | whole run | just the test part |
| --- | --- | --- |
| the six split files, before this change | 7m 04s | 101.2s |
| the one big file they replaced | 6m 02s | 72.2s |
| **the six split files, after this change** | **6m 04s** | **71.7s** |

So splitting a test file now costs nothing at checking time. The number of changes tried, the score, and the exact list of changes nothing caught are identical before and after — this is purely about how the tests are launched, not what they check.

**How it works.** The full test suite already had this exact problem and already solved it: it writes small "entry" files that import a handful of test files, so they load the app once between them. The mutation checker now uses that same machinery instead of having its own way of doing things. Along the way the two now share the pieces they were each about to duplicate — reading a file to decide whether it can share a worker, deciding what may be grouped, writing the entries, and cleaning them up afterwards.

Two limits are inherited rather than invented: a test file that sets things up for the whole file can never share with another, and an entry holds at most eight files, because a single worker holding many test files can run out of open files.

`deno task precommit` passes.

**Not included:** the run also reports four changes to the questions template that no test catches. They are not caused by this work and none of the files here touch that template, so they are left for their own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdDZCWRXwjqsidfRJFarXC)_