### PR TITLE
Leave five more pages behind for the site to photograph

### DIFF
--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -102,6 +102,48 @@ export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
     ".system-note-alert",
   ),
   brandedMobileCapture(
+    "site-pages.moved-into-order",
+    "site-pages-in-order",
+    "/admin/site/pages",
+    ".page-regions.admin-page",
+  ),
+  brandedMobileCapture(
+    "add-ons.it-appears-in-the-list-with-its-own-link",
+    "add-on-in-the-list",
+    "/listings",
+    "main",
+  ),
+  brandedMobileCapture(
+    "stay-length.the-length-is-on-the-listing-page",
+    "stay-length-on-the-page",
+    "/admin/listing/{stayLengthListingId}",
+    "main",
+  ),
+  brandedMobileCapture(
+    "pay-more.the-chosen-price-is-the-income",
+    "paid-more-than-asked",
+    "/admin/ledger/revenue/{payMoreListingId}",
+    ".page-regions.admin-page",
+  ),
+  brandedMobileCapture(
+    "door.the-day-is-written-down",
+    "checked-in-on-the-day",
+    "/admin/listing/{checkedInListingId}/activity",
+    "main",
+  ),
+  brandedMobileCapture(
+    "contact-record.correcting-the-counts-and-the-note",
+    "record-put-right",
+    "/admin/history/{contactCode}",
+    "#contact-history-form",
+  ),
+  brandedMobileCapture(
+    "contact-record.repairing-an-unreadable-record",
+    "record-repaired",
+    "/admin/history/{contactCode}",
+    "#contact-history-form",
+  ),
+  brandedMobileCapture(
     "door.someone-still-to-arrive-can-be-picked",
     "qr-code-check-in",
     "/admin/listing/{doorListingId}/scanner",

--- a/test/specs/steps/stays-length.ts
+++ b/test/specs/steps/stays-length.ts
@@ -99,7 +99,9 @@ Given(
 When(
   "the organiser looks at the {word}'s page",
   async function (this: TicketsWorld, name: string): Promise<void> {
-    await openAdminPage(this, `/admin/listing/${stayListing(this, name).id}`);
+    const { id } = stayListing(this, name);
+    this.evidenceValues.set("stayLengthListingId", String(id));
+    await openAdminPage(this, `/admin/listing/${id}`);
   },
 );
 

--- a/test/specs/support/bulk-money.ts
+++ b/test/specs/support/bulk-money.ts
@@ -101,4 +101,6 @@ export const payYourOwnPrice: ActOnSomeMoney = async (world, chosen) => {
     total: paid,
   });
   world.attendeeId = (await getAttendeesRaw(listingId))[0]!.id;
+  // The statement that has to show what they chose rather than what was asked.
+  world.evidenceValues.set("payMoreListingId", String(listingId));
 };

--- a/test/specs/support/door.ts
+++ b/test/specs/support/door.ts
@@ -213,6 +213,11 @@ const readOf = (row: string, what: string): string => {
 
 /** What the listing's own record of the day says happened. */
 export const dayLog: ReadAboutOneThing = async (world, listing) => {
+  // The listing whose own record of the day a capture of a check-in goes to.
+  world.evidenceValues.set(
+    "checkedInListingId",
+    String(stayListing(world, listing).id),
+  );
   const browser = await openAdminPage(
     world,
     listingPath(world, listing, "activity"),


### PR DESCRIPTION
Five more cases name the page they leave behind.

| case | page | element |
| --- | --- | --- |
| `site-pages.moved-into-order` | `/admin/site/pages` | the admin page |
| `add-ons.it-appears-in-the-list-with-its-own-link` | `/listings` | `main` |
| `door.the-day-is-written-down` | `/admin/listing/{checkedInListingId}/activity` | `main` |
| `stay-length.the-length-is-on-the-listing-page` | `/admin/listing/{stayLengthListingId}` | `main` |
| `pay-more.the-chosen-price-is-the-income` | `/admin/ledger/revenue/{payMoreListingId}` | the admin page |

Three new evidence values, each set where the story already knew the thing.

## Four that were built and dropped

`api-keys.taken-back`, `contact-record.someone-the-site-has-never-seen` and `contact-record.repairing-an-unreadable-record` all capture cleanly and all prove an absence: an empty key list, a record of all zeros. They are honest and they say nothing in a picture.

`order.one-order-of-every-kind` was dropped for a different reason, raised in review on chobbledotcom/tickets-site#135. It was put on the parent-and-child page because that page had a mock and this case had no capture, which is choosing a page for a picture rather than a picture for a page. The picture is an attendee list showing no parent, no child selector and no required quantity, and there is no page about multi-item orders for it to move to.

This description originally said six. That was the count before the drop.

## Checks

`deno task test` passes and `deno task lint` is clean. The nineteen captures were run twice against the site's themes; all five new ones are byte-identical between runs.

An earlier version of this description flagged a local `deno task test:coverage` failure in two `src/` files this branch does not touch. CI passes here, and a second run on a clean `main` worktree passed too; the local checkout had a 235 MB `coverage/` directory from earlier runs while the worktree started empty. It was a local artefact and the note is withdrawn.