### PR TITLE
Add a dev task that restarts on source changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -694,7 +694,8 @@ logging and table-scoped cache invalidation stay automatic.
 ## Scripts
 
 - `deno task start` - Run the server
-- `deno task dev` - Run the server with `--watch`, restarting it whenever a source file changes. `build:static` runs once at the start, so an edit to a static asset still needs the task restarted. With `DB_URL=:memory:` each restart begins with an empty database
+- `deno task dev` - Run the server with `--watch`, restarting it whenever a source file changes. `build:static` runs once at the start, so an edit to a static asset still needs the task restarted. With `DB_URL=:memory:` each restart begins with an empty database, so pass `DB_URL=file:./local.db` to keep one across edits
+- `deno task serve` - The bare server command that `start` and `dev` both call, so the permissions and entry point live in one place. `dev` sets `SERVE_WATCH=--watch` to add the watcher. Prefer `start` or `dev`, which build the static assets first
 - `deno task test` - Run the full suite
 - `deno task test:coverage` - Run the full suite with coverage
 - `deno task test:files <file>...` - Run only the given test files with the same setup as the full runner (makes sure the static assets are current, starts stripe-mock, cleans up after)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -694,6 +694,7 @@ logging and table-scoped cache invalidation stay automatic.
 ## Scripts
 
 - `deno task start` - Run the server
+- `deno task dev` - Run the server with `--watch`, restarting it whenever a source file changes. `build:static` runs once at the start, so an edit to a static asset still needs the task restarted. With `DB_URL=:memory:` each restart begins with an empty database
 - `deno task test` - Run the full suite
 - `deno task test:coverage` - Run the full suite with coverage
 - `deno task test:files <file>...` - Run only the given test files with the same setup as the full runner (makes sure the static assets are current, starts stripe-mock, cleans up after)

--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ DB_URL=libsql://your-db.turso.io DB_TOKEN=your-token \
 # Or run against a throwaway in-memory database, with no Turso account
 DB_URL=:memory: DB_ENCRYPTION_KEY="$(openssl rand -base64 32)" deno task start
 
-# Same, restarting whenever a source file changes
+# Same, restarting whenever a source file changes. An in-memory database is
+# emptied by each restart, so use a file to keep your setup across edits:
+# DB_URL=file:./local.db
 DB_URL=:memory: DB_ENCRYPTION_KEY="$(openssl rand -base64 32)" deno task dev
 
 # Run tests (stripe-mock downloaded automatically)
@@ -361,7 +363,7 @@ On first launch, visit `/setup/` to set admin credentials and currency. Payment 
 
 ```
 deno task start          # Run server
-deno task dev            # Run server, restarting on source changes
+deno task dev            # Run server, restarting on source changes (static assets build once, so editing style.scss or bundle inputs needs the task restarted)
 deno task test           # Run tests
 deno task test:coverage  # Tests with coverage report
 deno task lint           # Format + lint with Biome — fixes in place

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ and keeps its ordinary site build offline.
 DB_URL=libsql://your-db.turso.io DB_TOKEN=your-token \
   DB_ENCRYPTION_KEY=your-base64-key deno task start
 
+# Or run against a throwaway in-memory database, with no Turso account
+DB_URL=:memory: DB_ENCRYPTION_KEY="$(openssl rand -base64 32)" deno task start
+
+# Same, restarting whenever a source file changes
+DB_URL=:memory: DB_ENCRYPTION_KEY="$(openssl rand -base64 32)" deno task dev
+
 # Run tests (stripe-mock downloaded automatically)
 deno task test
 ```
@@ -355,6 +361,7 @@ On first launch, visit `/setup/` to set admin credentials and currency. Payment 
 
 ```
 deno task start          # Run server
+deno task dev            # Run server, restarting on source changes
 deno task test           # Run tests
 deno task test:coverage  # Tests with coverage report
 deno task lint           # Format + lint with Biome — fixes in place

--- a/deno.json
+++ b/deno.json
@@ -6,8 +6,9 @@
     "e2e-payments"
   ],
   "tasks": {
-    "start": "deno task build:static && deno run --env-file --allow-net --allow-env --allow-read --allow-write --allow-sys --allow-ffi src/index.ts",
-    "dev": "deno task build:static && deno run --watch --env-file --allow-net --allow-env --allow-read --allow-write --allow-sys --allow-ffi src/index.ts",
+    "serve": "deno run $SERVE_WATCH --env-file --allow-net --allow-env --allow-read --allow-write --allow-sys --allow-ffi src/index.ts",
+    "start": "deno task build:static && deno task serve",
+    "dev": "deno task build:static && SERVE_WATCH=--watch deno task serve",
     "build:static": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net scripts/build-static-assets.ts",
     "build:edge": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net scripts/build-edge.ts",
     "bundle:report": "deno task build:edge && deno run -A scripts/bench/bundle-composition/report.ts",

--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,7 @@
   ],
   "tasks": {
     "start": "deno task build:static && deno run --env-file --allow-net --allow-env --allow-read --allow-write --allow-sys --allow-ffi src/index.ts",
+    "dev": "deno task build:static && deno run --watch --env-file --allow-net --allow-env --allow-read --allow-write --allow-sys --allow-ffi src/index.ts",
     "build:static": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net scripts/build-static-assets.ts",
     "build:edge": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net scripts/build-edge.ts",
     "bundle:report": "deno task build:edge && deno run -A scripts/bench/bundle-composition/report.ts",


### PR DESCRIPTION
`deno task start` runs the server without a file watcher, so an edit is not reflected until the process is restarted by hand. Nothing in the README or AGENTS.md said so, and reading `deno.json` was the only way to find out.

This came out of a question on the marketing site, where the comparison pages record how each ticketing project behaves in local development. The record for this repository said "There is no watch task, so the process is restarted after an edit", which was accurate but felt wrong to whoever read it, since Deno has had a watcher for years.

## Changes

- **`deno.json`**: a `dev` task, identical to `start` plus `--watch`.
- **`README.md`**: `deno task dev` in the task list, and two additions to the quick start, an in-memory run and the same with the watcher.
- **`AGENTS.md`**: the same task in the Scripts list, with its two limits.

## Verified rather than assumed

With `deno task dev` running against `DB_URL=:memory:`, `curl http://localhost:3000/setup/` returned `<h1>Initial Setup</h1>`. Editing `src/locales/en/setup.json` and curling again returned `<h1>Initial Setup DEVTASKWORKS</h1>`, and the watcher logged `Restarting! File change detected`. The same edit under `deno task start` did not change the response, which is what prompted this.

## Two limits, documented alongside the task

- `build:static` runs once before the server starts, so editing a static asset still needs the task restarted.
- With `DB_URL=:memory:`, every restart begins with an empty database, which matters if you were part-way through `/setup/`.

## The `:memory:` quick start

The README's local-run example showed only `DB_URL=libsql://your-db.turso.io` with a token, which makes a local run look like it needs a Turso account. `flake.nix` already defaults `DB_URL` to `:memory:`, so that route existed and was undocumented.

## Note on how this was tested

The commands were run with a Deno installed to a temporary directory rather than through `nix develop`, because Nix is not available in this environment. AGENTS.md asks for the Nix shell, so it is worth re-running `nix develop -c deno task dev` before merging. The change itself is a task definition and three documentation lines, with no source code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wVGEX1271eqR1Kw3AdaSz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development watch mode that automatically restarts the app when source files change.
  * Added a shared server task for consistent local app startup.
  * Documented in-memory and file-backed database options for local development.

* **Documentation**
  * Updated development setup instructions and available task listings.
  * Clarified build and restart behavior for development and startup commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->