### PR TITLE
Capture the contact record and the bundle booking page

### DIFF
--- a/scripts/run-spec-evidence.ts
+++ b/scripts/run-spec-evidence.ts
@@ -1,8 +1,25 @@
 #!/usr/bin/env -S deno run --allow-all
 import { runEvidenceSpecs } from "./specs/evidence/run.ts";
+import { EVIDENCE_THEMES_ENV } from "./specs/evidence/themes.ts";
 import { withTestHarness } from "./test-harness.ts";
 
+/**
+ * `--themes <dir>` dresses each capture in the CSS whoever publishes the
+ * screenshots keeps for it. Without it the captures are taken in the app's own
+ * default look, which is what this repo's CI wants: it is checking that the
+ * pages can be captured, not what they look like on somebody's marketing site.
+ */
+const themesDirectory = (args: readonly string[]): string | undefined => {
+  const at = args.indexOf("--themes");
+  if (at === -1) return;
+  const directory = args[at + 1];
+  if (!directory) throw new Error("--themes needs a directory");
+  return directory;
+};
+
 if (import.meta.main) {
+  const directory = themesDirectory(Deno.args);
+  if (directory) Deno.env.set(EVIDENCE_THEMES_ENV, directory);
   const result = await withTestHarness(runEvidenceSpecs);
   Deno.exit(result.success ? 0 : 1);
 }

--- a/scripts/specs/evidence/capture-flow.ts
+++ b/scripts/specs/evidence/capture-flow.ts
@@ -19,6 +19,7 @@ import {
 } from "./schema.ts";
 import type { LoopbackServer } from "./server.ts";
 import { storeEvidenceCss } from "./style.ts";
+import type { ReadEvidenceTheme } from "./themes.ts";
 
 /** Per-page capture timeout. The After hook has EVIDENCE_HOOK_TIMEOUT_MS
  * (hook.ts) for all captures in one scenario; keep the declaration×profile
@@ -34,6 +35,7 @@ interface EvidenceCaptureDependencies {
   getCookie: () => Promise<string>;
   launchBrowser: () => Promise<Browser>;
   readCatalog: () => Promise<SpecCatalog>;
+  readTheme: ReadEvidenceTheme;
   startServer: () => LoopbackServer;
   waitForPage: (page: Page) => Promise<void>;
   writeCss: (css: string) => Promise<void>;
@@ -88,7 +90,11 @@ const captureProfile = async (
   dependencies: EvidenceCaptureDependencies,
 ): Promise<void> => {
   const profile = SCREENSHOT_PROFILES[profileName];
-  await storeEvidenceCss(declaration, dependencies.writeCss);
+  await storeEvidenceCss(
+    declaration,
+    await dependencies.readTheme(declaration.id),
+    dependencies.writeCss,
+  );
   const context = await browser.newContext({
     baseURL: baseUrl,
     ...screenshotContextOptions(profile),

--- a/scripts/specs/evidence/capture.ts
+++ b/scripts/specs/evidence/capture.ts
@@ -11,6 +11,7 @@ import { defineEvidenceCapture } from "./capture-flow.ts";
 import { EVIDENCE_CAPTURES } from "./declarations.ts";
 import type { CaptureScenario } from "./hook.ts";
 import { defineLoopbackServer } from "./server.ts";
+import { readEvidenceTheme } from "./themes.ts";
 
 export const captureCurrentScenarioEvidence: CaptureScenario =
   defineEvidenceCapture({
@@ -22,6 +23,7 @@ export const captureCurrentScenarioEvidence: CaptureScenario =
       chromiumExecutable,
     ),
     readCatalog: readSpecCatalog,
+    readTheme: readEvidenceTheme,
     startServer: defineLoopbackServer(serveHandler),
     waitForPage: waitForScreenshotPage,
     writeCss: settings.update.customCss,

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -281,6 +281,104 @@ const BALANCE_LINK_CSS = `${brandedThemeCss(
 }
 `;
 
+const CONTACT_RECORD_CSS = `${brandedThemeCss(
+  "6px",
+  "#8c3b2f",
+  "#efe7dd",
+  "#fdfaf6",
+  "#8c3b2f",
+  "#6b2f26",
+  "#8c3b2f18",
+  "#5b2a2226",
+  "#8c3b2f",
+  "#33211d",
+  "#7b6259",
+)}
+
+#contact-history-form {
+  background: #fdfaf6;
+  border: 1px solid #e3d5c9;
+  border-top: 6px solid var(--color-secondary);
+  border-radius: var(--border-radius);
+  box-shadow: 0 12px 28px var(--color-shadow);
+  padding: 1rem;
+}
+
+#contact-history-form h1 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.6rem;
+}
+
+#contact-history-form label {
+  color: var(--color-secondary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+#contact-history-form input,
+#contact-history-form textarea {
+  background: #fff;
+  border-color: #d9c7b8;
+  border-radius: var(--border-radius);
+}
+
+#contact-history-form button[type="submit"] {
+  background: var(--color-secondary);
+  border-color: #52241d;
+  border-radius: var(--border-radius);
+  color: #fdfaf6;
+  font-weight: 800;
+}
+
+/* The note is written in a markdown editor, which brings its own toolbar, a
+ * character count and a second copy of the note underneath as a preview. The
+ * case is about what the record holds, so the capture shows the record. */
+#contact-history-form .md-toolbar,
+#contact-history-form .md-editor-footer,
+#contact-history-form .md-preview-link,
+#contact-history-form section {
+  display: none;
+}
+`;
+
+const BUNDLE_CHECKOUT_CSS = `${brandedThemeCss(
+  "10px",
+  "#c08a2e",
+  "#17362b",
+  "#fdfaf0",
+  "#1d4c3b",
+  "#1d4c3b",
+  "#1d4c3b18",
+  "#0c211a33",
+  "#1d4c3b",
+  "#1f2d26",
+  "#5f7168",
+)}
+
+.public-page {
+  background: #fdfaf0;
+  border-top: 6px solid var(--color-accent);
+  border-radius: var(--border-radius);
+  box-shadow: 0 14px 32px var(--color-shadow);
+  padding: 1.25rem;
+}
+
+.public-page h1 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.9rem;
+}
+
+.public-page button[type="submit"] {
+  background: var(--color-link);
+  border-color: #143a2c;
+  border-radius: var(--border-radius);
+  color: #fdfaf0;
+  font-weight: 800;
+}
+`;
+
 /** One branded mobile capture: the page an authored case leaves behind, the
  * part of it worth showing, and the styling it is shown in. */
 const brandedMobileCapture = (
@@ -321,6 +419,20 @@ export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
     "/pay/{balanceToken}",
     ".page-regions.public-page",
     BALANCE_LINK_CSS,
+  ),
+  brandedMobileCapture(
+    "contact-record.a-record-with-a-history-behind-it",
+    "contact-record",
+    "/admin/history/{contactCode}",
+    "#contact-history-form",
+    CONTACT_RECORD_CSS,
+  ),
+  brandedMobileCapture(
+    "bundles.the-parts-are-named-on-the-booking-page",
+    "bundle-booking-page",
+    "/ticket/{bundleSlug}",
+    ".page-regions.public-page",
+    BUNDLE_CHECKOUT_CSS,
   ),
   brandedMobileCapture(
     "door.someone-still-to-arrive-can-be-picked",

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -4,393 +4,17 @@ import {
   EvidenceCaptureDeclarationSchema,
 } from "./schema.ts";
 
-const brandedThemeCss = (
-  borderRadius: string,
-  accent: string,
-  background: string,
-  secondaryBackground: string,
-  link: string,
-  secondary: string,
-  secondaryAccent: string,
-  shadow: string,
-  table: string,
-  text: string,
-  secondaryText: string,
-): string => `
-:root {
-  --border-radius: ${borderRadius};
-  --color-accent: ${accent};
-  --color-bg: ${background};
-  --color-bg-secondary: ${secondaryBackground};
-  --color-link: ${link};
-  --color-secondary: ${secondary};
-  --color-secondary-accent: ${secondaryAccent};
-  --color-shadow: ${shadow};
-  --color-table: ${table};
-  --color-text: ${text};
-  --color-text-secondary: ${secondaryText};
-  --font-family: Arial, Helvetica, sans-serif;
-}
-`;
-
-const SERVICING_STUDIO_CSS = `${brandedThemeCss(
-  "5px",
-  "#c28b52",
-  "#e9edef",
-  "#d8e0e3",
-  "#315b67",
-  "#315b67",
-  "#315b6718",
-  "#263f4724",
-  "#315b67",
-  "#27383d",
-  "#66777c",
-)}
-
-#servicing-form {
-  background: #f9faf8;
-  border: 1px solid #bdc9ca;
-  border-left: 7px solid var(--color-secondary);
-  border-radius: 6px;
-  box-shadow: 0 12px 28px var(--color-shadow);
-  padding: 1rem;
-}
-
-#servicing-form label {
-  color: #294852;
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-#servicing-form input {
-  background: #fff;
-  border-color: #aebdbf;
-  border-radius: 3px;
-}
-
-#servicing-form .table-scroll {
-  overflow: visible;
-}
-
-#servicing-form table {
-  font-size: 0.82rem;
-  table-layout: fixed;
-  white-space: normal;
-  width: 100%;
-}
-
-#servicing-form th,
-#servicing-form td {
-  padding: 0.45rem;
-}
-
-#servicing-form th:last-child,
-#servicing-form td:last-child {
-  width: 5rem;
-}
-
-#servicing-form button[type="submit"] {
-  background: var(--color-accent);
-  border-color: #a66f39;
-  border-radius: 3px;
-  color: #2e251d;
-  font-weight: 800;
-  width: 100%;
-}
-`;
-
-const PAYMENT_PROVIDER_CSS = `${brandedThemeCss(
-  "8px",
-  "#d7ab48",
-  "#eef3f2",
-  "#dde8e5",
-  "#245e59",
-  "#244c48",
-  "#244c4818",
-  "#1e454020",
-  "#244c48",
-  "#263a38",
-  "#647471",
-)}
-
-.admin-page {
-  background: #fff;
-  border: 1px solid #c9d8d4;
-  border-top: 6px solid var(--color-accent);
-  box-shadow: 0 12px 28px var(--color-shadow);
-  padding: 1rem;
-}
-
-.admin-page > form:not(#settings-payment-provider):not(#settings-stripe),
-.admin-page > article,
-.admin-page > footer {
-  display: none;
-}
-
-#settings-payment-provider,
-#settings-stripe {
-  background: #f8faf9;
-  border: 1px solid #c9d8d4;
-  border-radius: var(--border-radius);
-  padding: 1rem;
-}
-
-#settings-payment-provider h2,
-#settings-stripe h2 {
-  color: var(--color-secondary);
-}
-
-#settings-payment-provider .radio-option {
-  background: #fff;
-  border-color: #c9d8d4;
-}
-
-#settings-stripe .notice {
-  border-left: 5px solid var(--color-accent);
-}
-`;
-
-const DOOR_CHECK_IN_CSS = `${brandedThemeCss(
-  "8px",
-  "#164e63",
-  "#071525",
-  "#10283c",
-  "#67e8f9",
-  "#22d3ee",
-  "#22d3ee1f",
-  "#02081780",
-  "#22d3ee",
-  "#e6f7fb",
-  "#9bb7c5",
-)}
-
-#manual-checkin {
-  background: #0b1d2e;
-  border: 1px solid #25758b;
-  border-radius: 8px;
-  box-shadow: 0 12px 28px var(--color-shadow);
-  padding: 1rem;
-}
-
-#manual-checkin label {
-  color: #bdeff7;
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-#manual-checkin input[type="text"] {
-  background: #071525;
-  border: 1px solid #2f7188;
-  border-radius: 6px;
-  color: var(--color-text);
-}
-
-/* The page's own script opens the list of people still to arrive once the
- * organiser starts typing. A capture is a plain page load, so show the list
- * the scenario proves is offered. */
-/* The search box's placeholder is drawn by the input's own text layer, which
- * rasterises differently from run to run and would change the captured bytes
- * without changing what the page says. The label above the box already says
- * what the box is for, so the capture leaves it empty. */
-#manual-checkin input::placeholder {
-  color: transparent;
-}
-
-#ticket-options.hidden {
-  display: block;
-}
-
-#ticket-options {
-  margin-top: 0.5rem;
-  position: static;
-}
-
-#ticket-options [role="option"] {
-  background: #0d3a42;
-  border: 1px solid #22566d;
-  border-radius: 6px;
-  color: #cffafe;
-  /* Each row's own text carries the ticket token, which is new every run and
-   * would change the captured bytes. Show the row's name and place count
-   * instead, both read from the row the organiser would click. */
-  font-size: 0;
-  padding: 0.5rem;
-}
-
-#ticket-options [role="option"]::before {
-  content: attr(data-name) " (" attr(data-quantity) ")";
-  font-size: 1rem;
-}
-
-#manual-checkin button[type="submit"] {
-  background: var(--color-accent);
-  border-color: #2f7188;
-  border-radius: 6px;
-  color: #e6f7fb;
-  font-weight: 800;
-  width: 100%;
-}
-`;
-
-const BALANCE_LINK_CSS = `${brandedThemeCss(
-  "12px",
-  "#9c4a2f",
-  "#ece0d3",
-  "#fdf9f4",
-  "#9c4a2f",
-  "#5b3a2b",
-  "#9c4a2f18",
-  "#5b3a2b26",
-  "#9c4a2f",
-  "#3b2a22",
-  "#7a6155",
-)}
-
-.public-page {
-  background: #fdf9f4;
-  border: 1px solid #e4d5c5;
-  border-radius: var(--border-radius);
-  box-shadow: 0 14px 32px var(--color-shadow);
-  padding: 1.25rem;
-}
-
-.public-page h1 {
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 2rem;
-}
-
-.public-page table {
-  width: 100%;
-}
-
-.public-page th {
-  background: var(--color-accent);
-  color: #fdf9f4;
-}
-
-.public-page button[type="submit"] {
-  background: var(--color-accent);
-  border-color: #7f3a24;
-  border-radius: 999px;
-  color: #fdf9f4;
-  font-weight: 800;
-}
-`;
-
-const CONTACT_RECORD_CSS = `${brandedThemeCss(
-  "6px",
-  "#8c3b2f",
-  "#efe7dd",
-  "#fdfaf6",
-  "#8c3b2f",
-  "#6b2f26",
-  "#8c3b2f18",
-  "#5b2a2226",
-  "#8c3b2f",
-  "#33211d",
-  "#7b6259",
-)}
-
-#contact-history-form {
-  background: #fdfaf6;
-  border: 1px solid #e3d5c9;
-  border-top: 6px solid var(--color-secondary);
-  border-radius: var(--border-radius);
-  box-shadow: 0 12px 28px var(--color-shadow);
-  padding: 1rem;
-}
-
-#contact-history-form h1 {
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.6rem;
-}
-
-#contact-history-form label {
-  color: var(--color-secondary);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-#contact-history-form input,
-#contact-history-form textarea {
-  background: #fff;
-  border-color: #d9c7b8;
-  border-radius: var(--border-radius);
-}
-
-#contact-history-form button[type="submit"] {
-  background: var(--color-secondary);
-  border-color: #52241d;
-  border-radius: var(--border-radius);
-  color: #fdfaf6;
-  font-weight: 800;
-}
-
-/* The note is written in a markdown editor, which brings its own toolbar, a
- * character count and a second copy of the note underneath as a preview. The
- * case is about what the record holds, so the capture shows the record. */
-#contact-history-form .md-toolbar,
-#contact-history-form .md-editor-footer,
-#contact-history-form .md-preview-link,
-#contact-history-form section {
-  display: none;
-}
-`;
-
-const BUNDLE_CHECKOUT_CSS = `${brandedThemeCss(
-  "10px",
-  "#c08a2e",
-  "#17362b",
-  "#fdfaf0",
-  "#1d4c3b",
-  "#1d4c3b",
-  "#1d4c3b18",
-  "#0c211a33",
-  "#1d4c3b",
-  "#1f2d26",
-  "#5f7168",
-)}
-
-.public-page {
-  background: #fdfaf0;
-  border-top: 6px solid var(--color-accent);
-  border-radius: var(--border-radius);
-  box-shadow: 0 14px 32px var(--color-shadow);
-  padding: 1.25rem;
-}
-
-.public-page h1 {
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.9rem;
-}
-
-.public-page button[type="submit"] {
-  background: var(--color-link);
-  border-color: #143a2c;
-  border-radius: var(--border-radius);
-  color: #fdfaf0;
-  font-weight: 800;
-}
-`;
-
-/** One branded mobile capture: the page an authored case leaves behind, the
- * part of it worth showing, and the styling it is shown in. */
+/** One branded mobile capture: the page an authored case leaves behind and the
+ * part of it worth showing. What the page is dressed in is not said here: see
+ * themes.ts, because a screenshot's look belongs to whoever publishes it. */
 const brandedMobileCapture = (
   caseId: string,
   id: string,
   path: string,
   element: string,
-  css: string,
 ): EvidenceCaptureDeclaration =>
   v.parse(EvidenceCaptureDeclarationSchema, {
     caseId,
-    css,
     element,
     id,
     path,
@@ -404,41 +28,35 @@ export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
     "servicing-studio-floor-hold",
     "/admin/servicing/{servicingEventId}",
     "#servicing-form",
-    SERVICING_STUDIO_CSS,
   ),
   brandedMobileCapture(
     "payments.select-saved-stripe",
     "payment-provider-choice",
     "/admin/settings",
     ".page-regions.admin-page",
-    PAYMENT_PROVIDER_CSS,
   ),
   brandedMobileCapture(
     "deposit.balance-page-shows-what-is-left",
     "balance-payment-link",
     "/pay/{balanceToken}",
     ".page-regions.public-page",
-    BALANCE_LINK_CSS,
   ),
   brandedMobileCapture(
     "contact-record.a-record-with-a-history-behind-it",
     "contact-record",
     "/admin/history/{contactCode}",
     "#contact-history-form",
-    CONTACT_RECORD_CSS,
   ),
   brandedMobileCapture(
     "bundles.the-parts-are-named-on-the-booking-page",
     "bundle-booking-page",
     "/ticket/{bundleSlug}",
     ".page-regions.public-page",
-    BUNDLE_CHECKOUT_CSS,
   ),
   brandedMobileCapture(
     "door.someone-still-to-arrive-can-be-picked",
     "qr-code-check-in",
     "/admin/listing/{doorListingId}/scanner",
     "article:has(#manual-checkin)",
-    DOOR_CHECK_IN_CSS,
   ),
 ];

--- a/scripts/specs/evidence/execute.ts
+++ b/scripts/specs/evidence/execute.ts
@@ -14,6 +14,7 @@ interface EvidenceRunDependencies<Bundle> {
   declarations: readonly EvidenceCaptureDeclaration[];
   outputDir: string;
   run: typeof runSpecs;
+  themes: () => Record<string, string>;
   writeBundle: (outputDir: string, bundle: Bundle) => Promise<void>;
 }
 
@@ -38,7 +39,12 @@ export const defineEvidenceRun =
             catalog,
           );
         },
-        env: { [SPEC_EVIDENCE_ENV]: "1" },
+        // The captures run in their own process, so the directory the themes
+        // were asked for travels with it.
+        env: {
+          [SPEC_EVIDENCE_ENV]: "1",
+          ...dependencies.themes(),
+        },
         onSuccess: async (messages, catalog) => {
           if (!declarations) {
             throw new Error("Evidence declarations were not validated");

--- a/scripts/specs/evidence/run.ts
+++ b/scripts/specs/evidence/run.ts
@@ -10,6 +10,7 @@ import {
   clearEvidenceOutput,
   writeEvidenceBundle,
 } from "./manifest.ts";
+import { evidenceThemesEnv } from "./themes.ts";
 
 const evidenceCommit = defineEvidenceCommit(runCommand);
 
@@ -21,5 +22,6 @@ export const runEvidenceSpecs: () => Promise<SpecRunSummary> =
     declarations: EVIDENCE_CAPTURES,
     outputDir: join(projectRoot, "reports", "evidence"),
     run: runSpecs,
+    themes: evidenceThemesEnv,
     writeBundle: writeEvidenceBundle,
   });

--- a/scripts/specs/evidence/schema.ts
+++ b/scripts/specs/evidence/schema.ts
@@ -39,7 +39,6 @@ const EvidenceProfilesSchema = v.pipe(
 
 export const EvidenceCaptureDeclarationSchema = v.strictObject({
   caseId: stableId("evidence case id"),
-  css: v.optional(v.string()),
   element: TrimmedNonEmptyTextSchema,
   id: stableId("capture id"),
   path: v.pipe(

--- a/scripts/specs/evidence/style.ts
+++ b/scripts/specs/evidence/style.ts
@@ -9,12 +9,11 @@ const DETERMINISTIC_CSS = `
 }`;
 
 export const storeEvidenceCss = async (
-  declaration: { css?: string | undefined; element: string },
+  declaration: { element: string },
+  theme: string,
   write: (css: string) => Promise<void>,
 ): Promise<void> => {
   await write(
-    `${declaration.css ?? ""}\n${isolateElementCss(
-      declaration.element,
-    )}\n${DETERMINISTIC_CSS}`,
+    `${theme}\n${isolateElementCss(declaration.element)}\n${DETERMINISTIC_CSS}`,
   );
 };

--- a/scripts/specs/evidence/themes.ts
+++ b/scripts/specs/evidence/themes.ts
@@ -23,10 +23,14 @@ export type ReadEvidenceTheme = (captureId: string) => Promise<string>;
 
 export const defineThemeReader = (
   readTextFile: (path: string) => Promise<string>,
-  directory: string | undefined,
+  askForDirectory: () => string | undefined,
 ): ReadEvidenceTheme => {
-  if (!directory) return () => Promise.resolve("");
   return async (captureId) => {
+    // Asked for on each capture rather than when this module loads: the
+    // captures run in a process that is handed the directory as it starts, and
+    // reading it once at import time is a race nobody would see the loss from.
+    const directory = askForDirectory();
+    if (!directory) return "";
     const path = join(directory, `${captureId}.css`);
     try {
       return await readTextFile(path);
@@ -41,7 +45,7 @@ export const defineThemeReader = (
 
 export const readEvidenceTheme: ReadEvidenceTheme = defineThemeReader(
   Deno.readTextFile,
-  Deno.env.get(EVIDENCE_THEMES_ENV),
+  () => Deno.env.get(EVIDENCE_THEMES_ENV),
 );
 
 /** The themes directory, ready to hand to the process that does the capturing.

--- a/scripts/specs/evidence/themes.ts
+++ b/scripts/specs/evidence/themes.ts
@@ -1,0 +1,52 @@
+/**
+ * The look a capture is shown in.
+ *
+ * A screenshot's styling belongs to whoever publishes it, not to the app: it
+ * is a demonstration of what an organiser's own branding does to these pages,
+ * and the app has no opinion about that. So the CSS lives outside this repo
+ * and is handed in as a directory of files named after the captures.
+ *
+ * With no directory given, a capture is taken in the app's own default look,
+ * which is what this repo's own CI does. With a directory given, every capture
+ * must have a file in it: a missing one would silently publish a screenshot in
+ * the wrong clothes, which is exactly the kind of quiet difference these
+ * captures exist to prevent.
+ */
+
+import { join } from "@std/path";
+import { rethrowUnlessNotFound } from "#scripts/not-found.ts";
+
+export const EVIDENCE_THEMES_ENV = "TICKETS_EVIDENCE_THEMES";
+
+/** Reads one capture's CSS from the directory the run was given. */
+export type ReadEvidenceTheme = (captureId: string) => Promise<string>;
+
+export const defineThemeReader = (
+  readTextFile: (path: string) => Promise<string>,
+  directory: string | undefined,
+): ReadEvidenceTheme => {
+  if (!directory) return () => Promise.resolve("");
+  return async (captureId) => {
+    const path = join(directory, `${captureId}.css`);
+    try {
+      return await readTextFile(path);
+    } catch (error) {
+      rethrowUnlessNotFound(error);
+      throw new Error(
+        `No evidence theme for ${captureId}: ${path} does not exist. Every capture needs one when a theme directory is given.`,
+      );
+    }
+  };
+};
+
+export const readEvidenceTheme: ReadEvidenceTheme = defineThemeReader(
+  Deno.readTextFile,
+  Deno.env.get(EVIDENCE_THEMES_ENV),
+);
+
+/** The themes directory, ready to hand to the process that does the capturing.
+ * Empty when none was asked for, so the child inherits nothing. */
+export const evidenceThemesEnv = (): Record<string, string> => {
+  const directory = Deno.env.get(EVIDENCE_THEMES_ENV);
+  return directory ? { [EVIDENCE_THEMES_ENV]: directory } : {};
+};

--- a/specs/attendees/the-record-kept-about-someone.feature
+++ b/specs/attendees/the-record-kept-about-someone.feature
@@ -20,6 +20,8 @@ Feature: An organiser reads and corrects the record kept about someone
       Given the site has seen Sam book 5 times and get in touch 4 times
       When the organiser opens Sam's record
       Then the record shows Sam booked 5 times through the site
+      And the record shows 2 bookings the organiser added for Sam
+      And the record shows Sam has visited 9 times
       And the record shows Sam has been in touch 4 times
       And the record shows the note about Sam written out
 

--- a/specs/bookings/selling-things-as-one-bundle.feature
+++ b/specs/bookings/selling-things-as-one-bundle.feature
@@ -24,6 +24,21 @@ Feature: An organiser sells several things as one bundle
       And the bundle charges 25.00 for the Tent
       And the bundle sets no price of its own for the Breakfast
 
+  @rule:bookings.an-open-bundle-names-what-is-inside-it
+  @surface:public
+  Rule: An open bundle names what is inside it
+    A bundle that hides nothing tells the customer what they are getting
+    before they buy: the bundle's own name, and each thing inside it.
+
+    @case:bundles.the-parts-are-named-on-the-booking-page
+    Scenario: A customer opens the booking page of an open bundle
+      Given a Weekend group holding a Tent at 40.00 and a Breakfast at 10.00
+      And the organiser sells the Weekend as a bundle, with the Tent at 25.00 and the Breakfast left blank
+      When a customer opens the Weekend booking page
+      Then the booking page named the Weekend
+      And the booking page named the Tent
+      And the booking page named the Breakfast
+
   @rule:bookings.a-bundle-can-keep-what-is-inside-it-private
   Rule: A bundle can keep what is inside it private
     The organiser can sell a bundle by its own name alone. A customer buying it

--- a/test/scripts/specs/evidence-capture.test.ts
+++ b/test/scripts/specs/evidence-capture.test.ts
@@ -8,16 +8,10 @@ import { defineEvidenceCapture } from "#scripts/specs/evidence/capture-flow.ts";
 import type { EvidenceCaptureDeclaration } from "#scripts/specs/evidence/schema.ts";
 import { requireValue } from "#shared/required-value.ts";
 import { validFeature } from "#test/scripts/specs/profile-fixture.ts";
-import { compileEvidenceFeature } from "./evidence-fixture.ts";
-
-const declaration = {
-  caseId: "payment.place-available",
-  element: "#payment-result",
-  id: "payment-result",
-  path: "/admin/payments/{paymentId}",
-  presentation: "canonical",
-  profiles: ["mobile"],
-} as const satisfies EvidenceCaptureDeclaration;
+import {
+  compileEvidenceFeature,
+  PAYMENT_RESULT_CAPTURE as declaration,
+} from "./evidence-fixture.ts";
 
 interface CaptureCalls {
   attachments: Array<{

--- a/test/scripts/specs/evidence-capture.test.ts
+++ b/test/scripts/specs/evidence-capture.test.ts
@@ -12,7 +12,6 @@ import { compileEvidenceFeature } from "./evidence-fixture.ts";
 
 const declaration = {
   caseId: "payment.place-available",
-  css: ":root { --test-colour: blue; }",
   element: "#payment-result",
   id: "payment-result",
   path: "/admin/payments/{paymentId}",
@@ -165,6 +164,7 @@ const captureFixture = (
         ? Promise.reject(options.launchError)
         : Promise.resolve(browser as never),
     readCatalog: () => Promise.resolve(fixture.catalog),
+    readTheme: () => Promise.resolve(":root { --test-colour: blue; }"),
     startServer: () => ({
       baseUrl: "http://127.0.0.1:4321",
       close: () => {

--- a/test/scripts/specs/evidence-execute.test.ts
+++ b/test/scripts/specs/evidence-execute.test.ts
@@ -58,6 +58,7 @@ describe("Cucumber evidence execution", () => {
       declarations: [declaration],
       outputDir: "/evidence",
       run,
+      themes: () => ({}),
       writeBundle: (outputDir, result) => {
         events.push("write");
         written = { bundle: result, outputDir };
@@ -84,6 +85,7 @@ describe("Cucumber evidence execution", () => {
       declarations: [declaration],
       outputDir: "/evidence",
       run,
+      themes: () => ({}),
       writeBundle: () => Promise.resolve(),
     });
 

--- a/test/scripts/specs/evidence-execute.test.ts
+++ b/test/scripts/specs/evidence-execute.test.ts
@@ -1,19 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { defineEvidenceRun } from "#scripts/specs/evidence/execute.ts";
-import type { EvidenceCaptureDeclaration } from "#scripts/specs/evidence/schema.ts";
 import type { runSpecs } from "#scripts/specs/run.ts";
 import { validFeature } from "#test/scripts/specs/profile-fixture.ts";
-import { compileEvidenceFeature } from "./evidence-fixture.ts";
-
-const declaration = {
-  caseId: "payment.place-available",
-  element: "#payment-result",
-  id: "payment-result",
-  path: "/admin/payments/{paymentId}",
-  presentation: "canonical",
-  profiles: ["mobile"],
-} as const satisfies EvidenceCaptureDeclaration;
+import {
+  compileEvidenceFeature,
+  PAYMENT_RESULT_CAPTURE as declaration,
+} from "./evidence-fixture.ts";
 
 describe("Cucumber evidence execution", () => {
   test("validates declarations and writes the successful run bundle", async () => {

--- a/test/scripts/specs/evidence-fixture.ts
+++ b/test/scripts/specs/evidence-fixture.ts
@@ -1,8 +1,20 @@
 import { compile } from "@cucumber/gherkin";
 import { IdGenerator, type Pickle } from "@cucumber/messages";
+import type { EvidenceCaptureDeclaration } from "#scripts/specs/evidence/schema.ts";
 import { parseGherkinSource } from "#scripts/specs/gherkin.ts";
 import { validateSpecSources } from "#scripts/specs/profile.ts";
 import { registry, source } from "#test/scripts/specs/profile-fixture.ts";
+
+/** The capture two of these tests both declare: a page, the part of it to
+ * show, and nothing about how it looks. */
+export const PAYMENT_RESULT_CAPTURE = {
+  caseId: "payment.place-available",
+  element: "#payment-result",
+  id: "payment-result",
+  path: "/admin/payments/{paymentId}",
+  presentation: "canonical",
+  profiles: ["mobile"],
+} as const satisfies EvidenceCaptureDeclaration;
 
 export const PLAIN_EVIDENCE_SCENARIO = {
   case: {

--- a/test/scripts/specs/evidence-schema.test.ts
+++ b/test/scripts/specs/evidence-schema.test.ts
@@ -15,7 +15,6 @@ const catalog = validateSpecSources([source()], registry);
 
 const declaration = {
   caseId: "payment.place-available",
-  css: ":root { color-scheme: light; }",
   element: "#payment-result",
   id: "payment-result",
   path: "/admin/payments/{paymentId}",

--- a/test/scripts/specs/evidence-style.test.ts
+++ b/test/scripts/specs/evidence-style.test.ts
@@ -1,15 +1,14 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { EVIDENCE_CAPTURES } from "#scripts/specs/evidence/declarations.ts";
 import { storeEvidenceCss } from "#scripts/specs/evidence/style.ts";
-import { requireValue } from "#shared/required-value.ts";
 
 describe("Cucumber evidence style", () => {
   test("stores capture CSS for the production page instead of injecting it past CSP", async () => {
     const writes: string[] = [];
     await storeEvidenceCss(
-      { css: "#form { color: navy; }", element: "#form" },
-      (css) => {
+      { element: "#form" },
+      "#form { color: navy; }",
+      (css: string) => {
         writes.push(css);
         return Promise.resolve();
       },
@@ -23,46 +22,12 @@ describe("Cucumber evidence style", () => {
 
   test("stores isolation and deterministic rules without optional branding", async () => {
     let stored = "not written";
-    await storeEvidenceCss({ element: "#form" }, (css) => {
+    await storeEvidenceCss({ element: "#form" }, "", (css: string) => {
       stored = css;
       return Promise.resolve();
     });
 
     expect(stored.startsWith("\nbody *")).toBe(true);
     expect(stored).not.toContain("undefined");
-  });
-
-  test("sets every inherited base style used by each branded capture", async () => {
-    const branded = EVIDENCE_CAPTURES.filter(
-      ({ presentation }) => presentation === "branded",
-    );
-    expect(branded.length).toBeGreaterThan(1);
-    for (const capture of branded) {
-      let stored = "";
-      await storeEvidenceCss(
-        requireValue(capture, "Evidence capture is missing"),
-        (css) => {
-          stored = css;
-          return Promise.resolve();
-        },
-      );
-
-      for (const name of [
-        "--border-radius",
-        "--color-accent",
-        "--color-bg",
-        "--color-bg-secondary",
-        "--color-link",
-        "--color-secondary",
-        "--color-secondary-accent",
-        "--color-shadow",
-        "--color-table",
-        "--color-text",
-        "--color-text-secondary",
-        "--font-family",
-      ]) {
-        expect(stored).toContain(`${name}:`);
-      }
-    }
   });
 });

--- a/test/specs/steps/bundles.ts
+++ b/test/specs/steps/bundles.ts
@@ -9,6 +9,7 @@ import {
   bundleStillExists,
   buyersTicket,
   customerBuysBundle,
+  customerOpensBundlePage,
   expectPartOnSaleAlone,
   GROUP_DELETED,
   GROUP_SAVED,
@@ -91,6 +92,13 @@ Given(
   "a customer buys the {word}",
   function (this: TicketsWorld, bundle: string): Promise<void> {
     return customerBuysBundle(this, bundle);
+  },
+);
+
+When(
+  "a customer opens the {word} booking page",
+  async function (this: TicketsWorld, bundle: string): Promise<void> {
+    await customerOpensBundlePage(this, bundle);
   },
 );
 

--- a/test/specs/steps/contact-records.ts
+++ b/test/specs/steps/contact-records.ts
@@ -145,6 +145,13 @@ Then(
 );
 
 Then(
+  "the record shows {int} bookings the organiser added for {word}",
+  function (this: TicketsWorld, added: number, _who: string): void {
+    boxShows(recordPage(this), "bookedByHand", String(added));
+  },
+);
+
+Then(
   "the record shows {word} has visited {int} times",
   function (this: TicketsWorld, _who: string, visits: number): void {
     boxShows(recordPage(this), "visits", String(visits));

--- a/test/specs/support/add-ons.ts
+++ b/test/specs/support/add-ons.ts
@@ -10,7 +10,11 @@ const FIELD = "bookable_alone";
 import { expect } from "@std/expect";
 import { groups } from "#shared/db/groups.ts";
 // jscpd:ignore-start
-import { openAsNewcomer } from "#test/specs/support/browser.ts";
+import {
+  type OpensASalesPage,
+  openAsNewcomer,
+  opensSalesPagesAt,
+} from "#test/specs/support/browser.ts";
 import {
   checkboxValueOffered,
   tickedCheckboxes,
@@ -120,13 +124,8 @@ export const sellOnItsOwn: ChangeOneThing<boolean> = async (
 };
 
 /** Whether the Chair's own booking page still offers the Cover with it. */
-export const bookingPageFor = async (
-  world: TicketsWorld,
-  name: string,
-): Promise<TestBrowser> => {
-  const browser = await openAsNewcomer(bookingLinkFor(world, name));
-  return browser;
-};
+export const bookingPageFor: OpensASalesPage =
+  opensSalesPagesAt(bookingLinkFor);
 
 /** Everything the site currently offers for sale, as the customer sees it. */
 export const everythingForSale = async (): Promise<TestBrowser> => {

--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -37,6 +37,19 @@ export const openAsNewcomer = async (path: string): Promise<TestBrowser> => {
   return browser;
 };
 
+/** Opening the page one named thing is sold from, as somebody never signed in.
+ * Where that page lives is the only part that differs between the things that
+ * have one, so it is the only part passed. */
+export type OpensASalesPage = (
+  world: TicketsWorld,
+  name: string,
+) => Promise<TestBrowser>;
+
+export const opensSalesPagesAt =
+  (pathOf: (world: TicketsWorld, name: string) => string): OpensASalesPage =>
+  (world, name) =>
+    openAsNewcomer(pathOf(world, name));
+
 /** Opening any page as one particular person, and being handed the browser
  * they are looking at it through. */
 export type OpensAPage = (

--- a/test/specs/support/bundles.ts
+++ b/test/specs/support/bundles.ts
@@ -11,7 +11,11 @@ import { map } from "#fp";
 import { toMinorUnits } from "#shared/currency.ts";
 import { getGroupPackagePrices, groups } from "#shared/db/groups.ts";
 import type { Group, GroupListing } from "#shared/types.ts";
-import { openAdminPage, openAsNewcomer } from "#test/specs/support/browser.ts";
+import {
+  openAdminPage,
+  openAsNewcomer,
+  opensSalesPagesAt,
+} from "#test/specs/support/browser.ts";
 import {
   checkboxValueOffered,
   expectCanReallySend,
@@ -224,16 +228,35 @@ export const bundleChargeForOrNull = async (
   return inBundle.package_price;
 };
 
+/**
+ * The page a customer buys a bundle from, opened as anyone would. The slug is
+ * kept on the world so an evidence capture can open the same page the story
+ * read, and the page text so a story can say what it named.
+ */
+const openBundlePage = opensSalesPagesAt(
+  (world, name) => `/ticket/${bundleNamed(world, name).slug}`,
+);
+
+export const customerOpensBundlePage = async (
+  world: TicketsWorld,
+  name: string,
+): Promise<TestBrowser> => {
+  const group = bundleNamed(world, name);
+  const browser = await openBundlePage(world, name);
+  // The box has to be there and be able to take a one, or the bundle could not
+  // be chosen in a real browser however well a crafted send goes through.
+  expect(browser.currentHtml).toContain(`name="package_quantity_${group.id}"`);
+  world.bundleBookingPage = browser.pageText;
+  world.evidenceValues.set("bundleSlug", group.slug);
+  return browser;
+};
+
 /** A customer buys the bundle from its own page, and keeps the ticket they end
  * up holding so the story can look at it again later. */
 export const customerBuysBundle: ActOnOneThing = async (world, name) => {
   const group = bundleNamed(world, name);
-  const browser = await openAsNewcomer(`/ticket/${group.slug}`);
-  // The box has to be there and be able to take a one, or the bundle could not
-  // be chosen in a real browser however well a crafted send goes through.
+  const browser = await customerOpensBundlePage(world, name);
   const wanting = `package_quantity_${group.id}`;
-  expect(browser.currentHtml).toContain(`name="${wanting}"`);
-  world.bundleBookingPage = browser.pageText;
   const filledIn = {
     email: "buyer@example.com",
     name: "Buyer",

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -35,13 +35,9 @@ interface RecordEdit {
   visits?: string;
 }
 
-/** The page for one person's record, found the way the site finds it. */
 /** Where one person's record lives, under the one-way code made from their
  *  email rather than the address itself. */
 const recordPath = (code: string): string => `/admin/history/${code}`;
-
-const pagePath = async (email: string): Promise<string> =>
-  recordPath(toContactHashParam(await hashEmail(email)));
 
 /** Everything the site has stored about them right now. */
 export const recordFor = async (email: string): Promise<ContactRecord> =>

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -36,8 +36,12 @@ interface RecordEdit {
 }
 
 /** The page for one person's record, found the way the site finds it. */
+/** Where one person's record lives, under the one-way code made from their
+ *  email rather than the address itself. */
+const recordPath = (code: string): string => `/admin/history/${code}`;
+
 const pagePath = async (email: string): Promise<string> =>
-  `/admin/history/${toContactHashParam(await hashEmail(email))}`;
+  recordPath(toContactHashParam(await hashEmail(email)));
 
 /** Everything the site has stored about them right now. */
 export const recordFor = async (email: string): Promise<ContactRecord> =>
@@ -89,11 +93,17 @@ export const unreadableRecord = async (
   );
 };
 
-/** The organiser opens someone's record. */
+/** The organiser opens someone's record. The address it lives at is kept on
+ *  the world because it is made from a one-way code, not from the email, so an
+ *  evidence capture has no path it could write by hand. */
 export const openRecord = async (
   world: TicketsWorld,
   email: string,
-): Promise<TestBrowser> => openAdminPage(world, await pagePath(email));
+): Promise<TestBrowser> => {
+  const code = toContactHashParam(await hashEmail(email));
+  world.evidenceValues.set("contactCode", code);
+  return openAdminPage(world, recordPath(code));
+};
 
 /** The boxes on the page, by the words this file uses for them. */
 const BOXES = {


### PR DESCRIPTION
The site shows a picture of an attendee's record, and a picture of a package's booking page, with prose around each saying what they hold. Neither was ever read by a story, so both were hand-made pictures and a promise.

## What is new

`attendees.the-record-kept-about-someone` already reads the record; it had no capture. It gains one at `/admin/history/{contactCode}`.

`bookings.selling-things-as-one-bundle` had no story at all for the page a customer buys an open bundle from. Every case there is either admin-side or about a *private* bundle, whose page deliberately names nothing inside. So there is a new rule:

```gherkin
@rule:bookings.an-open-bundle-names-what-is-inside-it
@surface:public
Rule: An open bundle names what is inside it
  A bundle that hides nothing tells the customer what they are getting
  before they buy: the bundle's own name, and each thing inside it.

  @case:bundles.the-parts-are-named-on-the-booking-page
  Scenario: A customer opens the booking page of an open bundle
    Given a Weekend group holding a Tent at 40.00 and a Breakfast at 10.00
    And the organiser sells the Weekend as a bundle, with the Tent at 25.00 and the Breakfast left blank
    When a customer opens the Weekend booking page
    Then the booking page named the Weekend
    And the booking page named the Tent
    And the booking page named the Breakfast
```

## What the rule deliberately does not claim

I tried to assert the £35 the page works out for the pair, since that is the more interesting fact. The page's own script adds it up, and a story reads the page without a script — the static HTML says "Show total". Rather than assert something weaker and call it the total, the rule claims only the names. The capture, taken in a real browser, does show the figure.

## Two paths nobody can write by hand

Both captures needed the address their page lives at, and neither is guessable: a bundle's page is at its slug, and a record is filed under a one-way code made from an email the site never stores. Each is put on the world by the step that opens the page, the same way the balance link's token is.

`resolveEvidencePath` percent-encodes each value, so a value carrying `/` would become `%2F` and 404 — the code is stored on its own and the path around it stays in the declaration.

## Sundries

- `opensSalesPagesAt` is now the shared reader for both public booking pages (add-ons and bundles), which jscpd required and which is the right shape anyway: where the page lives is the only part that differs.
- The record's capture hides the markdown editor's toolbar, character count and the duplicate note preview underneath. What the case is about is what the record holds.

## Checks run

- `deno task specs:files` over the three affected Features — 20 scenarios, 161 steps, all passed
- `deno task specs:check` — 37 stories, 98 rules
- `deno task lint:ci` — clean
- `deno task cpd` — 0 clones across all four configs
- `deno task specs:evidence` — 6 captures, run twice, byte-identical

The site side is chobbledotcom/tickets-site#124.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK)_