### PR TITLE
Tie each screenshot's page to the capture it is for

### DIFF
--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -118,6 +118,9 @@ Execution is equally strict:
   separate stable capture ID. Its public contract is
   `reports/evidence/manifest.json` with files under `reports/evidence/assets/`;
   raw Cucumber Messages stay generated and private.
+- A capture that is always at one address declares it. A capture of a page the
+  story only finds an address for while it runs declares no address, and the
+  story hands the finished one over by capture ID with `leaveEvidencePage`.
 - A Cucumber journey never supplies the only coverage of a production line or
   branch. Keep 100% direct Deno coverage, and run direct tests before Cucumber
   integration tests in mutation runs.

--- a/scripts/specs/evidence/browser.ts
+++ b/scripts/specs/evidence/browser.ts
@@ -1,15 +1,3 @@
-export const resolveEvidencePath = (
-  template: string,
-  values: ReadonlyMap<string, string>,
-): string =>
-  template.replaceAll(/\{([a-zA-Z][a-zA-Z0-9]*)\}/g, (_, name: string) => {
-    const value = values.get(name);
-    if (value === undefined) {
-      throw new Error(`Evidence World value ${name} was not set`);
-    }
-    return encodeURIComponent(value);
-  });
-
 export const isAllowedEvidenceRequest = (
   baseUrl: string,
   requestUrl: string,

--- a/scripts/specs/evidence/capture-flow.ts
+++ b/scripts/specs/evidence/capture-flow.ts
@@ -6,12 +6,13 @@ import {
   screenshotContextOptions,
 } from "#scripts/screenshots/profile.ts";
 import type { SpecCatalog } from "#scripts/specs/types.ts";
-import { isAllowedEvidenceRequest, resolveEvidencePath } from "./browser.ts";
+import { isAllowedEvidenceRequest } from "./browser.ts";
 import type {
   CaptureScenario,
   EvidenceHookCase,
   EvidenceWorld,
 } from "./hook.ts";
+import { evidencePagePath } from "./pages.ts";
 import { resolveEvidenceScenario } from "./resolve.ts";
 import {
   type EvidenceCaptureDeclaration,
@@ -107,10 +108,9 @@ const captureProfile = async (
     ]);
     const page = await context.newPage();
     page.setDefaultTimeout(CAPTURE_TIMEOUT_MS);
-    await page.goto(
-      resolveEvidencePath(declaration.path, world.evidenceValues),
-      { waitUntil: "domcontentloaded" },
-    );
+    await page.goto(evidencePagePath(declaration, world.evidencePages), {
+      waitUntil: "domcontentloaded",
+    });
     await dependencies.waitForPage(page);
     const { png } = await dependencies.capturePage(page, declaration.element);
     assertNoBlockedRequests(blocked);

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -34,8 +34,10 @@ const brandedMobileCapture = <Id extends string>(
     presentation: "branded" as const,
     profiles: ["mobile" as const],
   };
-  v.parse(EvidenceCaptureDeclarationSchema, declaration);
-  return declaration;
+  const checked = v.parse(EvidenceCaptureDeclarationSchema, declaration);
+  // The checked values are the ones to keep; the id is put back only to hold
+  // on to its own name in the type, and checking never changes an id.
+  return { ...checked, id };
 };
 
 export const EVIDENCE_CAPTURES = [

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -4,149 +4,154 @@ import {
   EvidenceCaptureDeclarationSchema,
 } from "./schema.ts";
 
-/** One branded mobile capture: the page an authored case leaves behind and the
+/** One declared capture, still carrying its own id in the type. That is what
+ * lets the capture ids below be the whole list a story can leave a page for. */
+type DeclaredCapture<Id extends string> = EvidenceCaptureDeclaration & {
+  id: Id;
+};
+
+/**
+ * One branded mobile capture: the page an authored case leaves behind and the
  * part of it worth showing. What the page is dressed in is not said here: see
- * themes.ts, because a screenshot's look belongs to whoever publishes it. */
-const brandedMobileCapture = (
+ * themes.ts, because a screenshot's look belongs to whoever publishes it.
+ *
+ * A page that is always at the same address says so with `path`. A page whose
+ * address the story only knows once it has run — a new listing's number, a
+ * signed link, a one-way code — leaves `path` out, and the story hands the
+ * finished address over with leaveEvidencePage.
+ */
+const brandedMobileCapture = <Id extends string>(
   caseId: string,
-  id: string,
-  path: string,
+  id: Id,
   element: string,
-): EvidenceCaptureDeclaration =>
-  v.parse(EvidenceCaptureDeclarationSchema, {
+  path?: string,
+): DeclaredCapture<Id> => {
+  const declaration = {
     caseId,
     element,
     id,
     path,
-    presentation: "branded",
-    profiles: ["mobile"],
-  });
+    presentation: "branded" as const,
+    profiles: ["mobile" as const],
+  };
+  v.parse(EvidenceCaptureDeclarationSchema, declaration);
+  return declaration;
+};
 
-export const EVIDENCE_CAPTURES: EvidenceCaptureDeclaration[] = [
+export const EVIDENCE_CAPTURES = [
   brandedMobileCapture(
     "servicing.hold-on-dashboard",
     "servicing-studio-floor-hold",
-    "/admin/servicing/{servicingEventId}",
     "#servicing-form",
   ),
   brandedMobileCapture(
     "payments.select-saved-stripe",
     "payment-provider-choice",
-    "/admin/settings",
     ".page-regions.admin-page",
+    "/admin/settings",
   ),
   brandedMobileCapture(
     "deposit.balance-page-shows-what-is-left",
     "balance-payment-link",
-    "/pay/{balanceToken}",
     ".page-regions.public-page",
   ),
   brandedMobileCapture(
     "contact-record.a-record-with-a-history-behind-it",
     "contact-record",
-    "/admin/history/{contactCode}",
     "#contact-history-form",
   ),
   brandedMobileCapture(
     "bundles.the-parts-are-named-on-the-booking-page",
     "bundle-booking-page",
-    "/ticket/{bundleSlug}",
     ".page-regions.public-page",
   ),
   brandedMobileCapture(
     "bookings.volunteer-chooses-shift",
     "volunteer-shift-form",
-    "/ticket/{volunteerGroupSlug}",
     ".page-regions.public-page",
   ),
   brandedMobileCapture(
     "editors.joining-from-an-invite",
     "team-and-roles",
-    "/admin/users",
     ".page-regions.admin-page",
+    "/admin/users",
   ),
   brandedMobileCapture(
     "paid-booking.recorded-once",
     "listing-ledger",
-    "/admin/ledger/revenue/{paidListingId}",
     ".page-regions.admin-page",
   ),
   brandedMobileCapture(
     "site-pages.written-and-readable",
     "page-anybody-can-read",
-    "/page/{sitePageAddress}",
     "main",
   ),
   brandedMobileCapture(
     "api-keys.made-and-shown-once",
     "api-keys-list",
-    "/admin/api-keys",
     ".page-regions.admin-page",
+    "/admin/api-keys",
   ),
   brandedMobileCapture(
     "payment.refund-undoes-the-sale",
     "refunded-booking",
-    "/admin/attendees/{paidBookingId}/ledger",
     "#attendee-money",
   ),
   brandedMobileCapture(
     "booking.group-page-journey",
     "group-booking-arrives",
-    "/admin/listing/{groupBookingListingId}/attendees",
     "main",
   ),
   brandedMobileCapture(
     "payment.place-lost",
     "place-lost-while-paying",
-    "/admin/attendees/{lostPlaceAttendeeId}",
     ".system-note-alert",
   ),
   brandedMobileCapture(
     "site-pages.moved-into-order",
     "site-pages-in-order",
-    "/admin/site/pages",
     ".page-regions.admin-page",
+    "/admin/site/pages",
   ),
   brandedMobileCapture(
     "add-ons.it-appears-in-the-list-with-its-own-link",
     "add-on-in-the-list",
-    "/listings",
     "main",
+    "/listings",
   ),
   brandedMobileCapture(
     "stay-length.the-length-is-on-the-listing-page",
     "stay-length-on-the-page",
-    "/admin/listing/{stayLengthListingId}",
     "main",
   ),
   brandedMobileCapture(
     "pay-more.the-chosen-price-is-the-income",
     "paid-more-than-asked",
-    "/admin/ledger/revenue/{payMoreListingId}",
     ".page-regions.admin-page",
   ),
   brandedMobileCapture(
     "door.the-day-is-written-down",
     "checked-in-on-the-day",
-    "/admin/listing/{checkedInListingId}/activity",
     "main",
   ),
   brandedMobileCapture(
     "contact-record.correcting-the-counts-and-the-note",
     "record-put-right",
-    "/admin/history/{contactCode}",
     "#contact-history-form",
   ),
   brandedMobileCapture(
     "contact-record.repairing-an-unreadable-record",
     "record-repaired",
-    "/admin/history/{contactCode}",
     "#contact-history-form",
   ),
   brandedMobileCapture(
     "door.someone-still-to-arrive-can-be-picked",
     "qr-code-check-in",
-    "/admin/listing/{doorListingId}/scanner",
     "article:has(#manual-checkin)",
   ),
 ];
+
+/** Every screenshot this repo takes. A story can only leave a page for one of
+ * these names, so a typo is a compile error rather than a screenshot of the
+ * wrong page. */
+export type EvidenceCaptureId = (typeof EVIDENCE_CAPTURES)[number]["id"];

--- a/scripts/specs/evidence/hook.ts
+++ b/scripts/specs/evidence/hook.ts
@@ -10,7 +10,7 @@ export interface EvidenceWorld {
     data: Buffer,
     options: { fileName: string; mediaType: "image/png" },
   ): void | Promise<void>;
-  evidenceValues: Map<string, string>;
+  evidencePages: ReadonlyMap<string, string>;
 }
 
 export interface EvidenceHookCase {

--- a/scripts/specs/evidence/pages.ts
+++ b/scripts/specs/evidence/pages.ts
@@ -17,11 +17,8 @@ export interface EvidencePages {
   evidencePages: Map<EvidenceCaptureId, string>;
 }
 
-/**
- * The story says which page it has left for a screenshot to take. Naming the
- * screenshots means the page and the declaration are tied together, so a
- * screenshot cannot be pointed at a page nobody set up.
- */
+/** Naming the screenshots is what ties a page to a declared capture: a name
+ * nothing declares does not compile. */
 export const leaveEvidencePage = (
   world: EvidencePages,
   captureIds: readonly EvidenceCaptureId[],

--- a/scripts/specs/evidence/pages.ts
+++ b/scripts/specs/evidence/pages.ts
@@ -1,0 +1,48 @@
+/**
+ * Where a screenshot's page is. A capture either has one address forever, in
+ * which case its declaration says so, or the story makes the address as it
+ * runs and hands it over here, named after the screenshot it is for.
+ */
+
+import * as v from "valibot";
+import type { EvidenceCaptureId } from "./declarations.ts";
+import {
+  type EvidenceCaptureDeclaration,
+  EvidencePathSchema,
+} from "./schema.ts";
+
+/** The pages a running story has left behind, one for each screenshot it is
+ * setting up. */
+export interface EvidencePages {
+  evidencePages: Map<EvidenceCaptureId, string>;
+}
+
+/**
+ * The story says which page it has left for a screenshot to take. Naming the
+ * screenshots means the page and the declaration are tied together, so a
+ * screenshot cannot be pointed at a page nobody set up.
+ */
+export const leaveEvidencePage = (
+  world: EvidencePages,
+  captureIds: readonly EvidenceCaptureId[],
+  path: string,
+): void => {
+  const address = v.parse(EvidencePathSchema, path);
+  for (const captureId of captureIds)
+    world.evidencePages.set(captureId, address);
+};
+
+/** The address to open for one screenshot: the one its declaration fixes, or
+ * the one the story left. A screenshot with neither is a story that never
+ * reached the page it promised. */
+export const evidencePagePath = (
+  declaration: EvidenceCaptureDeclaration,
+  pages: ReadonlyMap<string, string>,
+): string => {
+  if (declaration.path !== undefined) return declaration.path;
+  const left = pages.get(declaration.id);
+  if (left === undefined) {
+    throw new Error(`The story left no page for the ${declaration.id} capture`);
+  }
+  return left;
+};

--- a/scripts/specs/evidence/schema.ts
+++ b/scripts/specs/evidence/schema.ts
@@ -15,8 +15,11 @@ const TrimmedNonEmptyTextSchema = v.pipe(TrimmedTextSchema, v.nonEmpty());
 const matchingText = (pattern: RegExp, message?: string) =>
   v.pipe(TrimmedNonEmptyTextSchema, v.regex(pattern, message));
 
+/** A stable id is refused rather than tidied when it carries stray spaces: a
+ * capture id is used as a key, so a tidied one would no longer be the id the
+ * code that named it was written with. */
 const stableId = (label: string) =>
-  matchingText(STABLE_ID_PATTERN, `Invalid ${label}`);
+  v.pipe(v.string(), v.regex(STABLE_ID_PATTERN, `Invalid ${label}`));
 
 const PositiveIntegerSchema = integerAtLeast(1);
 

--- a/scripts/specs/evidence/schema.ts
+++ b/scripts/specs/evidence/schema.ts
@@ -37,14 +37,23 @@ const EvidenceProfilesSchema = v.pipe(
   ),
 );
 
+/** A whole page address, ready to open. Placeholders are refused: a capture
+ * whose address the story has to make up says so by leaving `path` out and
+ * handing the finished address over with leaveEvidencePage. */
+export const EvidencePathSchema = v.pipe(
+  TrimmedTextSchema,
+  v.startsWith("/", "Evidence path must start with /"),
+  v.check(
+    (path) => !path.includes("{"),
+    "Evidence path must be a whole address, not a placeholder",
+  ),
+);
+
 export const EvidenceCaptureDeclarationSchema = v.strictObject({
   caseId: stableId("evidence case id"),
   element: TrimmedNonEmptyTextSchema,
   id: stableId("capture id"),
-  path: v.pipe(
-    TrimmedTextSchema,
-    v.startsWith("/", "Evidence path must start with /"),
-  ),
+  path: v.optional(EvidencePathSchema),
   presentation: EvidencePresentationSchema,
   profiles: EvidenceProfilesSchema,
 });

--- a/test/scripts/specs/evidence-capture.test.ts
+++ b/test/scripts/specs/evidence-capture.test.ts
@@ -1,9 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import {
-  isAllowedEvidenceRequest,
-  resolveEvidencePath,
-} from "#scripts/specs/evidence/browser.ts";
+import { isAllowedEvidenceRequest } from "#scripts/specs/evidence/browser.ts";
 import { defineEvidenceCapture } from "#scripts/specs/evidence/capture-flow.ts";
 import type { EvidenceCaptureDeclaration } from "#scripts/specs/evidence/schema.ts";
 import { requireValue } from "#shared/required-value.ts";
@@ -11,6 +8,7 @@ import { validFeature } from "#test/scripts/specs/profile-fixture.ts";
 import {
   compileEvidenceFeature,
   PAYMENT_RESULT_CAPTURE as declaration,
+  PAYMENT_RESULT_PAGE,
 } from "./evidence-fixture.ts";
 
 interface CaptureCalls {
@@ -42,6 +40,7 @@ interface CaptureFixtureOptions {
   feature?: string;
   hookPickle?: number;
   launchError?: Error;
+  leftPages?: ReadonlyArray<readonly [string, string]>;
   serverCloseError?: Error;
 }
 
@@ -194,7 +193,9 @@ const captureFixture = (
           options: attachmentOptions,
         });
       },
-      evidenceValues: new Map([["paymentId", "42"]]),
+      evidencePages: new Map(
+        options.leftPages ?? [[declaration.id, PAYMENT_RESULT_PAGE]],
+      ),
     },
   };
 };
@@ -213,24 +214,6 @@ const errorMessages = (error: unknown): string[] =>
     : [String(error)];
 
 describe("Cucumber evidence browser boundary", () => {
-  test("fills encoded World values into a declared path", () => {
-    expect(
-      resolveEvidencePath(
-        "/admin/servicing/{servicingEventId}/{label}",
-        new Map([
-          ["servicingEventId", "42"],
-          ["label", "floor treatment"],
-        ]),
-      ),
-    ).toBe("/admin/servicing/42/floor%20treatment");
-  });
-
-  test("fails when a declared path value was not set by the scenario", () => {
-    expect(() =>
-      resolveEvidencePath("/admin/servicing/{servicingEventId}", new Map()),
-    ).toThrow("Evidence World value servicingEventId was not set");
-  });
-
   test("allows only the scenario server and inline data", () => {
     const baseUrl = "http://127.0.0.1:3100";
     expect(isAllowedEvidenceRequest(baseUrl, `${baseUrl}/admin/`)).toBe(true);
@@ -270,7 +253,7 @@ describe("Cucumber evidence capture", () => {
     expect(calls.goto).toEqual([
       {
         navigation: { waitUntil: "domcontentloaded" },
-        path: "/admin/payments/42",
+        path: PAYMENT_RESULT_PAGE,
       },
     ]);
     expect(calls.timeout).toEqual([60_000]);
@@ -312,6 +295,31 @@ describe("Cucumber evidence capture", () => {
         "Test owner cookie is malformed",
       );
     }
+  });
+
+  test("opens the address a fixed-path capture declares", async () => {
+    const { calls, capture, hook, world } = captureFixture({
+      declarations: [{ ...declaration, path: "/admin/settings" }],
+      leftPages: [],
+    });
+
+    await capture(world, hook);
+
+    expect(calls.goto).toEqual([
+      {
+        navigation: { waitUntil: "domcontentloaded" },
+        path: "/admin/settings",
+      },
+    ]);
+  });
+
+  test("rejects a capture whose story left no page", async () => {
+    const { calls, capture, hook, world } = captureFixture({ leftPages: [] });
+
+    await expect(capture(world, hook)).rejects.toThrow(
+      "The story left no page for the payment-result capture",
+    );
+    expectCaptureClosed(calls);
   });
 
   test("rejects a scenario without a declared capture before opening IO", async () => {

--- a/test/scripts/specs/evidence-fixture.ts
+++ b/test/scripts/specs/evidence-fixture.ts
@@ -5,16 +5,18 @@ import { parseGherkinSource } from "#scripts/specs/gherkin.ts";
 import { validateSpecSources } from "#scripts/specs/profile.ts";
 import { registry, source } from "#test/scripts/specs/profile-fixture.ts";
 
-/** The capture two of these tests both declare: a page, the part of it to
- * show, and nothing about how it looks. */
+/** The capture two of these tests both declare: a page the story leaves
+ * behind, the part of it to show, and nothing about how it looks. */
 export const PAYMENT_RESULT_CAPTURE = {
   caseId: "payment.place-available",
   element: "#payment-result",
   id: "payment-result",
-  path: "/admin/payments/{paymentId}",
   presentation: "canonical",
   profiles: ["mobile"],
 } as const satisfies EvidenceCaptureDeclaration;
+
+/** The page that capture's story leaves behind. */
+export const PAYMENT_RESULT_PAGE = "/admin/payments/42";
 
 export const PLAIN_EVIDENCE_SCENARIO = {
   case: {

--- a/test/scripts/specs/evidence-hook.test.ts
+++ b/test/scripts/specs/evidence-hook.test.ts
@@ -14,7 +14,7 @@ import {
 
 const world = {
   attach: () => Promise.resolve(),
-  evidenceValues: new Map<string, string>(),
+  evidencePages: new Map<string, string>(),
 };
 
 const hook = {

--- a/test/scripts/specs/evidence-manifest.test.ts
+++ b/test/scripts/specs/evidence-manifest.test.ts
@@ -63,7 +63,7 @@ const declaration = {
   caseId: "payment.place-available",
   element: "#payment-result",
   id: "payment-result",
-  path: "/admin/payments/{paymentId}",
+  path: "/admin/payments/42",
   presentation: "canonical",
   profiles: ["mobile"],
 } as const;

--- a/test/scripts/specs/evidence-pages.test.ts
+++ b/test/scripts/specs/evidence-pages.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { EvidenceCaptureId } from "#scripts/specs/evidence/declarations.ts";
+import {
+  type EvidencePages,
+  evidencePagePath,
+  leaveEvidencePage,
+} from "#scripts/specs/evidence/pages.ts";
+import { PAYMENT_RESULT_CAPTURE as declaration } from "./evidence-fixture.ts";
+
+const emptyWorld = (): EvidencePages => ({
+  evidencePages: new Map<EvidenceCaptureId, string>(),
+});
+
+describe("Evidence pages a story leaves", () => {
+  test("names every capture the one page is for", () => {
+    const world = emptyWorld();
+
+    leaveEvidencePage(
+      world,
+      ["contact-record", "record-put-right"],
+      "/admin/history/abc123",
+    );
+
+    expect([...world.evidencePages]).toEqual([
+      ["contact-record", "/admin/history/abc123"],
+      ["record-put-right", "/admin/history/abc123"],
+    ]);
+  });
+
+  test("keeps the page a later step left instead of the earlier one", () => {
+    const world = emptyWorld();
+
+    leaveEvidencePage(world, ["listing-ledger"], "/admin/ledger/revenue/1");
+    leaveEvidencePage(world, ["listing-ledger"], "/admin/ledger/revenue/2");
+
+    expect(world.evidencePages.get("listing-ledger")).toBe(
+      "/admin/ledger/revenue/2",
+    );
+  });
+
+  test("refuses a page that is not a whole address", () => {
+    for (const path of ["admin/settings", "/ticket/{bundleSlug}", ""]) {
+      expect(() =>
+        leaveEvidencePage(emptyWorld(), ["listing-ledger"], path),
+      ).toThrow();
+    }
+  });
+
+  test("opens the address the declaration fixes, ignoring what was left", () => {
+    expect(
+      evidencePagePath(
+        { ...declaration, path: "/admin/settings" },
+        new Map([[declaration.id, "/admin/payments/42"]]),
+      ),
+    ).toBe("/admin/settings");
+  });
+
+  test("opens the page the story left when the declaration fixes none", () => {
+    expect(
+      evidencePagePath(
+        declaration,
+        new Map([[declaration.id, "/admin/payments/42"]]),
+      ),
+    ).toBe("/admin/payments/42");
+  });
+
+  test("fails when the story reached no page for the capture", () => {
+    expect(() => evidencePagePath(declaration, new Map())).toThrow(
+      "The story left no page for the payment-result capture",
+    );
+  });
+});

--- a/test/scripts/specs/evidence-schema.test.ts
+++ b/test/scripts/specs/evidence-schema.test.ts
@@ -17,7 +17,7 @@ const declaration = {
   caseId: "payment.place-available",
   element: "#payment-result",
   id: "payment-result",
-  path: "/admin/payments/{paymentId}",
+  path: "/admin/payments/42",
   presentation: "canonical",
   profiles: ["mobile"],
 } as const;
@@ -50,6 +50,10 @@ describe("Cucumber evidence schema", () => {
     const invalid = [
       [[{ ...declaration, id: "Not Stable" }], "capture id"],
       [[{ ...declaration, path: "admin/payments" }], "path"],
+      [
+        [{ ...declaration, path: "/admin/payments/{paymentId}" }],
+        "whole address",
+      ],
       [[{ ...declaration, profiles: [] }], "profile"],
       [[{ ...declaration, profiles: ["mobile", "mobile"] }], "unique"],
       [[{ ...declaration, presentation: "sales" }], "canonical"],

--- a/test/scripts/specs/evidence-schema.test.ts
+++ b/test/scripts/specs/evidence-schema.test.ts
@@ -49,6 +49,7 @@ describe("Cucumber evidence schema", () => {
   test("rejects invalid or duplicate capture declarations", () => {
     const invalid = [
       [[{ ...declaration, id: "Not Stable" }], "capture id"],
+      [[{ ...declaration, id: " payment-result " }], "capture id"],
       [[{ ...declaration, path: "admin/payments" }], "path"],
       [
         [{ ...declaration, path: "/admin/payments/{paymentId}" }],

--- a/test/scripts/specs/evidence/pages.test.ts
+++ b/test/scripts/specs/evidence/pages.test.ts
@@ -6,7 +6,7 @@ import {
   evidencePagePath,
   leaveEvidencePage,
 } from "#scripts/specs/evidence/pages.ts";
-import { PAYMENT_RESULT_CAPTURE as declaration } from "./evidence-fixture.ts";
+import { PAYMENT_RESULT_CAPTURE as declaration } from "#test/scripts/specs/evidence-fixture.ts";
 
 const emptyWorld = (): EvidencePages => ({
   evidencePages: new Map<EvidenceCaptureId, string>(),

--- a/test/specs/steps/booking-journey.ts
+++ b/test/specs/steps/booking-journey.ts
@@ -2,6 +2,7 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { adminBrowser } from "#test/specs/support/browser.ts";
 import {
   requiredWorldValue,
@@ -152,7 +153,11 @@ Then(
     const browser = await adminBrowser(this);
     // The list a booking made on a group page arrives in, which is what an
     // evidence capture of this journey has to show.
-    this.evidenceValues.set("groupBookingListingId", String(listingId(this)));
+    leaveEvidencePage(
+      this,
+      ["group-booking-arrives"],
+      `/admin/listing/${listingId(this)}/attendees`,
+    );
     await browser.visit(`/admin/listing/${listingId(this)}/attendees`);
     expect(browser.containsText(CUSTOMER)).toBe(true);
     expect(browser.containsText(CUSTOMER_EMAIL)).toBe(true);

--- a/test/specs/steps/payment-capacity.ts
+++ b/test/specs/steps/payment-capacity.ts
@@ -3,6 +3,7 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { handleRequest } from "#routes";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import { getNotesFor } from "#shared/db/notes/queries.ts";
 import { attendeeNotes } from "#shared/db/notes/target.ts";
@@ -137,7 +138,11 @@ Then(
     this.placeholderId = attendee.id;
     // The record the site kept for somebody whose payment arrived too late,
     // which is the page that shows an organiser what happened to them.
-    this.evidenceValues.set("lostPlaceAttendeeId", String(attendee.id));
+    leaveEvidencePage(
+      this,
+      ["place-lost-while-paying"],
+      `/admin/attendees/${attendee.id}`,
+    );
     expect((await getAttendeesRaw(listingId)).length).toBe(2);
   },
 );

--- a/test/specs/steps/servicing-hold.ts
+++ b/test/specs/steps/servicing-hold.ts
@@ -2,6 +2,7 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { getListingRemainingForRange } from "#shared/db/attendees/capacity/remaining.ts";
 import { submitRenderedAdminForm } from "#test/specs/support/browser.ts";
 import {
@@ -103,7 +104,11 @@ When(
     }
     const eventId = Number(requiredWorldValue(match[1], "service event id"));
     this.servicingEventId = eventId;
-    this.evidenceValues.set("servicingEventId", String(eventId));
+    leaveEvidencePage(
+      this,
+      ["servicing-studio-floor-hold"],
+      `/admin/servicing/${eventId}`,
+    );
   },
 );
 

--- a/test/specs/steps/stays-length.ts
+++ b/test/specs/steps/stays-length.ts
@@ -3,6 +3,7 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { t } from "#i18n";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { openAdminPage, scenarioBrowser } from "#test/specs/support/browser.ts";
 import {
   organiserSavesListing,
@@ -100,7 +101,11 @@ When(
   "the organiser looks at the {word}'s page",
   async function (this: TicketsWorld, name: string): Promise<void> {
     const { id } = stayListing(this, name);
-    this.evidenceValues.set("stayLengthListingId", String(id));
+    leaveEvidencePage(
+      this,
+      ["stay-length-on-the-page"],
+      `/admin/listing/${id}`,
+    );
     await openAdminPage(this, `/admin/listing/${id}`);
   },
 );

--- a/test/specs/steps/volunteer-sign-up.ts
+++ b/test/specs/steps/volunteer-sign-up.ts
@@ -2,6 +2,7 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { questionsTable } from "#shared/db/questions/tables.ts";
 import { adminBrowser, scenarioBrowser } from "#test/specs/support/browser.ts";
 import {
@@ -48,7 +49,7 @@ Given(
     this.groupSlug = group.slug;
     // The shifts are offered on the group's own page, which is where an
     // evidence capture of the sign-up form has to go.
-    this.evidenceValues.set("volunteerGroupSlug", group.slug);
+    leaveEvidencePage(this, ["volunteer-shift-form"], `/ticket/${group.slug}`);
     this.questionId = question.id;
   },
 );

--- a/test/specs/support/bulk-money.ts
+++ b/test/specs/support/bulk-money.ts
@@ -5,6 +5,7 @@
  */
 
 // jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import { sellSomethingAt } from "#test/specs/support/listings.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
@@ -102,5 +103,9 @@ export const payYourOwnPrice: ActOnSomeMoney = async (world, chosen) => {
   });
   world.attendeeId = (await getAttendeesRaw(listingId))[0]!.id;
   // The statement that has to show what they chose rather than what was asked.
-  world.evidenceValues.set("payMoreListingId", String(listingId));
+  leaveEvidencePage(
+    world,
+    ["paid-more-than-asked"],
+    `/admin/ledger/revenue/${listingId}`,
+  );
 };

--- a/test/specs/support/bundles.ts
+++ b/test/specs/support/bundles.ts
@@ -5,9 +5,10 @@
  * than being reached around.
  */
 
-// jscpd:ignore-start
 import { expect } from "@std/expect";
 import { map } from "#fp";
+// jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { toMinorUnits } from "#shared/currency.ts";
 import { getGroupPackagePrices, groups } from "#shared/db/groups.ts";
 import type { Group, GroupListing } from "#shared/types.ts";
@@ -247,7 +248,7 @@ export const customerOpensBundlePage = async (
   // be chosen in a real browser however well a crafted send goes through.
   expect(browser.currentHtml).toContain(`name="package_quantity_${group.id}"`);
   world.bundleBookingPage = browser.pageText;
-  world.evidenceValues.set("bundleSlug", group.slug);
+  leaveEvidencePage(world, ["bundle-booking-page"], `/ticket/${group.slug}`);
   return browser;
 };
 

--- a/test/specs/support/contact-records.ts
+++ b/test/specs/support/contact-records.ts
@@ -5,9 +5,10 @@
  * the story names and lets the site work that code out.
  */
 
-// jscpd:ignore-start
 import { expect } from "@std/expect";
 import { mapNotNullish } from "#fp";
+// jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { execute } from "#shared/db/client.ts";
 import {
   type ContactRecord,
@@ -97,7 +98,11 @@ export const openRecord = async (
   email: string,
 ): Promise<TestBrowser> => {
   const code = toContactHashParam(await hashEmail(email));
-  world.evidenceValues.set("contactCode", code);
+  leaveEvidencePage(
+    world,
+    ["contact-record", "record-put-right", "record-repaired"],
+    recordPath(code),
+  );
   return openAdminPage(world, recordPath(code));
 };
 

--- a/test/specs/support/deposits.ts
+++ b/test/specs/support/deposits.ts
@@ -3,8 +3,9 @@
  * not paid, a deposit against it, and settling the rest.
  */
 
-// jscpd:ignore-start
 import { expect } from "@std/expect";
+// jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { signBalanceToken } from "#shared/balance-link.ts";
 import { settleAttendeeBalance } from "#shared/db/attendees/balance.ts";
 import { sellSomethingAt } from "#test/specs/support/listings.ts";
@@ -65,7 +66,7 @@ export const payDeposit: ActOnSomeMoney = async (world, amount) => {
  *  evidence capture has no path it could write by hand. */
 export const balancePageHtml = async (world: TicketsWorld): Promise<string> => {
   const token = await signBalanceToken(theBooking(world));
-  world.evidenceValues.set("balanceToken", token);
+  leaveEvidencePage(world, ["balance-payment-link"], `/pay/${token}`);
   return publicPageHtml(`/pay/${token}`);
 };
 

--- a/test/specs/support/door.ts
+++ b/test/specs/support/door.ts
@@ -7,8 +7,9 @@
  * than being stepped around.
  */
 
-// jscpd:ignore-start
 import { expect } from "@std/expect";
+// jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { getAttendeesByTokens } from "#shared/db/attendees/tokens.ts";
 import { openAdminPage } from "#test/specs/support/browser.ts";
 import {
@@ -59,7 +60,11 @@ export const personWithTicket = async (
   );
   rememberStayListing(world, listing, created);
   // The door this person belongs to, so a screenshot capture can open it.
-  world.evidenceValues.set("doorListingId", String(created.id));
+  leaveEvidencePage(
+    world,
+    ["qr-code-check-in"],
+    listingPath(world, listing, "scanner"),
+  );
   rememberTicket(world, who, token);
 };
 
@@ -214,13 +219,8 @@ const readOf = (row: string, what: string): string => {
 /** What the listing's own record of the day says happened. */
 export const dayLog: ReadAboutOneThing = async (world, listing) => {
   // The listing whose own record of the day a capture of a check-in goes to.
-  world.evidenceValues.set(
-    "checkedInListingId",
-    String(stayListing(world, listing).id),
-  );
-  const browser = await openAdminPage(
-    world,
-    listingPath(world, listing, "activity"),
-  );
+  const path = listingPath(world, listing, "activity");
+  leaveEvidencePage(world, ["checked-in-on-the-day"], path);
+  const browser = await openAdminPage(world, path);
   return browser.pageText;
 };

--- a/test/specs/support/hooks.ts
+++ b/test/specs/support/hooks.ts
@@ -18,7 +18,7 @@ import {
 
 Before(async function (this: TicketsWorld): Promise<void> {
   this.cleanup = [];
-  this.evidenceValues = new Map();
+  this.evidencePages = new Map();
   this.listingIds = new Map();
   const cleanupDb = await setupTestDbEnvironment(true).catch((error) => {
     clearTestEncryptionKey();

--- a/test/specs/support/money.ts
+++ b/test/specs/support/money.ts
@@ -4,8 +4,9 @@
  * the provider was asked.
  */
 
-// jscpd:ignore-start
 import { expect } from "@std/expect";
+// jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { WORLD } from "#shared/accounting/accounts.ts";
 import { getAttendeesRaw } from "#shared/db/attendees/queries.ts";
 import type { Listing } from "#shared/types.ts";
@@ -67,8 +68,16 @@ export const buyOnePlace = async (
   world.attendeeName = who;
   // What the listing earned is read from its own ledger page, and what one
   // booking has paid from its own, which is where captures of each figure go.
-  world.evidenceValues.set("paidListingId", String(listingId));
-  world.evidenceValues.set("paidBookingId", String(attendeeId));
+  leaveEvidencePage(
+    world,
+    ["listing-ledger"],
+    `/admin/ledger/revenue/${listingId}`,
+  );
+  leaveEvidencePage(
+    world,
+    ["refunded-booking"],
+    `/admin/attendees/${attendeeId}/ledger`,
+  );
   return attendeeId;
 };
 

--- a/test/specs/support/site-pages.ts
+++ b/test/specs/support/site-pages.ts
@@ -3,8 +3,9 @@
  * opened by somebody never signed in, because that is who these pages are for.
  */
 
-// jscpd:ignore-start
 import { t } from "#i18n";
+// jscpd:ignore-start
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { sitePages } from "#shared/db/site-pages.ts";
 import {
   newcomerReading,
@@ -62,7 +63,7 @@ export const ownerWritesPage = async (
   world.sitePageTold = browser.pageText;
   // The address the owner chose, so a capture can open the page the way a
   // visitor would rather than being told the address a second time.
-  world.evidenceValues.set("sitePageAddress", address);
+  leaveEvidencePage(world, ["page-anybody-can-read"], `/page/${address}`);
   return browser.pageText;
 };
 

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -1,6 +1,7 @@
 // jscpd:ignore-start
 import type { World } from "@cucumber/cucumber";
 import { type CleanupTask, runCleanups } from "#scripts/cleanup.ts";
+import type { EvidencePages } from "#scripts/specs/evidence/pages.ts";
 import type { Group, Listing } from "#shared/types.ts";
 import type { ApiAnswer } from "#test/specs/support/booking-api.ts";
 import type { ThingForSale } from "#test/specs/support/bundles.ts";
@@ -83,7 +84,7 @@ export const asksIfThereIs =
   async (world, name) =>
     (await look(world, name)) !== null;
 
-export interface TicketsWorld extends World {
+export interface TicketsWorld extends World, EvidencePages {
   apiAnswer?: ApiAnswer;
   apiFirstDay?: string;
   apiKeyAnswer?: { answered: number; said: string };
@@ -122,7 +123,6 @@ export interface TicketsWorld extends World {
   editorAnswer?: number;
   editorBrowser?: TestBrowser;
   editorInvite?: string;
-  evidenceValues: Map<string, string>;
   firstBody?: string;
   firstDay?: string;
   firstFailureData?: string;


### PR DESCRIPTION
## What this changes

Our documentation screenshots are declared in one file, and the stories that set
them up live in another. Until now, a screenshot of a page whose address is only
known while the story runs — a new listing's number, a signed payment link, a
one-way contact code — was declared with a made-up name in curly brackets, like
`/ticket/{bundleSlug}`. Somewhere else, a story wrote the words `bundleSlug`
into a bag of loose values. The two halves only met when the screenshot was
taken, so a rename or a typo in either place quietly produced a screenshot of
the wrong page, or a run that failed late.

Now a screenshot either has one address forever, written in its declaration, or
the story hands the finished address over by name:

```ts
leaveEvidencePage(world, ["bundle-booking-page"], `/ticket/${group.slug}`);
```

The names it accepts are the screenshot names themselves, taken from the
declarations, so naming one that does not exist stops the build instead of
producing a wrong picture. The loose bag of value names is gone.

## Why it is better

- Adding a screenshot no longer means keeping three matching strings in step.
- A path is checked to be a whole address; a leftover `{placeholder}` is refused.
- A screenshot whose story never reached its page fails with a plain message
  saying which screenshot was left without one.

## Checks

`deno task precommit` passes, and all 163 Cucumber stories still pass. New
direct tests cover leaving a page, refusing a bad address, and choosing between
a declared address and one the story left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjUpiqcQ3YehSSWTgxLmHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjUpiqcQ3YehSSWTgxLmHr)_