### PR TITLE
Check a turned-away request goes to the login page, not just "not OK"

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1745,9 +1745,9 @@ refuses to start on a branch that touches them:
 - `src/features/admin/listing-page-data.ts` → `test/features/admin/listing-page-data/` (100%, one recorded equivalent)
 - `src/features/api/payment-processing/store-refund.ts` → `test/features/api/payment-processing/store-refund.test.ts` (100%)
 
-Every one of them is now at the 100% the gate demands, so a branch touching
-any of them can pass without first writing the tests that should already have
-existed.
+Every one of them now catches every mutation the gate demands, so a branch
+touching any of them can pass without first writing the tests that should
+already have existed.
 
 `src/features/admin/attendee-notes.ts` was in the same state and was fixed
 earlier: its route suite drives real pages through the session helpers, so it

--- a/test/features/admin/attendees-list.test.ts
+++ b/test/features/admin/attendees-list.test.ts
@@ -53,20 +53,23 @@ const twoBookedListings = async (): Promise<{
 
 describeWithEnv("the attendees browser", { db: true }, () => {
   describe("who may open it", () => {
-    test("a request with no session is turned away", async () => {
+    test("a request with no session is sent to the login page", async () => {
       const response = await handleAttendeesListGet(
         mockRequest("/admin/attendees"),
         {},
       );
-      expect(response.status).not.toBe(200);
+      // The exact redirect, so a 500 could never pass for "turned away".
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin");
     });
 
-    test("the export is turned away too", async () => {
+    test("the export is sent there too, rather than handing out a file", async () => {
       const response = await handleAttendeesCsvExport(
         mockRequest("/admin/attendees/csv"),
         {},
       );
-      expect(response.status).not.toBe(200);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/admin");
     });
   });
 


### PR DESCRIPTION
Two tests checked that someone with no login could not open the attendees list or download its spreadsheet. But all they actually checked was that the answer was "not OK" — which a crash would also satisfy. A broken page and a polite redirect to the login screen looked the same to them.

They now check what really happens: the request is sent to the login page, and they name that page. So if either one ever started crashing instead, or started sending people somewhere unexpected, a test would say so.

Also finishes a sentence in the backlog notes that stopped halfway: "now at the 100% the gate demands" now says what it is 100% of.

Both files were part of the four testless modules covered in #1993. The tests still catch every change the checker tries — 100%, unchanged.

`deno task precommit` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdDZCWRXwjqsidfRJFarXC)_