### PR TITLE
Let a new row report its own id, instead of asking the database driver

### DIFF
--- a/scripts/mutation/equivalent-mutants.txt
+++ b/scripts/mutation/equivalent-mutants.txt
@@ -113,11 +113,11 @@ src/fp.ts:455:49  ?? → ||   # items?.length is undefined or a non-negative int
 # Table inputs make these operators equivalent: nullable query results exclude
 # undefined, paired null checks already reject both nullish values, and optional
 # conditions/dependencies are objects or arrays.
-src/shared/db/table.ts:441:28  ?? → ||   # condition?.args is an array or undefined, and every array is truthy
-src/shared/db/table.ts:488:71  ?? → ||   # a found row is a truthy object, and a miss is undefined, so both operators give the row or null
-src/shared/db/table.ts:492:31  ?? → ||   # findByIds's element is a truthy row, null, or undefined, and all three agree
-src/shared/db/table.ts:580:21  ?? → ||   # dependsOn is a readonly array or undefined, and every array is truthy
-src/shared/db/table.ts:613:32  ?? → ||   # the cached table's dependsOn is the same array-or-undefined as above
+src/shared/db/table.ts:445:28  ?? → ||   # condition?.args is an array or undefined, and every array is truthy
+src/shared/db/table.ts:492:71  ?? → ||   # a found row is a truthy object, and a miss is undefined, so both operators give the row or null
+src/shared/db/table.ts:496:31  ?? → ||   # findByIds's element is a truthy row, null, or undefined, and all three agree
+src/shared/db/table.ts:584:21  ?? → ||   # dependsOn is a readonly array or undefined, and every array is truthy
+src/shared/db/table.ts:617:32  ?? → ||   # the cached table's dependsOn is the same array-or-undefined as above
 
 # Login attempt rows store an integer count. For undefined, null, zero, or any
 # non-zero integer, `(attempts ?? 0) + 1` and `(attempts || 0) + 1` agree.
@@ -875,7 +875,6 @@ src/shared/stripe/webhook.ts:28:30  1 → 2   # this changes only the no-separat
 src/features/admin/calendar-csv.ts:77:55  ?? → ||   # agentNames.get() is string|undefined; "" and the "" fallback are identical
 src/features/admin/calendar-csv.ts:94:59  ?? → ||   # startTime is string|undefined; every falsy value produces the same "" fallback
 src/features/admin/calendar-csv.ts:102:57  ?? → ||   # endTime is string|undefined; every falsy value produces the same "" fallback
-src/shared/db/activityLog.ts:187:69   → "mutated"   # the inserted word is an unused SQLite table alias, so rows, ordering, arguments, and limit are unchanged
 src/shared/forms/rendering.tsx:67:17   → "mutated"   # split("T")[0] always exists, and the empty input returned before this line
 src/shared/forms/rendering.tsx:194:35  || → &&   # publicLinkPath is absent or a function, so both boolean terms always agree
 src/shared/forms/rendering.tsx:209:20  ?? → ||   # beforeHtml is string|undefined and falls back to "", so both operators agree

--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -143,21 +143,21 @@ export const logActivity = async (
   attendeeId?: number | null,
   transaction?: TxScope,
 ): Promise<ActivityLogEntry> => {
-  const statement = await activityLogTable.insertStatement!({
-    attendeeId: attendeeId ?? null,
-    listingId: toListingId(listing),
-    // Encrypt with the owner's public key — a set-up site always has one, so
-    // there is no env-key fallback (ownerPublicKey loads it if the snapshot was
-    // reset earlier this request).
-    message: await encryptWithOwnerKey(message, await ownerPublicKey()),
-  });
-  const returning = {
-    ...statement,
-    sql: `${statement.sql} RETURNING ${ACTIVITY_LOG_COLUMNS}`,
-  };
+  const statement = await activityLogTable.insertStatement!(
+    {
+      attendeeId: attendeeId ?? null,
+      listingId: toListingId(listing),
+      // Encrypt with the owner's public key — a set-up site always has one, so
+      // there is no env-key fallback (ownerPublicKey loads it if the snapshot was
+      // reset earlier this request).
+      message: await encryptWithOwnerKey(message, await ownerPublicKey()),
+    },
+    undefined,
+    ACTIVITY_LOG_COLUMNS,
+  );
   const result = transaction
-    ? await transaction.execute(returning)
-    : await execute(returning.sql, returning.args);
+    ? await transaction.execute(statement)
+    : await execute(statement.sql, statement.args);
   const row = resultRows<StoredActivityLogEntry>(result)[0]!;
   return { ...row, message };
 };

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -771,15 +771,19 @@ export const useTransaction = <T>(
   transaction === undefined ? withTransaction(work) : work(transaction);
 
 /**
- * The row id an INSERT reported. Every generated key is a positive integer, so
- * anything else (`lastInsertRowid` is optional on a libsql result) means nothing
- * downstream can be keyed on this row and the write must fail here.
+ * The key of the row an `INSERT … RETURNING` wrote, read from the row itself
+ * rather than from the driver's optional `lastInsertRowid`. Every generated key
+ * is a positive integer, so anything else means nothing downstream can be keyed
+ * on this row and the write must fail here.
  */
-export const insertedRowId = (result: ResultSet): number => {
-  const id = Number(result.lastInsertRowid);
-  if (Number.isInteger(id) && id > 0) return id;
+export const insertedRowId = (
+  result: ResultSet,
+  primaryKey: string = "id",
+): number => {
+  const id = resultRows<Record<string, unknown>>(result)[0]?.[primaryKey];
+  if (typeof id === "number" && Number.isInteger(id) && id > 0) return id;
   throw new Error(
-    `INSERT did not report a row id (lastInsertRowid=${result.lastInsertRowid})`,
+    `INSERT did not return the ${primaryKey} of the row it wrote (got ${JSON.stringify(id)})`,
   );
 };
 
@@ -787,8 +791,8 @@ export const insertedRowId = (result: ResultSet): number => {
  * Write one row `statement` in a fresh write transaction and run `persist` (the
  * coupled join-table writes) on the same `tx`, so the row and its side writes
  * commit or roll back together. Returns the row id — `existingId` on update, or
- * the INSERT's `lastInsertRowid` on create (`existingId` null). Shared by the
- * REST resource (HTML forms) and CRUD API write paths.
+ * the key the INSERT returned on create (`existingId` null). Shared by the REST
+ * resource (HTML forms) and CRUD API write paths.
  */
 export const writeRowInTransaction = (
   statement: InStatement,
@@ -829,10 +833,14 @@ export const rawSql = (expr: string): RawSql => ({ [RAW_SQL]: expr }) as RawSql;
  * // → { sql: "INSERT INTO listing_attendees (...) VALUES (?, last_insert_rowid(), ?)",
  * //     args: [1, 2] }
  * ```
+ *
+ * Pass `returningColumns` when the caller needs the written row to report
+ * something back — a generated key, say, read with {@link insertedRowId}.
  */
 export const insert = (
   table: string,
   values: Record<string, InValue | RawSql>,
+  returningColumns?: string,
 ): { sql: string; args: InValue[] } => {
   const columns: string[] = [];
   const placeholders: string[] = [];
@@ -848,11 +856,12 @@ export const insert = (
     }
   }
 
+  const returning = returningColumns ? ` RETURNING ${returningColumns}` : "";
   return {
     args,
     sql: `INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders.join(
       ", ",
-    )})`,
+    )})${returning}`,
   };
 };
 

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -139,6 +139,8 @@ export interface Table<Row, Input> {
   insertStatement?: (
     input: Input,
     condition?: SqlStatement,
+    /** Columns the INSERT reports back. Defaults to the primary key. */
+    returningColumns?: string,
   ) => Promise<SqlStatement>;
   name: string;
   primaryKey: keyof Row & string;
@@ -204,16 +206,13 @@ export async function writeTableRow<Row, Input>(
 ): Promise<Row | null> {
   const statement =
     write.kind === "insert"
-      ? await table.insertStatement!(write.input, write.condition)
+      ? await table.insertStatement!(
+          write.input,
+          write.condition,
+          table.columns.join(", "),
+        )
       : await table.updateStatement!(write.id, write.input, write.condition);
-  const returning =
-    write.kind === "insert"
-      ? {
-          ...statement,
-          sql: `${statement.sql} RETURNING ${table.columns.join(", ")}`,
-        }
-      : statement;
-  const row = resultRows<Row>(await transaction.execute(returning))[0];
+  const row = resultRows<Row>(await transaction.execute(statement))[0];
   return row ? table.fromDb(row) : null;
 }
 
@@ -237,16 +236,19 @@ const applyWriteTransform = <T>(
 };
 
 /** Build INSERT SQL */
+/** Build INSERT SQL with RETURNING, so the written row itself reports the
+ * columns the caller needs — a generated key included. */
 const buildInsertSql = (
   name: string,
   columns: string[],
+  returningColumns: string,
   condition?: string,
 ): string => {
   const placeholders = columns.map(() => "?").join(", ");
   const values = condition
     ? `SELECT ${placeholders} WHERE ${condition}`
     : `VALUES (${placeholders})`;
-  return `INSERT INTO ${name} (${columns.join(", ")}) ${values}`;
+  return `INSERT INTO ${name} (${columns.join(", ")}) ${values} RETURNING ${returningColumns}`;
 };
 
 /** Build UPDATE SQL with RETURNING to get updated row in one round trip */
@@ -377,6 +379,7 @@ export const defineTable = <Row, Input = Row>(
    * lives in one place. */
   const buildInsert = async (
     input: Input,
+    returningColumns: string,
   ): Promise<{
     args: InValue[];
     columns: string[];
@@ -389,17 +392,17 @@ export const defineTable = <Row, Input = Row>(
       args: columns.map((col) => dbValues[col] as InValue),
       columns,
       dbValues,
-      sql: buildInsertSql(name, columns),
+      sql: buildInsertSql(name, columns, returningColumns),
     };
   };
 
   // Insert implementation
   const insert = async (input: Input): Promise<Row> => {
-    const { args, dbValues, sql } = await buildInsert(input);
+    const { args, dbValues, sql } = await buildInsert(input, primaryKey);
     const result = await execute(sql, args);
 
     const initialRow = schema[primaryKey].generated
-      ? { [primaryKey]: insertedRowId(result) }
+      ? { [primaryKey]: insertedRowId(result, primaryKey) }
       : {};
 
     return reduce((row: Record<string, unknown>, col: string) => {
@@ -414,12 +417,13 @@ export const defineTable = <Row, Input = Row>(
   const insertStatement = async (
     input: Input,
     condition?: SqlStatement,
+    returningColumns: string = primaryKey,
   ): Promise<SqlStatement> => {
-    const { args, columns, sql } = await buildInsert(input);
+    const { args, columns, sql } = await buildInsert(input, returningColumns);
     return condition
       ? {
           args: [...args, ...condition.args],
-          sql: buildInsertSql(name, columns, condition.sql),
+          sql: buildInsertSql(name, columns, returningColumns, condition.sql),
         }
       : { args, sql };
   };

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -154,7 +154,7 @@ const buildUserInsert = async (
     username_index: usernameIndex,
     wrapped_data_key: opts.wrappedDataKey,
   };
-  return { statement: insert("users", values), values };
+  return { statement: insert("users", values, "id"), values };
 };
 
 /** A user INSERT statement plus the row values needed to rebuild the User. */

--- a/test/integration/server/listings/duplicate.test.ts
+++ b/test/integration/server/listings/duplicate.test.ts
@@ -81,10 +81,8 @@ describeWithEnv("server listings > duplicate", { db: true }, () => {
   });
 
   describe("POST /admin/listing (duplicate)", () => {
-    // The reported failure: the copy commits, but reading it back finds nothing,
-    // so the handler used to reach `result.row.name` on a null row and die with
-    // "Cannot read properties of null (reading 'name')" — logged as the generic
-    // E_CDN_REQUEST, pointing nowhere near the read-back that actually failed.
+    // A copy that cannot be read back names the table and row, so the error
+    // points at the read-back rather than at whatever field was asked for next.
     test("fails with the table named when the copy cannot be read back", async () => {
       const { cookie, csrfToken } = await setupListingAndLogin({
         maxAttendees: 10,

--- a/test/shared/db/activityLog.test.ts
+++ b/test/shared/db/activityLog.test.ts
@@ -139,6 +139,21 @@ describeWithEnv("db > activity log", { db: true }, () => {
     expect(entries).toEqual([]);
   });
 
+  // Listing 0 is still a listing filter, not "no filter" — asking for a listing
+  // that cannot exist must return nothing rather than every listing's entries.
+  test("getListingActivityLog for listing 0 returns no entries", async () => {
+    const listing = await createTestListing({
+      maxAttendees: 50,
+      name: "Has entries",
+      thankYouUrl: "https://example.com",
+    });
+    await logActivity("Action for a real listing", listing.id);
+
+    const entries = await withTestSession(() => getListingActivityLog(0));
+
+    expect(entries).toEqual([]);
+  });
+
   test("getListingActivityLog respects limit", async () => {
     const listing = await createTestListing({
       maxAttendees: 50,

--- a/test/shared/db/client/transaction.test.ts
+++ b/test/shared/db/client/transaction.test.ts
@@ -230,14 +230,18 @@ describeWithEnv("db > client transaction", { db: true }, () => {
   test("writeRowInTransaction rejects an INSERT that returns no row", async () => {
     const { error, persistedIds } = await insertReturningRows([]);
 
-    expect(String(error)).toContain("did not return the id of the row it wrote");
+    expect(String(error)).toContain(
+      "did not return the id of the row it wrote",
+    );
     expect(persistedIds).toEqual([]);
   });
 
   test("writeRowInTransaction rejects a returned row whose id is 0", async () => {
     const { error, persistedIds } = await insertReturningRows([{ id: 0 }]);
 
-    expect(String(error)).toContain("did not return the id of the row it wrote");
+    expect(String(error)).toContain(
+      "did not return the id of the row it wrote",
+    );
     expect(persistedIds).toEqual([]);
   });
 

--- a/test/shared/db/client/transaction.test.ts
+++ b/test/shared/db/client/transaction.test.ts
@@ -198,16 +198,15 @@ describeWithEnv("db > client transaction", { db: true }, () => {
     expect(persistedIds).toEqual([0]);
   });
 
-  /** Run an INSERT through writeRowInTransaction against a driver whose result
-   *  reports `lastInsertRowid` as `reported`, recording the ids persist saw. */
-  const insertWithReportedRowid = async (
-    reported: unknown,
+  /** Run an INSERT through writeRowInTransaction against a driver whose
+   *  RETURNING gives back `rows`, recording the ids persist saw. */
+  const insertReturningRows = async (
+    rows: unknown[],
   ): Promise<{ persistedIds: number[]; error: unknown }> => {
     const persistedIds: number[] = [];
     using _txStub = stubTransaction({
       commit: () => Promise.resolve(),
-      execute: () =>
-        Promise.resolve({ lastInsertRowid: reported } as unknown as ResultSet),
+      execute: () => Promise.resolve({ rows } as unknown as ResultSet),
       rollback: () => Promise.resolve(),
     });
     try {
@@ -225,26 +224,25 @@ describeWithEnv("db > client transaction", { db: true }, () => {
     }
   };
 
-  // A driver that doesn't report the new rowid used to give `Number(undefined)`
-  // = NaN as the row id: the join writes were then written against NaN and the
-  // transaction committed, and only the read-back afterwards found nothing.
-  // Fail before persist runs so the whole write rolls back instead.
-  test("writeRowInTransaction rejects an INSERT that reports no row id", async () => {
-    const { error, persistedIds } = await insertWithReportedRowid(undefined);
+  // The join writes are keyed on the id, so an INSERT that hands back no row —
+  // or a row without a usable key — has to fail before persist runs, leaving the
+  // whole write to roll back rather than writing rows against a bad id.
+  test("writeRowInTransaction rejects an INSERT that returns no row", async () => {
+    const { error, persistedIds } = await insertReturningRows([]);
 
-    expect(String(error)).toContain("did not report a row id");
+    expect(String(error)).toContain("did not return the id of the row it wrote");
     expect(persistedIds).toEqual([]);
   });
 
-  test("writeRowInTransaction rejects an INSERT that reports row id 0", async () => {
-    const { error, persistedIds } = await insertWithReportedRowid(0n);
+  test("writeRowInTransaction rejects a returned row whose id is 0", async () => {
+    const { error, persistedIds } = await insertReturningRows([{ id: 0 }]);
 
-    expect(String(error)).toContain("did not report a row id");
+    expect(String(error)).toContain("did not return the id of the row it wrote");
     expect(persistedIds).toEqual([]);
   });
 
-  test("writeRowInTransaction persists against the INSERT's reported row id", async () => {
-    const { error, persistedIds } = await insertWithReportedRowid(7n);
+  test("writeRowInTransaction persists against the id the INSERT returned", async () => {
+    const { error, persistedIds } = await insertReturningRows([{ id: 7 }]);
 
     expect(error).toBeNull();
     expect(persistedIds).toEqual([7]);

--- a/test/shared/db/table/write-row.test.ts
+++ b/test/shared/db/table/write-row.test.ts
@@ -1,3 +1,4 @@
+import type { ResultSet } from "@libsql/client";
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
@@ -75,17 +76,39 @@ describeWithEnv("db > writeTableRow", { db: true }, () => {
     expect(await queryAll("SELECT id, name FROM table_write_rows")).toEqual([]);
   });
 
-  // The plain insert path keys the row it returns on the id the driver reports,
-  // so a driver that reports none must fail here rather than hand back a row
-  // whose id is NaN — which callers put straight into a redirect URL.
-  test("insert rejects a driver result that reports no row id", async () => {
+  // The id comes back from the row the INSERT wrote, so it needs no help from
+  // the driver's optional lastInsertRowid — which some drivers omit.
+  test("insert takes its id from the row the INSERT returned", async () => {
+    const table = await createWriteTable();
+    const withoutDriverRowid = (result: ResultSet): ResultSet =>
+      ({ ...result, lastInsertRowid: undefined }) as unknown as ResultSet;
+    const realExecute = getDb().execute.bind(getDb());
+    using _execute = stub(getDb(), "execute", (...args) =>
+      realExecute(...(args as Parameters<typeof realExecute>)).then(
+        withoutDriverRowid,
+      ),
+    );
+
+    const row = await table.insert({ name: "Named" });
+
+    // insert() reports the values it was given; the stored value keeps the
+    // column's write transform.
+    expect(row).toEqual({ id: 1, name: "Named" });
+    expect(await queryAll("SELECT id, name FROM table_write_rows")).toEqual([
+      { id: 1, name: "NAMED" },
+    ]);
+  });
+
+  // Nothing downstream can be keyed on a row the INSERT did not report, so the
+  // insert fails here rather than handing back a row with an unusable id.
+  test("insert rejects a result that returns no row", async () => {
     const table = await createWriteTable();
     using _execute = stub(getDb(), "execute", () =>
       Promise.resolve(emptyResultSet()),
     );
 
     await expect(table.insert({ name: "Nameless" })).rejects.toThrow(
-      "INSERT did not report a row id",
+      "INSERT did not return the id of the row it wrote",
     );
   });
 });

--- a/test/shared/db/table/write-row.test.ts
+++ b/test/shared/db/table/write-row.test.ts
@@ -80,14 +80,13 @@ describeWithEnv("db > writeTableRow", { db: true }, () => {
   // the driver's optional lastInsertRowid — which some drivers omit.
   test("insert takes its id from the row the INSERT returned", async () => {
     const table = await createWriteTable();
-    const withoutDriverRowid = (result: ResultSet): ResultSet =>
-      ({ ...result, lastInsertRowid: undefined }) as unknown as ResultSet;
     const realExecute = getDb().execute.bind(getDb());
-    using _execute = stub(getDb(), "execute", (...args) =>
-      realExecute(...(args as Parameters<typeof realExecute>)).then(
-        withoutDriverRowid,
-      ),
-    );
+    using _execute = stub(getDb(), "execute", async (...args) => {
+      const result = await realExecute(
+        ...(args as Parameters<typeof realExecute>),
+      );
+      return { ...result, lastInsertRowid: undefined } as unknown as ResultSet;
+    });
 
     const row = await table.insert({ name: "Named" });
 


### PR DESCRIPTION
Follow-up to #2002, from a review point on it.

## Why

When a record is saved, the rows that belong with it — a listing's groups and
its per-day prices, say — are written against the id of the new row. That id
came from a field the database driver is free to leave out of its reply. When it
was missing, there was no usable id to write those rows against.

#2002 made that a loud failure instead of a silent one, but it could only
notice after the fact: a save on its own is committed the moment it runs, so by
the time the check ran, the row was already written and could not be taken back.

Saves now ask for the id back as part of writing the row. It comes from the row
itself, so the driver's field is never consulted and the problem cannot arise —
rather than being something we watch for.

## What changed

Every save built by the shared table code ends by naming what it wants back,
and the new row's id is read from the row it wrote.

Two places already asked for the row back by adding to the statement after it
had been built — the row writer and the activity log. Both now say what they
want through the one shared step, so a save has a single place that decides
what it reports. The update code already worked this way; saves now match it.

## Tests

- A save takes its id from its own row even when the driver reports nothing —
  the exact condition behind the original fault.
- A save that reports no row fails, naming what was missing, rather than
  handing back a record nothing can be keyed on.
- The related rows are written against the id the save returned.

## Also here

Asking the activity log for listing 0 returned every listing's activity instead
of none. A listing id of 0 was treated as "no listing filter at all". No listing
has that id, so nothing was visibly wrong, but the rule it broke — a listing
filter is a filter, whatever the number — now has a test. Found by the mutation
check once this change brought that file into its scope.

The known-harmless list is updated for the lines this moves, and its activity
log records are removed: every change the checker makes to that file is now
caught by its tests, so a record excusing one would hide a real gap.

A test comment in the listing-duplicate tests is also trimmed to say what the
test checks now, rather than recounting the fault it was written for.

Full checks pass, and every source file this touches passes the mutation check
completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pSYxJBsnqcWPKK4KjmZrX

---
_Generated by [Claude Code](https://claude.ai/code/session_011pSYxJBsnqcWPKK4KjmZrX)_