### PR TITLE
Test what the news pages promise, and refuse a post date that isn't real

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -111,17 +111,18 @@ src/fp.ts:452:17  ++ → --   # either direction changes generation and invalida
 src/fp.ts:455:49  ?? → ||   # items?.length is undefined or a non-negative integer; 0 and undefined both produce 0
 
 # Table inputs make these operators equivalent: nullable query results exclude
-# undefined, paired null checks already reject both nullish values, optional
-# conditions/dependencies are objects or arrays, and non-generated primary keys
-# are overwritten from the input-column fold in either initial-row branch.
-src/shared/db/table.ts:521:24  ?: → consequent only   # generated keys use the consequent; non-generated keys are overwritten by their input-column value
-src/shared/db/table.ts:561:28  ?? → ||   # condition?.args is an array or undefined, and every array is truthy
-src/shared/db/table.ts:733:32  ?? → ||   # dependsOn is a readonly array or undefined, and every array is truthy
+# undefined, paired null checks already reject both nullish values, and optional
+# conditions/dependencies are objects or arrays.
+src/shared/db/table.ts:441:28  ?? → ||   # condition?.args is an array or undefined, and every array is truthy
+src/shared/db/table.ts:488:71  ?? → ||   # a found row is a truthy object, and a miss is undefined, so both operators give the row or null
+src/shared/db/table.ts:492:31  ?? → ||   # findByIds's element is a truthy row, null, or undefined, and all three agree
+src/shared/db/table.ts:580:21  ?? → ||   # dependsOn is a readonly array or undefined, and every array is truthy
+src/shared/db/table.ts:613:32  ?? → ||   # the cached table's dependsOn is the same array-or-undefined as above
 
 # Login attempt rows store an integer count. For undefined, null, zero, or any
 # non-zero integer, `(attempts ?? 0) + 1` and `(attempts || 0) + 1` agree.
 src/shared/db/login-attempts.ts:46:39  ?? → ||
-src/shared/db/users.ts:263:62  ?? → ||   # queryAll()[0] is a truthy UserAuthFields object or undefined, so both operators return the row or null
+src/shared/db/users.ts:264:62  ?? → ||   # queryAll()[0] is a truthy UserAuthFields object or undefined, so both operators return the row or null
 src/shared/db/query-log.ts:71:62  ?? → ||   # queryLogScope.current() is a truthy QueryLogState object or undefined
 src/shared/db/query-log.ts:252:43  ?? → ||   # stored read counts start at 1 and remain positive, so only undefined reaches the zero fallback
 src/shared/db/query-log.ts:292:22  ?? → ||   # store is a truthy QueryLogState object or undefined
@@ -990,3 +991,8 @@ src/shared/crypto/encryption.ts:120:5  false → true   # importKey is module-pr
 src/features/admin/attendee-page.ts:122:43  ?? → ||   # URLSearchParams.get returns string | null, and the fallback is the empty string: null and "" both yield "" under either operator, so no query can tell them apart
 src/features/admin/attendees-list.ts:56:52  ?? → ||   # parsePositiveInt validates against PositiveIntSchema (minValue 1), so it returns a number of 1 or more, or null — it can never return 0, the only falsy number that would tell ?? and || apart
 src/features/admin/listing-page-data.ts:282:61  ?? → ||   # Map.get returns ListingWithCount[] | undefined, and every array — empty included — is truthy, so only undefined reaches the fallback and both operators yield the same []
+
+# News post reads and writes: the card query names a single table, and no caller
+# can hand createNewsPost a blank created date.
+src/shared/db/news-posts.ts:147:47  news_post → ""   # dropping the alias leaves the column names unqualified, and the read selects from one table (news_posts AS news_post) plus scalar subqueries that carry their own qualified id, so every name still resolves to the same column
+src/shared/db/news-posts.ts:195:32  ?? → ||   # the two differ only for a blank created, which no caller produces: the admin write builds its input through newsContentInput, which has no created field at all, and a restore passes the timestamp it stored

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -992,7 +992,6 @@ src/features/admin/attendee-page.ts:122:43  ?? → ||   # URLSearchParams.get re
 src/features/admin/attendees-list.ts:56:52  ?? → ||   # parsePositiveInt validates against PositiveIntSchema (minValue 1), so it returns a number of 1 or more, or null — it can never return 0, the only falsy number that would tell ?? and || apart
 src/features/admin/listing-page-data.ts:282:61  ?? → ||   # Map.get returns ListingWithCount[] | undefined, and every array — empty included — is truthy, so only undefined reaches the fallback and both operators yield the same []
 
-# News post reads and writes: the card query names a single table, and no caller
-# can hand createNewsPost a blank created date.
-src/shared/db/news-posts.ts:147:47  news_post → ""   # dropping the alias leaves the column names unqualified, and the read selects from one table (news_posts AS news_post) plus scalar subqueries that carry their own qualified id, so every name still resolves to the same column
-src/shared/db/news-posts.ts:195:32  ?? → ||   # the two differ only for a blank created, which no caller produces: the admin write builds its input through newsContentInput, which has no created field at all, and a restore passes the timestamp it stored
+# The news card query names a single table, so its columns need no alias to
+# resolve.
+src/shared/db/news-posts.ts:148:47  news_post → ""   # dropping the alias leaves the column names unqualified, and the read selects from one table (news_posts AS news_post) plus scalar subqueries that carry their own qualified id, so every name still resolves to the same column

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -55,6 +55,7 @@ import type {
   NewsPostCard,
   NewsPostSummary,
 } from "#shared/types.ts";
+import { isInstant } from "#shared/validation/timestamp.ts";
 
 /** Create/update input (camelCase keys → snake_case columns). `created`, `slug`,
  * and `slugIndex` are computed in {@link createNewsPost}, never posted by the
@@ -193,6 +194,11 @@ export const createNewsPost = async (
   transaction?: TxScope,
 ): Promise<NewsPost> => {
   const created = input.created ?? nowIso();
+  // The permalink is built from this date and can never be rebuilt, so a caller
+  // that pins a date it made up gets an error rather than a broken /news link.
+  if (!isInstant(created)) {
+    throw new Error(`News post created is not a real timestamp: "${created}"`);
+  }
   return useTransaction(transaction, async (tx) => {
     const { slug, slugIndex } = await uniqueSlugFromBase({
       base: newsSlugBase(created, input.name),

--- a/test/shared/db/news-posts.test.ts
+++ b/test/shared/db/news-posts.test.ts
@@ -9,6 +9,7 @@ import {
   getNewsPostBySlugIndex,
   getNewsPostCards,
   getNewsPostNames,
+  getNewsPostSummaries,
   hasNewsPosts,
   updateNewsPost,
 } from "#shared/db/news-posts.ts";
@@ -234,6 +235,30 @@ describeWithEnv("db > news-posts", { db: true }, () => {
       const reloaded = await getNewsPostById(post.id);
       expect(reloaded?.name).toBe("Renamed");
       expect(reloaded?.slug).toBe("2026-07-06-original-name");
+    });
+  });
+
+  describe("getNewsPostSummaries", () => {
+    // The RSS feed and the admin list both read this projection in the order it
+    // returns, so the newest-first ordering is part of its contract.
+    test("lists newest first, most recently created of a shared day first", async () => {
+      await createTestNewsPost("Oldest", {
+        created: "2026-07-01T10:00:00.000Z",
+      });
+      await createTestNewsPost("Same day, written first", {
+        created: "2026-07-03T10:00:00.000Z",
+      });
+      await createTestNewsPost("Same day, written second", {
+        created: "2026-07-03T10:00:00.000Z",
+      });
+
+      const summaries = await getNewsPostSummaries();
+
+      expect(summaries.map((summary) => summary.name)).toEqual([
+        "Same day, written second",
+        "Same day, written first",
+        "Oldest",
+      ]);
     });
   });
 

--- a/test/shared/db/news-posts.test.ts
+++ b/test/shared/db/news-posts.test.ts
@@ -238,6 +238,19 @@ describeWithEnv("db > news-posts", { db: true }, () => {
     });
   });
 
+  describe("createNewsPost", () => {
+    // The /news permalink is built from this date and is never rebuilt, so a
+    // date that isn't a real moment has to fail before the post is written.
+    test("rejects a pinned created date that is not a real timestamp", async () => {
+      for (const created of ["", "not a date", "2026-02-30T10:00:00.000Z"]) {
+        await expect(
+          createTestNewsPost("Bad date", { created }),
+        ).rejects.toThrow("News post created is not a real timestamp");
+      }
+      expect(await hasNewsPosts()).toBe(false);
+    });
+  });
+
   describe("getNewsPostSummaries", () => {
     // The news feed and the admin news page both show these summaries in the
     // order they come back, so newest-first is part of what this returns.

--- a/test/shared/db/news-posts.test.ts
+++ b/test/shared/db/news-posts.test.ts
@@ -239,8 +239,8 @@ describeWithEnv("db > news-posts", { db: true }, () => {
   });
 
   describe("getNewsPostSummaries", () => {
-    // The RSS feed and the admin list both read this projection in the order it
-    // returns, so the newest-first ordering is part of its contract.
+    // The news feed and the admin news page both show these summaries in the
+    // order they come back, so newest-first is part of what this returns.
     test("lists newest first, most recently created of a shared day first", async () => {
       await createTestNewsPost("Oldest", {
         created: "2026-07-01T10:00:00.000Z",


### PR DESCRIPTION
## Why

Our mutation check makes small changes to the code on purpose, then checks that
a test notices. Anything it changes without a test noticing is a gap. Running it
over the listing-duplicate fix turned up nine, so this closes them.

Most were bookkeeping, but two were real.

## A news list that was never checked for order

The news feed and the admin news page both show posts newest first. The whole
sorting instruction could be deleted and every test still passed, so nothing
would have told us if the order broke.

There is now a test for it, covering both the date order and what happens when
two posts share a date — the one written last comes first.

## A news post could be given a date that isn't real

A post's web address is built from its date, and it is never rebuilt. The date
only had to be text, so a blank date, or a date like the 30th of February, was
stored as given and the post ended up with a nonsense address.

A post is now refused if its date is not a real moment. Adding a post through
the admin pages was never affected — that never sets a date by hand — so this
only concerns other code creating posts directly.

## The list of known-harmless changes

Some of what the checker changes genuinely cannot make any difference, and those
are recorded so it stops reporting them. That list had drifted out of date: it
pointed at line numbers where the code had since moved, so real entries looked
missing and moved ones looked new. It now matches the code, with the places that
were never recorded added.

One entry was deleted rather than moved. The change it excused is now caught by
the tests, thanks to the row id check added in #2002, so excusing it would have
hidden a real gap from then on.

One entry was also removed because it should never have been there. It claimed
no caller could give a post a blank date, which was true of the admin pages but
not of the code itself — which is the fault fixed above. Credit to the Codex
review for catching that.

Every source file this touches now passes the mutation check completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pSYxJBsnqcWPKK4KjmZrX

---
_Generated by [Claude Code](https://claude.ai/code/session_011pSYxJBsnqcWPKK4KjmZrX)_