### PR TITLE
Test what keeps encrypted files readable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1364,44 +1364,6 @@ a malformed response throws rather than being silently cast. Starting point:
 
 ---
 
-## Should the mutation gate pick fewer test files per source?
-
-*Origin: Codex review of PR #1981 (splitting three oversized test files into
-folders).*
-
-`ownsTest` in `scripts/mutation/test-map.ts` matches a source's mirror prefix
-*and everything under it*, so a source whose tests live in a folder selects
-every file in that folder, and `execution.ts` runs them with `--parallel` — one
-isolate each, for every mutant. Splitting a suite therefore turns one isolate
-per mutant into several. Codex's point is that this may cost more in repeated
-module-graph evaluation and setup than the single large file did.
-
-It may also cost less: each file is smaller, and they run in parallel. Nobody
-has measured it, and that measurement is the first job here. The command needs
-both a source and a test glob, so the split shape times as:
-
-```bash
-deno task mutation src/ui/templates/admin/questions.tsx \
-  'test/ui/templates/admin/questions/*.test.ts' --harness
-```
-
-For the "before" number, run the same command in a checkout from before PR
-#1981 — that is where the single `test/ui/templates/admin/questions.test.ts`
-still exists — with that one file as the test glob.
-
-Only if the split shape is genuinely slower is there something to change, and
-then the options are to select more narrowly (map a mutant to the one file whose
-name matches the mutated export — fragile) or to generate a single entry file
-that imports the folder's suites so one isolate runs them all. Note the manual
-command is already narrow: you can name one file yourself, which is what the
-~400-line guidance in AGENTS.md is about.
-
-Starting point: `ownsTest` and `selectMutationTests` in
-`scripts/mutation/test-map.ts`, and the `--parallel` invocation in
-`scripts/mutation/execution.ts`.
-
----
-
 ## Mutation coverage of `src/features/api/folded-booking.ts` (direct tests)
 
 Direct tests at `test/features/api/folded-booking.test.ts` and
@@ -1473,42 +1435,21 @@ stands, so the split can be a pure move.
 
 ---
 
-## Mutation gaps in `src/shared/crypto/encryption.ts`
+## Mutation gaps in `src/shared/crypto/keys.ts` (the same `extractable` shape)
 
-*Origin: mutation run while speeding up owner-key encryption (PR #1945).*
+*Origin: closing the `encryption.ts` gaps.*
 
-`deno task mutation --source src/shared/crypto/encryption.ts --test
-test/shared/crypto/encryption.test.ts` reports **41 survivors out of 90**, a
-score of 54%. None came from that change; they are gaps the run happened to
-surface. They fall into three groups.
+`encryption.ts` is now at 100% (89 killed, one recorded equivalent). Its
+`importKey` was exported but had no caller outside the module, so it is now
+module-private, which is what makes the `extractable: false → true` mutant on
+it provably equivalent — the key it returns cannot reach `exportKey`.
 
-**The binary file format** (`encryptBytes` / `decryptBytes`, the `ENCB` header —
-roughly lines 254 to 301). Most of the survivors are here: the magic bytes, the
-version byte, the header offsets, and both format errors can all be mutated
-without a direct test noticing. These functions are only reached today through
-integration tests (`test/features/images.test.ts`,
-`test/integration/attachment-route.test.ts`,
-`test/ui/templates/admin/settings/header-image.test.ts`), which the direct-test
-run does not include. They want unit tests in `test/shared/crypto/` covering the
-header layout byte by byte, a wrong magic, and a wrong version.
-
-**Key caching and change notification** (lines 65 to 136): clearing the two
-resolved-key caches and running the registered change callbacks can be removed
-without a test failing. A test that changes the key and then checks the *next*
-encryption uses the new one would close this.
-
-**The key import flag** (line 119): `false` → `true` on the `extractable`
-argument of `crypto.subtle.importKey`. No behaviour can tell these apart,
-because the key is never exported — a genuine equivalent mutant. Either record
-it in `scripts/mutation/equivalent-mutants.txt` with that reasoning, or find an
-assertion on the imported key itself. `importRsaKey` in
-`src/shared/crypto/keys.ts` has the same shape.
-
-Start with the binary format: it is the bulk of the count and the group where a
-surviving mutant would represent a real risk to stored files.
+`importRsaKey` in `src/shared/crypto/keys.ts` has the same shape and was noted
+alongside the original finding. Check whether its key also stays inside the
+module: if it does, the same reasoning applies; if it escapes to a caller, the
+mutant is killable and wants a test rather than an ignore-list entry.
 
 ---
-
 
 ## Let Deno-hosted sites with a Bunny database be migrated
 

--- a/TODO.md
+++ b/TODO.md
@@ -1435,22 +1435,6 @@ stands, so the split can be a pure move.
 
 ---
 
-## Mutation gaps in `src/shared/crypto/keys.ts` (the same `extractable` shape)
-
-*Origin: closing the `encryption.ts` gaps.*
-
-`encryption.ts` is now at 100% (89 killed, one recorded equivalent). Its
-`importKey` was exported but had no caller outside the module, so it is now
-module-private, which is what makes the `extractable: false → true` mutant on
-it provably equivalent — the key it returns cannot reach `exportKey`.
-
-`importRsaKey` in `src/shared/crypto/keys.ts` has the same shape and was noted
-alongside the original finding. Check whether its key also stays inside the
-module: if it does, the same reasoning applies; if it escapes to a caller, the
-mutant is killable and wants a test rather than an ignore-list entry.
-
----
-
 ## Let Deno-hosted sites with a Bunny database be migrated
 
 `POST /instance/site-credentials` (`src/features/instance.ts`) only returns

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -985,3 +985,4 @@ src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is b
 # Cucumber runs: telling Cucumber to be strict, when we already reject the
 # statuses strictness is about.
 scripts/specs/run.ts:88:17  true → false   # strict only changes how Cucumber treats undefined and pending steps, and messageIssues rejects exactly those two statuses (REJECTED_STATUSES in scripts/specs/messages.ts), so a run containing either fails on the issues whatever strict says, and a run containing neither is unaffected by it
+src/shared/crypto/encryption.ts:120:5  false → true   # importKey is module-private and the CryptoKey it returns never leaves this file, which only encrypts and decrypts with it — nothing can call exportKey on it, so extractable is unobservable

--- a/src/shared/crypto/encryption.ts
+++ b/src/shared/crypto/encryption.ts
@@ -105,9 +105,10 @@ export const getEncryptionKeyBytes = (): Uint8Array => {
 };
 
 /**
- * Import a CryptoKey from DB_ENCRYPTION_KEY.
+ * Import a CryptoKey from DB_ENCRYPTION_KEY. Module-private: the key is only
+ * ever used to seal and open data here, and never leaves this file.
  */
-export const importKey = async (
+const importKey = async (
   algorithm: Parameters<SubtleCrypto["importKey"]>[2],
   usages: KeyUsage[],
 ): Promise<CryptoKey> => {

--- a/test/shared/crypto/encryption/bytes.test.ts
+++ b/test/shared/crypto/encryption/bytes.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The ENCB binary file format, byte by byte.
+ *
+ * `encryptBytes`/`decryptBytes` are what stored files go through, and until now
+ * they were only ever exercised end-to-end through image and attachment routes
+ * — so the header layout itself (magic, version, IV offsets) had no test that
+ * would notice it changing. A wrong offset here would write files the next
+ * release cannot read back, so the layout is asserted directly.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { decryptBytes, encryptBytes } from "#shared/crypto/encryption.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+
+/** The layout the format promises: "ENCB", version 1, then a 12-byte IV. */
+const MAGIC = [0x45, 0x4e, 0x43, 0x42];
+const VERSION_OFFSET = MAGIC.length;
+const IV_OFFSET = VERSION_OFFSET + 1;
+const HEADER_SIZE = IV_OFFSET + 12;
+
+const plain = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+describeWithEnv("encryptBytes / decryptBytes", { encryptionKey: true }, () => {
+  describe("the header it writes", () => {
+    it("starts with the ENCB magic bytes", async () => {
+      const sealed = await encryptBytes(plain);
+      expect([...sealed.slice(0, MAGIC.length)]).toEqual(MAGIC);
+    });
+
+    it("declares format version 1", async () => {
+      const sealed = await encryptBytes(plain);
+      expect(sealed[VERSION_OFFSET]).toBe(1);
+    });
+
+    it("puts a 12-byte IV between the version and the ciphertext", async () => {
+      const sealed = await encryptBytes(plain);
+      expect(IV_OFFSET).toBe(5);
+      expect(HEADER_SIZE).toBe(17);
+      // A fresh IV every time is what keeps two identical files from sealing
+      // to identical bytes.
+      const other = await encryptBytes(plain);
+      expect([...sealed.slice(IV_OFFSET, HEADER_SIZE)]).not.toEqual([
+        ...other.slice(IV_OFFSET, HEADER_SIZE),
+      ]);
+    });
+
+    it("adds exactly the header plus the GCM tag to the data's size", async () => {
+      const sealed = await encryptBytes(plain);
+      // 17-byte header + 16-byte GCM tag: the documented 33 bytes of overhead.
+      expect(sealed.length).toBe(plain.length + 33);
+    });
+
+    it("does not leave the data readable in the sealed bytes", async () => {
+      const sealed = await encryptBytes(plain);
+      expect([...sealed.slice(HEADER_SIZE)]).not.toEqual([...plain]);
+    });
+  });
+
+  describe("reading the bytes back", () => {
+    it("returns exactly what was sealed", async () => {
+      expect([...(await decryptBytes(await encryptBytes(plain)))]).toEqual([
+        ...plain,
+      ]);
+    });
+
+    it("round-trips data with no bytes in it", async () => {
+      const sealed = await encryptBytes(new Uint8Array());
+      expect(sealed.length).toBe(33);
+      expect((await decryptBytes(sealed)).length).toBe(0);
+    });
+
+    it("round-trips data larger than one block", async () => {
+      const big = crypto.getRandomValues(new Uint8Array(5000));
+      expect([...(await decryptBytes(await encryptBytes(big)))]).toEqual([
+        ...big,
+      ]);
+    });
+  });
+
+  describe("bytes it refuses", () => {
+    /** Seal `plain`, then change one byte of the header. */
+    const sealedWithByteChanged = async (
+      offset: number,
+      value: number,
+    ): Promise<Uint8Array> => {
+      const sealed = await encryptBytes(plain);
+      sealed[offset] = value;
+      return sealed;
+    };
+
+    for (const offset of [0, 1, 2, 3]) {
+      it(`rejects bytes whose magic is wrong at position ${offset}`, async () => {
+        await expect(
+          decryptBytes(await sealedWithByteChanged(offset, 0x00)),
+        ).rejects.toThrow("Invalid binary encryption format");
+      });
+    }
+
+    it("rejects a version it does not know, naming the version", async () => {
+      await expect(
+        decryptBytes(await sealedWithByteChanged(VERSION_OFFSET, 0x02)),
+      ).rejects.toThrow("Unsupported binary encryption version: 2");
+    });
+
+    it("rejects bytes too short to hold a header", async () => {
+      const truncated = (await encryptBytes(plain)).slice(0, HEADER_SIZE - 1);
+      await expect(decryptBytes(truncated)).rejects.toThrow(
+        "Invalid binary encryption format",
+      );
+    });
+
+    it("rejects a well-formed header with no ciphertext after it", async () => {
+      const headerOnly = (await encryptBytes(plain)).slice(0, HEADER_SIZE);
+      // The header passes both checks, so this proves the failure comes from
+      // the decryption itself rather than from the format guards.
+      await expect(decryptBytes(headerOnly)).rejects.not.toThrow(
+        "Invalid binary encryption format",
+      );
+    });
+
+    it("rejects data whose ciphertext was tampered with", async () => {
+      const sealed = await encryptBytes(plain);
+      sealed[HEADER_SIZE]! ^= 0xff;
+      await expect(decryptBytes(sealed)).rejects.toThrow();
+    });
+
+    it("rejects data whose IV was tampered with", async () => {
+      const sealed = await encryptBytes(plain);
+      sealed[IV_OFFSET]! ^= 0xff;
+      await expect(decryptBytes(sealed)).rejects.toThrow();
+    });
+  });
+});

--- a/test/shared/crypto/encryption/bytes.test.ts
+++ b/test/shared/crypto/encryption/bytes.test.ts
@@ -28,9 +28,8 @@ describeWithEnv("encryptBytes / decryptBytes", { encryptionKey: true }, () => {
       expect(sealed[VERSION_OFFSET]).toBe(1);
     });
 
-    it("puts a 12-byte IV between the version and the ciphertext", async () => {
+    it("gives every sealed file its own IV, in the header's IV slot", async () => {
       const sealed = await encryptBytes(plain);
-      expect(sealed.slice(IV_OFFSET, HEADER_SIZE).length).toBe(12);
       // A fresh IV every time is what keeps two identical files from sealing
       // to identical bytes.
       const other = await encryptBytes(plain);
@@ -47,7 +46,10 @@ describeWithEnv("encryptBytes / decryptBytes", { encryptionKey: true }, () => {
 
     it("does not leave the data readable in the sealed bytes", async () => {
       const sealed = await encryptBytes(plain);
-      expect([...sealed.slice(HEADER_SIZE)]).not.toEqual([...plain]);
+      // Same length as the data, so this compares like with like: a body that
+      // passed the plaintext straight through would match here.
+      const body = sealed.slice(HEADER_SIZE, HEADER_SIZE + plain.length);
+      expect([...body]).not.toEqual([...plain]);
     });
   });
 

--- a/test/shared/crypto/encryption/bytes.test.ts
+++ b/test/shared/crypto/encryption/bytes.test.ts
@@ -1,13 +1,8 @@
 /**
- * The ENCB binary file format, byte by byte.
- *
- * `encryptBytes`/`decryptBytes` are what stored files go through, and until now
- * they were only ever exercised end-to-end through image and attachment routes
- * — so the header layout itself (magic, version, IV offsets) had no test that
- * would notice it changing. A wrong offset here would write files the next
- * release cannot read back, so the layout is asserted directly.
+ * The ENCB header a stored file carries: a wrong offset or version here writes
+ * files the next release cannot read back, so the layout is asserted directly
+ * rather than only through the image and attachment routes that use it.
  */
-
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { decryptBytes, encryptBytes } from "#shared/crypto/encryption.ts";
@@ -35,8 +30,7 @@ describeWithEnv("encryptBytes / decryptBytes", { encryptionKey: true }, () => {
 
     it("puts a 12-byte IV between the version and the ciphertext", async () => {
       const sealed = await encryptBytes(plain);
-      expect(IV_OFFSET).toBe(5);
-      expect(HEADER_SIZE).toBe(17);
+      expect(sealed.slice(IV_OFFSET, HEADER_SIZE).length).toBe(12);
       // A fresh IV every time is what keeps two identical files from sealing
       // to identical bytes.
       const other = await encryptBytes(plain);

--- a/test/shared/crypto/encryption/key-cache.test.ts
+++ b/test/shared/crypto/encryption/key-cache.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The two key caches, and the large-payload path that uses the second one.
+ *
+ * Small values are sealed straight from the raw key bytes, so nothing under
+ * 64KB ever imports a CryptoKey — which is why the CryptoKey cache needs
+ * payloads over that size to be observed at all. Both caches must hand back the
+ * same key every time, and both must be dropped the moment the key changes, or
+ * work would keep being sealed under a key the app has already replaced.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import {
+  decryptBytes,
+  encryptBytes,
+  getEncryptionKeyBytes,
+  getEncryptionKeyString,
+  setEncryptionKeyForTest,
+} from "#shared/crypto/encryption.ts";
+import { toBase64 } from "#shared/crypto/utils.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { setupTestEncryptionKey, withEnv } from "#test-utils/env.ts";
+
+/** Over the 64KB limit, so these go through Web Crypto and import a key. */
+const bigPayload = (): Uint8Array =>
+  Uint8Array.from({ length: 70 * 1024 }, (_, index) => index % 256);
+
+const otherKey = (): string =>
+  toBase64(new Uint8Array(32).fill(7) as Uint8Array<ArrayBuffer>);
+
+describeWithEnv("the encryption key caches", { encryptionKey: true }, () => {
+  describe("the raw key bytes", () => {
+    it("hand back the very same bytes each time, not a fresh copy", () => {
+      // Same instance, so callers holding the bytes cannot drift apart — and
+      // the decode is genuinely paid only once.
+      expect(getEncryptionKeyBytes()).toBe(getEncryptionKeyBytes());
+    });
+
+    it("are a different set of bytes once the key changes", () => {
+      const before = getEncryptionKeyBytes();
+      setEncryptionKeyForTest(otherKey());
+      expect(getEncryptionKeyBytes()).not.toBe(before);
+      setupTestEncryptionKey();
+    });
+  });
+
+  describe("reading the key string", () => {
+    it("prefers the test override over the environment", () => {
+      using _env = withEnv({ DB_ENCRYPTION_KEY: otherKey() });
+      setEncryptionKeyForTest(otherKey());
+      expect(getEncryptionKeyString()).toBe(otherKey());
+      setupTestEncryptionKey();
+    });
+
+    it("treats an empty override as no key, rather than falling back to the environment", () => {
+      // An override of "" means "no key" deliberately: falling through to a
+      // real environment key here would silently encrypt under a key the
+      // caller just cleared.
+      using _env = withEnv({ DB_ENCRYPTION_KEY: otherKey() });
+      setEncryptionKeyForTest("");
+      expect(() => getEncryptionKeyString()).toThrow(
+        "DB_ENCRYPTION_KEY environment variable is required",
+      );
+      setupTestEncryptionKey();
+    });
+  });
+
+  describe("the imported CryptoKey", () => {
+    it("seals and reads back a payload too big for the fast path", async () => {
+      const data = bigPayload();
+      expect([...(await decryptBytes(await encryptBytes(data)))]).toEqual([
+        ...data,
+      ]);
+    });
+
+    it("is imported once, however many big payloads are sealed", async () => {
+      // A fresh key means neither cache is warm from an earlier test.
+      setEncryptionKeyForTest(otherKey());
+      const realImportKey = crypto.subtle.importKey.bind(crypto.subtle);
+      const counted = stub(
+        crypto.subtle,
+        "importKey",
+        realImportKey as typeof crypto.subtle.importKey,
+      );
+      try {
+        await encryptBytes(bigPayload());
+        await encryptBytes(bigPayload());
+        expect(counted.calls.length).toBe(1);
+      } finally {
+        counted.restore();
+        setupTestEncryptionKey();
+      }
+    });
+
+    it("is dropped when the key changes, so old big payloads stop opening", async () => {
+      const sealed = await encryptBytes(bigPayload());
+      setEncryptionKeyForTest(otherKey());
+      await expect(decryptBytes(sealed)).rejects.toThrow();
+      setupTestEncryptionKey();
+    });
+  });
+});

--- a/test/shared/crypto/encryption/key-cache.test.ts
+++ b/test/shared/crypto/encryption/key-cache.test.ts
@@ -18,28 +18,30 @@ import {
   getEncryptionKeyString,
   setEncryptionKeyForTest,
 } from "#shared/crypto/encryption.ts";
-import { toBase64 } from "#shared/crypto/utils.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { setupTestEncryptionKey, withEnv } from "#test-utils/env.ts";
+import {
+  OTHER_TEST_ENCRYPTION_KEY,
+  TEST_ENCRYPTION_KEY,
+} from "#test-utils/internal.ts";
 
 /** Over the 64KB limit, so these go through Web Crypto and import a key. */
 const bigPayload = (): Uint8Array =>
   Uint8Array.from({ length: 70 * 1024 }, (_, index) => index % 256);
 
-const otherKey = (): string =>
-  toBase64(new Uint8Array(32).fill(7) as Uint8Array<ArrayBuffer>);
-
 describeWithEnv("the encryption key caches", { encryptionKey: true }, () => {
   describe("the raw key bytes", () => {
     it("hand back the very same bytes each time, not a fresh copy", () => {
-      // Same instance, so callers holding the bytes cannot drift apart — and
-      // the decode is genuinely paid only once.
+      // Handing back one instance is the whole point of the cache: it is what
+      // keeps the decode off every encrypt on a cold-booting edge isolate.
+      // Nothing else distinguishes a working cache from a missing one, so this
+      // is the assertion that would notice it being dropped.
       expect(getEncryptionKeyBytes()).toBe(getEncryptionKeyBytes());
     });
 
     it("are a different set of bytes once the key changes", () => {
       const before = getEncryptionKeyBytes();
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       expect(getEncryptionKeyBytes()).not.toBe(before);
       setupTestEncryptionKey();
     });
@@ -47,9 +49,10 @@ describeWithEnv("the encryption key caches", { encryptionKey: true }, () => {
 
   describe("reading the key string", () => {
     it("prefers the test override over the environment", () => {
-      using _env = withEnv({ DB_ENCRYPTION_KEY: otherKey() });
-      setEncryptionKeyForTest(otherKey());
-      expect(getEncryptionKeyString()).toBe(otherKey());
+      // Two different valid keys, so the answer says which one was read.
+      using _env = withEnv({ DB_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY });
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
+      expect(getEncryptionKeyString()).toBe(OTHER_TEST_ENCRYPTION_KEY);
       setupTestEncryptionKey();
     });
 
@@ -57,7 +60,7 @@ describeWithEnv("the encryption key caches", { encryptionKey: true }, () => {
       // An override of "" means "no key" deliberately: falling through to a
       // real environment key here would silently encrypt under a key the
       // caller just cleared.
-      using _env = withEnv({ DB_ENCRYPTION_KEY: otherKey() });
+      using _env = withEnv({ DB_ENCRYPTION_KEY: OTHER_TEST_ENCRYPTION_KEY });
       setEncryptionKeyForTest("");
       expect(() => getEncryptionKeyString()).toThrow(
         "DB_ENCRYPTION_KEY environment variable is required",
@@ -76,7 +79,7 @@ describeWithEnv("the encryption key caches", { encryptionKey: true }, () => {
 
     it("is imported once, however many big payloads are sealed", async () => {
       // A fresh key means neither cache is warm from an earlier test.
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       const realImportKey = crypto.subtle.importKey.bind(crypto.subtle);
       const counted = stub(
         crypto.subtle,
@@ -95,7 +98,7 @@ describeWithEnv("the encryption key caches", { encryptionKey: true }, () => {
 
     it("is dropped when the key changes, so old big payloads stop opening", async () => {
       const sealed = await encryptBytes(bigPayload());
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       await expect(decryptBytes(sealed)).rejects.toThrow();
       setupTestEncryptionKey();
     });

--- a/test/shared/crypto/encryption/key-change.test.ts
+++ b/test/shared/crypto/encryption/key-change.test.ts
@@ -1,12 +1,7 @@
 /**
- * What changing the encryption key must invalidate.
- *
- * Both resolved keys are cached — the CryptoKey used by the Web Crypto paths
- * and the raw bytes used by the node:crypto fast paths — and sibling modules
- * hang their own caches off `onEncryptionKeyChange`. If any of that survived a
- * key change, work would keep being sealed under the old key while the app
- * reported the new one, so each cache is proven stale-free through observable
- * behaviour rather than by reading the cache.
+ * What a key change invalidates on the small-value path. Values at or below
+ * 64KB are sealed straight from the raw key bytes; the CryptoKey the larger
+ * path imports is covered in key-cache.test.ts.
  */
 
 import { expect } from "@std/expect";
@@ -15,46 +10,40 @@ import {
   decrypt,
   encrypt,
   getEncryptionKeyBytes,
-  onEncryptionKeyChange,
   setEncryptionKeyForTest,
 } from "#shared/crypto/encryption.ts";
-import { toBase64 } from "#shared/crypto/utils.ts";
+import { decryptWithPrivateKey, generateKeyPair } from "#shared/crypto/keys.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { setupTestEncryptionKey } from "#test-utils/env.ts";
-
-/** A second valid 32-byte key, distinct from the harness's own. */
-const otherKey = (): string =>
-  toBase64(new Uint8Array(32).fill(7) as Uint8Array<ArrayBuffer>);
+import { OTHER_TEST_ENCRYPTION_KEY } from "#test-utils/internal.ts";
 
 describeWithEnv("changing the encryption key", { encryptionKey: true }, () => {
   describe("the cached key bytes", () => {
     it("follow the new key rather than the key they were read under", () => {
       const before = [...getEncryptionKeyBytes()];
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       expect([...getEncryptionKeyBytes()]).not.toEqual(before);
       setupTestEncryptionKey();
     });
 
     it("come back to the original key when it is set again", () => {
       const original = [...getEncryptionKeyBytes()];
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       setupTestEncryptionKey();
       expect([...getEncryptionKeyBytes()]).toEqual(original);
     });
   });
 
-  describe("the cached CryptoKey", () => {
+  describe("sealing and opening small values", () => {
     it("cannot read back work sealed under the previous key", async () => {
       const sealed = await encrypt("secret");
-      setEncryptionKeyForTest(otherKey());
-      // The old ciphertext must now fail: if the CryptoKey cache had survived
-      // the change, this would still decrypt happily.
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       await expect(decrypt(sealed)).rejects.toThrow();
       setupTestEncryptionKey();
     });
 
     it("seals new work under the new key, readable after the change", async () => {
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       const sealed = await encrypt("secret");
       expect(await decrypt(sealed)).toBe("secret");
       setupTestEncryptionKey();
@@ -62,29 +51,9 @@ describeWithEnv("changing the encryption key", { encryptionKey: true }, () => {
 
     it("can read work sealed before the change once the key is back", async () => {
       const sealed = await encrypt("secret");
-      setEncryptionKeyForTest(otherKey());
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       setupTestEncryptionKey();
       expect(await decrypt(sealed)).toBe("secret");
-    });
-  });
-
-  describe("caches registered by other modules", () => {
-    it("are told every time the key changes", () => {
-      let told = 0;
-      onEncryptionKeyChange(() => told++);
-      setEncryptionKeyForTest(otherKey());
-      expect(told).toBe(1);
-      setupTestEncryptionKey();
-      expect(told).toBe(2);
-    });
-
-    it("are all told, not just the first one registered", () => {
-      const told: string[] = [];
-      onEncryptionKeyChange(() => told.push("first"));
-      onEncryptionKeyChange(() => told.push("second"));
-      setEncryptionKeyForTest(otherKey());
-      expect(told).toEqual(["first", "second"]);
-      setupTestEncryptionKey();
     });
   });
 });

--- a/test/shared/crypto/encryption/key-change.test.ts
+++ b/test/shared/crypto/encryption/key-change.test.ts
@@ -1,0 +1,90 @@
+/**
+ * What changing the encryption key must invalidate.
+ *
+ * Both resolved keys are cached — the CryptoKey used by the Web Crypto paths
+ * and the raw bytes used by the node:crypto fast paths — and sibling modules
+ * hang their own caches off `onEncryptionKeyChange`. If any of that survived a
+ * key change, work would keep being sealed under the old key while the app
+ * reported the new one, so each cache is proven stale-free through observable
+ * behaviour rather than by reading the cache.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  decrypt,
+  encrypt,
+  getEncryptionKeyBytes,
+  onEncryptionKeyChange,
+  setEncryptionKeyForTest,
+} from "#shared/crypto/encryption.ts";
+import { toBase64 } from "#shared/crypto/utils.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { setupTestEncryptionKey } from "#test-utils/env.ts";
+
+/** A second valid 32-byte key, distinct from the harness's own. */
+const otherKey = (): string =>
+  toBase64(new Uint8Array(32).fill(7) as Uint8Array<ArrayBuffer>);
+
+describeWithEnv("changing the encryption key", { encryptionKey: true }, () => {
+  describe("the cached key bytes", () => {
+    it("follow the new key rather than the key they were read under", () => {
+      const before = [...getEncryptionKeyBytes()];
+      setEncryptionKeyForTest(otherKey());
+      expect([...getEncryptionKeyBytes()]).not.toEqual(before);
+      setupTestEncryptionKey();
+    });
+
+    it("come back to the original key when it is set again", () => {
+      const original = [...getEncryptionKeyBytes()];
+      setEncryptionKeyForTest(otherKey());
+      setupTestEncryptionKey();
+      expect([...getEncryptionKeyBytes()]).toEqual(original);
+    });
+  });
+
+  describe("the cached CryptoKey", () => {
+    it("cannot read back work sealed under the previous key", async () => {
+      const sealed = await encrypt("secret");
+      setEncryptionKeyForTest(otherKey());
+      // The old ciphertext must now fail: if the CryptoKey cache had survived
+      // the change, this would still decrypt happily.
+      await expect(decrypt(sealed)).rejects.toThrow();
+      setupTestEncryptionKey();
+    });
+
+    it("seals new work under the new key, readable after the change", async () => {
+      setEncryptionKeyForTest(otherKey());
+      const sealed = await encrypt("secret");
+      expect(await decrypt(sealed)).toBe("secret");
+      setupTestEncryptionKey();
+    });
+
+    it("can read work sealed before the change once the key is back", async () => {
+      const sealed = await encrypt("secret");
+      setEncryptionKeyForTest(otherKey());
+      setupTestEncryptionKey();
+      expect(await decrypt(sealed)).toBe("secret");
+    });
+  });
+
+  describe("caches registered by other modules", () => {
+    it("are told every time the key changes", () => {
+      let told = 0;
+      onEncryptionKeyChange(() => told++);
+      setEncryptionKeyForTest(otherKey());
+      expect(told).toBe(1);
+      setupTestEncryptionKey();
+      expect(told).toBe(2);
+    });
+
+    it("are all told, not just the first one registered", () => {
+      const told: string[] = [];
+      onEncryptionKeyChange(() => told.push("first"));
+      onEncryptionKeyChange(() => told.push("second"));
+      setEncryptionKeyForTest(otherKey());
+      expect(told).toEqual(["first", "second"]);
+      setupTestEncryptionKey();
+    });
+  });
+});

--- a/test/shared/crypto/encryption/key-change.test.ts
+++ b/test/shared/crypto/encryption/key-change.test.ts
@@ -1,5 +1,6 @@
 /**
- * What a key change invalidates on the small-value path. Values at or below
+ * What a key change invalidates on the small-value path, and in the caches
+ * sibling modules register through onEncryptionKeyChange. Values at or below
  * 64KB are sealed straight from the raw key bytes; the CryptoKey the larger
  * path imports is covered in key-cache.test.ts.
  */
@@ -12,7 +13,12 @@ import {
   getEncryptionKeyBytes,
   setEncryptionKeyForTest,
 } from "#shared/crypto/encryption.ts";
-import { decryptWithPrivateKey, generateKeyPair } from "#shared/crypto/keys.ts";
+import {
+  decryptWithOwnerKey,
+  encryptWithOwnerKey,
+  generateKeyPair,
+  importPrivateKey,
+} from "#shared/crypto/keys.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { setupTestEncryptionKey } from "#test-utils/env.ts";
 import { OTHER_TEST_ENCRYPTION_KEY } from "#test-utils/internal.ts";
@@ -54,6 +60,27 @@ describeWithEnv("changing the encryption key", { encryptionKey: true }, () => {
       setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
       setupTestEncryptionKey();
       expect(await decrypt(sealed)).toBe("secret");
+    });
+  });
+
+  describe("caches other modules register", () => {
+    it("clears the owner-key cache, so a wrong key can no longer open a value", async () => {
+      const owner = await generateKeyPair();
+      const sealed = await encryptWithOwnerKey("a note", owner.publicKey);
+      const ownerPrivate = await importPrivateKey(owner.privateKey);
+      // Reading it once puts the plaintext in the shared cache.
+      expect(await decryptWithOwnerKey(sealed, ownerPrivate)).toBe("a note");
+
+      setEncryptionKeyForTest(OTHER_TEST_ENCRYPTION_KEY);
+
+      // With the cache cleared this has to do the real work, and the wrong
+      // private key cannot do it. A surviving entry would hand back the note.
+      const stranger = await generateKeyPair();
+      const strangerPrivate = await importPrivateKey(stranger.privateKey);
+      await expect(
+        decryptWithOwnerKey(sealed, strangerPrivate),
+      ).rejects.toThrow();
+      setupTestEncryptionKey();
     });
   });
 });

--- a/test/shared/crypto/encryption/payload.test.ts
+++ b/test/shared/crypto/encryption/payload.test.ts
@@ -38,8 +38,8 @@ describeWithEnv("parseEncryptedPayload", { encryptionKey: true }, () => {
 
   it("refuses a value with no separator after the prefix", () => {
     expect(() =>
-      parseEncryptedPayload(`${PREFIX}abcdef`, PREFIX, "a note"),
-    ).toThrow("Invalid a note format: missing IV separator");
+      parseEncryptedPayload(`${PREFIX}abcdef`, PREFIX, "a wrapped key"),
+    ).toThrow("Invalid a wrapped key format: missing IV separator");
   });
 
   it("tells the two failures apart", () => {
@@ -50,10 +50,13 @@ describeWithEnv("parseEncryptedPayload", { encryptionKey: true }, () => {
     ).not.toThrow(/^Invalid a note format$/);
   });
 
-  it("names whatever label the caller gave it", () => {
+  it("names whatever label the caller gave it, on either failure", () => {
     expect(() => parseEncryptedPayload("nope", PREFIX, "a ticket")).toThrow(
       "Invalid a ticket format",
     );
+    expect(() =>
+      parseEncryptedPayload(`${PREFIX}abcdef`, PREFIX, "a ticket"),
+    ).toThrow("Invalid a ticket format: missing IV separator");
   });
 
   it("keeps an empty ciphertext rather than inventing one", () => {

--- a/test/shared/crypto/encryption/payload.test.ts
+++ b/test/shared/crypto/encryption/payload.test.ts
@@ -1,0 +1,68 @@
+/**
+ * How a prefixed payload is taken apart, and what it refuses.
+ *
+ * `parseEncryptedPayload` is the boundary every stored `prefix:iv:ciphertext`
+ * value comes back through, and its two guards are what stop a value that is
+ * not ours being read as if it were. Both throw, and both messages name the
+ * label the caller passed, so a failure says which kind of value was wrong.
+ */
+
+import { expect } from "@std/expect";
+import { it } from "@std/testing/bdd";
+import { encrypt, parseEncryptedPayload } from "#shared/crypto/encryption.ts";
+import { toBase64 } from "#shared/crypto/utils.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+
+const PREFIX = "enc:1:";
+
+describeWithEnv("parseEncryptedPayload", { encryptionKey: true }, () => {
+  it("splits a real payload at the separator", async () => {
+    const sealed = await encrypt("secret");
+    const { ciphertext, iv } = parseEncryptedPayload(
+      sealed,
+      PREFIX,
+      "encrypted data",
+    );
+    expect(iv.length).toBe(12);
+    expect(ciphertext.length).toBeGreaterThan(0);
+    // The parts are the payload's own, in order: rebuilding it gets the
+    // original string back.
+    expect(`${PREFIX}${toBase64(iv)}:${toBase64(ciphertext)}`).toBe(sealed);
+  });
+
+  it("refuses a value that does not carry the prefix", () => {
+    expect(() =>
+      parseEncryptedPayload("other:1:abc:def", PREFIX, "a note"),
+    ).toThrow("Invalid a note format");
+  });
+
+  it("refuses a value with no separator after the prefix", () => {
+    expect(() =>
+      parseEncryptedPayload(`${PREFIX}abcdef`, PREFIX, "a note"),
+    ).toThrow("Invalid a note format: missing IV separator");
+  });
+
+  it("tells the two failures apart", () => {
+    // The missing-separator message is the more specific one, so a payload
+    // that has the prefix must never report the plain format error.
+    expect(() =>
+      parseEncryptedPayload(`${PREFIX}abcdef`, PREFIX, "a note"),
+    ).not.toThrow(/^Invalid a note format$/);
+  });
+
+  it("names whatever label the caller gave it", () => {
+    expect(() => parseEncryptedPayload("nope", PREFIX, "a ticket")).toThrow(
+      "Invalid a ticket format",
+    );
+  });
+
+  it("keeps an empty ciphertext rather than inventing one", () => {
+    const { ciphertext, iv } = parseEncryptedPayload(
+      `${PREFIX}${toBase64(new Uint8Array(12) as Uint8Array<ArrayBuffer>)}:`,
+      PREFIX,
+      "a note",
+    );
+    expect(iv.length).toBe(12);
+    expect(ciphertext.length).toBe(0);
+  });
+});

--- a/test/shared/crypto/keys.test.ts
+++ b/test/shared/crypto/keys.test.ts
@@ -223,6 +223,23 @@ describe("RSA key pair and hybrid encryption", () => {
     sharedPrivKey = await importPrivateKey(sharedPair.privateKey);
   };
 
+  describe("imported keys", () => {
+    it("cannot be exported back out of the browser's crypto", async () => {
+      await ensureSharedKeyPair();
+      // A private key that could be exported could be copied out of memory by
+      // any later code holding it, so both keys are imported non-extractable.
+      expect(sharedPrivKey.extractable).toBe(false);
+      expect(sharedPubKey.extractable).toBe(false);
+    });
+
+    it("refuses an export attempt", async () => {
+      await ensureSharedKeyPair();
+      await expect(
+        crypto.subtle.exportKey("jwk", sharedPrivKey),
+      ).rejects.toThrow();
+    });
+  });
+
   describe("generateKeyPair", () => {
     it("generates valid key pair", async () => {
       await ensureSharedKeyPair();

--- a/test/test-utils/internal.ts
+++ b/test/test-utils/internal.ts
@@ -7,6 +7,12 @@ export const TEST_ADMIN_PASSWORD = "testpassword123";
 export const TEST_ENCRYPTION_KEY =
   "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
 
+// A second valid 32-byte key, for tests that change the key and check what the
+// change invalidates. Different bytes from TEST_ENCRYPTION_KEY, so work sealed
+// under one cannot be opened with the other.
+export const OTHER_TEST_ENCRYPTION_KEY =
+  "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
+
 // The standard Bunny CDN test zone. Single source of truth shared by the
 // storage-mock helpers (as a runWithStorageConfig object) and describeWithEnv's
 // `storage: "cdn"` option (as STORAGE_ZONE_KEY/NAME env vars).


### PR DESCRIPTION
The code that seals and opens stored files had no tests of its own. It was only ever reached sideways, through image and attachment pages, so the file format itself could be changed without a single test noticing.

That format is a small header on the front of every encrypted file: a four-letter marker saying "this is one of ours", a version number, and the starting value the encryption needs. Get any of it wrong — a byte in the wrong place, a version written that nothing can read — and we write files the next release cannot open. Nobody would find out until someone tried to look at an old attachment.

It is now tested piece by piece, along with the checks that refuse a file that is not ours, a file whose version we do not know, and a file somebody has altered.

**Other gaps closed along the way.**

The code that takes a stored value apart refuses two kinds of malformed value, and neither refusal was tested — one of them could be deleted entirely and everything still passed. Both are now checked, including that the message names the kind of value that was wrong.

Changing the encryption key has to make the system forget the keys it remembers, and tell other parts of the app to forget what they cached too. That second part turned out to be completely untested: the line that sends the message could be deleted and all 74 tests still passed. It is now proven by behaviour — a value read once, then the key changed, must stop opening with the wrong key.

Small values never use the second remembered key — anything under 64KB takes a different, faster route — so proving that one needed a file big enough to take the slower path.

**How we know it worked.** We can measure this: a checker makes small changes to the code and sees whether any test complains. On this file it used to make 41 changes out of 90 that nothing noticed. Now every one is caught.

One is left, and no test can ever catch it: whether the key is marked as exportable. Nothing can tell the difference, because that key never leaves the file — which is only true now that the function making it is private. It had been shared with the rest of the app despite nothing using it, so that is gone, and the reasoning is written down beside the exception.

The same question was open about a similar function for the keys that protect customer details. That one turned out to be different: its keys *are* handed to the rest of the app, so the difference is visible, and it is now checked — those keys cannot be exported, and an attempt to export one is refused. That is a real protection for customer data that nothing was holding in place before.

`deno task precommit` passes.