### PR TITLE
Stop duplicating a listing failing with an unexplained error

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1822,3 +1822,37 @@ listing, the same way an unreadable booking is raised.
 
 Start at `saveSessionAnswers`, and at `test/shared/booking-intent.test.ts`,
 where the shape rule is covered and the "names a booked listing" rule is not.
+
+---
+
+## A create whose row can't be read back should not look retryable
+
+*Origin: Codex review on PR #2002, which added the loud failure for a create
+whose just-written row can't be read back.*
+
+`writeEntity` (`src/shared/rest/write-entity.ts`) writes the row, commits, then
+reads it back on the primary. When a create's read-back finds nothing it now
+raises an error. That error leaves the API write path in
+`src/shared/rest/crud-api.ts` and reaches the request handler
+(`src/features/app/request.ts`), which turns any unhandled error into the shared
+503 page. The row itself was committed, so a client that treats the 503 as
+"try again" can post the same create twice and end up with two rows.
+
+The reviewer's suggestion was to read the row back *before* committing, so a
+failed read-back rolls the insert back and there is nothing to duplicate. That
+is more than a local change: each resource can supply its own
+`lookupAfterWrite`, several of which join extra columns, and every one of them
+would need a version that reads inside the open transaction. It also trades one
+rare wrong answer for another — a row read before the commit can still be
+reported to the caller when the commit afterwards fails.
+
+`writeTableRow` in `src/shared/db/table.ts` already inserts and reads back
+inside one transaction (see `test/shared/db/table/write-row.test.ts`), so it is
+the place to start if the pre-commit read-back is the direction taken. The
+smaller alternative is to keep the failure after the commit but answer with a
+response that says plainly the create is not to be repeated, and carries the id
+of the row that was made, rather than falling through to the generic 503.
+
+Note that the id that made this reachable in the first place is now checked at
+the insert (`insertedRowId` in `src/shared/db/client.ts`), so this is about the
+answer given for a failure that should no longer happen — not a live fault.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -175,7 +175,8 @@ src/shared/rest/crud-api.ts:342:31  ?? → ||   # policy is an AuthPolicy object
 src/shared/rest/crud-api.ts:346:18  ?? → ||   # lookup is a function or undefined
 src/shared/rest/crud-api.ts:353:28  ?? → ||   # lookupAfterWrite is a function or undefined
 src/shared/rest/crud-api.ts:363:31  ?? → ||   # hydrated map values are records or undefined; records are truthy
-src/shared/rest/crud-api.ts:572:27  ?? → ||   # extraRoutes is a route object or undefined
+src/shared/rest/crud-api.ts:573:27  ?? → ||   # extraRoutes is a route object or undefined
+src/shared/rest/resource.ts:157:25  ?? → ||   # validationError is an ErrorResult object or null; an object is truthy
 
 # Invariant-based, confirmed by reading toUnits: `lineIdxs` comes from toUnits,
 # which assigns lineIdx as the flatMap array index, so the sort's input is

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -771,6 +771,24 @@ export const useTransaction = <T>(
   transaction === undefined ? withTransaction(work) : work(transaction);
 
 /**
+ * The row id an INSERT reported, or a loud failure.
+ *
+ * `lastInsertRowid` is optional on a libsql result, and a driver that leaves it
+ * out (or reports 0) used to become `Number(undefined)` = NaN here — which the
+ * join writes were then written against, and which the row read-back afterwards
+ * could only report as a missing row, long after the transaction had committed.
+ * Every row this is used for has a positive integer key, so anything else means
+ * the write cannot be finished and must roll back.
+ */
+const insertedRowId = (result: ResultSet): number => {
+  const id = Number(result.lastInsertRowid);
+  if (Number.isInteger(id) && id > 0) return id;
+  throw new Error(
+    `INSERT did not report a row id (lastInsertRowid=${result.lastInsertRowid})`,
+  );
+};
+
+/**
  * Write one row `statement` in a fresh write transaction and run `persist` (the
  * coupled join-table writes) on the same `tx`, so the row and its side writes
  * commit or roll back together. Returns the row id — `existingId` on update, or
@@ -784,7 +802,7 @@ export const writeRowInTransaction = (
 ): Promise<number> =>
   withTransaction(async (tx) => {
     const res = await tx.execute(statement);
-    const id = existingId ?? Number(res.lastInsertRowid);
+    const id = existingId ?? insertedRowId(res);
     await persist(tx, id);
     return id;
   });

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -771,16 +771,11 @@ export const useTransaction = <T>(
   transaction === undefined ? withTransaction(work) : work(transaction);
 
 /**
- * The row id an INSERT reported, or a loud failure.
- *
- * `lastInsertRowid` is optional on a libsql result, and a driver that leaves it
- * out (or reports 0) used to become `Number(undefined)` = NaN here — which the
- * join writes were then written against, and which the row read-back afterwards
- * could only report as a missing row, long after the transaction had committed.
- * Every row this is used for has a positive integer key, so anything else means
- * the write cannot be finished and must roll back.
+ * The row id an INSERT reported. Every generated key is a positive integer, so
+ * anything else (`lastInsertRowid` is optional on a libsql result) means nothing
+ * downstream can be keyed on this row and the write must fail here.
  */
-const insertedRowId = (result: ResultSet): number => {
+export const insertedRowId = (result: ResultSet): number => {
   const id = Number(result.lastInsertRowid);
   if (Number.isInteger(id) && id > 0) return id;
   throw new Error(

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -18,6 +18,7 @@ import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
 import { chooseColumns, type StoredRowOf } from "#shared/db/chosen-columns.ts";
 import {
   executeBatch,
+  insertedRowId,
   queryAll,
   resultRows,
   type TxScope,
@@ -221,7 +222,7 @@ export const createNewsPost = async (
     return {
       content: input.content,
       created,
-      id: Number(result.lastInsertRowid),
+      id: insertedRowId(result),
       meta_description: input.metaDescription,
       meta_title: input.metaTitle,
       name: input.name,

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -18,6 +18,7 @@ import {
 } from "#shared/cache-registry.ts";
 import {
   execute,
+  insertedRowId,
   queryAll,
   queryOne,
   queryOnePrimary,
@@ -398,7 +399,7 @@ export const defineTable = <Row, Input = Row>(
     const result = await execute(sql, args);
 
     const initialRow = schema[primaryKey].generated
-      ? { [primaryKey]: Number(result.lastInsertRowid) }
+      ? { [primaryKey]: insertedRowId(result) }
       : {};
 
     return reduce((row: Record<string, unknown>, col: string) => {

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -24,6 +24,7 @@ import {
   execute,
   inPlaceholders,
   insert,
+  insertedRowId,
   queryAll,
 } from "#shared/db/client.ts";
 import {
@@ -165,7 +166,7 @@ const runUserInsert = async ({
   values,
 }: BuiltUserInsert): Promise<User> => {
   const result = await execute(statement.sql, statement.args);
-  return { id: Number(result.lastInsertRowid), ...values };
+  return { id: insertedRowId(result), ...values };
 };
 
 /** Shared user creation logic */

--- a/src/shared/rest/crud-api.ts
+++ b/src/shared/rest/crud-api.ts
@@ -459,11 +459,12 @@ export const defineCrudApi = <
       joinWrites,
       plainWrite: () => plainWrite() as unknown as Promise<FullRow | null>,
       readBack: lookupAfterWrite,
+      tableName: config.table.name,
     });
-    // writeEntity returns null when the just-written row can't be read back —
-    // an update whose row was deleted between the entityRoute lookup and the
-    // commit. Report a clean not-found (as defineResource's update path does)
-    // rather than dereferencing null in respondWithRow.
+    // writeEntity returns null only for an update whose row was deleted between
+    // the entityRoute lookup and the commit. Report a clean not-found (as
+    // defineResource's update path does) rather than dereferencing null in
+    // respondWithRow.
     if (!fullRow) return apiErrorResponse(`${singular} not found`, 404);
     return respondWithRow(fullRow, action, status);
   };

--- a/src/shared/rest/resource.ts
+++ b/src/shared/rest/resource.ts
@@ -223,6 +223,7 @@ export const defineResource = <
         : [],
       plainWrite: () => fallback(result.value),
       readBack: (rowId) => table.findByIdPrimary!(rowId),
+      tableName: table.name,
     });
     return { ok: true, row };
   };
@@ -231,6 +232,9 @@ export const defineResource = <
     const result = await parseWriteAndCommit(form, null, (input) =>
       table.insert(input),
     );
+    // A create's row is never null: `insert` returns the row it wrote, and a
+    // transactional write that can't read its own row back throws in
+    // `writeEntity` rather than reporting a null-row success.
     return result.ok ? { ok: true, row: result.row as Row } : result;
   };
 

--- a/src/shared/rest/write-entity.ts
+++ b/src/shared/rest/write-entity.ts
@@ -41,24 +41,51 @@ export interface EntityWrite<Row extends { id: number }> {
   plainWrite: () => Promise<Row | null>;
   /** Read the just-committed row back — this MUST be pinned to the primary. A
    *  "read"-mode lookup can hit a replica that still lags the commit and return
-   *  null for the row just written, which the create path would then dereference
-   *  (`row.id`) and crash on. Use `table.findByIdPrimary` or a primary-pinned
-   *  join lookup. */
+   *  null for the row just written. Use `table.findByIdPrimary` or a
+   *  primary-pinned join lookup. */
   readBack: (id: number) => Promise<Row | null>;
+  /** The table being written, for the error raised when a create's own row can't
+   *  be read back. */
+  tableName: string;
 }
+
+/**
+ * Read the just-committed row back, or fail loudly on a create.
+ *
+ * A create's INSERT has already committed here, so finding nothing means the
+ * read-back could not see its own write — a lagging replica, or an insert id
+ * that isn't the row's. That is never a normal outcome, and returning null for
+ * it strands the caller with a row-shaped null whose first field read
+ * ("Cannot read properties of null (reading 'name')") lands nowhere near this
+ * line. An update legitimately finds nothing: its row can be deleted between
+ * the caller's lookup and the commit.
+ */
+const readBackWritten = async <Row extends { id: number }>(
+  { existingId, readBack, tableName }: EntityWrite<Row>,
+  id: number,
+): Promise<Row | null> => {
+  const row = await readBack(id);
+  if (row || existingId !== null) return row;
+  throw new Error(
+    `${tableName}: row ${id} was inserted but could not be read back`,
+  );
+};
 
 /**
  * Write the row — transactionally with its join writes when there are any, else
  * as a plain single statement — read it back on the primary, then run
  * `afterCommit`. Returns the committed row, or null when the read-back finds
- * nothing (a plain write returning null, or an update whose id no longer exists).
+ * nothing — which only an update can legitimately do (its row was deleted before
+ * the commit); a create that can't read its own row back throws
+ * ({@link readBackWritten}).
  */
 export const writeEntity = async <Row extends { id: number }>(
   write: EntityWrite<Row>,
 ): Promise<Row | null> => {
   const row =
     write.joinWrites.length > 0
-      ? await write.readBack(
+      ? await readBackWritten(
+          write,
           await writeRowInTransaction(
             await write.buildStatement(),
             write.existingId,

--- a/src/shared/rest/write-entity.ts
+++ b/src/shared/rest/write-entity.ts
@@ -50,17 +50,12 @@ export interface EntityWrite<Row extends { id: number }> {
 }
 
 /**
- * Read the just-committed row back, or fail loudly on a create.
- *
- * A create's INSERT has already committed here, so finding nothing means the
- * read-back could not see its own write — a lagging replica, or an insert id
- * that isn't the row's. That is never a normal outcome, and returning null for
- * it strands the caller with a row-shaped null whose first field read
- * ("Cannot read properties of null (reading 'name')") lands nowhere near this
- * line. An update legitimately finds nothing: its row can be deleted between
- * the caller's lookup and the commit.
+ * Read the just-committed row back. Null only for an update, whose row can be
+ * deleted between the caller's lookup and the commit; a create's row is one it
+ * just inserted, so not finding it is a broken database rather than an outcome
+ * to hand back.
  */
-const readBackWritten = async <Row extends { id: number }>(
+const readBackWrittenOrNull = async <Row extends { id: number }>(
   { existingId, readBack, tableName }: EntityWrite<Row>,
   id: number,
 ): Promise<Row | null> => {
@@ -77,14 +72,14 @@ const readBackWritten = async <Row extends { id: number }>(
  * `afterCommit`. Returns the committed row, or null when the read-back finds
  * nothing — which only an update can legitimately do (its row was deleted before
  * the commit); a create that can't read its own row back throws
- * ({@link readBackWritten}).
+ * ({@link readBackWrittenOrNull}).
  */
 export const writeEntity = async <Row extends { id: number }>(
   write: EntityWrite<Row>,
 ): Promise<Row | null> => {
   const row =
     write.joinWrites.length > 0
-      ? await readBackWritten(
+      ? await readBackWrittenOrNull(
           write,
           await writeRowInTransaction(
             await write.buildStatement(),

--- a/test/integration/server/listings/duplicate.test.ts
+++ b/test/integration/server/listings/duplicate.test.ts
@@ -1,10 +1,13 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { listingsTable } from "#shared/db/listings/records.ts";
 import { assertAdminHtml, testRequiresAuth } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
-import { awaitTestRequest } from "#test-utils/mocks.ts";
+import { baseListingForm } from "#test-utils/factories.ts";
+import { awaitTestRequest, mockMultipartRequest } from "#test-utils/mocks.ts";
 import { adminGet, setupListingAndLogin } from "#test-utils/session.ts";
 
 // jscpd:ignore-end
@@ -74,6 +77,45 @@ describeWithEnv("server listings > duplicate", { db: true }, () => {
       const html = await getActionsTabHtml();
       expect(html).toContain('href="/admin/listing/1/export.json"');
       expect(html).toContain("<span>Export</span>");
+    });
+  });
+
+  describe("POST /admin/listing (duplicate)", () => {
+    // The reported failure: the copy commits, but reading it back finds nothing,
+    // so the handler used to reach `result.row.name` on a null row and die with
+    // "Cannot read properties of null (reading 'name')" — logged as the generic
+    // E_CDN_REQUEST, pointing nowhere near the read-back that actually failed.
+    test("fails with the table named when the copy cannot be read back", async () => {
+      const { cookie, csrfToken } = await setupListingAndLogin({
+        maxAttendees: 10,
+        name: "Original",
+        thankYouUrl: "https://example.com",
+      });
+      const readBack = stub(listingsTable, "findByIdPrimary", () =>
+        Promise.resolve(null),
+      );
+      const { handleRequest } = await import("#routes");
+
+      try {
+        // The message names the table and the id, instead of the null-field
+        // TypeError this used to raise from the redirect that followed.
+        await expect(
+          handleRequest(
+            mockMultipartRequest(
+              "/admin/listing",
+              {
+                ...baseListingForm,
+                csrf_token: csrfToken,
+                duplicated_from: "1",
+                name: "Copy",
+              },
+              cookie,
+            ),
+          ),
+        ).rejects.toThrow(/^listings: row \d+ was inserted/);
+      } finally {
+        readBack.restore();
+      }
     });
   });
 });

--- a/test/shared/db/client/transaction.test.ts
+++ b/test/shared/db/client/transaction.test.ts
@@ -197,4 +197,56 @@ describeWithEnv("db > client transaction", { db: true }, () => {
     expect(id).toBe(0);
     expect(persistedIds).toEqual([0]);
   });
+
+  /** Run an INSERT through writeRowInTransaction against a driver whose result
+   *  reports `lastInsertRowid` as `reported`, recording the ids persist saw. */
+  const insertWithReportedRowid = async (
+    reported: unknown,
+  ): Promise<{ persistedIds: number[]; error: unknown }> => {
+    const persistedIds: number[] = [];
+    using _txStub = stubTransaction({
+      commit: () => Promise.resolve(),
+      execute: () =>
+        Promise.resolve({ lastInsertRowid: reported } as unknown as ResultSet),
+      rollback: () => Promise.resolve(),
+    });
+    try {
+      await writeRowInTransaction(
+        "INSERT INTO rows (x) VALUES (1)",
+        null,
+        (_tx, rowId) => {
+          persistedIds.push(rowId);
+          return Promise.resolve();
+        },
+      );
+      return { error: null, persistedIds };
+    } catch (thrown) {
+      return { error: thrown, persistedIds };
+    }
+  };
+
+  // A driver that doesn't report the new rowid used to give `Number(undefined)`
+  // = NaN as the row id: the join writes were then written against NaN and the
+  // transaction committed, and only the read-back afterwards found nothing.
+  // Fail before persist runs so the whole write rolls back instead.
+  test("writeRowInTransaction rejects an INSERT that reports no row id", async () => {
+    const { error, persistedIds } = await insertWithReportedRowid(undefined);
+
+    expect(String(error)).toContain("did not report a row id");
+    expect(persistedIds).toEqual([]);
+  });
+
+  test("writeRowInTransaction rejects an INSERT that reports row id 0", async () => {
+    const { error, persistedIds } = await insertWithReportedRowid(0n);
+
+    expect(String(error)).toContain("did not report a row id");
+    expect(persistedIds).toEqual([]);
+  });
+
+  test("writeRowInTransaction persists against the INSERT's reported row id", async () => {
+    const { error, persistedIds } = await insertWithReportedRowid(7n);
+
+    expect(error).toBeNull();
+    expect(persistedIds).toEqual([7]);
+  });
 });

--- a/test/shared/db/table/write-row.test.ts
+++ b/test/shared/db/table/write-row.test.ts
@@ -1,8 +1,15 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { execute, queryAll, withTransaction } from "#shared/db/client.ts";
+import { stub } from "@std/testing/mock";
+import {
+  execute,
+  getDb,
+  queryAll,
+  withTransaction,
+} from "#shared/db/client.ts";
 import { col, defineTable, writeTableRow } from "#shared/db/table.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { emptyResultSet } from "#test-utils/db-helpers/result-set.ts";
 
 type WriteRow = { id: number; name: string };
 type WriteInput = { name: string };
@@ -66,5 +73,19 @@ describeWithEnv("db > writeTableRow", { db: true }, () => {
 
     expect(row).toBeNull();
     expect(await queryAll("SELECT id, name FROM table_write_rows")).toEqual([]);
+  });
+
+  // The plain insert path keys the row it returns on the id the driver reports,
+  // so a driver that reports none must fail here rather than hand back a row
+  // whose id is NaN — which callers put straight into a redirect URL.
+  test("insert rejects a driver result that reports no row id", async () => {
+    const table = await createWriteTable();
+    using _execute = stub(getDb(), "execute", () =>
+      Promise.resolve(emptyResultSet()),
+    );
+
+    await expect(table.insert({ name: "Nameless" })).rejects.toThrow(
+      "INSERT did not report a row id",
+    );
   });
 });

--- a/test/shared/rest/resource.test.ts
+++ b/test/shared/rest/resource.test.ts
@@ -209,6 +209,26 @@ describe("rest/resource", () => {
       );
       expect(result.ok).toBe(true);
     });
+
+    // The row commits but the read-back finds nothing, so create used to report
+    // `ok: true` with a null row — every caller's first field read (a listing
+    // create's `result.row.name`) then died as "Cannot read properties of null",
+    // a 500 far from the cause on a listing that HAD been created.
+    test("throws naming the table when the committed row can't be read back", async () => {
+      const table = createTestTable();
+      const resource = defineResource({
+        // A join write puts the create on the transactional read-back path,
+        // which is where every real create (listings, groups, …) runs.
+        afterWrite: () => Promise.resolve(),
+        form: testForm,
+        table: { ...table, findByIdPrimary: () => Promise.resolve(null) },
+        toInput,
+      });
+
+      await expect(
+        resource.create(new FormParams({ name: "Ghost", value: "1" })),
+      ).rejects.toThrow("test_items");
+    });
   });
 
   describe("update", () => {

--- a/test/shared/rest/write-entity.test.ts
+++ b/test/shared/rest/write-entity.test.ts
@@ -29,6 +29,7 @@ const writeWith = (
     joinWrites: [],
     plainWrite: () => table.insert({ name: "row" }),
     readBack: (id) => table.findByIdPrimary!(id),
+    tableName: "we_items",
     ...overrides,
   });
 
@@ -151,6 +152,36 @@ describe("writeEntity", () => {
 
     expect(row).toBeNull();
     expect(afterCommitRan).toBe(false);
+  });
+
+  test("throws when a create can't read its own inserted row back", async () => {
+    const table = makeTable();
+
+    await expect(
+      writeWith(table, {
+        existingId: null,
+        joinWrites: [() => Promise.resolve()],
+        plainWrite: reject("plainWrite"),
+        readBack: () => Promise.resolve(null),
+      }),
+    ).rejects.toThrow(
+      "we_items: row 1 was inserted but could not be read back",
+    );
+  });
+
+  test("returns null when an update's row is gone by the time it reads back", async () => {
+    const table = makeTable();
+    await table.insert({ name: "row" });
+
+    const row = await writeWith(table, {
+      buildStatement: () => table.updateStatement!(1, { name: "renamed" }),
+      existingId: 1,
+      joinWrites: [() => Promise.resolve()],
+      plainWrite: reject("plainWrite"),
+      readBack: () => Promise.resolve(null),
+    });
+
+    expect(row).toBeNull();
   });
 
   test("runs without an afterCommit hook", async () => {


### PR DESCRIPTION
## What was going wrong

Duplicating a listing sometimes showed an error page, even though the copy had
actually been made. The log said only "CDN request failed", which pointed
nowhere near the real problem.

Two things had to be fixed to get from that message to the cause.

## The row id an insert reports

When a listing is created, its row is written first, then the rows that must go
with it — its groups and its per-day prices — are written against the id the
database reports for the new row.

That id is optional in the database's reply. If it was missing, the code turned
it into "not a number" and carried on: the extra rows were written against that,
the save was committed anyway, and nothing noticed until the site tried to read
the new listing back and found nothing.

A save that doesn't get a usable row id now stops before anything is written
against it, so the whole save is undone rather than leaving a listing whose
groups and prices point nowhere. This fits a fault that repeated for one site
rather than happening at random, because it depends on which database that site
talks to, not on timing.

## Reading the new row back

Right after saving, the site reads the new row back. When that found nothing, it
was reported as a success carrying no row at all. The next line asked that
missing row for its name, and the page died with a message about names — which is
why the error looked unrelated to saving.

Reading back a row that was just created now fails with the table and the row id
in the message. Reading back an *edited* row can still legitimately find nothing,
because someone may have deleted it in the meantime, so that keeps working as
before.

## Tests

Each fix has a test that fails without it:

- Duplicating a listing whose copy can't be read back now names the table
  instead of failing with "Cannot read properties of null (reading 'name')" —
  the exact error from the report.
- Creating anything whose row can't be read back fails rather than reporting a
  success with nothing in it.
- A save whose insert reports no row id, or an id of 0, stops before the related
  rows are written.

Both fixes sit in the shared save path, so this covers creating any record, not
just duplicating a listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pSYxJBsnqcWPKK4KjmZrX


---
_Generated by [Claude Code](https://claude.ai/code/session_011pSYxJBsnqcWPKK4KjmZrX)_