### PR TITLE
Say why the owner has a person's name, without naming the old one

### DIFF
--- a/test/test-utils/internal.ts
+++ b/test/test-utils/internal.ts
@@ -1,8 +1,8 @@
 import { lazyRef } from "#fp";
 
-/** The owner every test starts with. A person's name rather than "testadmin",
- * because some stories leave a page behind that gets published: a screenshot
- * of the team is only worth showing if the team reads like one. */
+/** The owner every test starts with. A person's name, because some stories
+ * leave a page behind that gets published: a screenshot of the team is only
+ * worth showing if the team reads like one. */
 export const TEST_ADMIN_USERNAME = "jo";
 
 export const TEST_ADMIN_PASSWORD = "testpassword123";


### PR DESCRIPTION
Follow-up to #1994, which merged before this could be fixed on it.

The comment on `TEST_ADMIN_USERNAME` explained the name by comparing it to the fixture name it replaced. AGENTS.md forbids historical comparisons in comments on current code: a reader a year from now has no idea what the old value was, and does not need to.

The reason itself is worth keeping, so it stays: some stories leave a page behind that gets published, and a screenshot of a team is only worth showing if the team reads like one. The comparison is gone.

Found by the Codex review on #1994.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK)_