### PR TITLE
Fix Bunny deploy action supply chain risk

### DIFF
--- a/.github/actions/deploy-bunny-script/action.yml
+++ b/.github/actions/deploy-bunny-script/action.yml
@@ -15,8 +15,14 @@ runs:
   using: composite
   steps:
     - name: Deploy script to Bunny Edge Scripting
-      uses: BunnyWay/actions/deploy-script@main
-      with:
-        script_id: ${{ inputs.script_id }}
-        file: ${{ inputs.file }}
-        api_key: ${{ inputs.api_key }}
+      shell: bash
+      env:
+        BUNNY_SCRIPT_ID: ${{ inputs.script_id }}
+        BUNNY_SCRIPT_FILE: ${{ inputs.file }}
+        BUNNY_ACCESS_KEY: ${{ inputs.api_key }}
+      run: |
+        deno run \
+          --allow-env=BUNNY_ACCESS_KEY,BUNNY_API_KEY \
+          --allow-read="$BUNNY_SCRIPT_FILE" \
+          --allow-net=api.bunny.net \
+          scripts/deploy-built-edge.ts "$BUNNY_SCRIPT_ID" "$BUNNY_SCRIPT_FILE"

--- a/.github/actions/deploy-bunny-script/action.yml
+++ b/.github/actions/deploy-bunny-script/action.yml
@@ -21,8 +21,12 @@ runs:
         BUNNY_SCRIPT_FILE: ${{ inputs.file }}
         BUNNY_ACCESS_KEY: ${{ inputs.api_key }}
       run: |
+        # Trim whitespace so the read permission matches the path the script reads;
+        # parseDeployBuiltArgs trims the file again, so handing it an already-trimmed
+        # path keeps the permission and the read on the same value.
+        file="$(sed 's/^[[:space:]]*//;s/[[:space:]]*$//' <<<"$BUNNY_SCRIPT_FILE")"
         deno run \
           --allow-env=BUNNY_ACCESS_KEY,BUNNY_API_KEY \
-          --allow-read="$BUNNY_SCRIPT_FILE" \
+          --allow-read="$file" \
           --allow-net=api.bunny.net \
-          scripts/deploy-built-edge.ts "$BUNNY_SCRIPT_ID" "$BUNNY_SCRIPT_FILE"
+          scripts/deploy-built-edge.ts "$BUNNY_SCRIPT_ID" "$file"

--- a/scripts/deploy-built-edge.ts
+++ b/scripts/deploy-built-edge.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S deno run --allow-env=BUNNY_ACCESS_KEY,BUNNY_API_KEY --allow-read --allow-net=api.bunny.net
+
+import { runDenoScript } from "#scripts/script-runner.ts";
+import { runDeployBuiltEdge } from "./deploy-edge-lib.ts";
+import { fetchText } from "./fetch-text.ts";
+
+await runDenoScript((io) =>
+  runDeployBuiltEdge({
+    ...io,
+    fetchText,
+    readTextFile: (path) => Deno.readTextFile(path),
+  }),
+);

--- a/scripts/deploy-edge-lib.ts
+++ b/scripts/deploy-edge-lib.ts
@@ -2,8 +2,6 @@ import { mapNotNullish } from "#fp";
 import type { ScriptIo } from "#scripts/script-runner.ts";
 import type { FetchText, FetchTextResult } from "./fetch-text.ts";
 
-export type { FetchText, FetchTextResult } from "./fetch-text.ts";
-
 export const BUNNY_API_BASE = "https://api.bunny.net";
 export const BUNDLE_PATH = "bunny-script.ts";
 export const USAGE = "Usage: deno task deploy:edge <script-id>";

--- a/scripts/deploy-edge-lib.ts
+++ b/scripts/deploy-edge-lib.ts
@@ -1,22 +1,18 @@
 import { mapNotNullish } from "#fp";
 import type { ScriptIo } from "#scripts/script-runner.ts";
+import type { FetchText, FetchTextResult } from "./fetch-text.ts";
+
+export type { FetchText, FetchTextResult } from "./fetch-text.ts";
 
 export const BUNNY_API_BASE = "https://api.bunny.net";
 export const BUNDLE_PATH = "bunny-script.ts";
 export const USAGE = "Usage: deno task deploy:edge <script-id>";
+export const DEPLOY_BUILT_USAGE =
+  "Usage: deno run scripts/deploy-built-edge.ts <script-id> [file]";
+export const ACCESS_KEY_ERROR =
+  "BUNNY_ACCESS_KEY is required (BUNNY_API_KEY also works).";
 
 const ACCESS_KEY_ENV_KEYS = ["BUNNY_ACCESS_KEY", "BUNNY_API_KEY"] as const;
-
-export interface FetchTextResult {
-  ok: boolean;
-  status: number;
-  text: string;
-}
-
-export type FetchText = (
-  url: string,
-  init: RequestInit,
-) => Promise<FetchTextResult>;
 
 export type BunnyDeployResult = { ok: true } | { error: string; ok: false };
 
@@ -41,6 +37,31 @@ export interface DeployEdgeDeps extends ScriptIo {
   runBuildEdge: (cwd: string) => Promise<BuildResult>;
 }
 
+export interface DeployBuiltEdgeDeps extends ScriptIo {
+  fetchText: FetchText;
+  readTextFile: (path: string) => Promise<string>;
+}
+
+export interface DeployBuiltArgs {
+  bundlePath: string;
+  scriptId: string;
+}
+
+type ParsedScriptId =
+  | { ok: true; scriptId: string }
+  | {
+      error: string;
+      ok: false;
+    };
+
+const parseScriptId = (
+  value: string | undefined,
+  usage: string,
+): ParsedScriptId => {
+  const scriptId = value?.trim();
+  return scriptId ? { ok: true, scriptId } : { error: usage, ok: false };
+};
+
 export const parseScriptIdArg = (
   args: string[],
 ): { ok: true; scriptId: string } | { error: string; ok: false } => {
@@ -48,8 +69,24 @@ export const parseScriptIdArg = (
     return { error: USAGE, ok: false };
   }
 
-  const scriptId = args[0]?.trim();
-  return scriptId ? { ok: true, scriptId } : { error: USAGE, ok: false };
+  return parseScriptId(args[0], USAGE);
+};
+
+export const parseDeployBuiltArgs = (
+  args: string[],
+): ({ ok: true } & DeployBuiltArgs) | { error: string; ok: false } => {
+  if (args.length < 1 || args.length > 2) {
+    return { error: DEPLOY_BUILT_USAGE, ok: false };
+  }
+
+  const scriptId = parseScriptId(args[0], DEPLOY_BUILT_USAGE);
+  if (!scriptId.ok) return scriptId;
+
+  const fileArg = args[1];
+  const bundlePath = fileArg === undefined ? BUNDLE_PATH : fileArg.trim();
+  return bundlePath
+    ? { bundlePath, ok: true, scriptId: scriptId.scriptId }
+    : { error: DEPLOY_BUILT_USAGE, ok: false };
 };
 
 export const getAccessKey = (
@@ -147,28 +184,18 @@ export const deployScriptCode: ScriptCodeFn = async (
   return publishScript(scriptId, accessKey, fetchText);
 };
 
-export const runDeployEdge = async (deps: DeployEdgeDeps): Promise<number> => {
-  const scriptId = parseScriptIdArg(deps.args);
-  if (!scriptId.ok) {
-    deps.stderr(scriptId.error);
-    return 1;
-  }
+interface DeployBuiltBundleDeps extends Pick<ScriptIo, "stderr" | "stdout"> {
+  accessKey: string;
+  bundlePath: string;
+  fetchText: FetchText;
+  labelPath: string;
+  readTextFile: (path: string) => Promise<string>;
+  scriptId: string;
+}
 
-  const accessKey = getAccessKey(deps.getEnv);
-  if (!accessKey) {
-    deps.stderr(
-      "BUNNY_ACCESS_KEY is required in .env (BUNNY_API_KEY also works).",
-    );
-    return 1;
-  }
-
-  deps.stdout("Building edge bundle...");
-  const build = await deps.runBuildEdge(deps.cwd);
-  if (!build.success) {
-    deps.stderr(`build:edge failed with exit code ${build.code}`);
-    return 1;
-  }
-
+const deployBuiltBundle = async (
+  deps: DeployBuiltBundleDeps,
+): Promise<number> => {
   let code: string;
   try {
     code = await deps.readTextFile(deps.bundlePath);
@@ -178,12 +205,12 @@ export const runDeployEdge = async (deps: DeployEdgeDeps): Promise<number> => {
   }
 
   deps.stdout(
-    `Uploading ${BUNDLE_PATH} to Bunny script ${scriptId.scriptId}...`,
+    `Uploading ${deps.labelPath} to Bunny script ${deps.scriptId}...`,
   );
   const deploy = await deployScriptCode(
-    scriptId.scriptId,
+    deps.scriptId,
     code,
-    accessKey,
+    deps.accessKey,
     deps.fetchText,
   );
   if (!deploy.ok) {
@@ -191,6 +218,63 @@ export const runDeployEdge = async (deps: DeployEdgeDeps): Promise<number> => {
     return 1;
   }
 
-  deps.stdout(`Published Bunny script ${scriptId.scriptId}.`);
+  deps.stdout(`Published Bunny script ${deps.scriptId}.`);
   return 0;
+};
+
+const withAccessKey = async (
+  deps: Pick<ScriptIo, "getEnv" | "stderr">,
+  run: (accessKey: string) => Promise<number>,
+): Promise<number> => {
+  const accessKey = getAccessKey(deps.getEnv);
+  if (!accessKey) {
+    deps.stderr(ACCESS_KEY_ERROR);
+    return 1;
+  }
+
+  return run(accessKey);
+};
+
+export const runDeployBuiltEdge = async (
+  deps: DeployBuiltEdgeDeps,
+): Promise<number> => {
+  const args = parseDeployBuiltArgs(deps.args);
+  if (!args.ok) {
+    deps.stderr(args.error);
+    return 1;
+  }
+
+  return withAccessKey(deps, (accessKey) =>
+    deployBuiltBundle({
+      ...deps,
+      accessKey,
+      bundlePath: args.bundlePath,
+      labelPath: args.bundlePath,
+      scriptId: args.scriptId,
+    }),
+  );
+};
+
+export const runDeployEdge = async (deps: DeployEdgeDeps): Promise<number> => {
+  const scriptId = parseScriptIdArg(deps.args);
+  if (!scriptId.ok) {
+    deps.stderr(scriptId.error);
+    return 1;
+  }
+
+  return withAccessKey(deps, async (accessKey) => {
+    deps.stdout("Building edge bundle...");
+    const build = await deps.runBuildEdge(deps.cwd);
+    if (!build.success) {
+      deps.stderr(`build:edge failed with exit code ${build.code}`);
+      return 1;
+    }
+
+    return deployBuiltBundle({
+      ...deps,
+      accessKey,
+      labelPath: BUNDLE_PATH,
+      scriptId: scriptId.scriptId,
+    });
+  });
 };

--- a/scripts/deploy-edge.ts
+++ b/scripts/deploy-edge.ts
@@ -2,23 +2,12 @@
 
 import { fromFileUrl } from "@std/path";
 import { runDenoScript } from "#scripts/script-runner.ts";
-import { type FetchTextResult, runDeployEdge } from "./deploy-edge-lib.ts";
+import { runDeployEdge } from "./deploy-edge-lib.ts";
+import { fetchText } from "./fetch-text.ts";
 import { runBuildEdge } from "./run-build-edge.ts";
 
 const repoRoot = fromFileUrl(new URL("..", import.meta.url));
 const bundlePath = fromFileUrl(new URL("../bunny-script.ts", import.meta.url));
-
-const fetchText = async (
-  url: string,
-  init: RequestInit,
-): Promise<FetchTextResult> => {
-  const response = await fetch(url, init);
-  return {
-    ok: response.ok,
-    status: response.status,
-    text: await response.text(),
-  };
-};
 
 await runDenoScript((io) =>
   runDeployEdge({

--- a/scripts/fetch-text.ts
+++ b/scripts/fetch-text.ts
@@ -1,0 +1,19 @@
+export interface FetchTextResult {
+  ok: boolean;
+  status: number;
+  text: string;
+}
+
+export type FetchText = (
+  url: string,
+  init: RequestInit,
+) => Promise<FetchTextResult>;
+
+export const fetchText: FetchText = async (url, init) => {
+  const response = await fetch(url, init);
+  return {
+    ok: response.ok,
+    status: response.status,
+    text: await response.text(),
+  };
+};

--- a/test/scripts/bunny-deploy-workflow.test.ts
+++ b/test/scripts/bunny-deploy-workflow.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+
+const DEPLOY_ACTION_PATH = ".github/actions/deploy-bunny-script/action.yml";
+const BUNNY_DEPLOY_WORKFLOW_PATHS = [
+  ".github/workflows/bunny-deploy.yml",
+  ".github/workflows/production-deploy.yml",
+] as const;
+const RESTORE_WORKFLOW_PATH = ".github/workflows/restore-deploy.yml";
+const SHA = "[a-f0-9]{40}";
+
+const readText = (path: string): Promise<string> => Deno.readTextFile(path);
+const githubValue = (name: string): string =>
+  ["$", "{{ ", name, " }}"].join("");
+
+describe("Bunny deploy workflow", () => {
+  test("deploys built bundles through first-party code", async () => {
+    const action = await readText(DEPLOY_ACTION_PATH);
+
+    expect(action).toContain("scripts/deploy-built-edge.ts");
+    expect(action).toContain("--allow-net=api.bunny.net");
+    expect(action).toContain(
+      `BUNNY_ACCESS_KEY: ${githubValue("inputs.api_key")}`,
+    );
+    expect(action).not.toContain("BunnyWay/actions/deploy-script@main");
+    expect(action).not.toMatch(/uses:\s+BunnyWay\/actions\/deploy-script@/);
+  });
+
+  test("staging and production keep the deploy key in the local wrapper", async () => {
+    const workflows = await Promise.all(
+      BUNNY_DEPLOY_WORKFLOW_PATHS.map(readText),
+    );
+
+    for (const workflow of workflows) {
+      expect(workflow).toContain("uses: ./.github/actions/deploy-bunny-script");
+      expect(workflow).toContain(
+        `api_key: ${githubValue("secrets.BUNNY_ACCESS_KEY")}`,
+      );
+      expect(workflow).not.toContain("BunnyWay/actions/deploy-script@main");
+    }
+  });
+
+  test("restore deploy pins the external Bunny action to a commit SHA", async () => {
+    const workflow = await readText(RESTORE_WORKFLOW_PATH);
+
+    expect(workflow).toMatch(
+      new RegExp(`uses: BunnyWay/actions/deploy-script@${SHA}`),
+    );
+    expect(workflow).not.toContain("BunnyWay/actions/deploy-script@main");
+  });
+});

--- a/test/scripts/bunny-deploy-workflow.test.ts
+++ b/test/scripts/bunny-deploy-workflow.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { map } from "#fp";
 
 const DEPLOY_ACTION_PATH = ".github/actions/deploy-bunny-script/action.yml";
 const BUNNY_DEPLOY_WORKFLOW_PATHS = [
@@ -31,13 +32,43 @@ describe("Bunny deploy workflow", () => {
       BUNNY_DEPLOY_WORKFLOW_PATHS.map(readText),
     );
 
-    for (const workflow of workflows) {
-      expect(workflow).toContain("uses: ./.github/actions/deploy-bunny-script");
-      expect(workflow).toContain(
+    const expected = {
+      omitsMutableBunnyRef: true,
+      passesAccessKey: true,
+      usesLocalAction: true,
+    };
+
+    const checks = map((workflow: string) => ({
+      omitsMutableBunnyRef: !workflow.includes(
+        "BunnyWay/actions/deploy-script@main",
+      ),
+      passesAccessKey: workflow.includes(
         `api_key: ${githubValue("secrets.BUNNY_ACCESS_KEY")}`,
-      );
-      expect(workflow).not.toContain("BunnyWay/actions/deploy-script@main");
-    }
+      ),
+      usesLocalAction: workflow.includes(
+        "uses: ./.github/actions/deploy-bunny-script",
+      ),
+    }))(workflows);
+
+    expect(checks).toEqual(workflows.map(() => expected));
+  });
+
+  test("grants read permission for the same trimmed path it passes to the script", async () => {
+    const action = await readText(DEPLOY_ACTION_PATH);
+    const lines = action.split("\n").map((line) => line.trim());
+
+    const allowRead = lines
+      .find((line) => line.startsWith("--allow-read="))!
+      .match(/--allow-read="([^"]+)"/)![1]!;
+    const scriptFileArg = lines
+      .find((line) => line.startsWith("scripts/deploy-built-edge.ts"))!
+      .match(/deploy-built-edge\.ts\s+"[^"]+"\s+"([^"]+)"/)![1]!;
+
+    // parseDeployBuiltArgs trims the file internally, so the action must hand the
+    // script an already-trimmed path and grant the read permission for that same
+    // path — otherwise a padded `file:` input leaves Deno denying its own read.
+    expect(allowRead).not.toMatch(/BUNNY_SCRIPT_FILE/);
+    expect(scriptFileArg).toBe(allowRead);
   });
 
   test("restore deploy pins the external Bunny action to a commit SHA", async () => {

--- a/test/scripts/deploy-edge.test.ts
+++ b/test/scripts/deploy-edge.test.ts
@@ -1,16 +1,20 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  ACCESS_KEY_ERROR,
   BUNDLE_PATH,
   BUNNY_API_BASE,
+  DEPLOY_BUILT_USAGE,
   type DeployEdgeDeps,
   deployScriptCode,
   type FetchText,
   type FetchTextResult,
   formatBunnyError,
   getAccessKey,
+  parseDeployBuiltArgs,
   parseScriptIdArg,
   publishScript,
+  runDeployBuiltEdge,
   runDeployEdge,
   USAGE,
   uploadScriptCode,
@@ -44,7 +48,6 @@ const response = (
   status: number,
   text: string,
 ): FetchTextResult => ({ ok, status, text });
-
 const headersFrom = (init: RequestInit): Record<string, string> =>
   init.headers as Record<string, string>;
 
@@ -110,6 +113,31 @@ describe("deploy-edge argument parsing", () => {
       error: USAGE,
       ok: false,
     });
+  });
+});
+
+describe("deploy-built-edge argument parsing", () => {
+  test("accepts a script ID and optional bundle path", () => {
+    expect(parseDeployBuiltArgs([" 12345 "])).toEqual({
+      bundlePath: BUNDLE_PATH,
+      ok: true,
+      scriptId: "12345",
+    });
+    expect(parseDeployBuiltArgs([" 12345 ", " built.ts "])).toEqual({
+      bundlePath: "built.ts",
+      ok: true,
+      scriptId: "12345",
+    });
+  });
+
+  test("rejects missing, blank, or extra inputs", () => {
+    const usageError = { error: DEPLOY_BUILT_USAGE, ok: false };
+    expect([
+      parseDeployBuiltArgs([]),
+      parseDeployBuiltArgs([" "]),
+      parseDeployBuiltArgs(["1", " "]),
+      parseDeployBuiltArgs(["1", "built.ts", "extra"]),
+    ]).toEqual([usageError, usageError, usageError, usageError]);
   });
 });
 
@@ -274,9 +302,7 @@ describe("runDeployEdge", () => {
     const stderr = await expectDeployFailsBeforeBuild({
       getEnv: envReader({}),
     });
-    expect(stderr).toEqual([
-      "BUNNY_ACCESS_KEY is required in .env (BUNNY_API_KEY also works).",
-    ]);
+    expect(stderr).toEqual([ACCESS_KEY_ERROR]);
   });
 
   test("stops when the edge build fails", async () => {
@@ -322,5 +348,52 @@ describe("runDeployEdge", () => {
 
     expect(stderr).toEqual(["Upload script code failed (401): Unauthorized"]);
     expect(recorder.calls).toHaveLength(1);
+  });
+});
+
+describe("runDeployBuiltEdge", () => {
+  test("returns usage errors before reading", async () => {
+    const { deps, stderr } = deployDeps({ args: [] });
+
+    await expect(runDeployBuiltEdge(deps)).resolves.toBe(1);
+
+    expect(stderr).toEqual([DEPLOY_BUILT_USAGE]);
+  });
+
+  test("reads, uploads, and publishes an already-built bundle", async () => {
+    const recorder = fetchRecorder([
+      response(true, 200, "{}"),
+      response(true, 200, "{}"),
+    ]);
+    const { deps, stderr, stdout } = deployDeps({
+      args: ["42", "built.ts"],
+      fetchText: recorder.fetchText,
+    });
+
+    await expect(runDeployBuiltEdge(deps)).resolves.toBe(0);
+
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([
+      "Uploading built.ts to Bunny script 42...",
+      "Published Bunny script 42.",
+    ]);
+    expect(recorder.calls).toHaveLength(2);
+  });
+
+  test("requires a Bunny access key before reading the bundle", async () => {
+    let readCalled = false;
+    const { deps, stderr } = deployDeps({
+      args: ["42", "built.ts"],
+      getEnv: envReader({}),
+      readTextFile: () => {
+        readCalled = true;
+        return Promise.resolve("code");
+      },
+    });
+
+    await expect(runDeployBuiltEdge(deps)).resolves.toBe(1);
+
+    expect(stderr).toEqual([ACCESS_KEY_ERROR]);
+    expect(readCalled).toBe(false);
   });
 });

--- a/test/scripts/deploy-edge.test.ts
+++ b/test/scripts/deploy-edge.test.ts
@@ -7,8 +7,6 @@ import {
   DEPLOY_BUILT_USAGE,
   type DeployEdgeDeps,
   deployScriptCode,
-  type FetchText,
-  type FetchTextResult,
   formatBunnyError,
   getAccessKey,
   parseDeployBuiltArgs,
@@ -19,6 +17,7 @@ import {
   USAGE,
   uploadScriptCode,
 } from "#scripts/deploy-edge-lib.ts";
+import type { FetchText, FetchTextResult } from "#scripts/fetch-text.ts";
 
 interface FetchCall {
   init: RequestInit;

--- a/test/scripts/fetch-text.test.ts
+++ b/test/scripts/fetch-text.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { fetchText } from "#scripts/fetch-text.ts";
+import { stubFetch } from "#test-utils/fetch-stub.ts";
+
+describe("fetchText", () => {
+  test("returns the ok flag, status, and body text of the response", async () => {
+    using _fetch = stubFetch(new Response('{"Message":"ok"}', { status: 200 }));
+
+    const result = await fetchText("https://api.bunny.net/code", {
+      method: "POST",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      text: '{"Message":"ok"}',
+    });
+  });
+
+  test("forwards the url and request init to fetch", async () => {
+    using fetchStub = stubFetch(new Response("body", { status: 202 }));
+
+    await fetchText("https://api.bunny.net/code", {
+      body: '{"Code":"x"}',
+      headers: { AccessKey: "key" },
+      method: "POST",
+    });
+
+    expect(fetchStub.calls.length).toBe(1);
+    expect(fetchStub.calls[0]!.args[0]).toBe("https://api.bunny.net/code");
+    expect(fetchStub.calls[0]!.args[1]).toEqual({
+      body: '{"Code":"x"}',
+      headers: { AccessKey: "key" },
+      method: "POST",
+    });
+  });
+
+  test("surfaces a non-ok response with its status and body", async () => {
+    using _fetch = stubFetch(new Response("Unauthorized", { status: 401 }));
+
+    const result = await fetchText("https://api.bunny.net/publish", {
+      method: "POST",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      text: "Unauthorized",
+    });
+  });
+
+  test("reads a null body as empty text", async () => {
+    using _fetch = stubFetch(new Response(null, { status: 204 }));
+
+    const result = await fetchText("https://api.bunny.net/code", {
+      method: "POST",
+    });
+
+    expect(result).toEqual({ ok: true, status: 204, text: "" });
+  });
+});


### PR DESCRIPTION
## What changed

The Bunny deploy composite action now deploys built bundles through first-party Deno code instead of passing the Bunny API key to `BunnyWay/actions/deploy-script@main`.

The direct deploy path shares the existing Bunny API upload and publish code. The `fetchText` adapter it uses now has direct test coverage. A workflow test checks that staging and production use the local wrapper, that the mutable Bunny action ref does not return, that the read permission matches the path the script reads, and that restore deploy keeps its existing immutable action pin.

## Why

Staging and production deploys forwarded `BUNNY_ACCESS_KEY` to a third-party action pinned to the mutable `main` ref. If that upstream ref moved or was compromised, it could run with the production deploy key.

## Impact

Deploys still upload and publish `bunny-script.ts` to Bunny Edge Scripting, but the key now stays inside code from this repository. The restore workflow remains pinned to the reviewed immutable Bunny action SHA.

## Checks

- `nix develop -c deno task test:files test/scripts/deploy-edge.test.ts test/scripts/bunny-deploy-workflow.test.ts test/scripts/fetch-text.test.ts`
- `nix develop -c deno task precommit`
