### PR TITLE
Leave three more pages behind for the site to photograph

### DIFF
--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -72,6 +72,24 @@ export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
     ".page-regions.admin-page",
   ),
   brandedMobileCapture(
+    "site-pages.written-and-readable",
+    "page-anybody-can-read",
+    "/page/{sitePageAddress}",
+    "main",
+  ),
+  brandedMobileCapture(
+    "api-keys.made-and-shown-once",
+    "api-keys-list",
+    "/admin/api-keys",
+    ".page-regions.admin-page",
+  ),
+  brandedMobileCapture(
+    "payment.refund-undoes-the-sale",
+    "refunded-booking",
+    "/admin/attendees/{paidBookingId}/ledger",
+    "#attendee-money",
+  ),
+  brandedMobileCapture(
     "door.someone-still-to-arrive-can-be-picked",
     "qr-code-check-in",
     "/admin/listing/{doorListingId}/scanner",

--- a/specs/servicing/writing-the-pages-people-read.feature
+++ b/specs/servicing/writing-the-pages-people-read.feature
@@ -11,6 +11,7 @@ Feature: An owner writes the pages people read
   read it straight away.
 
   @rule:servicing.a-page-written-is-a-page-anybody-can-read
+  @surface:public
   Rule: A page written is a page anybody can read
     There is no separate step to publish. The owner writes it, and it is there
     at the address they chose — for a visitor who was never signed in and never

--- a/src/ui/templates/admin/attendee-ledger-panel.tsx
+++ b/src/ui/templates/admin/attendee-ledger-panel.tsx
@@ -182,7 +182,9 @@ const LedgerHistory = ({
 );
 
 export const AttendeeLedgerPanel = (view: AttendeeLedgerView): JSX.Element => (
-  <PageRegions>
+  // Named so one booking's money can be pointed at on its own: this tab sits
+  // inside the attendee page, among five other tabs' worth of chrome.
+  <PageRegions id="attendee-money">
     <div class="prose">
       <h3>{t("attendee_balance.heading")}</h3>
       <OrderSummaryList view={view} />

--- a/test/specs/support/money.ts
+++ b/test/specs/support/money.ts
@@ -65,9 +65,10 @@ export const buyOnePlace = async (
   );
   world.attendeeId = attendeeId;
   world.attendeeName = who;
-  // What the listing earned is read from its own ledger page, which is where
-  // an evidence capture of the figures has to go.
+  // What the listing earned is read from its own ledger page, and what one
+  // booking has paid from its own, which is where captures of each figure go.
   world.evidenceValues.set("paidListingId", String(listingId));
+  world.evidenceValues.set("paidBookingId", String(attendeeId));
   return attendeeId;
 };
 

--- a/test/specs/support/site-pages.ts
+++ b/test/specs/support/site-pages.ts
@@ -31,9 +31,11 @@ const PAGES_LIST = "/admin/site/pages";
 
 /** Wording that appears on one page and nowhere else. Every page's name is in
  * the navigation on every page, so a check that only looked for the name would
- * pass against any page at all. */
+ * pass against any page at all. Written as a sentence a visitor could really
+ * be reading, because one of these stories leaves a page behind that is
+ * published as a screenshot. */
 export const wordsOnlyOn = (name: string): string =>
-  `The body of ${name}, and of nothing else.`;
+  `Everything this site has to say about ${name} is on this page.`;
 
 /** The owner opens their list of pages, ready to write one. A page is no use
  * unless the public site is on, so a story that wrote one nobody could read
@@ -58,6 +60,9 @@ export const ownerWritesPage = async (
     t("site.pages.create_submit"),
   );
   world.sitePageTold = browser.pageText;
+  // The address the owner chose, so a capture can open the page the way a
+  // visitor would rather than being told the address a second time.
+  world.evidenceValues.set("sitePageAddress", address);
   return browser.pageText;
 };
 


### PR DESCRIPTION
Three more of the marketing site's pictures are drawn by mock generators, though a case here already proves what each claims. Each case now names the page it leaves behind.

## Captures added

| case | page | element |
| --- | --- | --- |
| `site-pages.written-and-readable` | `/page/{sitePageAddress}` | the whole public page, navigation included |
| `api-keys.made-and-shown-once` | `/admin/api-keys` | the admin page |
| `payment.refund-undoes-the-sale` | `/admin/attendees/{paidBookingId}/ledger` | `#attendee-money` |

The site-pages rule gains `@surface:public`, because what it proves is a visitor reading the page rather than the owner writing it.

## The words a written page is given

`wordsOnlyOn` produced "The body of Directions, and of nothing else." It has to be text that appears on one page and nowhere else, so a check cannot pass against any page at all — but it is now also text that gets published as a screenshot, so it reads as a sentence instead: "Everything this site has to say about Directions is on this page."

## One booking's money, on its own

`AttendeeLedgerPanel` renders inside the attendee entity page, which carries a heading, six tabs and a footer around it. The panel is now `id="attendee-money"` so a capture can point at the money without the chrome. Same reason `#manual-checkin` is already named for the door capture.

`buyOnePlace` keeps the booking it made alongside the listing, so a story about what one booking paid can be captured the way one about what a listing earned already is.

## Checks

`deno task test` passes and `deno task lint` is clean. The twelve captures were run three times against the site's themes; all three new ones are byte-identical between runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy7Q7X9UJsKKyCP9FCAtqK)_