### PR TITLE
Prevent duplicate first-run setup

### DIFF
--- a/src/features/setup.ts
+++ b/src/features/setup.ts
@@ -14,7 +14,7 @@ import { createRouter, defineRoutes } from "#routes/router.ts";
 import { isValidCountry } from "#shared/countries.ts";
 import { signCsrfToken, verifySignedCsrfToken } from "#shared/csrf.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
-import { settings } from "#shared/db/settings.ts";
+import { SetupAlreadyCompleteError, settings } from "#shared/db/settings.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import { ErrorCode, logDbError, logDebug, logError } from "#shared/logger.ts";
 import { getSetupForm } from "#templates/fields/admin.ts";
@@ -150,6 +150,10 @@ const handleSetupPost: SetupHandler = async (request, isSetupComplete) => {
     logDebug("Setup", "Setup completed successfully!");
     return redirectResponse("/setup/complete");
   } catch (error) {
+    if (error instanceof SetupAlreadyCompleteError) {
+      logDebug("Setup", "Setup already completed by another request");
+      return redirectResponse("/");
+    }
     logDbError("setup completion", error);
     throw error;
   }

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -70,6 +70,7 @@ import {
   clearSetupCompleteCache,
   completeSetup,
   isSetupComplete,
+  SetupAlreadyCompleteError,
 } from "#shared/db/settings/setup.ts";
 import {
   clearTestOverrides,
@@ -112,6 +113,7 @@ export {
   CONFIG_KEYS,
   EMAIL_BODY_KEYS,
   getCurrentSettingsVersion,
+  SetupAlreadyCompleteError,
   SNAPSHOT_KEYS,
 };
 

--- a/src/shared/db/settings/setup.ts
+++ b/src/shared/db/settings/setup.ts
@@ -5,7 +5,7 @@
  * permanent in-memory short-circuit (set once setup flipped to true) on top of
  * the on-demand loader. `completeSetup` is the one-time write that lands the
  * owner account, its wrapped DATA_KEY and keypair, and the `setup_complete`
- * flag in a single batch — no half-initialised site can result.
+ * flag in one guarded transaction — no half-initialised site can result.
  */
 
 import { lazyRef } from "#fp";
@@ -17,7 +17,7 @@ import {
   generateKeyPair,
   wrapDataKeyForPassword,
 } from "#shared/crypto/keys.ts";
-import { executeBatch } from "#shared/db/client.ts";
+import { type SqlStatement, withTransaction } from "#shared/db/client.ts";
 import { bumpSettingsVersion } from "#shared/db/settings/cache.ts";
 import { invalidateCache, loadKeys } from "#shared/db/settings/load.ts";
 import { getRawCached, settingUpsert } from "#shared/db/settings/raw-writes.ts";
@@ -28,6 +28,15 @@ const [getSetupCompleteCache, setSetupCompleteCache] = lazyRef<boolean>(
   () => false,
 );
 const [getSetupConfirmed, setSetupConfirmed] = lazyRef<boolean>(() => false);
+const SETUP_CLAIM_VALUE = "claiming";
+const SETUP_DONE_VALUE = "true";
+
+export class SetupAlreadyCompleteError extends Error {
+  constructor() {
+    super("Setup is already complete");
+    this.name = "SetupAlreadyCompleteError";
+  }
+}
 
 export const isSetupComplete = async (): Promise<boolean> => {
   const confirmed = getSetupConfirmed();
@@ -53,12 +62,20 @@ export const clearSetupCompleteCache = (): void => {
 // registration covers it (it never re-reads once true), so hook the sweep.
 registerCacheReset(clearSetupCompleteCache);
 
+const claimSetupSlot = (): SqlStatement => ({
+  args: [CONFIG_KEYS.SETUP_COMPLETE, SETUP_CLAIM_VALUE, SETUP_DONE_VALUE],
+  sql:
+    "INSERT INTO settings (key, value) VALUES (?, ?) " +
+    "ON CONFLICT(key) DO UPDATE SET value = excluded.value " +
+    "WHERE settings.value <> ?",
+});
+
 /**
  * The initial site-setup ceremony — creates the owner account, generates and
  * stores the DATA_KEY and keypair, sets the country, and flips
- * `setup_complete` on, all in one batch so a mid-write failure rolls back
- * every piece. The owner's wrapped DATA_KEY is v2 (bound to the raw password),
- * so attendee PII can't be unwrapped from a DB dump alone.
+ * `setup_complete` on in one transaction. The settings primary key is the
+ * cross-isolate setup slot: once any request claims and commits it as done,
+ * every later request fails before it can create another owner or keypair.
  */
 export const completeSetup = async (
   username: string,
@@ -77,25 +94,23 @@ export const completeSetup = async (
   );
   const encryptedPrivateKey = await encryptWithKey(privateKey, dataKey);
 
-  // The whole setup ceremony commits in one transaction: the owner account and
-  // every config key land together, so a mid-write failure can never leave a
-  // half-initialised site (an owner with no keypair, or setup_complete set
-  // before the owner row exists). All values are computed above, so this is a
-  // plain batch — no inter-statement logic — rather than an interactive
-  // transaction.
   const ownerInsert = await buildCreateUserStatement(
     username,
     hashedPassword,
     wrappedDataKey,
     "owner",
   );
-  await executeBatch([
-    ownerInsert,
-    settingUpsert(CONFIG_KEYS.WRAPPED_PRIVATE_KEY, encryptedPrivateKey),
-    settingUpsert(CONFIG_KEYS.PUBLIC_KEY, publicKey),
-    settingUpsert(CONFIG_KEYS.COUNTRY, country),
-    settingUpsert(CONFIG_KEYS.SETUP_COMPLETE, "true"),
-  ]);
+  await withTransaction(async (tx) => {
+    const claim = await tx.execute(claimSetupSlot());
+    if (claim.rowsAffected !== 1) throw new SetupAlreadyCompleteError();
+    await tx.batch([
+      ownerInsert,
+      settingUpsert(CONFIG_KEYS.WRAPPED_PRIVATE_KEY, encryptedPrivateKey),
+      settingUpsert(CONFIG_KEYS.PUBLIC_KEY, publicKey),
+      settingUpsert(CONFIG_KEYS.COUNTRY, country),
+      settingUpsert(CONFIG_KEYS.SETUP_COMPLETE, SETUP_DONE_VALUE),
+    ]);
+  });
   // Setup's config lands via a batch (not writeRaw), so bump the version by hand
   // to keep the cross-isolate signal consistent.
   await bumpSettingsVersion();

--- a/test/integration/server/setup-concurrency.test.ts
+++ b/test/integration/server/setup-concurrency.test.ts
@@ -1,0 +1,84 @@
+import { expect } from "@std/expect";
+import { beforeEach, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { handleRequest } from "#routes";
+import { getDb } from "#shared/db/client.ts";
+import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
+import { getSetupCsrfToken } from "#test-utils/csrf.ts";
+import { createTestDb, describeWithEnv, resetDb } from "#test-utils/db.ts";
+import { mockRequest, mockSetupFormRequest } from "#test-utils/mocks.ts";
+
+describeWithEnv("server (setup concurrency)", { db: true }, () => {
+  beforeEach(async () => {
+    resetDb();
+    await createTestDb();
+  });
+
+  test("concurrent setup posts only let one owner commit", async () => {
+    let attempts = 0;
+    let releaseAttempts!: () => void;
+    const bothAttemptsStarted = new Promise<void>((resolve) => {
+      releaseAttempts = resolve;
+    });
+    const originalComplete = settings.setup.complete;
+    const completeStub = stub(
+      settings.setup,
+      "complete",
+      async (...args: Parameters<typeof originalComplete>) => {
+        attempts++;
+        if (attempts === 2) releaseAttempts();
+        await bothAttemptsStarted;
+        await originalComplete(...args);
+      },
+    );
+
+    try {
+      const getToken = async (): Promise<string> => {
+        const response = await handleRequest(mockRequest("/setup/"));
+        const token = getSetupCsrfToken(await response.text());
+        if (!token) throw new Error("Setup page did not include a CSRF token");
+        return token;
+      };
+
+      const [firstToken, secondToken] = await Promise.all([
+        getToken(),
+        getToken(),
+      ]);
+      const postSetup = (
+        username: string,
+        csrfToken: string,
+      ): Promise<Response> =>
+        handleRequest(
+          mockSetupFormRequest(
+            {
+              admin_password: "mypassword123",
+              admin_password_confirm: "mypassword123",
+              admin_username: username,
+              country: "GB",
+            },
+            csrfToken,
+          ),
+        );
+
+      const responses = await Promise.all([
+        postSetup("firstadmin", firstToken),
+        postSetup("secondadmin", secondToken),
+      ]);
+
+      expect(
+        responses.map((response) => response.headers.get("location")).sort(),
+      ).toEqual(["/", "/setup/complete"]);
+      const count = await getDb().execute(
+        "SELECT COUNT(*) AS n FROM users AS user",
+      );
+      expect(Number(count.rows[0]!.n)).toBe(1);
+      const setupDone = await getDb().execute({
+        args: [CONFIG_KEYS.SETUP_COMPLETE],
+        sql: "SELECT value FROM settings AS setting WHERE key = ?",
+      });
+      expect(setupDone.rows.map((row) => row.value)).toEqual(["true"]);
+    } finally {
+      completeStub.restore();
+    }
+  });
+});


### PR DESCRIPTION
## What changed

First-run setup now claims the setup state inside the same database transaction that creates the owner account and stores the keys. If another setup request finishes first, the later request fails closed and leaves the existing owner and keys in place.

I also added a regression test that submits two setup forms at the same time and checks that only one owner is created.

## Why

Two setup requests could both see that setup was not complete before either one wrote the final setup state. Both requests could then create owner and key state, and the later request could replace the keys.

## Checks

- `nix develop -c deno task test:files test/integration/server/setup-concurrency.test.ts test/integration/server/setup.test.ts test/shared/db/settings.test.ts`
- `nix develop -c deno task precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate setup submissions from creating multiple users or inconsistent settings.
  * Concurrent setup attempts now complete safely, with the successful request continuing and others redirected appropriately.

* **Tests**
  * Added coverage for simultaneous setup requests, verifying correct redirects and single-user creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->