### PR TITLE
Give stories one typed memory, and one place to put things back

### DIFF
--- a/test/scripts/specs/run/basics.test.ts
+++ b/test/scripts/specs/run/basics.test.ts
@@ -12,9 +12,9 @@ import {
   shouldCheckUnusedSteps,
   shouldRunFocusedSpecs,
 } from "#scripts/specs/options.ts";
+import { putsThingsBack } from "#test/specs/support/memory.ts";
 import {
   addDatabaseCleanup,
-  cleanupWorld,
   requiredWorldValue,
 } from "#test/specs/support/world.ts";
 
@@ -122,29 +122,10 @@ describe("Cucumber runner", () => {
     expect(shouldCheckUnusedSteps({ tags: "@risk:high" })).toBe(false);
   });
 
-  test("runs every scenario cleanup after one fails", async () => {
-    const calls: string[] = [];
-    const restoreError = new Error("restore failed");
-    const error = await cleanupWorld({
-      cleanup: [
-        () => {
-          calls.push("database");
-        },
-        () => {
-          calls.push("provider");
-          throw restoreError;
-        },
-      ],
-    }).catch((error) => error);
-
-    expect(calls).toEqual(["provider", "database"]);
-    expect(error).toBe(restoreError);
-  });
-
   test("clears the encryption key after database cleanup fails", async () => {
     const calls: string[] = [];
     const databaseError = new Error("database cleanup failed");
-    const world = { cleanup: [] };
+    const world = { cleanup: putsThingsBack() };
     addDatabaseCleanup(
       world,
       () => {
@@ -156,7 +137,7 @@ describe("Cucumber runner", () => {
       },
     );
 
-    const error = await cleanupWorld(world).catch((error) => error);
+    const error = await world.cleanup.runAll().catch((error: unknown) => error);
     expect(calls).toEqual(["database", "encryption key"]);
     expect(error).toBe(databaseError);
   });

--- a/test/specs/steps/add-ons.ts
+++ b/test/specs/steps/add-ons.ts
@@ -13,16 +13,18 @@ import {
   sellWithAddOn,
 } from "#test/specs/support/add-ons.ts";
 import {
-  requiredWorldValue,
-  type TicketsWorld,
-} from "#test/specs/support/world.ts";
+  browserSeenBy,
+  CUSTOMER,
+  rememberBrowser,
+} from "#test/specs/support/browser.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
 // jscpd:ignore-end
 
 /** The page of everything for sale, as the customer last saw it. */
 const forSalePage = (world: TicketsWorld): TestBrowser =>
-  requiredWorldValue(world.customerBrowser, "the page the customer saw");
+  browserSeenBy(world, CUSTOMER);
 
 Given(
   "a {word} sold with a {word} that can also be bought on its own",
@@ -62,7 +64,7 @@ When(
 When(
   "a customer looks at everything for sale",
   async function (this: TicketsWorld): Promise<void> {
-    this.customerBrowser = await everythingForSale();
+    rememberBrowser(this, CUSTOMER, await everythingForSale());
   },
 );
 

--- a/test/specs/steps/attendee-editing.ts
+++ b/test/specs/steps/attendee-editing.ts
@@ -4,6 +4,11 @@ import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { adminBrowser, scenarioBrowser } from "#test/specs/support/browser.ts";
 import {
+  listingIdNamed,
+  rememberListing,
+  rememberListingById,
+} from "#test/specs/support/listings.ts";
+import {
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
@@ -57,9 +62,6 @@ const BOB: Rename = {
   special_instructions: "Vegetarian meals",
 };
 
-const listingIdFor = (world: TicketsWorld, name: string): string =>
-  String(requiredWorldValue(world.listingIds.get(name), `${name} listing id`));
-
 /** Add the person to a fresh Art Class through the quick-add form. */
 const addToArtClass = async (
   world: TicketsWorld,
@@ -67,7 +69,7 @@ const addToArtClass = async (
 ): Promise<TestBrowser> => {
   const browser = await adminBrowser(world);
   const id = await createListing(browser, { name: ART_CLASS });
-  world.listingIds.set(ART_CLASS, Number(id));
+  await rememberListingById(world, ART_CLASS, Number(id));
   await addAttendee(browser, {
     name: person.oldName,
     quantity: person.places,
@@ -118,7 +120,7 @@ const expectKeptBooking = (
   checkedIn: boolean,
 ): void => {
   const browser = scenarioBrowser(world);
-  expect(linePlacesOnPage(browser, listingIdFor(world, ART_CLASS))).toBe(
+  expect(linePlacesOnPage(browser, listingIdNamed(world, ART_CLASS))).toBe(
     person.places,
   );
   expect(browser.currentHtml.includes("Checked in")).toBe(checkedIn);
@@ -129,7 +131,7 @@ const expectKeptBooking = (
 const savePlaces = async (
   browser: TestBrowser,
   name: string,
-  listingId: string,
+  listingId: number,
   places: string,
 ): Promise<void> => {
   await browser.submitForm(
@@ -218,12 +220,12 @@ Given(
         maxQuantity: 5,
         name,
       });
-      this.listingIds.set(name, listing.id);
+      rememberListing(this, name, listing);
     }
     this.attendeeIds = [];
     for (const person of [ALICE, BOB]) {
       const { attendee } = await createTestAttendeeDirect(
-        Number(listingIdFor(this, MORNING)),
+        listingIdNamed(this, MORNING),
         person.oldName,
         person.email,
       );
@@ -237,8 +239,8 @@ When(
   async function (this: TicketsWorld): Promise<void> {
     const browser = await adminBrowser(this);
     const ids = requiredWorldValue(this.attendeeIds, "attendee ids");
-    const morning = listingIdFor(this, MORNING);
-    const evening = listingIdFor(this, EVENING);
+    const morning = listingIdNamed(this, MORNING);
+    const evening = listingIdNamed(this, EVENING);
     for (const [index, attendeeId] of ids.entries()) {
       const name = [ALICE, BOB][index]!.oldName;
       // Give the new listing a place, then take the old listing's place away.
@@ -258,8 +260,12 @@ Then(
     const ids = requiredWorldValue(this.attendeeIds, "attendee ids");
     for (const attendeeId of ids) {
       await browser.visit(`/admin/attendees/${attendeeId}/edit`);
-      expect(linePlacesOnPage(browser, listingIdFor(this, EVENING))).toBe("1");
-      expect(linePlacesOnPage(browser, listingIdFor(this, MORNING))).toBe("0");
+      expect(linePlacesOnPage(browser, listingIdNamed(this, EVENING))).toBe(
+        "1",
+      );
+      expect(linePlacesOnPage(browser, listingIdNamed(this, MORNING))).toBe(
+        "0",
+      );
     }
   },
 );

--- a/test/specs/steps/backup-restore.ts
+++ b/test/specs/steps/backup-restore.ts
@@ -8,6 +8,7 @@ import {
   resetScenarioBrowser,
   scenarioBrowser,
 } from "#test/specs/support/browser.ts";
+import { rememberListing } from "#test/specs/support/listings.ts";
 import {
   requiredWorldValue,
   type TicketsWorld,
@@ -30,14 +31,14 @@ const seedListingWithBooking = async (world: TicketsWorld): Promise<void> => {
     maxQuantity: 5,
     name: LISTING,
   });
-  world.listingIds.set(LISTING, listing.id);
+  rememberListing(world, LISTING, listing);
   await createTestAttendeeDirect(listing.id, CUSTOMER, CUSTOMER_EMAIL);
 };
 
 /** Keep backup files on disk for this Scenario, and clear them afterwards. */
 const useLocalBackupStorage = (world: TicketsWorld): void => {
   const dir = setupTestStorage("local");
-  world.cleanup.push(() => teardownTestStorage(dir));
+  world.cleanup.add(() => teardownTestStorage(dir));
 };
 
 /** Empty the site and walk the fresh-install setup wizard again. The old

--- a/test/specs/steps/booking-api.ts
+++ b/test/specs/steps/booking-api.ts
@@ -9,7 +9,7 @@ import {
   daysTheApiOffers,
   openTheApi,
 } from "#test/specs/support/booking-api.ts";
-import { stayListing } from "#test/specs/support/listings.ts";
+import { listingNamed } from "#test/specs/support/listings.ts";
 import { guest, newestStayOn, staysOn } from "#test/specs/support/stays.ts";
 import {
   requiredWorldValue,
@@ -52,7 +52,7 @@ Given(
     const { addDays } = await import("#shared/dates.ts");
     const middle = addDays(await firstDayOffered(this, name), 1);
     // A one-day booking, so only the middle day of the coming stay is full.
-    const booked = await bookAttendee(stayListing(this, name), {
+    const booked = await bookAttendee(listingNamed(this, name), {
       date: middle,
       durationDays: 1,
       quantity: places,

--- a/test/specs/steps/booking-journey.ts
+++ b/test/specs/steps/booking-journey.ts
@@ -2,13 +2,21 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
-import { adminBrowser } from "#test/specs/support/browser.ts";
+import {
+  adminBrowser,
+  browserOf,
+  CUSTOMER as CUSTOMERS_OWN_BROWSER,
+} from "#test/specs/support/browser.ts";
+import {
+  listingIdNamed,
+  rememberListingById,
+} from "#test/specs/support/listings.ts";
 import {
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
 import { linePlacesOnPage, openAttendeeEditor } from "#test-utils/e2e.ts";
-import { ALL_CHECKBOXES, TestBrowser } from "#test-utils/test-browser.ts";
+import { ALL_CHECKBOXES, type TestBrowser } from "#test-utils/test-browser.ts";
 
 // jscpd:ignore-end
 
@@ -22,13 +30,11 @@ const CUSTOMER_EMAIL = "jane@example.com";
 
 /** The customer is a member of the public: their own browser, never signed in
  * as the organiser, so the journey proves what a real visitor can do. */
-const customerBrowser = (world: TicketsWorld): TestBrowser => {
-  world.customerBrowser ??= new TestBrowser();
-  return world.customerBrowser;
-};
+const customerBrowser = (world: TicketsWorld): TestBrowser =>
+  browserOf(world, CUSTOMERS_OWN_BROWSER);
 
 const listingId = (world: TicketsWorld): number =>
-  requiredWorldValue(world.listingIds.get(LISTING), `${LISTING} listing id`);
+  listingIdNamed(world, LISTING);
 
 /** Build the listing the way an organiser does: pick the type from the
  * template chooser, then fill in the advanced form. */
@@ -102,7 +108,7 @@ Given(
   async function (this: TicketsWorld): Promise<void> {
     const browser = await adminBrowser(this);
     const id = await createListingThroughChooser(browser);
-    this.listingIds.set(LISTING, id);
+    await rememberListingById(this, LISTING, id);
     await askSizeQuestion(browser, id);
     this.bookingPath = await groupTheListing(browser);
   },

--- a/test/specs/steps/bulk-money.ts
+++ b/test/specs/steps/bulk-money.ts
@@ -10,7 +10,8 @@ import {
   payYourOwnPrice,
   refundedPeople,
 } from "#test/specs/support/bulk-money.ts";
-import { listingIdFor, minorUnits } from "#test/specs/support/money.ts";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
+import { minorUnits } from "#test/specs/support/money.ts";
 import {
   assertRenderedIncome,
   attendeeLegsOfKind,
@@ -35,7 +36,7 @@ Given(
   ): Promise<void> {
     await paidPlaceEach(this, listing, price, ["One", "Two", "Three"]);
     // The premise the rest of the story rests on: all three sales counted.
-    expect(await incomeOf(listingIdFor(this, listing))).toBe(
+    expect(await incomeOf(listingIdNamed(this, listing))).toBe(
       3 * minorUnits(price),
     );
   },
@@ -85,7 +86,7 @@ Then(
     expect((await attendeeLegsOfKind(turnedDown, "refund_cash")).length).toBe(
       0,
     );
-    expect(await incomeOf(listingIdFor(this, listing))).toBe(
+    expect(await incomeOf(listingIdNamed(this, listing))).toBe(
       minorUnits(earned),
     );
     expect(await sumOfAllBalances()).toBe(0);
@@ -113,7 +114,7 @@ Then(
     listing: string,
     earned: string,
   ): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, listing))).toBe(
+    expect(await incomeOf(listingIdNamed(this, listing))).toBe(
       minorUnits(earned),
     );
     expect(await worldBalance()).toBe(-minorUnits(earned));

--- a/test/specs/steps/bundles.ts
+++ b/test/specs/steps/bundles.ts
@@ -176,10 +176,7 @@ Then(
 );
 
 const onlyBundle = (world: TicketsWorld): string => {
-  const [name, ...rest] = requiredWorldValue(
-    world.bundles,
-    "the story's bundles",
-  ).keys();
+  const [name, ...rest] = world.things.names("bundle");
   if (!name || rest.length > 0)
     throw new Error("The story has no single bundle");
   return name;

--- a/test/specs/steps/contact-records.ts
+++ b/test/specs/steps/contact-records.ts
@@ -3,6 +3,11 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import {
+  browserSeenBy,
+  CUSTOMER,
+  rememberBrowser,
+} from "#test/specs/support/browser.ts";
+import {
   boxShows,
   contactWithHistory,
   openRecord,
@@ -10,10 +15,7 @@ import {
   saveRecord,
   unreadableRecord,
 } from "#test/specs/support/contact-records.ts";
-import {
-  requiredWorldValue,
-  type TicketsWorld,
-} from "#test/specs/support/world.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
 // jscpd:ignore-end
@@ -27,7 +29,7 @@ const HAND_BOOKINGS = 2;
 
 /** The record page the organiser is looking at. */
 const recordPage = (world: TicketsWorld): TestBrowser =>
-  requiredWorldValue(world.customerBrowser, "the record page");
+  browserSeenBy(world, CUSTOMER);
 
 Given(
   "the site has seen {word} book {int} times and get in touch {int} times",
@@ -81,7 +83,7 @@ Given(
 When(
   "the organiser opens {word}'s record",
   async function (this: TicketsWorld, who: string): Promise<void> {
-    this.customerBrowser = await openRecord(this, emailFor(who));
+    rememberBrowser(this, CUSTOMER, await openRecord(this, emailFor(who)));
   },
 );
 
@@ -92,9 +94,13 @@ When(
     who: string,
     messages: number,
   ): Promise<void> {
-    this.customerBrowser = await saveRecord(this, emailFor(who), {
-      messages: String(messages),
-    });
+    rememberBrowser(
+      this,
+      CUSTOMER,
+      await saveRecord(this, emailFor(who), {
+        messages: String(messages),
+      }),
+    );
   },
 );
 
@@ -106,19 +112,27 @@ When(
     booked: number,
     note: string,
   ): Promise<void> {
-    this.customerBrowser = await saveRecord(this, emailFor(who), {
-      bookedThroughTheSite: String(booked),
-      note,
-    });
+    rememberBrowser(
+      this,
+      CUSTOMER,
+      await saveRecord(this, emailFor(who), {
+        bookedThroughTheSite: String(booked),
+        note,
+      }),
+    );
   },
 );
 
 When(
   "the organiser leaves {word}'s site bookings blank",
   async function (this: TicketsWorld, who: string): Promise<void> {
-    this.customerBrowser = await saveRecord(this, emailFor(who), {
-      bookedThroughTheSite: "",
-    });
+    rememberBrowser(
+      this,
+      CUSTOMER,
+      await saveRecord(this, emailFor(who), {
+        bookedThroughTheSite: "",
+      }),
+    );
   },
 );
 
@@ -133,7 +147,11 @@ When(
     // pressing Save on the repaired form actually sends.
     const page = recordPage(this);
     expect(page.currentHtml).toContain('name="admin_notes"');
-    this.customerBrowser = await saveRecord(this, emailFor(who), { note });
+    rememberBrowser(
+      this,
+      CUSTOMER,
+      await saveRecord(this, emailFor(who), { note }),
+    );
   },
 );
 

--- a/test/specs/steps/corrections.ts
+++ b/test/specs/steps/corrections.ts
@@ -28,10 +28,10 @@ import {
   settleTheRest,
   unpaidPlace,
 } from "#test/specs/support/deposits.ts";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
 import {
   bookingId,
   expectMoneyHandedBack,
-  listingIdFor,
   minorUnits,
 } from "#test/specs/support/money.ts";
 import {
@@ -82,7 +82,10 @@ Then(
     listing: string,
     amount: string,
   ): Promise<void> {
-    await assertRenderedIncome(listingIdFor(this, listing), minorUnits(amount));
+    await assertRenderedIncome(
+      listingIdNamed(this, listing),
+      minorUnits(amount),
+    );
   },
 );
 
@@ -105,7 +108,7 @@ const correctListingIncome = function (
   listing: string,
   amount: string,
 ): Promise<void> {
-  const page = `/admin/listing/${listingIdFor(this, listing)}/edit`;
+  const page = `/admin/listing/${listingIdNamed(this, listing)}/edit`;
   return correctEarnings(this, page, "income", amount, LISTING_TOLD);
 };
 
@@ -121,7 +124,7 @@ Then(
     listing: string,
     amount: string,
   ): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, listing))).toBe(
+    expect(await incomeOf(listingIdNamed(this, listing))).toBe(
       minorUnits(amount),
     );
   },
@@ -207,7 +210,7 @@ const earnedAnd = (alsoTrue: (world: TicketsWorld) => Promise<void>) =>
     listing: string,
     amount: string,
   ): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, listing))).toBe(
+    expect(await incomeOf(listingIdNamed(this, listing))).toBe(
       minorUnits(amount),
     );
     await alsoTrue(this);

--- a/test/specs/steps/extra-charges.ts
+++ b/test/specs/steps/extra-charges.ts
@@ -12,11 +12,11 @@ import {
   transfersByAccount,
 } from "#shared/accounting/queries.ts";
 import { settings } from "#shared/db/settings.ts";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
 import {
   bookingId,
   buyPlaceWithExtra,
   expectMoneyHandedBack,
-  listingIdFor,
   sellPlacesAt,
   soleBookingOn,
 } from "#test/specs/support/money.ts";
@@ -72,7 +72,7 @@ When(
 Then(
   "the Fee Day place has earned 50.00 and the booking fee has earned 5.00",
   async function (this: TicketsWorld): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, FEE_DAY))).toBe(5000);
+    expect(await incomeOf(listingIdNamed(this, FEE_DAY))).toBe(5000);
     expect(await accountBalance(BOOKING_FEE_INCOME)).toBe(500);
     expect(await worldBalance()).toBe(-5500);
     // The fee is its own line on the booking, not part of the ticket's price.
@@ -103,7 +103,7 @@ Given(
 Then(
   "the Fee Day place and the booking fee have both earned nothing",
   async function (this: TicketsWorld): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, FEE_DAY))).toBe(0);
+    expect(await incomeOf(listingIdNamed(this, FEE_DAY))).toBe(0);
     expect(await accountBalance(BOOKING_FEE_INCOME)).toBe(0);
     const handedBackFee = await attendeeLegsOfKind(
       bookingId(this),
@@ -135,7 +135,7 @@ Given(
 When(
   "a customer pays for one Talk place",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, TALK);
+    const listingId = listingIdNamed(this, TALK);
     const modifierId = requiredWorldValue(this.modifierId, "modifier id");
     await runStripeSuccess({
       email: "svc@example.com",
@@ -156,7 +156,7 @@ Then(
   async function (this: TicketsWorld): Promise<void> {
     const modifierId = requiredWorldValue(this.modifierId, "modifier id");
     expect(await accountBalance(modifierAccount(modifierId))).toBe(500);
-    expect(await incomeOf(listingIdFor(this, TALK))).toBe(5000);
+    expect(await incomeOf(listingIdNamed(this, TALK))).toBe(5000);
     expect(await owedBy(bookingId(this))).toBe(0);
     // The charge is its own line, paid to the charge itself.
     const legs = await transfersByAccount(attendeeAccount(bookingId(this)));

--- a/test/specs/steps/listing-changes.ts
+++ b/test/specs/steps/listing-changes.ts
@@ -7,7 +7,7 @@ import {
   stopOpeningOn,
   weekdayOf,
 } from "#test/specs/support/listing-changes.ts";
-import { stayListing } from "#test/specs/support/listings.ts";
+import { listingNamed } from "#test/specs/support/listings.ts";
 import {
   daysOfferedFor,
   expectRefusedForWantOfRoom,
@@ -59,7 +59,7 @@ Then(
   ): Promise<void> {
     // A stay reaching a day the listing no longer takes cannot start at all,
     // so the day drops off the chooser the customer is shown.
-    expect(await daysOfferedFor(stayListing(this, name))).not.toContain(
+    expect(await daysOfferedFor(listingNamed(this, name))).not.toContain(
       dayFromToday(this, startsIn),
     );
   },
@@ -90,7 +90,7 @@ When(
     name: string,
     startsIn: number,
   ): Promise<void> {
-    const listing = stayListing(this, name);
+    const listing = listingNamed(this, name);
     const day = dayFromToday(this, startsIn);
     // Both customers fill the form in first. Only once both are waiting do they
     // press Continue, so one cannot quietly finish before the other starts and

--- a/test/specs/steps/money-actions.ts
+++ b/test/specs/steps/money-actions.ts
@@ -13,6 +13,7 @@ import {
 } from "#shared/accounting/queries.ts";
 import { formatSignedCurrency } from "#shared/currency.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
 import {
   askForRefund,
   bookFreePlace,
@@ -20,7 +21,6 @@ import {
   buyOnePlace,
   correctIncomeTo,
   expectRefundMessage,
-  listingIdFor,
   minorUnits,
   sellPlacesAt,
   timesProviderWasAsked,
@@ -73,7 +73,7 @@ Then(
     expect(
       (await transfersByAccount(attendeeAccount(bookingId(this)))).length,
     ).toBe(0);
-    expect(await incomeOf(listingIdFor(this, FREE_MEETUP))).toBe(0);
+    expect(await incomeOf(listingIdNamed(this, FREE_MEETUP))).toBe(0);
   },
 );
 
@@ -94,7 +94,9 @@ Given(
     listing: string,
   ): Promise<void> {
     await buyOnePlace(this, listing, price, `${listing} Buyer`);
-    expect(await incomeOf(listingIdFor(this, listing))).toBe(minorUnits(price));
+    expect(await incomeOf(listingIdNamed(this, listing))).toBe(
+      minorUnits(price),
+    );
   },
 );
 
@@ -120,7 +122,7 @@ Then(
 Then(
   "the Show has still earned 45.00 and no money was handed back",
   async function (this: TicketsWorld): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, SHOW))).toBe(4500);
+    expect(await incomeOf(listingIdNamed(this, SHOW))).toBe(4500);
     expect(await owedBy(bookingId(this))).toBe(0);
     const legs = await transfersByAccount(attendeeAccount(bookingId(this)));
     expect(legsOfKind(legs, "refund_cash").length).toBe(0);
@@ -132,7 +134,7 @@ Then(
 When(
   "the same payment message arrives again",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, REPEAT);
+    const listingId = listingIdNamed(this, REPEAT);
     // An already-handled payment is a no-op, so the page just renders again.
     await withStripeSuccess(
       {
@@ -153,7 +155,9 @@ When(
 Then(
   "there is still one booking and one sale",
   async function (this: TicketsWorld): Promise<void> {
-    expect((await getAttendeesRaw(listingIdFor(this, REPEAT))).length).toBe(1);
+    expect((await getAttendeesRaw(listingIdNamed(this, REPEAT))).length).toBe(
+      1,
+    );
     expect(
       kindsOf(await transfersByAccount(attendeeAccount(bookingId(this)))),
     ).toEqual(["payment", "sale"]);
@@ -164,7 +168,7 @@ Then(
 When(
   "the organiser sets the Repeat income to 40.00 twice",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, REPEAT);
+    const listingId = listingIdNamed(this, REPEAT);
     await correctIncomeTo(this, listingId, "40.00");
     await correctIncomeTo(this, listingId, "40.00");
   },
@@ -173,7 +177,7 @@ When(
 Then(
   "the Repeat has earned 40.00 from a single correction",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, REPEAT);
+    const listingId = listingIdNamed(this, REPEAT);
     expect(await incomeOf(listingId)).toBe(4000);
     // The second save works out a change of nothing, so it records nothing.
     const corrections = legsOfKind(
@@ -187,7 +191,7 @@ Then(
 Given(
   "the organiser corrected the Reconciled income to 40.00",
   function (this: TicketsWorld): Promise<void> {
-    return correctIncomeTo(this, listingIdFor(this, RECONCILED), "40.00");
+    return correctIncomeTo(this, listingIdNamed(this, RECONCILED), "40.00");
   },
 );
 
@@ -195,7 +199,7 @@ Then(
   "the Reconciled page breaks the money down line by line",
   async function (this: TicketsWorld): Promise<void> {
     const breakdown = incomeLedgerArticle(
-      await adminPageHtml(`/admin/listing/${listingIdFor(this, RECONCILED)}`),
+      await adminPageHtml(`/admin/listing/${listingIdNamed(this, RECONCILED)}`),
     );
     expect(breakdown).toContain("Money in and out");
     // Each figure is read from its own row: the 50.00 sale, the 10.00 taken off
@@ -219,7 +223,7 @@ Then(
 Then(
   "the breakdown links to the Reconciled money record",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, RECONCILED);
+    const listingId = listingIdNamed(this, RECONCILED);
     expect(
       incomeLedgerArticle(await adminPageHtml(`/admin/listing/${listingId}`)),
     ).toContain(`/admin/ledger?listing=${listingId}`);

--- a/test/specs/steps/money-shares.ts
+++ b/test/specs/steps/money-shares.ts
@@ -4,12 +4,12 @@ import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { attendeeAccount } from "#shared/accounting/accounts.ts";
 import { transfersByAccount } from "#shared/accounting/queries.ts";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
 import {
   askForRefund,
   bookingId,
   buyOnePlace,
   correctIncomeTo,
-  listingIdFor,
   sellPlacesAt,
   soleBookingOn,
   timesProviderWasAsked,
@@ -44,12 +44,12 @@ Given(
 When(
   "a customer pays 50.00 for one place on each",
   async function (this: TicketsWorld): Promise<void> {
-    const first = listingIdFor(this, "Part One");
+    const first = listingIdNamed(this, "Part One");
     await runStripeSuccess({
       email: "both@example.com",
       items: JSON.stringify([
         { e: first, p: 3000, q: 1 },
-        { e: listingIdFor(this, "Part Two"), p: 2000, q: 1 },
+        { e: listingIdNamed(this, "Part Two"), p: 2000, q: 1 },
       ]),
       name: "Both Buyer",
       paymentIntent: "pi_multi",
@@ -64,8 +64,8 @@ When(
 Then(
   "Part One has earned 30.00 and Part Two has earned 20.00",
   async function (this: TicketsWorld): Promise<void> {
-    expect(await incomeOf(listingIdFor(this, "Part One"))).toBe(3000);
-    expect(await incomeOf(listingIdFor(this, "Part Two"))).toBe(2000);
+    expect(await incomeOf(listingIdNamed(this, "Part One"))).toBe(3000);
+    expect(await incomeOf(listingIdNamed(this, "Part Two"))).toBe(2000);
     expect(await owedBy(bookingId(this))).toBe(0);
     expect(await worldBalance()).toBe(-5000);
     expect(await sumOfAllBalances()).toBe(0);
@@ -78,8 +78,8 @@ Then(
     // Both listings must hold the very same booking — money alone could add up
     // while one of the places was never given to anybody.
     const booking = bookingId(this);
-    expect(await soleBookingOn(listingIdFor(this, "Part One"))).toBe(booking);
-    expect(await soleBookingOn(listingIdFor(this, "Part Two"))).toBe(booking);
+    expect(await soleBookingOn(listingIdNamed(this, "Part One"))).toBe(booking);
+    expect(await soleBookingOn(listingIdNamed(this, "Part Two"))).toBe(booking);
     const legs = await transfersByAccount(attendeeAccount(booking));
     expect(legsOfKind(legs, "sale").length).toBe(2);
     expect(new Set(legs.map((leg) => leg.eventGroup)).size).toBe(1);
@@ -89,8 +89,8 @@ Then(
 Then(
   "each listing's page shows its own earnings",
   async function (this: TicketsWorld): Promise<void> {
-    await assertEditPageIncome(listingIdFor(this, "Part One"), 3000);
-    await assertEditPageIncome(listingIdFor(this, "Part Two"), 2000);
+    await assertEditPageIncome(listingIdNamed(this, "Part One"), 3000);
+    await assertEditPageIncome(listingIdNamed(this, "Part Two"), 2000);
   },
 );
 
@@ -99,20 +99,20 @@ Given(
   async function (this: TicketsWorld): Promise<void> {
     await buyOnePlace(this, FESTIVAL, "70.00", "Mixed One");
     await createPaidTestAttendee(
-      listingIdFor(this, FESTIVAL),
+      listingIdNamed(this, FESTIVAL),
       "Mixed Two",
       "mixed2@example.com",
       "pi_mix2",
       7000,
     );
-    expect(await incomeOf(listingIdFor(this, FESTIVAL))).toBe(14000);
+    expect(await incomeOf(listingIdNamed(this, FESTIVAL))).toBe(14000);
   },
 );
 
 Given(
   "the organiser corrected the Festival income to 100.00",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, FESTIVAL);
+    const listingId = listingIdNamed(this, FESTIVAL);
     await correctIncomeTo(this, listingId, "100.00");
     expect(await incomeOf(listingId)).toBe(10000);
   },
@@ -128,7 +128,7 @@ When(
 Then(
   "the Festival earnings and the refunded customer's balance agree",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, FESTIVAL);
+    const listingId = listingIdNamed(this, FESTIVAL);
     expect(timesProviderWasAsked(this)).toBe(1);
     expect(await owedBy(bookingId(this))).toBe(0);
     // 140 sold − 40 written down − 70 refunded = 30 on the money record, while

--- a/test/specs/steps/no-quantity.ts
+++ b/test/specs/steps/no-quantity.ts
@@ -3,6 +3,10 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import {
+  listingIdNamed,
+  rememberListing,
+} from "#test/specs/support/listings.ts";
+import {
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
@@ -22,9 +26,6 @@ const WORKSHOP = "Workshop";
 const REAL_SHOW = "RealShow";
 const GHOST_SHOW = "GhostShow";
 
-const listingIdFor = (world: TicketsWorld, name: string): number =>
-  requiredWorldValue(world.listingIds.get(name), `${name} listing id`);
-
 const ticketToken = (world: TicketsWorld): string =>
   requiredWorldValue(world.ticketToken, "ticket token");
 
@@ -37,7 +38,7 @@ const addListing = async (
     maxQuantity: 5,
     name,
   });
-  world.listingIds.set(name, listing.id);
+  rememberListing(world, name, listing);
   return listing.id;
 };
 
@@ -81,7 +82,7 @@ const changeListingLines = async (
   change: (line: AttendeeLineInput) => AttendeeLineInput,
 ): Promise<void> => {
   const attendeeId = requiredWorldValue(world.attendeeId, "attendee id");
-  const listingId = listingIdFor(world, listingName);
+  const listingId = listingIdNamed(world, listingName);
   const lines = await existingAttendeeLines(attendeeId);
   if (!lines.some((line) => line.eventId === listingId)) {
     throw new Error(`${listingName} attendee line was not found`);
@@ -106,7 +107,7 @@ const attendeeList = async (
   listingName: string,
 ): Promise<string> => {
   const response = await awaitTestRequest(
-    `/admin/listing/${listingIdFor(world, listingName)}/attendees`,
+    `/admin/listing/${listingIdNamed(world, listingName)}/attendees`,
     { cookie: await testCookie() },
   );
   expect(response.status).toBe(200);
@@ -216,7 +217,7 @@ When(
     const attendeeId = requiredWorldValue(this.attendeeId, "attendee id");
     await saveLines(this, [
       ...(await existingAttendeeLines(attendeeId)),
-      { eventId: listingIdFor(this, GHOST_SHOW), noQuantity: true },
+      { eventId: listingIdNamed(this, GHOST_SHOW), noQuantity: true },
     ]);
   },
 );

--- a/test/specs/steps/payment-capacity.ts
+++ b/test/specs/steps/payment-capacity.ts
@@ -180,7 +180,7 @@ Given(
       paymentIntent: "pi_spec_replay",
       sessionId,
     });
-    this.cleanup.push(
+    this.cleanup.add(
       () => retrieve.restore(),
       () => refund.restore(),
     );

--- a/test/specs/steps/refunds.ts
+++ b/test/specs/steps/refunds.ts
@@ -2,6 +2,7 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
 import {
   askForRefund,
   bookingId,
@@ -9,7 +10,6 @@ import {
   buyOnePlace,
   expectMoneyHandedBack,
   expectRefundMessage,
-  listingIdFor,
   timesProviderWasAsked,
 } from "#test/specs/support/money.ts";
 import {
@@ -49,7 +49,7 @@ Then(
 Then(
   "the Concert has earned nothing and the customer owes nothing",
   async function (this: TicketsWorld): Promise<void> {
-    const listingId = listingIdFor(this, CONCERT);
+    const listingId = listingIdNamed(this, CONCERT);
     expect(await incomeOf(listingId)).toBe(0);
     expect(await owedBy(bookingId(this))).toBe(0);
     expect(await sumOfAllBalances()).toBe(0);

--- a/test/specs/steps/servicing-hold.ts
+++ b/test/specs/steps/servicing-hold.ts
@@ -5,6 +5,10 @@ import { expect } from "@std/expect";
 import { getListingRemainingForRange } from "#shared/db/attendees/capacity/remaining.ts";
 import { submitRenderedAdminForm } from "#test/specs/support/browser.ts";
 import {
+  listingIdNamed,
+  rememberListing,
+} from "#test/specs/support/listings.ts";
+import {
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
@@ -75,7 +79,7 @@ Given(
       unitPrice: 2_800,
     });
     this.holdListingId = listing.id;
-    this.listingIds.set(STUDIO_LISTING, listing.id);
+    rememberListing(this, STUDIO_LISTING, listing);
   },
 );
 
@@ -83,7 +87,7 @@ When(
   "the organiser creates a two-day Studio floor treatment hold for four places",
   async function (this: TicketsWorld): Promise<void> {
     const listingId = requiredWorldValue(
-      this.listingIds.get(STUDIO_LISTING),
+      listingIdNamed(this, STUDIO_LISTING),
       "studio listing id",
     );
     const browser = await submitRenderedAdminForm(

--- a/test/specs/steps/setting-up.ts
+++ b/test/specs/steps/setting-up.ts
@@ -3,7 +3,12 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { t } from "#i18n";
-import { newcomerReading } from "#test/specs/support/browser.ts";
+import {
+  browserSeenBy,
+  LATECOMER,
+  newcomerReading,
+  rememberBrowser,
+} from "#test/specs/support/browser.ts";
 import {
   aSiteNobodyHasSetUp,
   firstOwnerCanSignIn,
@@ -15,10 +20,7 @@ import {
   somebodySetsUp,
   whatSetterWasTold,
 } from "#test/specs/support/setting-up.ts";
-import {
-  requiredWorldValue,
-  type TicketsWorld,
-} from "#test/specs/support/world.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
 
 // jscpd:ignore-end
 
@@ -92,16 +94,14 @@ Then(
 Given(
   "somebody else already had the setup page open",
   async function (this: TicketsWorld): Promise<void> {
-    this.latecomerBrowser = await openSetup();
+    rememberBrowser(this, LATECOMER, await openSetup());
   },
 );
 
 When(
   "they send their setup after the site is somebody's",
   function (this: TicketsWorld): Promise<void> {
-    return latecomerSendsSetup(
-      requiredWorldValue(this.latecomerBrowser, "the latecomer's page"),
-    );
+    return latecomerSendsSetup(browserSeenBy(this, LATECOMER));
   },
 );
 

--- a/test/specs/steps/shown-code.ts
+++ b/test/specs/steps/shown-code.ts
@@ -3,7 +3,7 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { QR_TOKEN_MAX_AGE_S } from "#shared/qr-token.ts";
-import { stayListing } from "#test/specs/support/listings.ts";
+import { listingNamed } from "#test/specs/support/listings.ts";
 import {
   customerPaysMore,
   customerScans,
@@ -199,7 +199,7 @@ Then(
 );
 
 Then("it is for the {word}", function (this: TicketsWorld, name: string): void {
-  expect(payingNow(this).forWhat).toBe(stayListing(this, name).slug);
+  expect(payingNow(this).forWhat).toBe(listingNamed(this, name).slug);
 });
 
 Then(

--- a/test/specs/steps/site-pages.ts
+++ b/test/specs/steps/site-pages.ts
@@ -6,6 +6,7 @@ import { t } from "#i18n";
 import {
   ownerMovesPageUp,
   ownerTakesPageDown,
+  ownerTriesToTakePageDown,
   ownerWritesPage,
   ownerWritesPages,
   pageIsOfferedAMoveUp,
@@ -147,7 +148,7 @@ When(
     name: string,
     typed: string,
   ): Promise<void> {
-    this.sitePageTold = await ownerTakesPageDown(this, name, typed);
+    await ownerTriesToTakePageDown(this, name, typed);
   },
 );
 

--- a/test/specs/steps/stays-booking.ts
+++ b/test/specs/steps/stays-booking.ts
@@ -4,8 +4,13 @@ import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { addDays, formatDateRangeLabel } from "#shared/dates.ts";
 import { getAttendeeRaw } from "#shared/db/attendees/queries.ts";
-import { adminBrowser } from "#test/specs/support/browser.ts";
-import { stayListing } from "#test/specs/support/listings.ts";
+import {
+  adminBrowser,
+  browserSeenBy,
+  CUSTOMER,
+  rememberBrowser,
+} from "#test/specs/support/browser.ts";
+import { listingNamed } from "#test/specs/support/listings.ts";
 import {
   daysOfferedOn,
   expectRefusedForWantOfRoom,
@@ -35,10 +40,7 @@ const stayStart = (world: TicketsWorld): string =>
 
 /** The days a listing's page offered when the customer looked at it. */
 export const offeredDaysOf = (world: TicketsWorld, name: string): string[] =>
-  requiredWorldValue(
-    world.daysOffered?.get(name),
-    `the days the ${name} page offered`,
-  );
+  world.things.require("daysOffered", name);
 
 /** The days the page offered the last time a customer looked. */
 const offeredDays = (world: TicketsWorld): string[] =>
@@ -62,7 +64,7 @@ const bookStay = async (
   dayCount?: number,
 ): Promise<void> => {
   world.stayStartsOn = dayFromToday(world, startsIn);
-  await visitorBooks(world, stayListing(world, name), {
+  await visitorBooks(world, listingNamed(world, name), {
     ...guest(order),
     day: world.stayStartsOn,
     places,
@@ -81,13 +83,13 @@ export const tryToBook = async (
   places = 1,
   dayCount?: number,
 ): Promise<void> => {
-  const attempt = await visitorTriesToBook(stayListing(world, name), {
+  const attempt = await visitorTriesToBook(listingNamed(world, name), {
     ...guest(9),
     day: dayFromToday(world, startsIn),
     places,
     ...(dayCount === undefined ? {} : { dayCount }),
   });
-  world.customerBrowser = attempt.browser;
+  rememberBrowser(world, CUSTOMER, attempt.browser);
   world.bookingWasTaken = attempt.wasBooked;
 };
 
@@ -101,7 +103,7 @@ export const expectStayCanBeBooked = async (
   who = guest(8),
   dayCount?: number,
 ): Promise<void> => {
-  const attempt = await visitorTriesToBook(stayListing(world, name), {
+  const attempt = await visitorTriesToBook(listingNamed(world, name), {
     ...who,
     day,
     ...(dayCount === undefined ? {} : { dayCount }),
@@ -215,17 +217,20 @@ When(
   async function (this: TicketsWorld, name: string): Promise<void> {
     // The page itself is kept too, so a later step can read what it said
     // beside the days — like how long each booking lasts.
-    const browser = await openBookingPage(stayListing(this, name));
-    this.customerBrowser = browser;
-    this.daysOffered ??= new Map();
-    this.daysOffered.set(name, daysOfferedOn(browser.currentHtml));
+    const browser = await openBookingPage(listingNamed(this, name));
+    rememberBrowser(this, CUSTOMER, browser);
+    this.things.remember(
+      "daysOffered",
+      name,
+      daysOfferedOn(browser.currentHtml),
+    );
     this.daysOfferedLastLook = name;
   },
 );
 
 /** The page the customer was looking at when they last looked. */
 const pageLookedAt = (world: TicketsWorld): string =>
-  requiredWorldValue(world.customerBrowser, "the page looked at").pageText;
+  browserSeenBy(world, CUSTOMER).pageText;
 
 Then(
   "they are told each booking reserves {int} days",
@@ -291,7 +296,10 @@ Then(
   "a {word} stay can still start the day after it ends",
   function (this: TicketsWorld, name: string): Promise<void> {
     // A stay of N days starting on day 0 ends on day N-1, so day N is free.
-    const day = addDays(stayStart(this), stayListing(this, name).duration_days);
+    const day = addDays(
+      stayStart(this),
+      listingNamed(this, name).duration_days,
+    );
     return expectStayCanBeBooked(this, name, day, true, guest(3));
   },
 );
@@ -301,7 +309,7 @@ Then(
   function (this: TicketsWorld, name: string): void {
     expectRefusedForWantOfRoom(
       {
-        browser: requiredWorldValue(this.customerBrowser, "the page shown"),
+        browser: browserSeenBy(this, CUSTOMER),
         wasBooked: this.bookingWasTaken === true,
       },
       name,

--- a/test/specs/steps/stays-length.ts
+++ b/test/specs/steps/stays-length.ts
@@ -5,9 +5,10 @@ import { expect } from "@std/expect";
 import { t } from "#i18n";
 import { openAdminPage, scenarioBrowser } from "#test/specs/support/browser.ts";
 import {
+  listingIdNamed,
+  listingNamed,
   organiserSavesListing,
-  rememberStayListing,
-  stayListing,
+  rememberListing,
 } from "#test/specs/support/listings.ts";
 import { visitorBooks } from "#test/specs/support/public-booking.ts";
 import {
@@ -54,7 +55,7 @@ Given(
       quantity: onFirst,
       secondQuantity: onSecond,
     });
-    rememberStayListing(this, FIRST, listingA);
+    rememberListing(this, FIRST, listingA);
     this.sharedDayOver = dayFromToday(this, 11);
   },
 );
@@ -76,7 +77,7 @@ Given(
     startsIn: number,
   ): Promise<void> {
     this.stayStartsOn = dayFromToday(this, startsIn);
-    await visitorBooks(this, stayListing(this, "Retreat"), {
+    await visitorBooks(this, listingNamed(this, "Retreat"), {
       ...guest(1),
       day: this.stayStartsOn,
       dayCount: days,
@@ -88,7 +89,7 @@ Given(
 Given(
   "a {word} that is not booked by the day",
   async function (this: TicketsWorld, name: string): Promise<void> {
-    rememberStayListing(
+    rememberListing(
       this,
       name,
       await createTestListing({ maxAttendees: 5, name }),
@@ -99,7 +100,7 @@ Given(
 When(
   "the organiser looks at the {word}'s page",
   async function (this: TicketsWorld, name: string): Promise<void> {
-    const { id } = stayListing(this, name);
+    const { id } = listingNamed(this, name);
     this.evidenceValues.set("stayLengthListingId", String(id));
     await openAdminPage(this, `/admin/listing/${id}`);
   },
@@ -138,7 +139,7 @@ Then(
   "the {word}'s history says nothing about a length change",
   async function (this: TicketsWorld, name: string): Promise<void> {
     await expectListingActivityLogLacks(
-      stayListing(this, name).id,
+      listingIdNamed(this, name),
       "duration changed",
     );
   },
@@ -220,7 +221,7 @@ Then(
 Then(
   "the warning is kept in the listing's history",
   async function (this: TicketsWorld): Promise<void> {
-    const listing = stayListing(this, FIRST);
+    const listing = listingNamed(this, FIRST);
     // Both entries matter: the ordinary record of the change every edit gets,
     // and the warning about the day that went over.
     await expectListingActivityLogContains(

--- a/test/specs/steps/stays-shared-days.ts
+++ b/test/specs/steps/stays-shared-days.ts
@@ -2,7 +2,12 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
-import { stayListing } from "#test/specs/support/listings.ts";
+import {
+  browserSeenBy,
+  CUSTOMER,
+  rememberBrowser,
+} from "#test/specs/support/browser.ts";
+import { listingNamed } from "#test/specs/support/listings.ts";
 import {
   visitorBooks,
   visitorTriesToBook,
@@ -71,7 +76,7 @@ const bookPlaces = async (
   startsIn: number,
   order: number,
 ): Promise<void> => {
-  await visitorBooks(world, stayListing(world, name), {
+  await visitorBooks(world, listingNamed(world, name), {
     ...guest(order),
     day: dayFromToday(world, startsIn),
     places,
@@ -110,12 +115,12 @@ When(
     places: number,
     startsIn: number,
   ): Promise<void> {
-    const attempt = await visitorTriesToBook(stayListing(this, "Saturday"), {
+    const attempt = await visitorTriesToBook(listingNamed(this, "Saturday"), {
       ...guest(3),
       day: dayFromToday(this, startsIn),
       places,
     });
-    this.customerBrowser = attempt.browser;
+    rememberBrowser(this, CUSTOMER, attempt.browser);
     this.bookingWasTaken = attempt.wasBooked;
   },
 );
@@ -146,12 +151,12 @@ When(
     const attempt = await visitorTriesToOrder(
       `/ticket/${slug}`,
       [
-        { listing: stayListing(this, "Short"), places: onShort },
-        { listing: stayListing(this, "Long"), places: onLong },
+        { listing: listingNamed(this, "Short"), places: onShort },
+        { listing: listingNamed(this, "Long"), places: onLong },
       ],
       { ...guest(5), day: dayFromToday(this, 10) },
     );
-    this.customerBrowser = attempt.browser;
+    rememberBrowser(this, CUSTOMER, attempt.browser);
     this.bookingWasTaken = attempt.wasBooked;
   },
 );
@@ -161,7 +166,9 @@ Then(
   async function (this: TicketsWorld): Promise<void> {
     expect(this.bookingWasTaken).toBe(false);
     // Refused for want of room, not for some unrelated reason.
-    expect(this.customerBrowser?.pageText).toContain("enough spots available");
+    expect(browserSeenBy(this, CUSTOMER).pageText).toContain(
+      "enough spots available",
+    );
     // Neither half of the order may be taken — a partly-booked order would
     // leave the customer paying for a stay they cannot use.
     expect((await staysOn(this, "Short")).length).toBe(0);

--- a/test/specs/steps/volunteer-sign-up.ts
+++ b/test/specs/steps/volunteer-sign-up.ts
@@ -5,6 +5,10 @@ import { expect } from "@std/expect";
 import { questionsTable } from "#shared/db/questions/tables.ts";
 import { adminBrowser, scenarioBrowser } from "#test/specs/support/browser.ts";
 import {
+  listingIdNamed,
+  rememberListing,
+} from "#test/specs/support/listings.ts";
+import {
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
@@ -38,7 +42,7 @@ Given(
         thankYouUrl: "",
         unitPrice: 0,
       });
-      this.listingIds.set(name, listing.id);
+      rememberListing(this, name, listing);
     }
     const question = await questionsTable.insert({
       assignAll: true,
@@ -66,8 +70,7 @@ When(
       {
         email: VOLUNTEER_EMAIL,
         name: VOLUNTEER_NAME,
-        [`quantity_${requiredWorldValue(this.listingIds.get(SETUP_SHIFT), "set-up shift listing id")}`]:
-          "1",
+        [`quantity_${listingIdNamed(this, SETUP_SHIFT)}`]: "1",
         [`question_${requiredWorldValue(this.questionId, "access question id")}`]:
           ACCESS_ANSWER,
       },
@@ -93,7 +96,7 @@ Then(
   async function (this: TicketsWorld): Promise<void> {
     const browser = await adminBrowser(this);
     const listingId = requiredWorldValue(
-      this.listingIds.get(SETUP_SHIFT),
+      listingIdNamed(this, SETUP_SHIFT),
       "set-up shift listing id",
     );
     await browser.visit(`/admin/listing/${listingId}/attendees`);

--- a/test/specs/support/add-ons.ts
+++ b/test/specs/support/add-ons.ts
@@ -20,9 +20,9 @@ import {
   tickedCheckboxes,
 } from "#test/specs/support/form-controls.ts";
 import {
-  rememberStayListing,
+  listingNamed,
+  rememberListing,
   setBoxOnListing,
-  stayListing,
 } from "#test/specs/support/listings.ts";
 
 import type {
@@ -50,8 +50,8 @@ export const sellWithAddOn = async (
     children: [{ bookableAlone: onItsOwn, name: addOn }],
     parent: { name: mainThing },
   });
-  rememberStayListing(world, mainThing, parent);
-  rememberStayListing(world, addOn, children[0]!);
+  rememberListing(world, mainThing, parent);
+  rememberListing(world, addOn, children[0]!);
 };
 
 /** A bundle whose parts the organiser has chosen to keep hidden, holding one
@@ -67,7 +67,7 @@ export const sellHiddenBundle: ChangeOneThing<string> = async (
     hidePackageListings: true,
     isPackage: true,
   });
-  rememberStayListing(
+  rememberListing(
     world,
     part,
     await createTestListing({
@@ -80,7 +80,7 @@ export const sellHiddenBundle: ChangeOneThing<string> = async (
 
 /** The link a customer would follow to book something on its own. */
 export const bookingLinkFor = (world: TicketsWorld, name: string): string =>
-  `/ticket/${stayListing(world, name).slug}`;
+  `/ticket/${listingNamed(world, name).slug}`;
 
 /** A customer opens something's own page and is shown it. Both halves matter:
  * the page has to answer at all, and it has to be the page for this thing
@@ -95,7 +95,7 @@ export const expectCustomerCanOpen: ActOnOneThing = async (world, name) => {
 const expectTicketPageAnswers =
   (answer: number) =>
   async (world: TicketsWorld, name: string): Promise<void> => {
-    expect(await ticketPageStatus(stayListing(world, name).slug)).toBe(answer);
+    expect(await ticketPageStatus(listingNamed(world, name).slug)).toBe(answer);
   };
 
 /** There is no page for this thing at all — the site's way of saying it is only

--- a/test/specs/support/api-keys.ts
+++ b/test/specs/support/api-keys.ts
@@ -59,13 +59,12 @@ export const ownerMakesKey: ActOnOneThing = async (world, name) => {
     /<pre><code>([A-Za-z0-9_-]+)<\/code><\/pre>/,
   );
   if (!shown) throw new Error(`The owner was shown no ${name} key to copy`);
-  world.apiKeys ??= new Map();
-  world.apiKeys.set(name, shown[1]!);
+  world.things.remember("key", name, shown[1]!);
 };
 
 /** The key the story handed to one system. */
 export const keyNamed = (world: TicketsWorld, name: string): string =>
-  requiredWorldValue(world.apiKeys?.get(name), `the ${name} key`);
+  world.things.require("key", name);
 
 /** The owner's keys page as words on a screen, or as the whole response the
  * site sent. A key hidden in a link or an attribute is still a key anybody

--- a/test/specs/support/booking-api.ts
+++ b/test/specs/support/booking-api.ts
@@ -9,7 +9,7 @@
 import { expect } from "@std/expect";
 import { settings } from "#shared/db/settings.ts";
 
-import { stayListing } from "#test/specs/support/listings.ts";
+import { listingNamed } from "#test/specs/support/listings.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { mockRequest } from "#test-utils/mocks.ts";
 // jscpd:ignore-end
@@ -50,7 +50,7 @@ export const daysTheApiOffers = async (
   name: string,
 ): Promise<string[]> => {
   const { body, status } = await ask(
-    `/api/listings/${stayListing(world, name).slug}`,
+    `/api/listings/${listingNamed(world, name).slug}`,
   );
   expect(status).toBe(200);
   const { availableDates } = (body.listing ?? {}) as Record<string, unknown>;
@@ -71,7 +71,7 @@ export const apiSaysThereIsRoom = async (
   name: string,
   day: string,
 ): Promise<boolean> => {
-  const slug = stayListing(world, name).slug;
+  const slug = listingNamed(world, name).slug;
   const { body, status } = await ask(
     `/api/listings/${slug}/availability?date=${day}&quantity=1`,
   );
@@ -93,7 +93,7 @@ export const apiBooks = async (
   day: string,
   who: string,
 ): Promise<ApiAnswer> =>
-  ask(`/api/listings/${stayListing(world, name).slug}/book`, {
+  ask(`/api/listings/${listingNamed(world, name).slug}/book`, {
     body: {
       date: day,
       email: `${who.toLowerCase().replaceAll(" ", ".")}@example.com`,

--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -9,15 +9,37 @@ import { TestBrowser } from "#test-utils/test-browser.ts";
 import type { TicketsWorld } from "./world.ts";
 // jscpd:ignore-end
 
-export const scenarioBrowser = (world: TicketsWorld): TestBrowser => {
-  world.testBrowser ??= new TestBrowser();
-  return world.testBrowser;
-};
+/** Whose browser each story keeps. The organiser's is the story's own, so a
+ * step that does not say who is doing something is the organiser doing it. */
+export const ORGANISER = "the organiser";
+export const CUSTOMER = "the customer";
+export const EDITOR = "the editor";
+export const LATECOMER = "the latecomer";
+
+/** Keep the window somebody is looking at, so the next step can read the page
+ * they really ended on. */
+export const rememberBrowser = (
+  world: TicketsWorld,
+  who: string,
+  browser: TestBrowser,
+): TestBrowser => world.things.remember("browser", who, browser);
+
+/** The window somebody is already looking at. A story that never gave them one
+ * has nothing to read, so it says so rather than opening a fresh window and
+ * reporting on a page nobody was ever shown. */
+export const browserSeenBy = (world: TicketsWorld, who: string): TestBrowser =>
+  world.things.require("browser", who);
+
+export const browserOf = (world: TicketsWorld, who: string): TestBrowser =>
+  world.things.orMake("browser", who, () => new TestBrowser());
+
+export const scenarioBrowser = (world: TicketsWorld): TestBrowser =>
+  browserOf(world, ORGANISER);
 
 /** Forget the Scenario's browser, so the next ask starts a fresh one. Use this
  * after the site itself is replaced and the old session can no longer work. */
 export const resetScenarioBrowser = (world: TicketsWorld): void => {
-  delete world.testBrowser;
+  world.things.forget("browser", ORGANISER);
 };
 
 export const adminBrowser = async (

--- a/test/specs/support/bundles.ts
+++ b/test/specs/support/bundles.ts
@@ -23,8 +23,9 @@ import {
   whyValueCannotBeSent,
 } from "#test/specs/support/form-controls.ts";
 import {
-  rememberStayListing,
-  stayListing,
+  listingIdNamed,
+  listingNamed,
+  rememberListing,
 } from "#test/specs/support/listings.ts";
 import {
   type ActOnOneThing,
@@ -58,7 +59,7 @@ export interface ThingForSale extends PartOfBundle {
 
 /** The bundle a story is talking about. */
 const bundleNamed = (world: TicketsWorld, name: string): Group =>
-  requiredWorldValue(world.bundles?.get(name), `the ${name} bundle`);
+  world.things.require("bundle", name);
 
 /** Things that exist and belong together, before the organiser has decided
  * they are a bundle at all. */
@@ -69,10 +70,9 @@ export const thingsGroupedTogether = async (
 ): Promise<void> => {
   await enablePublicSite();
   const group = await createTestGroup({ name });
-  world.bundles ??= new Map();
-  world.bundles.set(name, group);
+  world.things.remember("bundle", name, group);
   for (const part of parts) {
-    rememberStayListing(
+    rememberListing(
       world,
       part.name,
       await createTestListing({
@@ -96,7 +96,7 @@ const bundleForm = (
 ): Record<string, string> => {
   const filledIn = Object.fromEntries(
     map((part: PartOfBundle) => {
-      const box = `package_price_${stayListing(world, part.name).id}`;
+      const box = `package_price_${listingIdNamed(world, part.name)}`;
       expect(html).toContain(`name="${box}"`);
       return [
         box,
@@ -221,7 +221,7 @@ export const bundleChargeForOrNull = async (
   name: string,
   part: string,
 ): Promise<number | null> => {
-  const wanted = stayListing(world, part).id;
+  const wanted = listingIdNamed(world, part);
   const rows = await getGroupPackagePrices(bundleNamed(world, name).id);
   const inBundle = rows.find((row: GroupListing) => row.listing_id === wanted);
   if (!inBundle) throw new Error(`The ${part} is not in the ${name} at all`);
@@ -303,7 +303,7 @@ export const bundleStillExists: AsksAboutOneThing =
  * answer, be that thing's page, and offer a way to book it — a row left in the
  * database that nobody can reach is not "for sale". */
 export const expectPartOnSaleAlone: ActOnOneThing = async (world, part) => {
-  const listing = stayListing(world, part);
+  const listing = listingNamed(world, part);
   const browser = await openAsNewcomer(`/ticket/${listing.slug}`);
   expect(browser.pageText).toContain(part);
   const box = `quantity_${listing.id}`;

--- a/test/specs/support/by-hand.ts
+++ b/test/specs/support/by-hand.ts
@@ -7,7 +7,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { openAdminPage } from "#test/specs/support/browser.ts";
-import { stayListing } from "#test/specs/support/listings.ts";
+import { listingIdNamed } from "#test/specs/support/listings.ts";
 import type { BookingChoices } from "#test/specs/support/public-booking.ts";
 import type {
   ReadAboutOneThing,
@@ -18,7 +18,7 @@ import type {
 
 /** The listing's roster — where the add form and the download both live. */
 const rosterPath = (world: TicketsWorld, name: string): string =>
-  `/admin/listing/${stayListing(world, name).id}/attendees`;
+  `/admin/listing/${listingIdNamed(world, name)}/attendees`;
 
 /** The organiser adds a booking through the form on the listing's roster. Keeps
  * the page they land on, so a story can read what they were told. */

--- a/test/specs/support/contact.ts
+++ b/test/specs/support/contact.ts
@@ -12,10 +12,14 @@ import {
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
+import { withEnv } from "#test-utils/env.ts";
 import { installRecordingFetch } from "#test-utils/mocks.ts";
 import { activateContactForm } from "#test-utils/settings.ts";
 
 // jscpd:ignore-end
+
+/** The person writing in. Everything the site says back is said to them. */
+const VISITOR = "the visitor";
 
 /** Where a visitor writes from. */
 const CONTACT_PAGE = "/contact";
@@ -50,7 +54,7 @@ const watchOutgoing = (
     }
     return null;
   });
-  world.cleanup.push(watching.restore);
+  world.cleanup.add(watching.restore);
   world.messagesOut = watching;
   return watching;
 };
@@ -60,21 +64,20 @@ const watchOutgoing = (
  * keys are put back afterwards — otherwise a machine whose shell already
  * exports them would switch protection on for every story here, and every
  * message would be turned down for a reason the story never mentions. */
-const SPAM_KEYS = {
+const SPAM_KEYS: Record<string, string> = {
   BOTPOISON_PUBLIC_KEY: "pk_test_public",
   BOTPOISON_SECRET_KEY: "sk_test_secret",
 };
 
 const setSpamProtection = (world: TicketsWorld, wanted: boolean): void => {
-  for (const [name, value] of Object.entries(SPAM_KEYS)) {
-    const before = process.env[name];
-    world.cleanup.push(() => {
-      if (before === undefined) delete process.env[name];
-      else process.env[name] = before;
-    });
-    if (wanted) process.env[name] = value;
-    else delete process.env[name];
-  }
+  const keys = Object.keys(SPAM_KEYS);
+  world.cleanup.add(
+    withEnv(
+      Object.fromEntries(
+        keys.map((name) => [name, wanted ? SPAM_KEYS[name] : undefined]),
+      ),
+    ),
+  );
 };
 
 /** The site set up to take messages, with the outside world answering the way
@@ -133,13 +136,13 @@ export const visitorWrites = async (
 ): Promise<string> => {
   const browser = await openAsNewcomer(CONTACT_PAGE);
   await fillInAndSend(browser, { email: from, message }, SEND);
-  world.visitorTold = browser.pageText;
+  world.things.remember("told", VISITOR, browser.pageText);
   return browser.pageText;
 };
 
 /** What the visitor was told the last time they wrote. */
 export const whatVisitorWasTold = (world: TicketsWorld): string =>
-  requiredWorldValue(world.visitorTold, "what the visitor was told");
+  world.things.require("told", VISITOR);
 
 /** Whether the site asked the spam checker anything at all. */
 export const spamCheckWasAsked = (world: TicketsWorld): boolean =>

--- a/test/specs/support/contact.ts
+++ b/test/specs/support/contact.ts
@@ -64,17 +64,19 @@ const watchOutgoing = (
  * keys are put back afterwards — otherwise a machine whose shell already
  * exports them would switch protection on for every story here, and every
  * message would be turned down for a reason the story never mentions. */
-const SPAM_KEYS: Record<string, string> = {
+const SPAM_KEYS = {
   BOTPOISON_PUBLIC_KEY: "pk_test_public",
   BOTPOISON_SECRET_KEY: "sk_test_secret",
 };
 
 const setSpamProtection = (world: TicketsWorld, wanted: boolean): void => {
-  const keys = Object.keys(SPAM_KEYS);
   world.cleanup.add(
     withEnv(
       Object.fromEntries(
-        keys.map((name) => [name, wanted ? SPAM_KEYS[name] : undefined]),
+        Object.entries(SPAM_KEYS).map(([name, key]) => [
+          name,
+          wanted ? key : undefined,
+        ]),
       ),
     ),
   );

--- a/test/specs/support/door.ts
+++ b/test/specs/support/door.ts
@@ -12,8 +12,9 @@ import { expect } from "@std/expect";
 import { getAttendeesByTokens } from "#shared/db/attendees/tokens.ts";
 import { openAdminPage } from "#test/specs/support/browser.ts";
 import {
-  rememberStayListing,
-  stayListing,
+  listingIdNamed,
+  listingNamed,
+  rememberListing,
 } from "#test/specs/support/listings.ts";
 import { visitorBooks } from "#test/specs/support/public-booking.ts";
 import { dayFromToday, openStayListing } from "#test/specs/support/stays.ts";
@@ -41,7 +42,7 @@ const listingPath = (
   world: TicketsWorld,
   listing: string,
   page: string,
-): string => `/admin/listing/${stayListing(world, listing).id}/${page}`;
+): string => `/admin/listing/${listingIdNamed(world, listing)}/${page}`;
 
 /** Someone with a ticket for one of the story's listings. Both the listing and
  * the ticket are kept under the names the story uses for them. */
@@ -57,7 +58,7 @@ export const personWithTicket = async (
     { name: listing, nonTransferable: options.needsIdChecked ?? false },
     options.places ?? 1,
   );
-  rememberStayListing(world, listing, created);
+  rememberListing(world, listing, created);
   // The door this person belongs to, so a screenshot capture can open it.
   world.evidenceValues.set("doorListingId", String(created.id));
   rememberTicket(world, who, token);
@@ -69,8 +70,7 @@ const rememberTicket = (
   who: string,
   ticket: string,
 ): void => {
-  world.doorTickets ??= new Map();
-  world.doorTickets.set(who, ticket);
+  world.things.remember("ticket", who, ticket);
 };
 
 /** Someone who booked a stay of several days through the listing's own page.
@@ -83,7 +83,7 @@ export const personWithStayTicket = async (
   days: number,
 ): Promise<void> => {
   await openStayListing(world, listing, days, 5);
-  await visitorBooks(world, stayListing(world, listing), {
+  await visitorBooks(world, listingNamed(world, listing), {
     day: dayFromToday(world, 10),
     email: `${who.toLowerCase()}@example.com`,
     who,
@@ -97,7 +97,7 @@ export const personWithStayTicket = async (
 
 /** Another listing running its own door, with nobody booked on it yet. */
 export const otherListing: ActOnOneThing = async (world, listing) => {
-  rememberStayListing(
+  rememberListing(
     world,
     listing,
     await createTestListing({ maxAttendees: 10, name: listing }),
@@ -105,11 +105,8 @@ export const otherListing: ActOnOneThing = async (world, listing) => {
 };
 
 /** The ticket code the story gave this person. */
-export const ticketOf = (world: TicketsWorld, who: string): string => {
-  const token = world.doorTickets?.get(who);
-  if (!token) throw new Error(`${who} was never given a ticket`);
-  return token;
-};
+export const ticketOf = (world: TicketsWorld, who: string): string =>
+  world.things.require("ticket", who);
 
 /** Their money is given back, so the ticket should no longer let them in. */
 export const refundTicket = async (
@@ -121,7 +118,7 @@ export const refundTicket = async (
   if (!attendee) throw new Error(`${who}'s ticket is not on any booking`);
   await postAttendeeRefund({
     attendeeId: attendee.id,
-    listingId: stayListing(world, listing).id,
+    listingId: listingIdNamed(world, listing),
   });
 };
 
@@ -216,7 +213,7 @@ export const dayLog: ReadAboutOneThing = async (world, listing) => {
   // The listing whose own record of the day a capture of a check-in goes to.
   world.evidenceValues.set(
     "checkedInListingId",
-    String(stayListing(world, listing).id),
+    String(listingIdNamed(world, listing)),
   );
   const browser = await openAdminPage(
     world,

--- a/test/specs/support/editors.ts
+++ b/test/specs/support/editors.ts
@@ -16,20 +16,24 @@ import {
 } from "#shared/db/listings/records.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import {
+  browserSeenBy,
+  EDITOR,
   type OpensAPage,
   openAdminPage,
   openAsNewcomer,
   opensPagesAs,
+  rememberBrowser,
 } from "#test/specs/support/browser.ts";
 import {
   expectCanReallySend,
   fillInAndSend,
 } from "#test/specs/support/form-controls.ts";
 import {
+  listingIdNamed,
+  listingNamed,
   organiserSavesListing,
-  rememberStayListing,
+  rememberListing,
   saveListingEdit,
-  stayListing,
 } from "#test/specs/support/listings.ts";
 
 import {
@@ -118,7 +122,7 @@ export const editorFollowsInvite = async (
     { password: CHOSEN_PASSWORD, password_confirm: CHOSEN_PASSWORD },
     t("join.set_password.submit"),
   );
-  world.editorBrowser = browser;
+  rememberBrowser(world, EDITOR, browser);
 };
 
 /** The editor logs in the ordinary way, and stays logged in for the rest of
@@ -130,7 +134,7 @@ export const editorLogsIn: ActOnOnePerson = async (world, who) => {
     { password: CHOSEN_PASSWORD, username: who },
     t("login.submit"),
   );
-  world.editorBrowser = browser;
+  rememberBrowser(world, EDITOR, browser);
 };
 
 /** Somebody who is already an editor and already logged in. Saying it twice of
@@ -138,7 +142,7 @@ export const editorLogsIn: ActOnOnePerson = async (world, who) => {
  * one editor is ever signed in and every later step would quietly be taken by
  * the first one. */
 export const signedInEditor: ActOnOnePerson = async (world, who) => {
-  if (world.editorBrowser) {
+  if (world.things.recall("browser", EDITOR)) {
     if (world.signedInEditorName !== who) {
       throw new Error(
         `${world.signedInEditorName} is already the signed-in editor, so ${who} cannot be as well`,
@@ -154,7 +158,7 @@ export const signedInEditor: ActOnOnePerson = async (world, who) => {
 
 /** The editor's own browser, once the story has signed them in. */
 export const editorBrowser = (world: TicketsWorld): TestBrowser =>
-  requiredWorldValue(world.editorBrowser, "the editor's browser");
+  browserSeenBy(world, EDITOR);
 
 /** The editor opens one of their own pages. */
 const openAsEditor: OpensAPage = opensPagesAs(editorBrowser);
@@ -165,7 +169,7 @@ export const somethingForSale = async (
   name: string,
   options: { forwardingTo?: string } = {},
 ): Promise<void> => {
-  rememberStayListing(
+  rememberListing(
     world,
     name,
     await createTestListing({
@@ -184,7 +188,7 @@ export const TAKINGS = 37.5;
  * figure to show — or to keep from an editor. */
 export const somethingSoldAndPaidFor: ActOnOneThing = async (world, name) => {
   await somethingForSale(world, name);
-  const listing = stayListing(world, name);
+  const listing = listingNamed(world, name);
   const buyer = await createTestAttendee(
     listing.id,
     listing.slug,
@@ -231,7 +235,7 @@ export const forwardingAddressOrNull = async (
   world: TicketsWorld,
   name: string,
 ): Promise<string | null> => {
-  const found = await getListingWithCount(stayListing(world, name).id);
+  const found = await getListingWithCount(listingIdNamed(world, name));
   return stillThere(found, name).webhook_url;
 };
 
@@ -245,7 +249,7 @@ export const editorRenames: ChangeOneThing<string> = async (
 ) => {
   await saveListingEdit(
     editorBrowser(world),
-    stayListing(world, from).id,
+    listingIdNamed(world, from),
     (served) => {
       expectCanReallySend(served, { name: to });
       return { name: to };
@@ -264,7 +268,7 @@ export const editorCraftsForwardingTo: ChangeOneThing<string> = (
   // The save being accepted is what organiserSavesListing checks for us. A whole edit
   // turned away would leave the address alone too, and prove nothing about this
   // one field.
-  saveListingEdit(editorBrowser(world), stayListing(world, name).id, () => ({
+  saveListingEdit(editorBrowser(world), listingIdNamed(world, name), () => ({
     webhook_url: address,
   }));
 
@@ -285,6 +289,6 @@ export const ownerSetsForwardingTo: ChangeOneThing<string> = async (
 export const editorOpensListing: ActOnOneThing = async (world, name) => {
   await openAsEditor(
     world,
-    `/admin/listing/${stayListing(world, name).id}/edit`,
+    `/admin/listing/${listingIdNamed(world, name)}/edit`,
   );
 };

--- a/test/specs/support/hooks.ts
+++ b/test/specs/support/hooks.ts
@@ -8,18 +8,15 @@ import {
 import { setupTestDbEnvironment } from "#test-utils/db.ts";
 import { clearTestEncryptionKey } from "#test-utils/env.ts";
 import { reclaimLeakedFdsNow } from "#test-utils/reclaim-fds.ts";
-import {
-  addDatabaseCleanup,
-  cleanupWorld,
-  type TicketsWorld,
-} from "./world.ts";
+import { namedThings, putsThingsBack } from "./memory.ts";
+import { addDatabaseCleanup, type TicketsWorld } from "./world.ts";
 
 // jscpd:ignore-end
 
 Before(async function (this: TicketsWorld): Promise<void> {
-  this.cleanup = [];
+  this.cleanup = putsThingsBack();
   this.evidenceValues = new Map();
-  this.listingIds = new Map();
+  this.things = namedThings();
   const cleanupDb = await setupTestDbEnvironment(true).catch((error) => {
     clearTestEncryptionKey();
     throw error;
@@ -44,7 +41,7 @@ After(
       );
     } finally {
       try {
-        await cleanupWorld(this);
+        await this.cleanup.runAll();
       } finally {
         reclaimLeakedFdsNow();
       }

--- a/test/specs/support/listings.ts
+++ b/test/specs/support/listings.ts
@@ -9,33 +9,39 @@
 
 // jscpd:ignore-start
 import { expect } from "@std/expect";
+import { requireListingWithCount } from "#shared/db/listings/records.ts";
 import type { Listing } from "#shared/types.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
-import {
-  requiredWorldValue,
-  type TicketsWorld,
-} from "#test/specs/support/world.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 // jscpd:ignore-end
 
 /** Keep a listing under the name the story calls it, so later steps can find
  * it however it was set up. */
-export const rememberStayListing = (
+export const rememberListing = (
   world: TicketsWorld,
   name: string,
   listing: Listing,
-): Listing => {
-  world.listingIds.set(name, listing.id);
-  world.stayListings ??= new Map();
-  world.stayListings.set(name, listing);
-  return listing;
-};
+): Listing => world.things.remember("listing", name, listing);
 
 /** The listing a story set up under this name. */
-export const stayListing = (world: TicketsWorld, name: string): Listing =>
-  requiredWorldValue(world.stayListings?.get(name), `${name} stay listing`);
+export const listingNamed = (world: TicketsWorld, name: string): Listing =>
+  world.things.require("listing", name);
+
+/** Keep the listing with this id, for a story that made one through a form
+ * and was handed nothing but its id back. */
+export const rememberListingById = async (
+  world: TicketsWorld,
+  name: string,
+  id: number,
+): Promise<Listing> =>
+  rememberListing(world, name, await requireListingWithCount(id));
+
+/** The id of the listing a story set up under this name. */
+export const listingIdNamed = (world: TicketsWorld, name: string): number =>
+  listingNamed(world, name).id;
 
 /** Something the site sells at a price, remembered under the name the story
  * calls it. The listing a money story starts from, so its price and its id are
@@ -59,7 +65,7 @@ export const sellSomethingAt = async (
     ...(options.keepThankYouPage ? { thankYouUrl: "" } : {}),
     unitPrice: minorUnits(price),
   });
-  world.listingIds.set(name, listing.id);
+  rememberListing(world, name, listing);
   world.listingId = listing.id;
   return listing;
 };
@@ -122,7 +128,7 @@ export const organiserSavesListing = async (
 ): Promise<void> => {
   await saveListingEdit(
     await adminBrowser(world),
-    stayListing(world, name).id,
+    listingIdNamed(world, name),
     fillsIn,
   );
 };

--- a/test/specs/support/memory.test.ts
+++ b/test/specs/support/memory.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The one place a story keeps what it named, and the one place it says what to
+ * put back. Both are leaned on by every story, so a fault here would show up as
+ * a puzzling failure somewhere else — these check them directly.
+ */
+
+// jscpd:ignore-start
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  namedThings,
+  type PutsThingsBack,
+  putsThingsBack,
+} from "#test/specs/support/memory.ts";
+import { TestBrowser } from "#test-utils/test-browser.ts";
+
+// jscpd:ignore-end
+
+describe("what a story remembers", () => {
+  test("hands back the thing it was given, so setting up and keeping is one step", () => {
+    const things = namedThings();
+    const browser = new TestBrowser();
+    expect(things.remember("browser", "the customer", browser)).toBe(browser);
+  });
+
+  test("gives back what was kept under a name", () => {
+    const things = namedThings();
+    things.remember("ticket", "Ada", "abc123");
+    expect(things.require("ticket", "Ada")).toBe("abc123");
+  });
+
+  test("keeps each kind apart, so one name can mean two things", () => {
+    const things = namedThings();
+    things.remember("ticket", "Pottery", "abc123");
+    things.remember("key", "Pottery", "sk_live");
+    expect(things.require("ticket", "Pottery")).toBe("abc123");
+    expect(things.require("key", "Pottery")).toBe("sk_live");
+  });
+
+  test("says nothing was kept, rather than failing, when only asked", () => {
+    expect(namedThings().recall("listing", "the Pottery")).toBeUndefined();
+  });
+
+  test("names the kind and the name when the story never set one up", () => {
+    expect(() => namedThings().require("bundle", "the Weekend")).toThrow(
+      'The story never set up the bundle "the Weekend"',
+    );
+  });
+
+  test("makes a thing the first time it is asked for", () => {
+    const things = namedThings();
+    const made = things.orMake(
+      "browser",
+      "the editor",
+      () => new TestBrowser(),
+    );
+    expect(things.require("browser", "the editor")).toBe(made);
+  });
+
+  test("makes it only once, so later asks get the same one", () => {
+    const things = namedThings();
+    let made = 0;
+    const makeOne = () => {
+      made += 1;
+      return new TestBrowser();
+    };
+    const first = things.orMake("browser", "the editor", makeOne);
+    expect(things.orMake("browser", "the editor", makeOne)).toBe(first);
+    expect(made).toBe(1);
+  });
+
+  test("forgets one name, so the next ask starts again", () => {
+    const things = namedThings();
+    const first = things.orMake(
+      "browser",
+      "the organiser",
+      () => new TestBrowser(),
+    );
+    things.forget("browser", "the organiser");
+    expect(
+      things.orMake("browser", "the organiser", () => new TestBrowser()),
+    ).not.toBe(first);
+  });
+
+  test("lists the names one kind holds, in the order they were first used", () => {
+    const things = namedThings();
+    things.remember("daysOffered", "the Weekend", ["2026-01-01"]);
+    things.remember("ticket", "Ada", "abc123");
+    things.remember("daysOffered", "the Pottery", ["2026-01-02"]);
+    expect(things.names("daysOffered")).toEqual(["the Weekend", "the Pottery"]);
+  });
+
+  test("lists nothing for a kind the story never used", () => {
+    expect(namedThings().names("key")).toEqual([]);
+  });
+});
+
+describe("what a story puts back", () => {
+  /** What one story's put-backs did, in the order they really ran, and
+   * whatever they raised. Every check here is the same three steps: say what
+   * to put back, run them all, read what happened. */
+  const whatHappened = async (
+    sayWhatToPutBack: (
+      cleanup: PutsThingsBack,
+      note: (what: string) => () => void,
+    ) => void,
+  ): Promise<{ done: string[]; raised: unknown }> => {
+    const done: string[] = [];
+    const cleanup = putsThingsBack();
+    sayWhatToPutBack(cleanup, (what) => () => {
+      done.push(what);
+    });
+    const raised = await cleanup.runAll().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    return { done, raised };
+  };
+
+  /** Each way a story can say what to put back, and what running them all
+   * should have done. */
+  const PUT_BACKS: Array<{
+    does: string;
+    ran: string[];
+    say: (cleanup: PutsThingsBack, note: (what: string) => () => void) => void;
+  }> = [
+    {
+      does: "runs a task it was given",
+      ran: ["first"],
+      say: (cleanup, note) => cleanup.add(note("first")),
+    },
+    {
+      does: "puts back what was changed last, first",
+      ran: ["third", "second", "first"],
+      say: (cleanup, note) => {
+        cleanup.add(note("first"), note("second"));
+        cleanup.add(note("third"));
+      },
+    },
+    {
+      does: "throws away anything that tidies itself up",
+      ran: ["disposed"],
+      say: (cleanup, note) =>
+        cleanup.add({ [Symbol.dispose]: note("disposed") }),
+    },
+    {
+      does: "waits for a task that takes a moment",
+      ran: ["later"],
+      say: (cleanup, note) =>
+        cleanup.add(() => Promise.resolve().then(note("later"))),
+    },
+  ];
+
+  for (const { does, ran, say } of PUT_BACKS) {
+    test(does, async () => {
+      expect((await whatHappened(say)).done).toEqual(ran);
+    });
+  }
+
+  test("reports a task that failed, having still run the rest", async () => {
+    const failed = new Error("could not put it back");
+    const { done, raised } = await whatHappened((cleanup, note) => {
+      cleanup.add(note("ran anyway"));
+      cleanup.add(() => {
+        throw failed;
+      });
+    });
+    expect(raised).toBe(failed);
+    expect(done).toEqual(["ran anyway"]);
+  });
+});

--- a/test/specs/support/memory.test.ts
+++ b/test/specs/support/memory.test.ts
@@ -110,11 +110,12 @@ describe("what a story puts back", () => {
     sayWhatToPutBack(cleanup, (what) => () => {
       done.push(what);
     });
-    const raised = await cleanup.runAll().then(
-      () => null,
-      (error: unknown) => error,
-    );
-    return { done, raised };
+    try {
+      await cleanup.runAll();
+      return { done, raised: null };
+    } catch (raised) {
+      return { done, raised };
+    }
   };
 
   /** Each way a story can say what to put back, and what running them all
@@ -147,7 +148,10 @@ describe("what a story puts back", () => {
       does: "waits for a task that takes a moment",
       ran: ["later"],
       say: (cleanup, note) =>
-        cleanup.add(() => Promise.resolve().then(note("later"))),
+        cleanup.add(async () => {
+          await Promise.resolve();
+          note("later")();
+        }),
     },
   ];
 

--- a/test/specs/support/memory.ts
+++ b/test/specs/support/memory.ts
@@ -1,0 +1,120 @@
+/**
+ * What a story remembers while it runs, and what it puts back at the end.
+ *
+ * Stories give the things they set up names of their own ("the Pottery", "the
+ * editor", "Ada's ticket"). Rather than a field per kind of thing, everything
+ * named is kept in one store, split by what kind of thing the name holds. The
+ * kind decides the type, so asking for a listing can never hand back a browser,
+ * and a new story adds a name instead of a new world field.
+ */
+
+// jscpd:ignore-start
+import { type CleanupTask, runCleanups } from "#scripts/cleanup.ts";
+import type { Group, Listing } from "#shared/types.ts";
+import type { TestBrowser } from "#test-utils/test-browser.ts";
+// jscpd:ignore-end
+
+/** Every kind of thing a story can keep by name, and what each name holds. */
+export interface ThingsByKind {
+  /** Somebody's own window on the site: the organiser's, a customer's. */
+  browser: TestBrowser;
+  /** Things sold together under one name. */
+  bundle: Group;
+  /** The days a listing's own page offered, the last time it was looked at. */
+  daysOffered: string[];
+  /** A key the owner made for another system, as it was handed to them once. */
+  key: string;
+  /** Something the site sells. */
+  listing: Listing;
+  /** The code one person holds to get in. */
+  ticket: string;
+  /** What somebody was told the last time they did something. */
+  told: string;
+}
+
+export type ThingKind = keyof ThingsByKind;
+
+export interface RemembersThings {
+  /** Forget the thing under this name, so the next ask starts again. */
+  forget(kind: ThingKind, name: string): void;
+  /** Every name the story has used for this kind of thing, in the order it
+   * first used them. */
+  names(kind: ThingKind): string[];
+  /** The thing under this name, made and kept the first time it is asked for. */
+  orMake<Kind extends ThingKind>(
+    kind: Kind,
+    name: string,
+    make: () => ThingsByKind[Kind],
+  ): ThingsByKind[Kind];
+  /** The thing under this name, or nothing when the story never set one up. */
+  recall<Kind extends ThingKind>(
+    kind: Kind,
+    name: string,
+  ): ThingsByKind[Kind] | undefined;
+  /** Keep a thing under the name the story calls it, and hand it straight
+   * back, so setting one up and remembering it is one step. */
+  remember<Kind extends ThingKind>(
+    kind: Kind,
+    name: string,
+    thing: ThingsByKind[Kind],
+  ): ThingsByKind[Kind];
+  /** The thing under this name, or a loud failure. A story that carried on
+   * without it would report the site's behaviour when the fault is its own. */
+  require<Kind extends ThingKind>(kind: Kind, name: string): ThingsByKind[Kind];
+}
+
+/** One store for every named thing, so two kinds can share a name without
+ * treading on each other. */
+export const namedThings = (): RemembersThings => {
+  const kept = new Map<string, unknown>();
+  const under = (kind: ThingKind, name: string): string => `${kind}: ${name}`;
+  const store: RemembersThings = {
+    forget: (kind, name) => {
+      kept.delete(under(kind, name));
+    },
+    names: (kind) =>
+      [...kept.keys()]
+        .filter((key) => key.startsWith(`${kind}: `))
+        .map((key) => key.slice(kind.length + 2)),
+    orMake: (kind, name, make) =>
+      store.recall(kind, name) ?? store.remember(kind, name, make()),
+    recall: <Kind extends ThingKind>(kind: Kind, name: string) =>
+      kept.get(under(kind, name)) as ThingsByKind[Kind] | undefined,
+    remember: (kind, name, thing) => {
+      kept.set(under(kind, name), thing);
+      return thing;
+    },
+    require: <Kind extends ThingKind>(kind: Kind, name: string) => {
+      const thing = store.recall(kind, name);
+      if (thing === undefined) {
+        throw new Error(`The story never set up the ${kind} "${name}"`);
+      }
+      return thing;
+    },
+  };
+  return store;
+};
+
+/** Something to undo when the story ends: a task to run, or anything that puts
+ * itself back when it is thrown away — a scoped environment, say. */
+export type Undoable = CleanupTask | Disposable;
+
+const asTask = (undo: Undoable): CleanupTask =>
+  typeof undo === "function" ? undo : () => undo[Symbol.dispose]();
+
+export interface PutsThingsBack {
+  add(...undo: Undoable[]): void;
+  runAll(): Promise<void>;
+}
+
+/** Whatever a story changed outside itself, put back in the opposite order it
+ * was changed, so one story's stand-in cannot leak into the next. */
+export const putsThingsBack = (): PutsThingsBack => {
+  const undo: CleanupTask[] = [];
+  return {
+    add: (...added) => {
+      undo.push(...added.map(asTask));
+    },
+    runAll: () => runCleanups(undo.toReversed()),
+  };
+};

--- a/test/specs/support/money.ts
+++ b/test/specs/support/money.ts
@@ -26,10 +26,6 @@ import {
 import { setupStripe } from "#test-utils/settings.ts";
 // jscpd:ignore-end
 
-/** The id of a listing the story put on sale, by the name it used. */
-export const listingIdFor = (world: TicketsWorld, name: string): number =>
-  requiredWorldValue(world.listingIds.get(name), `${name} listing id`);
-
 /** The booking the story is about. */
 export const bookingId = (world: TicketsWorld): number =>
   requiredWorldValue(world.attendeeId, "attendee id");
@@ -98,7 +94,8 @@ export const buyPlaceWithExtra = async (
   // The story may already have put this listing on sale (with its extra charge
   // attached), so reuse it rather than selling a second one of the same name.
   const listingId =
-    world.listingIds.get(name) ?? (await sellPlacesAt(world, name, pounds)).id;
+    world.things.recall("listing", name)?.id ??
+    (await sellPlacesAt(world, name, pounds)).id;
   const price = minorUnits(pounds);
   await runStripeSuccess({
     email: `${who.toLowerCase().replaceAll(" ", ".")}@example.com`,

--- a/test/specs/support/public-booking.ts
+++ b/test/specs/support/public-booking.ts
@@ -15,7 +15,11 @@ import { expect } from "@std/expect";
 import { bookingError } from "#shared/booking/form.ts";
 import type { Listing } from "#shared/types.ts";
 // jscpd:ignore-start
-import { openAsNewcomer } from "#test/specs/support/browser.ts";
+import {
+  CUSTOMER,
+  openAsNewcomer,
+  rememberBrowser,
+} from "#test/specs/support/browser.ts";
 import {
   optionsOffered,
   whyValueCannotBeSent,
@@ -163,7 +167,7 @@ export const visitorBooks = async (
 ): Promise<TestBrowser> => {
   const { browser, wasBooked } = await visitorTriesToBook(listing, choices);
   expect(wasBooked).toBe(true);
-  world.customerBrowser = browser;
+  rememberBrowser(world, CUSTOMER, browser);
   world.attendeeName = choices.who;
   return browser;
 };

--- a/test/specs/support/setting-up.ts
+++ b/test/specs/support/setting-up.ts
@@ -7,10 +7,7 @@ import {
   checkboxValueOffered,
   fillInAndSend,
 } from "#test/specs/support/form-controls.ts";
-import {
-  requiredWorldValue,
-  type TicketsWorld,
-} from "#test/specs/support/world.ts";
+import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { createTestDb, resetDb } from "#test-utils/db.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
@@ -65,6 +62,10 @@ const sendSetup = (
     t("setup.submit"),
   );
 
+/** Whoever is doing the setting up — the story only ever has one of them, and
+ * what they are told is read back a step later. */
+const SETTER = "the setter";
+
 /** Somebody opens the setup page and sets the site up. */
 export const somebodySetsUp = async (
   world: TicketsWorld,
@@ -73,7 +74,7 @@ export const somebodySetsUp = async (
 ): Promise<string> => {
   const browser = await openSetup();
   await sendSetup(browser, { ...CHOSEN, password }, confirmation);
-  world.setUpTold = browser.pageText;
+  world.things.remember("told", SETTER, browser.pageText);
   return browser.pageText;
 };
 
@@ -90,7 +91,7 @@ export const latecomerSendsSetup = async (
 export const GOOD_PASSWORD = CHOSEN.password;
 
 export const whatSetterWasTold = (world: TicketsWorld): string =>
-  requiredWorldValue(world.setUpTold, "what the setter was told");
+  world.things.require("told", SETTER);
 
 /** Whether somebody can sign in with a name and password. Proving the ceremony
  * finished means using it, not reading a page that says it did. */

--- a/test/specs/support/shown-code.ts
+++ b/test/specs/support/shown-code.ts
@@ -10,8 +10,8 @@ import { expect } from "@std/expect";
 import type { CheckoutIntent } from "#shared/payments.ts";
 import { openAdminPage, openAsNewcomer } from "#test/specs/support/browser.ts";
 import {
-  rememberStayListing,
-  stayListing,
+  listingIdNamed,
+  rememberListing,
 } from "#test/specs/support/listings.ts";
 import type { ActOnOneThing, TicketsWorld } from "#test/specs/support/world.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -37,7 +37,7 @@ export const somethingForSale = async (
 ): Promise<void> => {
   await enablePublicSite();
   await setupStripe();
-  rememberStayListing(
+  rememberListing(
     world,
     name,
     await createTestListing({
@@ -70,7 +70,7 @@ export const organiserShowsCode = async (
 ): Promise<CodeOnScreen> => {
   const browser = await openAdminPage(
     world,
-    `/admin/listing/${stayListing(world, name).id}/qr`,
+    `/admin/listing/${listingIdNamed(world, name)}/qr`,
   );
   await browser.submitForm(
     {
@@ -255,7 +255,7 @@ export const meddledWith = (link: string): string => {
 /** The organiser takes something off sale after the codes are printed. */
 export const takeOffSale: ActOnOneThing = async (world, name) => {
   const { listingsTable } = await import("#shared/db/listings/records.ts");
-  await listingsTable.update(stayListing(world, name).id, { active: false });
+  await listingsTable.update(listingIdNamed(world, name), { active: false });
 };
 
 /** Nothing at all was booked, whatever the page said. */
@@ -263,5 +263,5 @@ export const expectNothingBooked: ActOnOneThing = async (world, name) => {
   const { getAttendeesRaw } = await import(
     "#test-utils/db-helpers/attendees.ts"
   );
-  expect(await getAttendeesRaw(stayListing(world, name).id)).toEqual([]);
+  expect(await getAttendeesRaw(listingIdNamed(world, name))).toEqual([]);
 };

--- a/test/specs/support/site-pages.ts
+++ b/test/specs/support/site-pages.ts
@@ -17,7 +17,6 @@ import {
   type ActOnOneThing,
   type AsksAboutOneThing,
   asksIfThereIs,
-  requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
 import { adminFormPost } from "#test-utils/session.ts";
@@ -28,6 +27,10 @@ import type { TestBrowser } from "#test-utils/test-browser.ts";
 
 /** The owner's own list of the site's pages. */
 const PAGES_LIST = "/admin/site/pages";
+
+/** Whose reading of the site's own pages the story keeps: the owner writes
+ * them, so the owner is who each answer was told to. */
+const OWNER = "the owner";
 
 /** Wording that appears on one page and nowhere else. Every page's name is in
  * the navigation on every page, so a check that only looked for the name would
@@ -59,7 +62,7 @@ export const ownerWritesPage = async (
     { content: wordsOnlyOn(name), name, slug: address },
     t("site.pages.create_submit"),
   );
-  world.sitePageTold = browser.pageText;
+  world.things.remember("told", OWNER, browser.pageText);
   // The address the owner chose, so a capture can open the page the way a
   // visitor would rather than being told the address a second time.
   world.evidenceValues.set("sitePageAddress", address);
@@ -165,6 +168,20 @@ export const ownerTakesPageDown: TakesOneThingDown = takesDownFromList(
   },
 );
 
+/** The owner tries to take a page down, and what they were told is kept for
+ * the step that reads it back. */
+export const ownerTriesToTakePageDown = async (
+  world: TicketsWorld,
+  name: string,
+  typed: string,
+): Promise<void> => {
+  world.things.remember(
+    "told",
+    OWNER,
+    await ownerTakesPageDown(world, name, typed),
+  );
+};
+
 /** What the owner was told the last time they wrote a page. */
 export const whatOwnerWasTold = (world: TicketsWorld): string =>
-  requiredWorldValue(world.sitePageTold, "what the owner was told");
+  world.things.require("told", OWNER);

--- a/test/specs/support/stays.ts
+++ b/test/specs/support/stays.ts
@@ -12,9 +12,9 @@ import type { Attendee, Listing } from "#shared/types.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
 import { expectCanReallySend } from "#test/specs/support/form-controls.ts";
 import {
+  listingIdNamed,
   organiserSavesListing,
-  rememberStayListing,
-  stayListing,
+  rememberListing,
 } from "#test/specs/support/listings.ts";
 import type { TicketsWorld } from "#test/specs/support/world.ts";
 import { createDailyTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -32,7 +32,7 @@ export const guest = (order: number): { email: string; who: string } => ({
 export const staysOn = (
   world: TicketsWorld,
   name: string,
-): Promise<Attendee[]> => getAttendeesRaw(stayListing(world, name).id);
+): Promise<Attendee[]> => getAttendeesRaw(listingIdNamed(world, name));
 
 /** The stay booked most recently on a listing — the highest id, so the answer
  * does not depend on the order the rows come back in. Fails loudly when nothing
@@ -93,7 +93,7 @@ export const openStayListing = async (
         }
       : {}),
   });
-  return rememberStayListing(world, name, listing);
+  return rememberListing(world, name, listing);
 };
 
 /** Change how many days each new stay covers, through the listing's own edit

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -1,10 +1,13 @@
 // jscpd:ignore-start
 import type { World } from "@cucumber/cucumber";
-import { type CleanupTask, runCleanups } from "#scripts/cleanup.ts";
-import type { Group, Listing } from "#shared/types.ts";
+import type { CleanupTask } from "#scripts/cleanup.ts";
 import type { ApiAnswer } from "#test/specs/support/booking-api.ts";
 import type { ThingForSale } from "#test/specs/support/bundles.ts";
 import type { DoorAnswer } from "#test/specs/support/door.ts";
+import type {
+  PutsThingsBack,
+  RemembersThings,
+} from "#test/specs/support/memory.ts";
 import type { BookingAttempt } from "#test/specs/support/public-booking.ts";
 import type {
   CodeOnScreen,
@@ -14,7 +17,6 @@ import type {
   JourneyCatalogSpec,
   OrderJourneyCtx,
 } from "#test-utils/order-journey.ts";
-import type { TestBrowser } from "#test-utils/test-browser.ts";
 // jscpd:ignore-end
 
 /** Something a story does, told which one to do it to. The three below differ
@@ -89,7 +91,6 @@ export interface TicketsWorld extends World {
   apiKeyAnswer?: { answered: number; said: string };
   apiKeyPageAnswer?: number;
   apiKeyShownOnce?: string;
-  apiKeys?: Map<string, string>;
   apiKeyTakeBack?: string;
   apiKeyWrite?: number;
   apiListing?: string;
@@ -105,22 +106,17 @@ export interface TicketsWorld extends World {
   bundleBookingPage?: string;
   bundleOutcome?: string;
   bundleParts?: ThingForSale[];
-  bundles?: Map<string, Group>;
   bundleTicketPath?: string;
   cashBefore?: number;
-  cleanup: Array<() => void | Promise<void>>;
+  cleanup: PutsThingsBack;
   closedDayOn?: string;
   codeLedTo?: WhereTheCodeLed;
   confirmName?: string;
-  customerBrowser?: TestBrowser;
-  daysOffered?: Map<string, string[]>;
   daysOfferedLastLook?: string;
   doorAnswer?: DoorAnswer;
-  doorTickets?: Map<string, string>;
   duplicateId?: number;
   duplicateToken?: string;
   editorAnswer?: number;
-  editorBrowser?: TestBrowser;
   editorInvite?: string;
   evidenceValues: Map<string, string>;
   firstBody?: string;
@@ -129,10 +125,8 @@ export interface TicketsWorld extends World {
   firstStatus?: number;
   groupSlug?: string;
   holdListingId?: number;
-  latecomerBrowser?: TestBrowser;
   lengthChangeMessage?: string;
   listingId?: number;
-  listingIds: Map<string, number>;
   mergeOutcome?: { applied: boolean; message: string };
   mergePreviewHtml?: string;
   messagesOut?: {
@@ -154,30 +148,22 @@ export interface TicketsWorld extends World {
   secondStatus?: number;
   servicingEventId?: number;
   sessionId?: string;
-  setUpTold?: string;
   sharedDayLimit?: number;
   sharedDayOver?: string;
   shownCode?: CodeOnScreen;
   signedInEditorName?: string;
-  sitePageTold?: string;
-  stayListings?: Map<string, Listing>;
   stayStartsOn?: string;
-  testBrowser?: TestBrowser;
+  things: RemembersThings;
   ticketToken?: string;
-  visitorTold?: string;
   writeoffBefore?: number;
 }
-
-export const cleanupWorld = (
-  world: Pick<TicketsWorld, "cleanup">,
-): Promise<void> => runCleanups(world.cleanup.reverse());
 
 export const addDatabaseCleanup = (
   world: Pick<TicketsWorld, "cleanup">,
   cleanupDb: CleanupTask,
   clearEncryptionKey: CleanupTask,
 ): void => {
-  world.cleanup.push(clearEncryptionKey, cleanupDb);
+  world.cleanup.add(clearEncryptionKey, cleanupDb);
 };
 
 export const requiredWorldValue = <Value>(


### PR DESCRIPTION
This is a change to how our Cucumber stories keep track of things while they run. Nothing about the site itself changes — the same 163 stories pass, and they test the same things.

## What it was like before

Every story runs against a shared "world", and anything a story set up had to be kept in a field of its own on that world. There was a map of listing ids, a second map of the same listings, one for bundles, one for keys the owner made, one for door tickets, one for the days a page offered, a field per person's browser, and a field for "what somebody was told". Around eighty fields in all, nearly all of them optional.

Writing a new story meant adding another field, and then another little helper that fails when the field is empty.

## What it is like now

There is one store. A story says what kind of thing it is remembering and the name it calls it:

```
world.things.remember("listing", "the Pottery", listing)
world.things.require("listing", "the Pottery")
```

The kind decides the type of the thing. Asking for a listing can never hand back a browser, and a name the story never set up fails straight away, saying which kind and which name were missing. A new story adds a name, not a new field.

Beside it is one place to say what should be put back when the story ends. It takes either a job to run or anything that tidies itself up when it is thrown away. That second part matters: the contact story was saving and restoring the spam-check settings by hand, even though we already had a tidy way to change a setting for the length of one story. It now uses that instead.

## Also cleared up along the way

- Two helpers that were nothing but a second name for the same lookup are gone.
- The "get the id of the listing called X" lookup had been written out again in five different step files. There is one now.
- One helper was quietly returning a listing under a name that said "stay", though it was used for every kind of listing. It is now called what it is.

## How it was checked

All 163 stories pass, plus new tests for the store itself and for putting things back. The usual checks — formatting, types, duplication, coverage — are run as normal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D4uXbqE7QqLegrPREp9A1H)_