### PR TITLE
Take a real migration lock as soon as the settings table exists

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,41 +100,6 @@ actual size before marking an item complete.
 
 ---
 
-## Migration lock: re-acquire after a tolerated missing settings table
-
-*Origin: CodeRabbit review on PR #1965 (`src/shared/db/migrations/lock.ts`).*
-
-`acquireMigrationLock(true)` returns a lease token when the `settings` table
-does not exist yet, because the lock row lives in the very table the caller is
-about to create. Setup, restore, and bootstrap rely on this: their route is
-`initializeFreshSchema` → `sealFreshSchema`, which writes with a plain
-`executeBatch` and never checks lock ownership, so the unpersisted token is
-harmless there.
-
-There is one narrow interleaving where it is not harmless. Request A probes a
-missing `settings` table and takes the tolerated token; request B then creates
-and stamps the schema; A's re-probe inside `runAcquiredMigrations` now sees
-real markers, and if they read as stale it takes the pending-migrations branch
-and reaches `recordMigrationBatch` with a token no row ever backed. The
-ownership check finds zero rows and throws `MigrationInProgressError`.
-
-The outcome today is fail-closed and retryable — no markers are written and no
-data is corrupted, and another isolate genuinely was migrating — so this is a
-tidiness issue, not a correctness bug. Still, A is running migrations without
-holding a real lock until that final check catches it.
-
-The fix: after the re-probe in `runAcquiredMigrations`, when the initial
-acquisition was the tolerated one and the database now has a `settings` table,
-re-acquire the lease (and bail out the normal way if another request holds it)
-before entering the pending-migrations branch. A regression test needs to
-control the interleaving: acquire with `allowMissingSettings` against a wiped
-database, create and stamp the schema from another path, then assert the
-lock-gated write either succeeds against a real lease or refuses before any
-migration runs.
-
-Out of scope for #1965, which moved this code verbatim out of `migrations.ts`
-without changing behaviour.
-
 ## Booking unification — phases 3 & 4
 
 *Origin: `booking-unification.md`, `booking-unification-phase2.md`.*

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -980,7 +980,7 @@ scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it a
 
 # Isolated mutation runs: the exit code before any path has set one.
 scripts/mutation/isolation.ts:188:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
-src/shared/db/migrations.ts:255:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
+src/shared/db/migrations.ts:252:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the
 # statuses strictness is about.

--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -980,7 +980,7 @@ scripts/process.ts:62:12  = → +=   # the handle starts at 0, so adding to it a
 
 # Isolated mutation runs: the exit code before any path has set one.
 scripts/mutation/isolation.ts:188:18  1 → 0   # every path overwrites this before it is returned: the lock always runs its callback, which either sets 130 on an interrupt or hands back a child whose status sets the code, and any throw is caught and sets it there
-src/shared/db/migrations.ts:254:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
+src/shared/db/migrations.ts:255:49  ?? → ||   # opts.allowMissingSettings is boolean | undefined, and false ?? false and false || false both yield false
 
 # Cucumber runs: telling Cucumber to be strict, when we already reject the
 # statuses strictness is about.

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -37,6 +37,7 @@ import {
   MigrationInProgressError,
   MissingSettingsTableError,
 } from "./migrations/errors.ts";
+import type { MigrationLease } from "./migrations/lock.ts";
 import {
   acquireMigrationLock,
   MIGRATION_LOCK_TTL_MS,
@@ -291,11 +292,39 @@ const finishIfUpToDate = async (probe: DbProbe): Promise<boolean> => {
 
 type LockedMigrationResult = "continue" | "release" | "released";
 
+/** Tell a request another one is migrating, and let the operator know. */
+const migrationLockHeldError = (): MigrationInProgressError => {
+  void sendNtfyError(`E_DB_MIGRATION_LOCK ${getEnv("DB_URL") ?? "unknown"}`);
+  return new MigrationInProgressError(
+    "Database migration is already in progress (migration_lock held). " +
+      `The request can be retried; a crashed migration's lock is reclaimed automatically after ${
+        MIGRATION_LOCK_TTL_MS / 60000
+      } minutes, or manually DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'.`,
+  );
+};
+
+/**
+ * The token this request may actually write with.
+ *
+ * A lease taken while the `settings` table was missing has no row behind it. If
+ * another request created that table in the meantime, the token owns nothing, so
+ * take a real lease before any lock-gated write — and step aside if that other
+ * request is still holding one.
+ */
+const storedToken = async (
+  lease: MigrationLease,
+  recheck: DbProbe,
+): Promise<string> => {
+  if (lease.stored || recheck.state === "missing_settings") return lease.token;
+  const retaken = await acquireMigrationLock(false);
+  if (retaken === null) throw migrationLockHeldError();
+  return retaken.token;
+};
+
 const runAcquiredMigrations = async (
+  recheck: DbProbe,
   lockToken: string,
 ): Promise<LockedMigrationResult> => {
-  // Re-check after acquiring lock because another process may have finished.
-  const recheck = await probeDbState();
   if (await finishIfUpToDate(recheck)) return "release";
 
   if (
@@ -335,20 +364,17 @@ const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
   if (await finishIfUpToDate(probe)) return;
   requireAllowedInitialDbState(probe.state, allowMissingSettings);
 
-  const lockToken = await acquireMigrationLock(allowMissingSettings);
-  if (lockToken === null) {
-    void sendNtfyError(`E_DB_MIGRATION_LOCK ${getEnv("DB_URL") ?? "unknown"}`);
-    throw new MigrationInProgressError(
-      "Database migration is already in progress (migration_lock held). " +
-        `The request can be retried; a crashed migration's lock is reclaimed automatically after ${
-          MIGRATION_LOCK_TTL_MS / 60000
-        } minutes, or manually DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'.`,
-    );
-  }
+  const lease = await acquireMigrationLock(allowMissingSettings);
+  if (lease === null) throw migrationLockHeldError();
 
+  let lockToken = lease.token;
   let result: LockedMigrationResult;
   try {
-    result = await runAcquiredMigrations(lockToken);
+    // Re-check after acquiring the lock because another process may have
+    // finished, which is also what decides whether the lease is real yet.
+    const recheck = await probeDbState();
+    lockToken = await storedToken(lease, recheck);
+    result = await runAcquiredMigrations(recheck, lockToken);
   } catch (error) {
     return await releaseAfterMigrationFailure(lockToken, error);
   }

--- a/src/shared/db/migrations.ts
+++ b/src/shared/db/migrations.ts
@@ -21,10 +21,8 @@ import { lazyRef } from "#fp";
 import { resetAllCaches } from "#shared/cache-registry.ts";
 import { executeBatch, getDb, inPlaceholders } from "#shared/db/client.ts";
 import { isDatabaseRoundTripLimited } from "#shared/db/query-log.ts";
-import { getEnv } from "#shared/env.ts";
 import { logDebug } from "#shared/logger.ts";
 import { nowIso } from "#shared/now.ts";
-import { sendNtfyError } from "#shared/ntfy.ts";
 import { addPendingWork, hasPendingWorkScope } from "#shared/pending-work.ts";
 import { recordScriptVersion } from "#shared/update.ts";
 import {
@@ -37,12 +35,12 @@ import {
   MigrationInProgressError,
   MissingSettingsTableError,
 } from "./migrations/errors.ts";
-import type { MigrationLease } from "./migrations/lock.ts";
 import {
   acquireMigrationLock,
-  MIGRATION_LOCK_TTL_MS,
+  migrationLockHeldError,
   releaseAfterMigrationFailure,
   releaseMigrationLock,
+  storedLease,
 } from "./migrations/lock.ts";
 import {
   migrationMarkerStatement,
@@ -62,7 +60,6 @@ import {
   DB_SCHEMA_HASH_KEY,
   LATEST_DB_UPDATE_KEY,
   LATEST_UPDATE,
-  MIGRATION_LOCK_KEY,
   SCHEMA_MIGRATIONS_TABLE,
 } from "./migrations/schema/version.ts";
 import {
@@ -292,35 +289,6 @@ const finishIfUpToDate = async (probe: DbProbe): Promise<boolean> => {
 
 type LockedMigrationResult = "continue" | "release" | "released";
 
-/** Tell a request another one is migrating, and let the operator know. */
-const migrationLockHeldError = (): MigrationInProgressError => {
-  void sendNtfyError(`E_DB_MIGRATION_LOCK ${getEnv("DB_URL") ?? "unknown"}`);
-  return new MigrationInProgressError(
-    "Database migration is already in progress (migration_lock held). " +
-      `The request can be retried; a crashed migration's lock is reclaimed automatically after ${
-        MIGRATION_LOCK_TTL_MS / 60000
-      } minutes, or manually DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'.`,
-  );
-};
-
-/**
- * The token this request may actually write with.
- *
- * A lease taken while the `settings` table was missing has no row behind it. If
- * another request created that table in the meantime, the token owns nothing, so
- * take a real lease before any lock-gated write — and step aside if that other
- * request is still holding one.
- */
-const storedToken = async (
-  lease: MigrationLease,
-  recheck: DbProbe,
-): Promise<string> => {
-  if (lease.stored || recheck.state === "missing_settings") return lease.token;
-  const retaken = await acquireMigrationLock(false);
-  if (retaken === null) throw migrationLockHeldError();
-  return retaken.token;
-};
-
 const runAcquiredMigrations = async (
   recheck: DbProbe,
   lockToken: string,
@@ -367,18 +335,24 @@ const initDbUncached = async (allowMissingSettings: boolean): Promise<void> => {
   const lease = await acquireMigrationLock(allowMissingSettings);
   if (lease === null) throw migrationLockHeldError();
 
-  let lockToken = lease.token;
+  // Only a stored lease is ever given back: a database with no settings table
+  // has no row to delete, and trying would swap this request's retry message
+  // for whatever the pointless write failed with.
+  let held = lease;
   let result: LockedMigrationResult;
   try {
     // Re-check after acquiring the lock because another process may have
     // finished, which is also what decides whether the lease is real yet.
     const recheck = await probeDbState();
-    lockToken = await storedToken(lease, recheck);
-    result = await runAcquiredMigrations(recheck, lockToken);
+    held = await storedLease(lease, recheck.state === "missing_settings");
+    result = await runAcquiredMigrations(recheck, held.token);
   } catch (error) {
-    return await releaseAfterMigrationFailure(lockToken, error);
+    if (!held.stored) throw error;
+    return await releaseAfterMigrationFailure(held.token, error);
   }
-  if (result === "release") await releaseMigrationLock(lockToken);
+  if (result === "release" && held.stored) {
+    await releaseMigrationLock(held.token);
+  }
   if (result === "continue") {
     throw new MigrationInProgressError(
       "Database update is continuing on the next request.",

--- a/src/shared/db/migrations/lock.ts
+++ b/src/shared/db/migrations/lock.ts
@@ -6,7 +6,9 @@
 
 import type { SqlStatement } from "#shared/db/client.ts";
 import { executeBatchWithResults, getDb } from "#shared/db/client.ts";
+import { getEnv } from "#shared/env.ts";
 import { errorMessage } from "#shared/error-message.ts";
+import { sendNtfyError } from "#shared/ntfy.ts";
 
 import {
   combinedFailures,
@@ -21,7 +23,7 @@ import { MIGRATION_LOCK_KEY } from "./schema/version.ts";
  * orphaning the lock; the TTL lets the next boot self-heal instead of
  * requiring a manual DELETE FROM settings.
  */
-export const MIGRATION_LOCK_TTL_MS = 2 * 60 * 1000;
+const MIGRATION_LOCK_TTL_MS = 2 * 60 * 1000;
 
 /**
  * A migration lock this request holds. `stored` is false only for the tolerated
@@ -61,6 +63,35 @@ export const acquireMigrationLock = async (
     });
   if (result === null) return { stored: false, token: lockToken };
   return result.rowsAffected === 1 ? { stored: true, token: lockToken } : null;
+};
+
+/** Tell a request another one is migrating, and let the operator know. */
+export const migrationLockHeldError = (): MigrationInProgressError => {
+  void sendNtfyError(`E_DB_MIGRATION_LOCK ${getEnv("DB_URL") ?? "unknown"}`);
+  return new MigrationInProgressError(
+    "Database migration is already in progress (migration_lock held). " +
+      `The request can be retried; a crashed migration's lock is reclaimed automatically after ${
+        MIGRATION_LOCK_TTL_MS / 60000
+      } minutes, or manually DELETE FROM settings WHERE key = '${MIGRATION_LOCK_KEY}'.`,
+  );
+};
+
+/**
+ * The lease this request may actually write with.
+ *
+ * A lease taken while the `settings` table was missing has no row behind it. If
+ * another request created that table in the meantime, the token owns nothing, so
+ * take a real lease before any lock-gated write — and step aside if that other
+ * request is still holding one.
+ */
+export const storedLease = async (
+  lease: MigrationLease,
+  settingsStillMissing: boolean,
+): Promise<MigrationLease> => {
+  if (lease.stored || settingsStillMissing) return lease;
+  const retaken = await acquireMigrationLock(false);
+  if (retaken === null) throw migrationLockHeldError();
+  return retaken;
 };
 
 /** The statement that gives up this request's lease. */

--- a/src/shared/db/migrations/lock.ts
+++ b/src/shared/db/migrations/lock.ts
@@ -24,8 +24,15 @@ import { MIGRATION_LOCK_KEY } from "./schema/version.ts";
 export const MIGRATION_LOCK_TTL_MS = 2 * 60 * 1000;
 
 /**
+ * A migration lock this request holds. `stored` is false only for the tolerated
+ * acquisition against a database with no `settings` table: there was no row to
+ * write, so nothing backs the token until that table exists.
+ */
+export type MigrationLease = { stored: boolean; token: string };
+
+/**
  * Acquire an advisory migration lock via the settings table.
- * Returns this request's timestamp-prefixed lease token when acquired, or null
+ * Returns this request's timestamp-prefixed lease when acquired, or null
  * when another process holds a fresh lock. The ISO-8601 prefix sorts
  * lexicographically, so one atomic UPSERT both takes a free lock and steals an
  * expired one: DO UPDATE only fires when the held lock predates the cutoff, and
@@ -34,7 +41,7 @@ export const MIGRATION_LOCK_TTL_MS = 2 * 60 * 1000;
  */
 export const acquireMigrationLock = async (
   allowMissingSettings: boolean,
-): Promise<string | null> => {
+): Promise<MigrationLease | null> => {
   const now = new Date();
   const cutoff = new Date(now.getTime() - MIGRATION_LOCK_TTL_MS).toISOString();
   const stamp = now.toISOString();
@@ -52,7 +59,8 @@ export const acquireMigrationLock = async (
       }
       throw error;
     });
-  return result === null || result.rowsAffected === 1 ? lockToken : null;
+  if (result === null) return { stored: false, token: lockToken };
+  return result.rowsAffected === 1 ? { stored: true, token: lockToken } : null;
 };
 
 /** The statement that gives up this request's lease. */

--- a/test/integration/db/migration-runtime.test.ts
+++ b/test/integration/db/migration-runtime.test.ts
@@ -5,7 +5,6 @@ import { stub } from "@std/testing/mock";
 import { executeBatch, getDb, inPlaceholders } from "#shared/db/client.ts";
 import { loadMigrations } from "#shared/db/migrations/context.ts";
 import { MigrationInProgressError } from "#shared/db/migrations/errors.ts";
-import { MIGRATION_LOCK_TTL_MS } from "#shared/db/migrations/lock.ts";
 import { baselineCurrentSchemaIfNeeded } from "#shared/db/migrations/runner.ts";
 import {
   DB_SCHEMA_HASH_KEY,
@@ -37,6 +36,10 @@ import {
   TEST_ADMIN_PASSWORD,
   TEST_ADMIN_USERNAME,
 } from "#test-utils/internal.ts";
+import {
+  freshLockStamp,
+  LONG_EXPIRED_LOCK_STAMP,
+} from "#test-utils/migrations.ts";
 import { expectNtfyNotification, stubNtfyFetch } from "#test-utils/mocks.ts";
 import { invalidateTestDbCache } from "#test-utils/test-state.ts";
 
@@ -206,9 +209,7 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
           STORAGE_ZONE_KEY: undefined,
           STORAGE_ZONE_NAME: undefined,
         });
-        await setStaleSchemaAndLock(
-          new Date(Date.now() - MIGRATION_LOCK_TTL_MS - 1000),
-        );
+        await setStaleSchemaAndLock(new Date(LONG_EXPIRED_LOCK_STAMP));
         await markCurrentSchemaMigrationPending();
 
         await initDb();
@@ -226,9 +227,7 @@ describeWithEnv("db > migration runtime", { db: true }, () => {
 
     test("keeps blocking while a lock is still within its TTL", async () => {
       try {
-        await setStaleSchemaAndLock(
-          new Date(Date.now() - MIGRATION_LOCK_TTL_MS / 2),
-        );
+        await setStaleSchemaAndLock(new Date(freshLockStamp()));
         invalidateInitDbCache();
 
         await expect(initDb()).rejects.toThrow("migration_lock held");

--- a/test/shared/db/migrations/boot.test.ts
+++ b/test/shared/db/migrations/boot.test.ts
@@ -224,13 +224,6 @@ describeWithEnv(
       );
     });
 
-    /**
-     * Report a missing settings table for this many boot probes and lock
-     * writes, the way a request that arrives while another one is still
-     * creating that table sees the database. Everything past those counts runs
-     * against the real database, so the request's second look finds a table it
-     * holds no lock on.
-     */
     /** Which boot step a statement belongs to, by the SQL it starts with. */
     const bootStep = (statement: InStatement): "lock" | "probe" | "other" => {
       const sql = typeof statement === "string" ? statement : statement.sql;
@@ -238,6 +231,9 @@ describeWithEnv(
       return sql.startsWith("INSERT INTO settings") ? "lock" : "other";
     };
 
+    /** Report a missing settings table for this many probes and lock writes,
+     *  then let the rest through — so boot takes the tolerated lease and its
+     *  second look finds a table another request has since created. */
     const hideSettings = (probes: number, locks: number) => {
       const leftToHide = { lock: locks, probe: probes };
       const client = getDb();

--- a/test/shared/db/migrations/boot.test.ts
+++ b/test/shared/db/migrations/boot.test.ts
@@ -225,31 +225,36 @@ describeWithEnv(
     });
 
     /**
-     * Hide the settings table from the first boot probe and the first lock
-     * write, the way a request that arrives while another one is still creating
-     * that table sees the database. Everything after runs against the real
-     * database, so the request's second look finds a table it has no lock on.
+     * Report a missing settings table for this many boot probes and lock
+     * writes, the way a request that arrives while another one is still
+     * creating that table sees the database. Everything past those counts runs
+     * against the real database, so the request's second look finds a table it
+     * holds no lock on.
      */
-    const hideSettingsOnce = () => {
+    /** Which boot step a statement belongs to, by the SQL it starts with. */
+    const bootStep = (statement: InStatement): "lock" | "probe" | "other" => {
+      const sql = typeof statement === "string" ? statement : statement.sql;
+      if (sql.startsWith("SELECT key, value FROM settings")) return "probe";
+      return sql.startsWith("INSERT INTO settings") ? "lock" : "other";
+    };
+
+    const hideSettings = (probes: number, locks: number) => {
+      const leftToHide = { lock: locks, probe: probes };
       const client = getDb();
       const execute = client.execute.bind(client);
-      const stillToHide = new Set(["lock", "probe"]);
       return stub(client, "execute", (statement: InStatement) => {
-        const sql = typeof statement === "string" ? statement : statement.sql;
-        const step = sql.startsWith("SELECT key, value FROM settings")
-          ? "probe"
-          : sql.startsWith("INSERT INTO settings")
-            ? "lock"
-            : "other";
-        return stillToHide.delete(step)
-          ? Promise.reject(new Error("no such table: settings"))
-          : execute(statement);
+        const step = bootStep(statement);
+        if (step !== "other" && leftToHide[step] > 0) {
+          leftToHide[step] -= 1;
+          return Promise.reject(new Error("no such table: settings"));
+        }
+        return execute(statement);
       });
     };
 
     test("a lock taken before the settings table existed is taken again for real", async () => {
       await markMigrationsForRerun();
-      using _execute = hideSettingsOnce();
+      using _execute = hideSettings(1, 1);
 
       // Without a real lease, recording the migrations would be refused as
       // somebody else's migration and the database would stay out of date.
@@ -257,6 +262,23 @@ describeWithEnv(
 
       expect(await settingsValueOrNull("db_schema_hash")).toBe(SCHEMA_HASH);
       expect(await appliedMigrationIds()).toEqual([...MIGRATION_IDS].sort());
+    });
+
+    test("taking that lock again is not allowed to shrug off a missing table", async () => {
+      await markMigrationsForRerun();
+      try {
+        using _execute = hideSettings(1, 2);
+
+        // The table was there a moment ago, so it cannot be missing now. Only
+        // setup and restore may carry on without a lock, and this is neither.
+        await expect(initDb({ allowMissingSettings: true })).rejects.toThrow(
+          "no such table: settings",
+        );
+      } finally {
+        // Leave the database fully migrated for the tests that follow.
+        invalidateInitDbCache();
+        await initDb();
+      }
     });
 
     test("one missing marker is a database to update, not a blank one", async () => {

--- a/test/shared/db/migrations/boot.test.ts
+++ b/test/shared/db/migrations/boot.test.ts
@@ -264,6 +264,36 @@ describeWithEnv(
       expect(await appliedMigrationIds()).toEqual([...MIGRATION_IDS].sort());
     });
 
+    test("losing the race for that second lock refuses before migrating", async () => {
+      await markMigrationsForRerun();
+      // The request that created the table is still holding the lock.
+      const otherLease = new Date(Date.now() - 30_000).toISOString();
+      await getDb().execute({
+        args: ["migration_lock", otherLease],
+        sql: "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+      });
+      const { fetchStub, restore } = stubNtfyFetch({});
+      try {
+        using _env = restore;
+        using _fetch = fetchStub;
+        using _execute = hideSettings(1, 1);
+
+        await expect(initDb({ allowMissingSettings: true })).rejects.toThrow(
+          "Database migration is already in progress",
+        );
+
+        // The other request keeps its lease, and nothing was migrated past it.
+        expect(await settingsValueOrNull("migration_lock")).toBe(otherLease);
+        expect(await settingsValueOrNull("db_schema_hash")).toBe("stale");
+      } finally {
+        await getDb().execute(
+          "DELETE FROM settings WHERE key = 'migration_lock'",
+        );
+        invalidateInitDbCache();
+        await initDb();
+      }
+    });
+
     test("taking that lock again is not allowed to shrug off a missing table", async () => {
       await markMigrationsForRerun();
       try {

--- a/test/shared/db/migrations/boot.test.ts
+++ b/test/shared/db/migrations/boot.test.ts
@@ -1,5 +1,7 @@
+import type { InStatement } from "@libsql/client";
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import { getDb } from "#shared/db/client.ts";
 import { MIGRATION_IDS } from "#shared/db/migrations/registry.ts";
 import {
@@ -220,6 +222,41 @@ describeWithEnv(
       expect(bodies.some((body) => body.endsWith("E_DB_MIGRATION_LOCK "))).toBe(
         true,
       );
+    });
+
+    /**
+     * Hide the settings table from the first boot probe and the first lock
+     * write, the way a request that arrives while another one is still creating
+     * that table sees the database. Everything after runs against the real
+     * database, so the request's second look finds a table it has no lock on.
+     */
+    const hideSettingsOnce = () => {
+      const client = getDb();
+      const execute = client.execute.bind(client);
+      const stillToHide = new Set(["lock", "probe"]);
+      return stub(client, "execute", (statement: InStatement) => {
+        const sql = typeof statement === "string" ? statement : statement.sql;
+        const step = sql.startsWith("SELECT key, value FROM settings")
+          ? "probe"
+          : sql.startsWith("INSERT INTO settings")
+            ? "lock"
+            : "other";
+        return stillToHide.delete(step)
+          ? Promise.reject(new Error("no such table: settings"))
+          : execute(statement);
+      });
+    };
+
+    test("a lock taken before the settings table existed is taken again for real", async () => {
+      await markMigrationsForRerun();
+      using _execute = hideSettingsOnce();
+
+      // Without a real lease, recording the migrations would be refused as
+      // somebody else's migration and the database would stay out of date.
+      await initDb({ allowMissingSettings: true });
+
+      expect(await settingsValueOrNull("db_schema_hash")).toBe(SCHEMA_HASH);
+      expect(await appliedMigrationIds()).toEqual([...MIGRATION_IDS].sort());
     });
 
     test("one missing marker is a database to update, not a blank one", async () => {

--- a/test/shared/db/migrations/lock.test.ts
+++ b/test/shared/db/migrations/lock.test.ts
@@ -16,12 +16,12 @@ import {
 } from "#shared/db/migrations/lock.ts";
 import { MIGRATION_LOCK_KEY } from "#shared/db/migrations/schema/version.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { stubNtfyFetch } from "#test-utils/mocks.ts";
 import {
   freshLockStamp,
   LONG_EXPIRED_LOCK_STAMP,
   takeMigrationLock,
 } from "#test-utils/migrations.ts";
+import { stubNtfyFetch } from "#test-utils/mocks.ts";
 
 describeWithEnv("db > migrations > lock", { db: true }, () => {
   const heldLock = async (): Promise<string | null> => {

--- a/test/shared/db/migrations/lock.test.ts
+++ b/test/shared/db/migrations/lock.test.ts
@@ -32,6 +32,12 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
     });
   };
 
+  /** Hold the lock from half a minute ago: comfortably inside the time limit,
+   *  but not the same instant as the acquisition under test — two writes that
+   *  land in one millisecond would leave the limit untested. */
+  const holdFreshLock = (): Promise<void> =>
+    holdLockSince(new Date(Date.now() - 30_000).toISOString());
+
   const clearLock = async (): Promise<void> => {
     await getDb().execute({
       args: [MIGRATION_LOCK_KEY],
@@ -39,19 +45,27 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
     });
   };
 
-  test("acquiring stores this request's lease", async () => {
+  /** Take the lock and check the row now holding it is this lease's own. */
+  const expectLeaseStored = async (): Promise<void> => {
     try {
-      const lockToken = await acquireMigrationLock(false);
+      const lease = await acquireMigrationLock(false);
+      if (lease === null)
+        throw new Error("the lock was not free for this test");
 
-      expect(await heldLock()).toBe(lockToken);
+      expect(lease.stored).toBe(true);
+      expect(await heldLock()).toBe(lease.token);
     } finally {
       await clearLock();
     }
+  };
+
+  test("acquiring stores this request's lease", async () => {
+    await expectLeaseStored();
   });
 
   test("a test that cannot take the lock fails loudly", async () => {
     try {
-      await holdLockSince(new Date().toISOString());
+      await holdFreshLock();
 
       await expect(takeMigrationLock()).rejects.toThrow(
         "Could not take the migration lock for this test",
@@ -61,9 +75,9 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
     }
   });
 
-  test("a fresh lock held by someone else is not taken", async () => {
+  test("a lock still inside the time limit is not taken", async () => {
     try {
-      await holdLockSince(new Date().toISOString());
+      await holdFreshLock();
 
       expect(await acquireMigrationLock(false)).toBeNull();
     } finally {
@@ -72,19 +86,12 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
   });
 
   test("a lock older than the time limit is stolen", async () => {
-    try {
-      const expired = new Date(
-        Date.now() - MIGRATION_LOCK_TTL_MS - 1000,
-      ).toISOString();
-      await holdLockSince(expired);
+    const expired = new Date(
+      Date.now() - MIGRATION_LOCK_TTL_MS - 1000,
+    ).toISOString();
+    await holdLockSince(expired);
 
-      const lockToken = await acquireMigrationLock(false);
-
-      expect(lockToken).not.toBeNull();
-      expect(await heldLock()).toBe(lockToken);
-    } finally {
-      await clearLock();
-    }
+    await expectLeaseStored();
   });
 
   test("releasing leaves another request's lease alone", async () => {
@@ -163,7 +170,11 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
         ],
         lockToken,
       ),
-    ).rejects.toThrow(MigrationInProgressError);
+    ).rejects.toThrow(
+      new MigrationInProgressError(
+        "Database migration lock ownership was lost before completion.",
+      ),
+    );
 
     const result = await getDb().execute(
       "SELECT value FROM settings WHERE key = 'lock_test_marker'",
@@ -197,8 +208,12 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
   test("a missing settings table is only tolerated when it is expected", async () => {
     using _execute = failLockWriteWith("no such table: settings");
 
-    // Setup and restore create the table, so they carry on without a lock...
-    expect(await acquireMigrationLock(true)).not.toBeNull();
+    // Setup and restore create the table, so they carry on without a lock —
+    // and the lease says so, because no row was written to back it.
+    expect(await acquireMigrationLock(true)).toEqual({
+      stored: false,
+      token: expect.any(String),
+    });
     // ...but an ordinary request must not treat it as a free lock.
     await expect(acquireMigrationLock(false)).rejects.toThrow(
       "no such table: settings",

--- a/test/shared/db/migrations/lock.test.ts
+++ b/test/shared/db/migrations/lock.test.ts
@@ -7,14 +7,17 @@ import { MigrationInProgressError } from "#shared/db/migrations/errors.ts";
 import {
   acquireMigrationLock,
   executeWhileMigrationLockOwned,
-  MIGRATION_LOCK_TTL_MS,
   releaseAfterMigrationFailure,
   releaseMigrationLock,
   whileMigrationLockOwned,
 } from "#shared/db/migrations/lock.ts";
 import { MIGRATION_LOCK_KEY } from "#shared/db/migrations/schema/version.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { takeMigrationLock } from "#test-utils/migrations.ts";
+import {
+  freshLockStamp,
+  LONG_EXPIRED_LOCK_STAMP,
+  takeMigrationLock,
+} from "#test-utils/migrations.ts";
 
 describeWithEnv("db > migrations > lock", { db: true }, () => {
   const heldLock = async (): Promise<string | null> => {
@@ -32,11 +35,7 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
     });
   };
 
-  /** Hold the lock from half a minute ago: comfortably inside the time limit,
-   *  but not the same instant as the acquisition under test — two writes that
-   *  land in one millisecond would leave the limit untested. */
-  const holdFreshLock = (): Promise<void> =>
-    holdLockSince(new Date(Date.now() - 30_000).toISOString());
+  const holdFreshLock = (): Promise<void> => holdLockSince(freshLockStamp());
 
   const clearLock = async (): Promise<void> => {
     await getDb().execute({
@@ -86,10 +85,7 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
   });
 
   test("a lock older than the time limit is stolen", async () => {
-    const expired = new Date(
-      Date.now() - MIGRATION_LOCK_TTL_MS - 1000,
-    ).toISOString();
-    await holdLockSince(expired);
+    await holdLockSince(LONG_EXPIRED_LOCK_STAMP);
 
     await expectLeaseStored();
   });

--- a/test/shared/db/migrations/lock.test.ts
+++ b/test/shared/db/migrations/lock.test.ts
@@ -1,18 +1,22 @@
 import type { InStatement } from "@libsql/client";
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { getDb } from "#shared/db/client.ts";
 import { MigrationInProgressError } from "#shared/db/migrations/errors.ts";
+import type { MigrationLease } from "#shared/db/migrations/lock.ts";
 import {
   acquireMigrationLock,
   executeWhileMigrationLockOwned,
+  migrationLockHeldError,
   releaseAfterMigrationFailure,
   releaseMigrationLock,
+  storedLease,
   whileMigrationLockOwned,
 } from "#shared/db/migrations/lock.ts";
 import { MIGRATION_LOCK_KEY } from "#shared/db/migrations/schema/version.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { stubNtfyFetch } from "#test-utils/mocks.ts";
 import {
   freshLockStamp,
   LONG_EXPIRED_LOCK_STAMP,
@@ -200,6 +204,90 @@ describeWithEnv("db > migrations > lock", { db: true }, () => {
         : execute(statement),
     );
   };
+
+  test("the held-lock message says how long a crashed lock is honoured", () => {
+    using _fetch = stubNtfyFetch({}).fetchStub;
+
+    expect(migrationLockHeldError().message).toContain(
+      "reclaimed automatically after 2 minutes",
+    );
+  });
+
+  /** The held-lock error's ntfy notification bodies. */
+  const heldLockNotifications = (dbUrl: string | undefined): string[] => {
+    const { fetchStub, restore } = stubNtfyFetch({ DB_URL: dbUrl });
+    using _env = restore;
+    using _fetch = fetchStub;
+    migrationLockHeldError();
+    return fetchStub.calls.map((call) =>
+      String((call.args[1] as { body?: string })?.body),
+    );
+  };
+
+  test("a held lock tells the operator which database it is", () => {
+    expect(heldLockNotifications("libsql://named.example")).toEqual([
+      "E_DB_MIGRATION_LOCK libsql://named.example",
+    ]);
+  });
+
+  test("a held lock calls an unset database unknown", () => {
+    expect(heldLockNotifications(undefined)).toEqual([
+      "E_DB_MIGRATION_LOCK unknown",
+    ]);
+  });
+
+  test("a held lock reports a blank database name as blank", () => {
+    // An empty DB_URL is a real, if odd, setting — it is not missing, so it is
+    // not reported as "unknown".
+    expect(heldLockNotifications("")).toEqual(["E_DB_MIGRATION_LOCK "]);
+  });
+
+  describe("taking the lock again once the settings table is there", () => {
+    const PHANTOM: MigrationLease = { stored: false, token: "phantom" };
+
+    test("keeps a lease a row already backs, rather than taking a second", async () => {
+      const stored: MigrationLease = { stored: true, token: "mine" };
+
+      expect(await storedLease(stored, false)).toBe(stored);
+    });
+
+    test("keeps the unstored lease while the table is still missing", async () => {
+      expect(await storedLease(PHANTOM, true)).toBe(PHANTOM);
+    });
+
+    test("takes a real lease once the table is there", async () => {
+      try {
+        const retaken = await storedLease(PHANTOM, false);
+
+        expect(retaken.stored).toBe(true);
+        expect(await heldLock()).toBe(retaken.token);
+      } finally {
+        await clearLock();
+      }
+    });
+
+    test("stands aside when another request holds the lock", async () => {
+      using _fetch = stubNtfyFetch({}).fetchStub;
+      try {
+        await holdFreshLock();
+
+        await expect(storedLease(PHANTOM, false)).rejects.toThrow(
+          "Database migration is already in progress",
+        );
+      } finally {
+        await clearLock();
+      }
+    });
+
+    test("does not shrug off a settings table that has gone missing", async () => {
+      using _execute = failLockWriteWith("no such table: settings");
+
+      // The caller only reaches here because a probe just found the table.
+      await expect(storedLease(PHANTOM, false)).rejects.toThrow(
+        "no such table: settings",
+      );
+    });
+  });
 
   test("a missing settings table is only tolerated when it is expected", async () => {
     using _execute = failLockWriteWith("no such table: settings");

--- a/test/test-utils/migrations.ts
+++ b/test/test-utils/migrations.ts
@@ -61,11 +61,11 @@ export const appliedMigrationIds = async (): Promise<string[]> => {
 /** Take the migration lock for a test, failing loudly if another lease holds
  *  it — a test that cannot lock has nothing meaningful to assert. */
 export const takeMigrationLock = async (): Promise<string> => {
-  const lockToken = await acquireMigrationLock(false);
-  if (lockToken === null) {
+  const lease = await acquireMigrationLock(false);
+  if (lease === null) {
     throw new Error("Could not take the migration lock for this test");
   }
-  return lockToken;
+  return lease.token;
 };
 
 export const schemaMarkerKeys = async (): Promise<string[]> => {

--- a/test/test-utils/migrations.ts
+++ b/test/test-utils/migrations.ts
@@ -58,6 +58,21 @@ export const appliedMigrationIds = async (): Promise<string[]> => {
   return result.rows.map((row) => String(row.id));
 };
 
+/**
+ * A lock stamp from long enough ago that no sane time limit still honours it.
+ * Tests wanting an abandoned lock use this rather than working a date back from
+ * the production limit, which would hide a change to the limit itself.
+ */
+export const LONG_EXPIRED_LOCK_STAMP = "2020-01-01T00:00:00.000Z";
+
+/**
+ * A lock stamp the time limit still honours — but not the same instant as the
+ * acquisition under test, since two writes landing in one millisecond would
+ * leave the limit untested.
+ */
+export const freshLockStamp = (): string =>
+  new Date(Date.now() - 30_000).toISOString();
+
 /** Take the migration lock for a test, failing loudly if another lease holds
  *  it — a test that cannot lock has nothing meaningful to assert. */
 export const takeMigrationLock = async (): Promise<string> => {


### PR DESCRIPTION
Before the site can update its database, it takes a lock so two copies of the site cannot both start updating at once. That lock is stored as a row in the settings table.

That leaves a chicken-and-egg problem on a brand-new database: the settings table does not exist yet, so there is nowhere to store the lock. Setup and restore are allowed to carry on without one, which is safe, because they are the ones creating the table.

But if another request created and stamped that table in the meantime, the first request was left holding a lock that nothing recorded. It would then start updating the database anyway, and only find out at the very last step — its writes were refused as somebody else's update, and the database stayed out of date until someone tried again.

Now the lock says whether anything is actually holding it. As soon as the settings table is there, the request takes a real one, and steps aside politely if another request already has it. It also only ever gives back a lock something is really holding: a database with no settings table has no row to delete, and trying anyway could have swapped the "please try again" message for whatever that pointless write failed with.

Nothing changes for a normal boot, which already had a real lock and takes no extra database call. A brand-new database now does one write fewer.

### Also in here

Changes the checker and the reviewer asked for while these files were open:

- Two tests held a lock stamped "right now". A lock stamped in the same millisecond as the one being taken cannot be told apart from an expired one, so those tests were not really checking the two-minute limit — and could go either way from run to run. They now hold a lock from half a minute ago.
- One test only checked the *kind* of error, so it would have passed with an empty message. It now checks what the message says.
- New tests for each way taking the lock again can go wrong: another request wins the race (the boot must stop before updating anything and leave that request's lock alone), and the table has somehow gone missing again (the boot must say so loudly rather than shrug).
- The lock's own behaviour moved into the lock's own file, along with its tests, so the boot file stays the size it was.
- The two-minute limit is no longer shared outside the lock file. Tests that need an expired or still-honoured lock use shared example times instead of working the date back from the limit they are checking.
- Removes the finished note about this from the backlog.

`deno task precommit` passes. `deno task precommit:mutation` reports 100% — every change the checker tries to either file is caught (154/154, 1 suppressed as known-equivalent).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdDZCWRXwjqsidfRJFarXC)_