### PR TITLE
One way to read a table's rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -649,7 +649,7 @@ Some reads legitimately need the full row — these are the exceptions, not the 
 
 - **An entity cache that also backs single-record reads.** When one request-scoped cache serves both the collection view and the `getById`/`getByKey` detail/auth reads (listings, users, groups, holidays, built-sites, attendee-statuses), it loads the full entity once so the detail, edit, and login paths it feeds have every column. Narrowing the cache load would break those reads. (`getAllListings`' `SELECT listing.*` is deliberately wide — it also carries the trigger-maintained `booked_quantity`/`income`/`tickets_count` aggregate columns.)
 - **Full-table backup/restore** (`backup.ts`) — a dump needs every column to round-trip.
-- **The generic `Table.findById`/`findAll` helpers** (`table.ts`) — they `SELECT *` by design and feed edit pages that need the whole row; specific tables narrow at the cache `fetchAll` layer instead.
+- **A table's whole-row read** (`table.read.one`/`read.many` with no columns named, in `table-reader.ts`) — it selects every stored column by design and feeds edit pages that need the whole row; a read that wants less names its columns with `read.pick`, and specific tables narrow at the cache `fetchAll` layer instead.
 
 Even when a caller genuinely needs many columns, list them explicitly rather than `SELECT *`, so adding a column later doesn't silently widen every read.
 

--- a/src/features/admin/built-site-action.ts
+++ b/src/features/admin/built-site-action.ts
@@ -34,8 +34,8 @@ export type BuiltSitePost = (
   id: number,
 ) => Promise<Response>;
 
-const builtSiteHandler = createIdEntityHandler<BuiltSite>(
-  builtSitesCrudTable.findById,
+const builtSiteHandler = createIdEntityHandler<BuiltSite>((id) =>
+  builtSitesCrudTable.read.one({ id }),
 );
 
 export const builtSiteAction = (action: BuiltSitePost): IdRouteHandler =>

--- a/src/features/admin/built-site-page.tsx
+++ b/src/features/admin/built-site-page.tsx
@@ -70,6 +70,6 @@ export const builtSitePage: EditEntityPage<BuiltSite> = defineEditEntityPage({
   extraTabs: [renewalTab, maintenanceTab, secretsTab, updateTab],
   guard: requireOwnerOr,
   guideFooter: () => Promise.resolve(<BuiltSitesGuideFooter />),
-  load: (id) => builtSitesCrudTable.findById(id),
+  load: (id) => builtSitesCrudTable.read.one({ id }),
   navActive: "/admin/built-sites",
 });

--- a/src/features/admin/bulk-actions.ts
+++ b/src/features/admin/bulk-actions.ts
@@ -30,6 +30,7 @@ import { executeBatch } from "#shared/db/client.ts";
 import {
   cloneGroupMembershipStatement,
   generateUniqueGroupSlug,
+  getGroupById,
   getGroupBySlugIndex,
   getGroupPackagePrices,
   getListingsByGroupId,
@@ -106,7 +107,7 @@ const groupTogglePost = (opts: { active: boolean; action: string }) =>
     actionLabel: `${opts.action}ion`,
     identifier: (group) => group.name,
     identifierLabel: "Group name",
-    loadContext: ({ id }) => groups.table.findById(id),
+    loadContext: ({ id }) => getGroupById(id),
     mismatchRedirect: (group) =>
       `/admin/groups/${group.id}/bulk-actions/${opts.action}`,
     onConfirm: async ({ context: group }) => {

--- a/src/features/admin/catalog-transfer/import.ts
+++ b/src/features/admin/catalog-transfer/import.ts
@@ -152,7 +152,7 @@ const firstPackageGroup = async (
   groupIds: readonly number[],
 ): Promise<Group | null> => {
   if (groupIds.length === 0) return null;
-  // Resolve against the cached group set rather than one findById per group, so a
+  // Resolve against the cached group set rather than one read per group, so a
   // child listing that belongs to many groups doesn't trip the request N+1 guard.
   const byId = await getGroupsById();
   for (const groupId of groupIds) {

--- a/src/features/admin/find-group.ts
+++ b/src/features/admin/find-group.ts
@@ -1,12 +1,11 @@
-import { groups } from "#shared/db/groups.ts";
+import { getGroupById } from "#shared/db/groups.ts";
 import { type FindByIdThen, findByIdThen } from "#shared/find-by-id.ts";
 
 /** The stored group row as loaded from the table. */
-type GroupRow = NonNullable<Awaited<ReturnType<typeof groups.table.findById>>>;
+type GroupRow = NonNullable<Awaited<ReturnType<typeof getGroupById>>>;
 
 /** Load the group with `id` and hand it to `whenFound`. When no group has that
  * id, skip the callback and return null — so a caller writes the found-group
  * path once instead of repeating the "look it up, bail if missing" load. */
-export const withGroupOrNull: FindByIdThen<GroupRow> = findByIdThen((id) =>
-  groups.table.findById(id),
-);
+export const withGroupOrNull: FindByIdThen<GroupRow> =
+  findByIdThen(getGroupById);

--- a/src/features/admin/group-page-data.ts
+++ b/src/features/admin/group-page-data.ts
@@ -17,9 +17,9 @@ import { getEffectiveDomain } from "#shared/config.ts";
 import { decryptAttendees } from "#shared/db/attendees/pii.ts";
 import { getListingsNotInGroup } from "#shared/db/groups/candidates.ts";
 import {
+  getGroupById,
   getGroupPackagePrices,
   getListingsByGroupId,
-  groups,
 } from "#shared/db/groups.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getGroupDayPrices } from "#shared/db/listing-prices.ts";
@@ -45,7 +45,7 @@ import { loadItemImagesPanel } from "./item-images.ts";
  * remaining data is fetched by its own loader below, so a bare page frame never
  * decrypts a roster it isn't about to show. */
 export const loadGroupForPage = (id: number): Promise<Group | null> =>
-  groups.table.findById(id);
+  getGroupById(id);
 
 /** Whether a group's roster has any paid attendee data to decrypt. A package
  * member can carry a `package_price` override while its own `unit_price` is 0,

--- a/src/features/admin/groups.ts
+++ b/src/features/admin/groups.ts
@@ -1,4 +1,5 @@
 /* jscpd:ignore-start */
+import type { InValue } from "@libsql/client";
 import { defineRoutes } from "#routes/router.ts";
 
 /**
@@ -27,6 +28,7 @@ import {
   assignListingsToGroup,
   computeGroupSlugIndex,
   generateUniqueGroupSlug,
+  getGroupById,
   getListingsByGroupId,
   groups,
   hasPackageBookings,
@@ -234,9 +236,7 @@ const extractGroupEditInput = async (
 };
 
 /** Delete a group and reset its listings to ungrouped */
-export const deleteGroup = async (
-  id: Parameters<typeof groups.table.findById>[0],
-) => {
+export const deleteGroup = async (id: InValue) => {
   const groupId = Number(id);
   await resetGroupListings(groupId);
   // Clear site-page membership edges atomically with the group row: a failed
@@ -331,7 +331,7 @@ const staffCrud = createCrudHandlers({
 });
 
 /** Look up group by id, return 404 if not found */
-export const withGroup = withEntityLoader(groups.table.findById);
+export const withGroup = withEntityLoader((id: number) => getGroupById(id));
 
 /**
  * POST handler factory: CSRF-validated form + loaded group.
@@ -343,7 +343,7 @@ export const groupFormPost = (
 ): TypedRouteHandler<"POST /admin/groups/:id"> =>
   createAuthedHandler<{ id: number }, Group>({
     handle: ({ context, form }) => handler(context, form),
-    loadContext: ({ id }) => groups.table.findById(id),
+    loadContext: ({ id }) => getGroupById(id),
   });
 
 /** Validate that all listing types match the group; returns error message or
@@ -399,7 +399,7 @@ const handleAddListingsToGroup = groupFormPost(async (group, form) => {
 const groupImageHandlers = createItemImageHandlers({
   disabledPath: (id) => `/admin/groups/${id}/edit`,
   itemType: "group",
-  load: groups.table.findById,
+  load: (id) => getGroupById(id),
   nameOf: (group) => group.name,
   path: (id) => `/admin/groups/${id}/images`,
 });

--- a/src/features/admin/holiday-page.ts
+++ b/src/features/admin/holiday-page.ts
@@ -24,6 +24,6 @@ export const holidayPage: EditEntityPage<Holiday> = defineEditEntityPage({
       HolidayEditPanel({ holiday, ...submittedValueProps(rejected) }),
     ),
   guard: requireOwnerOr,
-  load: (id) => holidays.table.findById(id),
+  load: (id) => holidays.table.read.one({ id }),
   navActive: "/admin/holidays",
 });

--- a/src/features/admin/listings-view.ts
+++ b/src/features/admin/listings-view.ts
@@ -11,7 +11,7 @@ import { getDateFilter } from "#routes/admin/actions.ts";
 import type { AuthSession } from "#routes/auth.ts";
 import { formatDateLabel } from "#shared/dates.ts";
 import { getGroupRemainingByGroupId } from "#shared/db/attendees/capacity/groups.ts";
-import { groups, listingGroups } from "#shared/db/groups.ts";
+import { getGroupById, listingGroups } from "#shared/db/groups.ts";
 import {
   type AttendeeQuestionData,
   getAttendeeAnswersBatch,
@@ -122,7 +122,7 @@ export const loadGroupContext = async (
 ): Promise<GroupContext | undefined> => {
   let tightest: { ctx: GroupContext; remaining: number } | undefined;
   for (const groupId of await listingGroups.getIds(listing.id)) {
-    const group = await groups.table.findById(groupId);
+    const group = await getGroupById(groupId);
     if (!group || group.max_attendees <= 0) continue;
     const remainingMap = await getGroupRemainingByGroupId(
       [group.id],

--- a/src/features/admin/logistics-agent-page.tsx
+++ b/src/features/admin/logistics-agent-page.tsx
@@ -63,6 +63,6 @@ export const logisticsAgentPage: EditEntityPage<LogisticsAgent> =
     },
     editSlug: "",
     guard: requireOwnerOr,
-    load: (id) => logisticsAgents.table.findById(id),
+    load: (id) => logisticsAgents.table.read.one({ id }),
     navActive: { section: "/admin/logistics" },
   });

--- a/src/features/api/payment-processing/cancel.ts
+++ b/src/features/api/payment-processing/cancel.ts
@@ -16,7 +16,7 @@ import { lacksStandalonePublicPage } from "#routes/public/ticket-payment.ts";
 import { htmlResponse } from "#routes/response.ts";
 import { lineGroupIds } from "#shared/booking/signed-metadata.ts";
 import type { BookingIntent } from "#shared/booking-intent.ts";
-import { groups } from "#shared/db/groups.ts";
+import { getGroupById } from "#shared/db/groups.ts";
 import { getListingWithCount } from "#shared/db/listings/records.ts";
 import type { ValidatedPaymentSession } from "#shared/payments.ts";
 import { paymentCancelPage } from "#templates/payment.tsx";
@@ -45,7 +45,7 @@ const retryHrefFor = async (
       : `/ticket/${listing.slug}`;
   const groupIds = lineGroupIds(intent.items);
   for (const groupId of groupIds) {
-    const group = await groups.table.findById(groupId);
+    const group = await getGroupById(groupId);
     const bundleServes =
       group !== null &&
       (await groupBookable(group, await getVisibleGroupMembers(group)));

--- a/src/shared/db/built-sites.ts
+++ b/src/shared/db/built-sites.ts
@@ -10,6 +10,11 @@ import { queryAll, queryOne, rowExistsForIdList } from "#shared/db/client.ts";
 import { retryWrite } from "#shared/db/retry-write.ts";
 import type { Table, TableSchema } from "#shared/db/table.ts";
 import { cachedTable, col, defineTable } from "#shared/db/table.ts";
+import type {
+  RowFilter,
+  RowOptions,
+  TableReader,
+} from "#shared/db/table-reader.ts";
 import {
   blobToSiteFields,
   buildSiteDataBlobFromInput,
@@ -110,9 +115,51 @@ const queryAndDecrypt = async (sql: string): Promise<BuiltSite[]> => {
   return sites;
 };
 
-const findBuiltSiteById = async (id: InValue): Promise<BuiltSite | null> => {
-  const row = await rawBuiltSitesTable.findById(id);
-  return row ? rowToBuiltSite(row) : null;
+/**
+ * The façade's reads. A built site is assembled from the raw row's encrypted
+ * blob, so every read goes through the raw table's reader and is opened here.
+ *
+ * A filter therefore names the one column a caller reads sites by, `id`. The
+ * site's other fields live inside the blob, so no read of any kind can filter
+ * on them, and `pick` has no narrower set of columns to offer.
+ */
+const rawFilter = (
+  filter: RowFilter<BuiltSite> = {},
+): RowFilter<BuiltSiteRow> => {
+  const { id, ...notAColumn } = filter;
+  const named = Object.keys(notAColumn);
+  if (named.length > 0) {
+    throw new Error(
+      `Cannot filter built sites by ${named.join(", ")}: a site's fields are stored inside one encrypted blob, not as columns. Filter by id.`,
+    );
+  }
+  return id === undefined ? {} : { id };
+};
+
+/** Read built sites through the raw table and open each one's blob. One site is
+ * this same read capped at one row, so there is no second path for it. */
+const readSites = async (
+  filter: RowFilter<BuiltSiteRow>,
+  options: RowOptions | undefined,
+): Promise<BuiltSite[]> =>
+  (await rawBuiltSitesTable.read.many(filter, options)).map(rowToBuiltSite);
+
+const firstOf = async <Item>(items: Promise<Item[]>): Promise<Item | null> => {
+  const [first = null] = await items;
+  return first;
+};
+
+const builtSiteReads: TableReader<BuiltSite> = {
+  // The filter is checked before anything is awaited, so a field that is not a
+  // column fails at the call rather than in a rejected promise later.
+  many: (filter, options) => readSites(rawFilter(filter), options),
+  one: (filter, options) =>
+    firstOf(readSites(rawFilter(filter), { ...options, limit: 1 })),
+  pick: () => {
+    throw new Error(
+      "A built site's fields are stored in one encrypted blob, so a read cannot pick out some of them. Read the whole site.",
+    );
+  },
 };
 
 export const findBuiltSiteByIdPrimary = async (
@@ -159,15 +206,6 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
   columns: rawBuiltSitesTable.columns,
   deleteById: (id: InValue): Promise<void> => builtSites.table.deleteById(id),
 
-  findAll: (): Promise<BuiltSite[]> => builtSites.getAll(),
-
-  findById: findBuiltSiteById,
-
-  findByIds: async (ids: InValue[]): Promise<(BuiltSite | null)[]> =>
-    (await rawBuiltSitesTable.findByIds(ids)).map((row) =>
-      row === null ? null : rowToBuiltSite(row),
-    ),
-
   // findByIdPrimary is intentionally omitted: it is optional on Table (like
   // insertStatement/updateStatement) and only used on the transactional
   // afterWrite write-back path, which this façade resource never takes.
@@ -181,6 +219,7 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
   },
   name: "built_sites",
   primaryKey: "id",
+  read: builtSiteReads,
   // The façade's rows are already decrypted (its fromDb is identity), so a
   // single column's stored value is already its readable value.
   readColumn: <K extends keyof BuiltSite & string>(

--- a/src/shared/db/chosen-columns.ts
+++ b/src/shared/db/chosen-columns.ts
@@ -1,19 +1,30 @@
 /**
- * Reading a chosen set of a table's columns.
+ * Opening a chosen set of a table's columns.
  *
  * A chosen set names the columns a read wants and reuses the table's own read
  * transforms to open them, so a narrow read decrypts and converts exactly what
- * it selected. Paired with the shared filters it also knows how to fetch
- * itself — {@link ChosenColumns.select} — so an ordinary single-table read
- * needs no SQL of its own.
+ * it selected. It says which columns a read must select and turns the values
+ * that come back into a row — nothing more. Running the read is the reader's
+ * job (`#shared/db/table-reader.ts` for a table's own rows, `readRows` for a
+ * join), and both of them open their rows with this.
  */
 
 import { mapParallel } from "#fp";
-import { type Read, readOneRow, readRows } from "#shared/db/read.ts";
-import type { Table } from "#shared/db/table.ts";
-import type { WhereClause } from "#shared/db/where-clauses.ts";
+import type { ReadColumn, TableSchema } from "#shared/db/table.ts";
 
 type TableColumn<Row> = keyof Row & string;
+
+/** What reading a table's own rows needs to know about it: which columns it
+ * has, what to call them, and how to open a stored value. Every defined table
+ * is one of these — naming the part a read uses keeps a reader from depending
+ * on the write half of a table. */
+export type ReadableTable<Row> = {
+  columns: readonly string[];
+  name: string;
+  primaryKey: keyof Row & string;
+  readColumn: ReadColumn<Row>;
+  schema: TableSchema<Row>;
+};
 
 /** One or more of a row's own column names — a read must select something. */
 export type ColumnNames<Row> = readonly [
@@ -28,30 +39,16 @@ export type StoredRowOf<Row, Columns extends ColumnNames<Row>> = {
   [Column in Columns[number]]: unknown;
 };
 
-type ChosenRow<Row, Columns extends ColumnNames<Row>> = Pick<
+/** The row a chosen set hands back: exactly the columns it named. */
+export type ChosenRow<Row, Columns extends ColumnNames<Row>> = Pick<
   Row,
   Columns[number]
 >;
 
-/**
- * A read declared rather than written. The chosen set already knows its table
- * and columns, so this is the whole of an ordinary single-table read; one that
- * joins or carries a subquery says so with {@link readRows} instead, passing
- * this set's {@link ChosenColumns.columnsSql} as its columns.
- */
-export type ReadRequest = {
-  /** The filters, from `#shared/db/where-clauses.ts`. Absent keeps every row. */
-  where?: WhereClause[];
-  /** An `ORDER BY` body without the keyword. Omit for no ordering. */
-  order?: string;
-  /** A row cap. Omit for no limit. */
-  limit?: number;
-  /** Table alias, when the clauses qualify their columns with one. */
-  alias?: string;
-};
-
 export interface ChosenColumns<Row, Columns extends ColumnNames<Row>> {
   readonly columns: Columns;
+  /** The chosen columns as a SELECT list — what a join must select for this set
+   * to open its rows. */
   columnsSql: (alias?: string) => string;
   read: (
     row: StoredRowOf<Row, Columns>,
@@ -60,21 +57,17 @@ export interface ChosenColumns<Row, Columns extends ColumnNames<Row>> {
   readAll: (
     rows: StoredRowOf<Row, Columns>[],
   ) => Promise<ChosenRow<Row, Columns>[]>;
-  /** Run a declared read and return every matching row. A filter that cannot
-   * match anything skips the round-trip. */
-  select: (query?: ReadRequest) => Promise<ChosenRow<Row, Columns>[]>;
-  /** Run a declared read for at most one row. */
-  selectOne: (query?: ReadRequest) => Promise<ChosenRow<Row, Columns> | null>;
+  /** The same list a read of this table's own rows must select: the chosen
+   * columns, plus the row's own key when it was not chosen. A column's read
+   * transform may name the row a bad value came from, and it can only do that
+   * if the key came back too. */
+  readColumnsSql: (alias?: string) => string;
 }
 
 /** Choose an explicit set of a table's own columns and reuse its read
  * transforms without loading or decrypting the rest of the row. */
-export const chooseColumns = <
-  Row,
-  Input,
-  const Columns extends ColumnNames<Row>,
->(
-  table: Table<Row, Input>,
+export const chooseColumns = <Row, const Columns extends ColumnNames<Row>>(
+  table: ReadableTable<Row>,
   columns: Columns,
 ): ChosenColumns<Row, Columns> => {
   const missingColumn = columns.find(
@@ -124,38 +117,10 @@ export const chooseColumns = <
   const columnsSql = (alias?: string): string =>
     columns.map((column) => qualified(column, alias)).join(", ");
 
-  /** What a declared read actually selects: the chosen columns, plus the row's
-   * own key when it was not chosen. A column's read transform may name the row
-   * a bad value came from, and it can only do that if the key came back too.
-   * The key is dropped again before the row is handed back. */
   const readColumnsSql = (alias?: string): string =>
     columns.some((column) => column === table.primaryKey)
       ? columnsSql(alias)
       : `${columnsSql(alias)}, ${qualified(table.primaryKey, alias)}`;
 
-  /** The chosen set supplies the columns and the table; the caller supplies
-   * the rest of the read. */
-  const readFor = (query: ReadRequest): Read => ({
-    ...query,
-    columns: readColumnsSql(query.alias),
-    from: query.alias ? `${table.name} AS ${query.alias}` : table.name,
-  });
-
-  /** The stored rows a declared read selects, before the read transforms. */
-  const storedRowsFor = (
-    query: ReadRequest,
-  ): Promise<StoredRowOf<Row, Columns>[]> =>
-    readRows<StoredRowOf<Row, Columns>>(readFor(query));
-
-  return {
-    columns,
-    columnsSql,
-    read,
-    readAll,
-    select: async (query = {}) => readAll(await storedRowsFor(query)),
-    selectOne: async (query = {}) => {
-      const row = await readOneRow<StoredRowOf<Row, Columns>>(readFor(query));
-      return row === null ? null : read(row);
-    },
-  };
+  return { columns, columnsSql, read, readAll, readColumnsSql };
 };

--- a/src/shared/db/email-templates.ts
+++ b/src/shared/db/email-templates.ts
@@ -37,7 +37,7 @@ export const getAllRawEmailTemplates = (): Promise<RawEmailTemplate[]> =>
 
 export const getRawEmailTemplate = (
   id: number,
-): Promise<RawEmailTemplate | null> => emailTemplatesTable.findById(id);
+): Promise<RawEmailTemplate | null> => emailTemplatesTable.read.one({ id });
 
 export const countEmailTemplates = (): Promise<number> =>
   countRows("email_templates");

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -22,7 +22,6 @@ import {
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex } from "#shared/crypto/sealed.ts";
-import { chooseColumns } from "#shared/db/chosen-columns.ts";
 import {
   execute,
   executeBatch,
@@ -91,7 +90,7 @@ const rawGroupsTable = defineIdTable<Group, GroupInput>("groups", {
   ...projectCatalogFields(groupCatalogFields, "columns", {}),
 });
 
-const packageDisplayColumns = chooseColumns(rawGroupsTable, [
+const packageDisplayColumns = rawGroupsTable.read.pick([
   "id",
   "hide_package_listings",
   "name",
@@ -140,7 +139,7 @@ export const listingGroups = {
 };
 
 /** Every group keyed by id, from the request-cached set — the batched
- * alternative to one findById per id when resolving or validating many groups
+ * alternative to one read per id when resolving or validating many groups
  * without tripping the N+1 read guard. */
 export const getGroupsById = async (): Promise<Map<number, Group>> =>
   mapById(identity<Group>)(await groups.cache.getAll());
@@ -149,6 +148,12 @@ export const getGroupsById = async (): Promise<Map<number, Group>> =>
  * pickers/labels that must not load the whole groups cache. */
 export const getAllGroupNames = (): Promise<Map<number, string>> =>
   envNameSource("groups", "groupRecord").all();
+
+/** One group by id, read straight from the table: a group about to be shown,
+ * edited or acted on must be the stored row, not a cached copy. Null when no
+ * group has that id. */
+export const getGroupById = (id: number): Promise<Group | null> =>
+  rawGroupsTable.read.one({ id });
 
 /**
  * Get a single group by slug_index (from cache)
@@ -453,16 +458,19 @@ export const hasPackageBookings = (groupId: number): Promise<boolean> =>
 export const getPackageDisplaysByIds = async (
   groupIds: readonly number[],
 ): Promise<Map<number, PackageDisplay>> => {
-  const packageGroups = await packageDisplayColumns.select({
-    alias: "groupRecord",
-    where: [
-      ...inList(
-        "groupRecord.id",
-        [...new Set(groupIds)].filter((groupId) => groupId > 0),
-      ),
-      ...equals("groupRecord.is_package", 1),
-    ],
-  });
+  const packageGroups = await packageDisplayColumns.many(
+    {},
+    {
+      alias: "groupRecord",
+      where: [
+        ...inList(
+          "groupRecord.id",
+          [...new Set(groupIds)].filter((groupId) => groupId > 0),
+        ),
+        ...equals("groupRecord.is_package", 1),
+      ],
+    },
+  );
   return new Map(
     packageGroups.map((group) => [
       group.id,

--- a/src/shared/db/groups/candidates.ts
+++ b/src/shared/db/groups/candidates.ts
@@ -1,6 +1,5 @@
 /** The listings a group's "add listings" form can offer. */
 
-import { chooseColumns } from "#shared/db/chosen-columns.ts";
 import { LISTING_ORDER_SQL } from "#shared/db/listings/select.ts";
 import { rawListingsTable } from "#shared/db/listings/table.ts";
 import { settings } from "#shared/db/settings.ts";
@@ -15,7 +14,7 @@ import type { SortableListing } from "#shared/types.ts";
  * ones, so it sorts the same way a full listing record does. */
 export type GroupListingCandidate = SortableListing & { active: boolean };
 
-const candidateColumns = chooseColumns(rawListingsTable, [
+const candidateColumns = rawListingsTable.read.pick([
   "id",
   "name",
   "active",
@@ -39,14 +38,17 @@ const candidateColumns = chooseColumns(rawListingsTable, [
 export const getListingsNotInGroup = async (
   groupId: number,
 ): Promise<GroupListingCandidate[]> => {
-  const rows = await candidateColumns.select({
-    alias: "listing",
-    order: LISTING_ORDER_SQL.created_desc,
-    where: notInSubquery("listing.id", {
-      args: [groupId],
-      sql: "SELECT groupListing.listing_id FROM group_listings AS groupListing WHERE groupListing.group_id = ?",
-    }),
-  });
+  const rows = await candidateColumns.many(
+    {},
+    {
+      alias: "listing",
+      order: LISTING_ORDER_SQL.created_desc,
+      where: notInSubquery("listing.id", {
+        args: [groupId],
+        sql: "SELECT groupListing.listing_id FROM group_listings AS groupListing WHERE groupListing.group_id = ?",
+      }),
+    },
+  );
   return rows.map((row) => {
     // The flag has done its job once the settings are applied; leaving it on the
     // candidate would invite a second, pointless overlay.

--- a/src/shared/db/images.ts
+++ b/src/shared/db/images.ts
@@ -4,7 +4,7 @@
 
 /* jscpd:ignore-start */
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
-import { chooseColumns, type StoredRowOf } from "#shared/db/chosen-columns.ts";
+import type { StoredRowOf } from "#shared/db/chosen-columns.ts";
 import {
   executeBatch,
   type SqlStatement,
@@ -58,7 +58,7 @@ export const imagesTable = defineIdTable<Image, ImageInput>("images", {
   name: col.encryptedText(encrypt, decrypt),
 });
 
-const imageColumns = chooseColumns(imagesTable, [
+const imageColumns = imagesTable.read.pick([
   "id",
   "name",
   "filename",
@@ -66,7 +66,7 @@ const imageColumns = chooseColumns(imagesTable, [
   "alt_text",
 ]);
 
-const imageFileColumns = chooseColumns(imagesTable, [
+const imageFileColumns = imagesTable.read.pick([
   "id",
   "filename",
   "filename_thumb",
@@ -74,10 +74,10 @@ const imageFileColumns = chooseColumns(imagesTable, [
 ]);
 
 export const getAllImages = (): Promise<Image[]> =>
-  imageColumns.select({ order: "id DESC" });
+  imageColumns.many({}, { order: "id DESC" });
 
 export const getImageById = (id: number): Promise<Image | null> =>
-  imagesTable.findById(id);
+  imagesTable.read.one({ id });
 
 export const imageFilenameSubquery = (
   itemType: ImageUseItemType,

--- a/src/shared/db/listings/catalog.ts
+++ b/src/shared/db/listings/catalog.ts
@@ -1,8 +1,7 @@
 /** Narrow listing reads for catalogs and site-page pickers. */
 
-import { chooseColumns } from "#shared/db/chosen-columns.ts";
 import { settings } from "#shared/db/settings.ts";
-import { equals, notInSubquery } from "#shared/db/where-clauses.ts";
+import { notInSubquery } from "#shared/db/where-clauses.ts";
 import type { CatalogSourceListing } from "#shared/external-order.ts";
 import type { Listing } from "#shared/types.ts";
 import { rawListingsTable } from "./table.ts";
@@ -14,20 +13,20 @@ export type ListingOfferFlags = Pick<
 
 type ListingPickerRow = ListingOfferFlags & { name: string };
 
-const listingOfferFlagsColumns = chooseColumns(rawListingsTable, [
+const listingOfferFlagsColumns = rawListingsTable.read.pick([
   "active",
   "hidden",
   "months_per_unit",
   "purchase_only",
 ]);
 
-const listingPickerColumns = chooseColumns(rawListingsTable, [
+const listingPickerColumns = rawListingsTable.read.pick([
   "id",
   "name",
   ...listingOfferFlagsColumns.columns,
 ]);
 
-const catalogListingColumns = chooseColumns(rawListingsTable, [
+const catalogListingColumns = rawListingsTable.read.pick([
   "id",
   "slug",
   "name",
@@ -41,10 +40,7 @@ const catalogListingColumns = chooseColumns(rawListingsTable, [
 export const getListingOfferFlags = async (
   id: number,
 ): Promise<ListingOfferFlags | undefined> => {
-  const row = await listingOfferFlagsColumns.selectOne({
-    alias: "listing",
-    where: equals("listing.id", id),
-  });
+  const row = await listingOfferFlagsColumns.one({ id }, { alias: "listing" });
   return row ?? undefined;
 };
 
@@ -52,10 +48,10 @@ export const getListingOfferFlags = async (
 export const getListingPickerNames = async (): Promise<
   Map<number, ListingPickerRow>
 > => {
-  const rows = await listingPickerColumns.select({
-    alias: "listing",
-    order: "listing.id ASC",
-  });
+  const rows = await listingPickerColumns.many(
+    {},
+    { alias: "listing", order: "listing.id ASC" },
+  );
   return new Map(rows.map(({ id, ...listing }) => [id, listing] as const));
 };
 
@@ -70,30 +66,33 @@ const catalogVisibleSql = (hiddenDefault: boolean | undefined): string => {
 
 /** Read only active, effectively visible listings for the public catalog. */
 export const getCatalogListings = async (): Promise<CatalogSourceListing[]> => {
-  const rows = await catalogListingColumns.select({
-    alias: "listing",
-    where: [
-      { args: [], clause: "listing.active = 1" },
-      {
-        args: [],
-        clause: catalogVisibleSql(settings.listingDefaults.hidden),
-      },
-      // A child listing is only offered on its own when it says it may be.
-      {
-        args: [],
-        clause: `(listing.bookable_alone = 1 OR listing.id NOT IN (
+  const rows = await catalogListingColumns.many(
+    {},
+    {
+      alias: "listing",
+      where: [
+        { args: [], clause: "listing.active = 1" },
+        {
+          args: [],
+          clause: catalogVisibleSql(settings.listingDefaults.hidden),
+        },
+        // A child listing is only offered on its own when it says it may be.
+        {
+          args: [],
+          clause: `(listing.bookable_alone = 1 OR listing.id NOT IN (
           SELECT listingParent.child_listing_id FROM listing_parents AS listingParent))`,
-      },
-      ...notInSubquery("listing.id", {
-        args: [],
-        sql: `SELECT groupListing.listing_id
+        },
+        ...notInSubquery("listing.id", {
+          args: [],
+          sql: `SELECT groupListing.listing_id
                 FROM group_listings AS groupListing
                 JOIN groups AS listingGroup ON listingGroup.id = groupListing.group_id
                WHERE listingGroup.is_package = 1
                  AND listingGroup.hide_package_listings = 1`,
-      }),
-    ],
-  });
+        }),
+      ],
+    },
+  );
   return rows.map((row) => ({
     active: true,
     hidden: false,

--- a/src/shared/db/listings/records.ts
+++ b/src/shared/db/listings/records.ts
@@ -179,7 +179,7 @@ export const getListingsById = async (): Promise<
 
 /** Read the narrow listing option projection used by item pickers. */
 export const getAllListingOptions = (): Promise<ListingOption[]> =>
-  listingOptionColumns.select({ alias: "listing", order: "listing.id ASC" });
+  listingOptionColumns.many({}, { alias: "listing", order: "listing.id ASC" });
 
 /** Read and decrypt listing names without loading full records. */
 export const listingNames = envNameSource("listings", "listing");

--- a/src/shared/db/listings/select.ts
+++ b/src/shared/db/listings/select.ts
@@ -6,7 +6,7 @@
  * The whole record is read on purpose: every caller here builds a
  * `ListingWithCount`, which needs the money, day-price and image values. A read
  * that does not need them should select its own narrow column list with
- * `chooseColumns` instead, as `catalog.ts` and the group-membership
+ * `table.read.pick` instead, as `catalog.ts` and the group-membership
  * picker in `groups.ts` do.
  */
 

--- a/src/shared/db/listings/table.ts
+++ b/src/shared/db/listings/table.ts
@@ -8,7 +8,6 @@ import {
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
-import { chooseColumns } from "#shared/db/chosen-columns.ts";
 import {
   encryptedNameSchema,
   idAndEncryptedSlugSchema,
@@ -107,7 +106,7 @@ export const rawListingsTable = defineIdTable<Listing, ListingInput>(
 export type ListingOption = Pick<Listing, "active" | "id" | "name">;
 
 /** The shared narrow listing shape used by listing and attribute pickers. */
-export const listingOptionColumns = chooseColumns(rawListingsTable, [
+export const listingOptionColumns = rawListingsTable.read.pick([
   "id",
   "name",
   "active",

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -156,7 +156,7 @@ export const getActiveModifiers = (): Promise<Modifier[]> =>
 /** Get a single modifier by id, decrypted, with its ledger-projected
  * total_revenue — the single-row read the admin edit/recalculate pages use, so
  * they see the projected figure rather than the dropped column (the bare
- * `modifiersTable.findById` returns only the stored {@link ModifierRow}). */
+ * a plain read of the table returns only the stored {@link ModifierRow}). */
 export const getModifier = async (id: number): Promise<Modifier | null> => {
   const parts = equals("id", id);
   const row = await queryOne<Modifier>(

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -15,7 +15,7 @@ import { registerTableInvalidation } from "#shared/cache-registry.ts";
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex, EnvKeyEncrypted } from "#shared/crypto/sealed.ts";
-import { chooseColumns, type StoredRowOf } from "#shared/db/chosen-columns.ts";
+import type { StoredRowOf } from "#shared/db/chosen-columns.ts";
 import {
   executeBatch,
   insertedRowId,
@@ -43,7 +43,6 @@ import {
 } from "#shared/db/slug-registry.ts";
 import type { SluggedContentInput } from "#shared/db/slugged-content-input.ts";
 import { col } from "#shared/db/table.ts";
-import { readerFor } from "#shared/db/table-reader.ts";
 import { decryptImageFilenameOrEmpty } from "#shared/images/broken.ts";
 import { nowIso } from "#shared/now.ts";
 import { requestCache } from "#shared/request-cache.ts";
@@ -78,7 +77,7 @@ export const newsPostsTable = defineIdTable<NewsPost, NewsPostInput>(
   },
 );
 
-const newsSummaryColumns = chooseColumns(newsPostsTable, [
+const newsSummaryColumns = newsPostsTable.read.pick([
   "id",
   "created",
   "slug",
@@ -86,7 +85,7 @@ const newsSummaryColumns = chooseColumns(newsPostsTable, [
   "snippet",
 ]);
 
-const newsNameColumns = chooseColumns(newsPostsTable, ["id", "name"]);
+const newsNameColumns = newsPostsTable.read.pick(["id", "name"]);
 
 /** What the admin form provides: every editable column. The permalink is
  * derived on create, never entered, so `slug`/`slugIndex`/`created` are out. */
@@ -138,7 +137,7 @@ type SealedCardRow = StoredRowOf<
  * slug, name, snippet — no image reads or decrypts. Feeds the RSS feed and the
  * admin list, which render no images. */
 export const getNewsPostSummaries = (): Promise<NewsPostSummary[]> =>
-  newsSummaryColumns.select({ order: "created DESC, id DESC" });
+  newsSummaryColumns.many({}, { order: "created DESC, id DESC" });
 
 /** Load the card projection for every post, newest first: the summary plus
  * the post's first linked image — for the public /news list, the one reader
@@ -166,25 +165,24 @@ export const getNewsPostCards = async (): Promise<NewsPostCard[]> => {
 /** id → decrypted name for every post, newest first — the image library's
  * link-target labels (nothing but the name decrypted). */
 export const getNewsPostNames = async (): Promise<Map<number, string>> => {
-  const rows = await newsNameColumns.select({
-    order: "created DESC, id DESC",
-  });
+  const rows = await newsNameColumns.many(
+    {},
+    { order: "created DESC, id DESC" },
+  );
   return fieldById("name")(rows);
 };
 
 /** One full post (fully decrypted) by id — the admin single-post views.
  * Null when absent. */
 export const getNewsPostById = (id: number): Promise<NewsPost | null> =>
-  newsPostsTable.findById(id);
-
-/** The whole post, fully decrypted. */
-const wholeNewsPost = readerFor(newsPostsTable);
+  newsPostsTable.read.one({ id });
 
 /** One full post (fully decrypted) by blind-index slug lookup — the public
  * `/news/:slug` read. Null when absent. */
 export const getNewsPostBySlugIndex = (
   slugIndex: BlindIndex,
-): Promise<NewsPost | null> => wholeNewsPost.one({ slug_index: slugIndex });
+): Promise<NewsPost | null> =>
+  newsPostsTable.read.one({ slug_index: slugIndex });
 
 /** Create a post, stamping `created` now (the admin flow) or at a pinned time
  * (tests/restore), and deriving its immutable `/news` permalink from that date

--- a/src/shared/db/site-pages.ts
+++ b/src/shared/db/site-pages.ts
@@ -13,7 +13,6 @@
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex } from "#shared/crypto/sealed.ts";
-import { chooseColumns } from "#shared/db/chosen-columns.ts";
 import { type TxScope, useTransaction } from "#shared/db/client.ts";
 import { idAndEncryptedSlugSchema } from "#shared/db/common-schema.ts";
 import { encryptedNameAndSeoSchema } from "#shared/db/content-columns.ts";
@@ -25,7 +24,6 @@ import {
 } from "#shared/db/slug-registry.ts";
 import type { SluggedContentInput } from "#shared/db/slugged-content-input.ts";
 import { cachedTable, col, writeTableRow } from "#shared/db/table.ts";
-import { readerFor } from "#shared/db/table-reader.ts";
 import { errorResult, okResult, type Result } from "#shared/result.ts";
 import type { SitePage, SitePageNavRow } from "#shared/types.ts";
 /* jscpd:ignore-end */
@@ -46,7 +44,7 @@ const rawSitePagesTable = defineIdTable<SitePage, SitePageInput>("site_pages", {
   sort_order: col.simple<number>(),
 });
 
-const sitePageNavColumns = chooseColumns(rawSitePagesTable, [
+const sitePageNavColumns = rawSitePagesTable.read.pick([
   "id",
   "slug",
   "name",
@@ -57,7 +55,7 @@ const sitePageNavColumns = chooseColumns(rawSitePagesTable, [
  * and name (never content/meta). Ordered by (sort_order, id). The raw row
  * carries name and slug still sealed; the map below opens them. */
 const fetchNavRows = (): Promise<SitePageNavRow[]> =>
-  sitePageNavColumns.select({ order: "sort_order ASC, id ASC" });
+  sitePageNavColumns.many({}, { order: "sort_order ASC, id ASC" });
 
 // Request-scoped cache over those columns: computed once per request, fresh on
 // the next request (no cross-isolate staleness), and auto-cleared on any write
@@ -73,17 +71,15 @@ export const sitePageOrder = defineOrderedCollection({
   table: "site_pages",
 });
 
-/** The whole page, fully decrypted — for the public/admin single-page views. */
-const wholePage = readerFor(rawSitePagesTable);
-
 /** One full page by blind-index slug lookup (the `/page/:slug` read). */
 export const getSitePageBySlugIndex = (
   slugIndex: BlindIndex,
-): Promise<SitePage | null> => wholePage.one({ slug_index: slugIndex });
+): Promise<SitePage | null> =>
+  rawSitePagesTable.read.one({ slug_index: slugIndex });
 
 /** One full page by id (the admin edit read). */
 export const getSitePageById = (id: number): Promise<SitePage | null> =>
-  wholePage.one({ id });
+  rawSitePagesTable.read.one({ id });
 
 /** A create/update provides every editable column; the blind index is computed
  * HERE from the slug (never caller-supplied), so `slug` and `slug_index` move

--- a/src/shared/db/table-reader.ts
+++ b/src/shared/db/table-reader.ts
@@ -3,22 +3,27 @@
  *
  * A table already declares its columns, their types, and how to open them. A
  * read of that table should not have to say any of it again — so it doesn't:
- * name the table and the reader knows what to select, what shape comes back,
- * and how to decrypt it.
+ * `table.read` knows what to select, what shape comes back, and how to decrypt
+ * it. Every ordinary read of a table's own rows goes through it.
  *
  * The filter is the row's own shape, so a column that does not exist, or a
  * value of the wrong type, is a mistake the compiler catches rather than the
  * database. A read that joins, or that selects something SQL invents, has no
- * table to infer from — those say their read with `readRows` instead.
+ * table to infer from — those say their read with `readRows` instead, and open
+ * their rows with the same chosen set (`table.read.pick([...])`).
  */
 
 import type { InValue } from "@libsql/client";
 import {
   type ChosenColumns,
+  type ChosenRow,
   type ColumnNames,
   chooseColumns,
+  type ReadableTable,
+  type StoredRowOf,
 } from "#shared/db/chosen-columns.ts";
-import type { Table, TableSchema } from "#shared/db/table.ts";
+import { type Read, readOneRow, readRows } from "#shared/db/read.ts";
+import type { TableSchema } from "#shared/db/table.ts";
 import { equals, inList, type WhereClause } from "#shared/db/where-clauses.ts";
 
 /**
@@ -35,8 +40,17 @@ export type RowFilter<Row> = {
     : never;
 };
 
-/** The rest of a read: how the rows come back, and how many. */
+/** The rest of a read: which other rows to keep, how they come back, and how
+ * many. */
 export type RowOptions = {
+  /**
+   * Filters the row shape cannot say — a subquery, a comparison, a condition
+   * built from settings. Written with the shared clause helpers in
+   * `#shared/db/where-clauses.ts`, and combined with the row filter by AND.
+   */
+  where?: WhereClause[];
+  /** Table alias, when the clauses or the order qualify their columns. */
+  alias?: string;
   /** An `ORDER BY` body without the keyword. Omit for no ordering. */
   order?: string;
   /** A row cap. Omit for no limit. */
@@ -55,6 +69,7 @@ export type RowOptions = {
 const filterClauses = <Row>(
   table: { name: string; schema: TableSchema<Row> },
   filter: RowFilter<Row>,
+  alias: string | undefined,
 ): WhereClause[] =>
   Object.entries(filter).flatMap(([column, value]) => {
     if (table.schema[column as keyof Row]?.write !== undefined) {
@@ -62,9 +77,10 @@ const filterClauses = <Row>(
         `Cannot filter ${table.name} by ${column}: it is stored in a different form from the value you have. Filter on the column holding its one-way code instead.`,
       );
     }
+    const named = alias ? `${alias}.${column}` : column;
     return Array.isArray(value)
-      ? inList(column, value as readonly InValue[])
-      : equals(column, value as Exclude<InValue, null>);
+      ? inList(named, value as readonly InValue[])
+      : equals(named, value as Exclude<InValue, null>);
   });
 
 /**
@@ -82,53 +98,93 @@ export type Rows<Row, Selected = Row> = {
   ) => Promise<Selected | null>;
 };
 
-/** Reading a table: its whole row, or just the columns a caller names. */
+/**
+ * A named set of a table's columns: it reads them, and it opens the rows a
+ * join read for it. One set, so a join and a plain read can never disagree
+ * about which columns they mean.
+ */
+export type Selection<Row, Columns extends ColumnNames<Row>> = ChosenColumns<
+  Row,
+  Columns
+> &
+  Rows<Row, Pick<Row, Columns[number]>>;
+
+/**
+ * Reading a table: its whole stored row, or just the columns a caller names.
+ *
+ * "Whole" means every column the table stores. A table that works some of its
+ * values out from other tables — a listing's first image, say — does not carry
+ * those here, and cannot: they are not columns, so `pick` refuses to name them
+ * too. A read that wants them says so in its own SQL.
+ */
 export type TableReader<Row> = Rows<Row> & {
   /** The same reads over a narrower set of columns — nothing else is selected,
    * so nothing else is fetched or decrypted. */
   pick: <const Columns extends ColumnNames<Row>>(
     columns: Columns,
-  ) => Rows<Row, Pick<Row, Columns[number]>>;
+  ) => Selection<Row, Columns>;
 };
 
-const rowsOf = <Row, Input, Columns extends ColumnNames<Row>>(
-  table: Table<Row, Input>,
+/**
+ * The filter naming one row by its own key. Code that works over any table —
+ * the CRUD resources — cannot spell a key column it does not know the name of,
+ * so the one place that has to is here.
+ */
+export const byPrimaryKey = <Row>(
+  table: { primaryKey: keyof Row & string },
+  key: InValue,
+): RowFilter<Row> => ({ [table.primaryKey]: key }) as RowFilter<Row>;
+
+const selectionOf = <Row, Columns extends ColumnNames<Row>>(
+  table: ReadableTable<Row>,
   chosen: ChosenColumns<Row, Columns>,
-): Rows<Row, Pick<Row, Columns[number]>> => ({
-  many: (filter = {}, options = {}) =>
-    chosen.select({ ...options, where: filterClauses(table, filter) }),
-  one: (filter = {}, options = {}) =>
-    chosen.selectOne({ ...options, where: filterClauses(table, filter) }),
-});
+): Selection<Row, Columns> => {
+  /** The chosen set supplies the columns and the table; the caller supplies
+   * the rest of the read. */
+  const readFor = (
+    filter: RowFilter<Row>,
+    { alias, limit, order, where = [] }: RowOptions,
+  ): Read => ({
+    columns: chosen.readColumnsSql(alias),
+    from: alias ? `${table.name} AS ${alias}` : table.name,
+    limit,
+    order,
+    where: [...filterClauses(table, filter, alias), ...where],
+  });
+
+  const rowsOf = async (read: Read): Promise<ChosenRow<Row, Columns>[]> =>
+    chosen.readAll(await readRows<StoredRowOf<Row, Columns>>(read));
+
+  const rowOf = async (read: Read): Promise<ChosenRow<Row, Columns> | null> => {
+    const row = await readOneRow<StoredRowOf<Row, Columns>>(read);
+    return row === null ? null : chosen.read(row);
+  };
+
+  // The read is built before anything is awaited, so a filter the table refuses
+  // fails at the call rather than in a rejected promise later.
+  return {
+    ...chosen,
+    many: (filter = {}, options = {}) => rowsOf(readFor(filter, options)),
+    one: (filter = {}, options = {}) => rowOf(readFor(filter, options)),
+  };
+};
 
 /**
  * The reader for a table. `pick` narrows the columns; calling the reader's own
  * `one`/`many` reads the whole row.
  */
-export const readerFor = <Row, Input>(
-  table: Table<Row, Input>,
-): TableReader<Row> => {
-  // A whole-row read can only promise the whole row when the row IS its stored
-  // columns. A table that works some of its values out from other tables has
-  // more in its row than it stores, so those reads must name their columns.
-  const workedOut = Object.keys(table.schema).filter(
-    (column) => table.schema[column as keyof Row]?.projected,
-  );
-  if (workedOut.length > 0) {
-    throw new Error(
-      `${table.name} has values that are not stored columns (${workedOut.join(", ")}), so a whole-row read cannot return them. Choose the columns you want with chooseColumns instead.`,
-    );
-  }
-
+export const readerFor = <Row>(table: ReadableTable<Row>): TableReader<Row> => {
   const pick = <const Columns extends ColumnNames<Row>>(
     columns: Columns,
-  ): Rows<Row, Pick<Row, Columns[number]>> =>
-    rowsOf(table, chooseColumns(table, columns));
+  ): Selection<Row, Columns> =>
+    selectionOf(table, chooseColumns(table, columns));
+
   // A table's declared columns are exactly the keys of its row, and a table
-  // with no columns cannot be declared — so this is the whole row.
+  // with no columns cannot be declared — so this is the whole stored row.
   const whole = pick(table.columns as unknown as ColumnNames<Row>) as Rows<
     Row,
     Row
   >;
+
   return { ...whole, pick };
 };

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -19,7 +19,6 @@ import {
 import {
   execute,
   insertedRowId,
-  queryAll,
   queryOne,
   queryOnePrimary,
   resultRows,
@@ -27,6 +26,11 @@ import {
   type TxScope,
 } from "#shared/db/client.ts";
 import { queryAndMap } from "#shared/db/query.ts";
+import {
+  byPrimaryKey,
+  readerFor,
+  type TableReader,
+} from "#shared/db/table-reader.ts";
 import { requestCache } from "#shared/request-cache.ts";
 import { defineStoredJson } from "#shared/validation/stored-json.ts";
 
@@ -106,16 +110,10 @@ export interface Table<Row, Input> {
   /** Delete a row by primary key */
   deleteById: (id: InValue) => Promise<void>;
 
-  /** Find all rows */
-  findAll: () => Promise<Row[]>;
-
-  /** Find a row by primary key, or null when it does not exist. */
-  findById: (id: InValue) => Promise<Row | null>;
-
   /**
    * Find a row by primary key, pinned to the primary (read-your-writes). Use
    * when reading a row back immediately after committing its own write: a plain
-   * {@link findById} runs in "read" mode, which Turso may serve from a replica
+   * {@link read} runs in "read" mode, which Turso may serve from a replica
    * that lags behind the just-committed write and so miss the row (returning
    * null). This reads on the primary, which always reflects the write.
    *
@@ -124,9 +122,6 @@ export interface Table<Row, Input> {
    * façade table that never takes that path may omit it.
    */
   findByIdPrimary?: (id: InValue) => Promise<Row | null>;
-
-  /** Find rows in input order, retaining nulls for missing primary keys. */
-  findByIds: (ids: InValue[]) => Promise<(Row | null)[]>;
 
   /** Transform a row from DB (apply read transforms) */
   fromDb: (row: Row) => Promise<Row>;
@@ -144,6 +139,12 @@ export interface Table<Row, Input> {
   ) => Promise<SqlStatement>;
   name: string;
   primaryKey: keyof Row & string;
+
+  /**
+   * Every ordinary read of this table's rows: the whole row, or the columns a
+   * caller names. See `#shared/db/table-reader.ts`.
+   */
+  read: TableReader<Row>;
 
   readColumn: ReadColumn<Row>;
 
@@ -307,6 +308,16 @@ export const defineTable = <Row, Input = Row>(
     return value;
   };
 
+  /** The table's own rows, read by the shared reader. */
+  const table = {
+    columns: physicalColumns,
+    name,
+    primaryKey,
+    readColumn,
+    schema,
+  };
+  const read = readerFor<Row>(table);
+
   // The columns whose stored value has to be turned back into its real value
   // (decrypted, parsed, looked up). Every other column is copied straight
   // across, so a wide table does not pay for an await per column.
@@ -459,56 +470,28 @@ export const defineTable = <Row, Input = Row>(
     id: InValue,
     input: Partial<Input>,
   ): Promise<Row | null> => {
-    if (getProvidedColumns(input).length === 0) return findById(id);
+    if (getProvidedColumns(input).length === 0) {
+      return read.one(byPrimaryKey(table, id));
+    }
     const { args, sql } = await updateStatement(id, input);
     const row = await queryOne<Row>(sql, args);
     return row ? fromDb(row) : null;
   };
 
-  // Find by ID via the given single-row query — a plain "read" (findById) or the
-  // primary read-your-writes read (findByIdPrimary), for reading a row back right
-  // after its own write (see Table.findByIdPrimary).
-  const findByIdVia = async (
-    query: (sql: string, args: InValue[]) => Promise<Row | null>,
-    id: InValue,
-  ): Promise<Row | null> => {
-    const row = await query(
+  /** Read one row back on the primary, right after its own write — the one
+   * read that cannot go through {@link read}, which runs where a replica may
+   * still be behind the write (see {@link Table.findByIdPrimary}). */
+  const findByIdPrimary = async (id: InValue): Promise<Row | null> => {
+    const row = await queryOnePrimary<Row>(
       `SELECT ${qualifiedPhysicalColumnsSql} FROM ${name} AS record WHERE record.${primaryKey} = ?`,
       [id],
     );
     return row ? fromDb(row) : null;
   };
 
-  const findByIds = async (ids: InValue[]): Promise<(Row | null)[]> => {
-    if (ids.length === 0) return [];
-    const rows = await queryAll<Row>(
-      `SELECT ${qualifiedPhysicalColumnsSql} FROM ${name} AS record WHERE record.${primaryKey} IN (${ids.map(() => "?").join(", ")})`,
-      ids,
-    );
-    const readRows = await mapParallel(fromDb)(rows);
-    const rowsById = new Map(
-      readRows.map((row) => [row[primaryKey], row] as const),
-    );
-    return ids.map((id) => rowsById.get(id as Row[keyof Row & string]) ?? null);
-  };
-
-  const findById = async (id: InValue): Promise<Row | null> =>
-    (await findByIds([id]))[0] ?? null;
-
-  const findByIdPrimary = (id: InValue): Promise<Row | null> =>
-    findByIdVia(queryOnePrimary, id);
-
   // Delete by ID implementation
   const deleteById = async (id: InValue): Promise<void> => {
     await execute(`DELETE FROM ${name} WHERE ${primaryKey} = ?`, [id]);
-  };
-
-  // Find all implementation
-  const findAll = async (): Promise<Row[]> => {
-    const rows = await queryAll<Row>(
-      `SELECT ${physicalColumnsSql} FROM ${name}`,
-    );
-    return mapParallel(fromDb)(rows);
   };
 
   // Row → Input: copy input-eligible columns from a row, translating
@@ -533,16 +516,14 @@ export const defineTable = <Row, Input = Row>(
   return {
     columns: physicalColumns,
     deleteById,
-    findAll,
-    findById,
     findByIdPrimary,
-    findByIds,
     fromDb,
     inputKeyMap,
     insert,
     insertStatement,
     name,
     primaryKey,
+    read,
     readColumn,
     rowToInput,
     schema,

--- a/src/shared/rest/crud-api.ts
+++ b/src/shared/rest/crud-api.ts
@@ -17,7 +17,6 @@
  *   });
  */
 
-/* jscpd:ignore-start */
 import type { InValue } from "@libsql/client";
 import { isNotNullish, reduce } from "#fp";
 import { verifyIdentifierOrJsonError } from "#routes/admin/confirmation.ts";
@@ -28,6 +27,8 @@ import type { RouteHandlerFn } from "#routes/router.ts";
 import { logActivity } from "#shared/db/activityLog.ts";
 import type { TxScope } from "#shared/db/client.ts";
 import type { Table } from "#shared/db/table.ts";
+/* jscpd:ignore-start */
+import { byPrimaryKey } from "#shared/db/table-reader.ts";
 import type { ResponseHandler } from "#shared/response-steps.ts";
 import { type JoinWrite, writeEntity } from "#shared/rest/write-entity.ts";
 import {
@@ -241,7 +242,7 @@ export interface CrudApiConfig<
   linkActivityToRow?: boolean;
   /** Extra keys added to the list response alongside the row array (e.g. admin_level) */
   listExtras?: (session: AdminSession) => Record<string, unknown>;
-  /** Custom single-row lookup (e.g. to include joined counts). Defaults to table.findById. */
+  /** Custom single-row lookup (e.g. to include joined counts). Defaults to reading the row by its key. */
   lookup?: (id: number) => Promise<FullRow | null>;
   /** Custom single-row lookup used ONLY to read a row back right after committing
    * its own write, which must be pinned to the primary (read-your-writes): the
@@ -344,7 +345,10 @@ export const defineCrudApi = <
   const listKey = name;
   const lookup: (id: number) => Promise<FullRow | null> =
     config.lookup ??
-    ((id) => table.findById(id) as unknown as Promise<FullRow | null>);
+    ((id) =>
+      table.read.one(
+        byPrimaryKey(table, id),
+      ) as unknown as Promise<FullRow | null>);
   // Reading a row back right after committing its write must hit the primary, or
   // a lagging replica can return null and the create/update path crashes on
   // `.id`. Defaults to the primary-pinned base-row read; a resource whose

--- a/src/shared/rest/resource.ts
+++ b/src/shared/rest/resource.ts
@@ -16,10 +16,11 @@
  *   return redirect('/admin/');
  */
 
-/* jscpd:ignore-start */
 import type { InValue } from "@libsql/client";
 import type { TxScope } from "#shared/db/client.ts";
 import type { Table } from "#shared/db/table.ts";
+/* jscpd:ignore-start */
+import { byPrimaryKey } from "#shared/db/table-reader.ts";
 import type { FormParams } from "#shared/form-data.ts";
 import type { FormSchema } from "#shared/forms/definition.ts";
 import type { Field } from "#shared/forms/field.ts";
@@ -192,7 +193,9 @@ export const defineResource = <
     id: InValue,
     fn: () => Promise<Outcome>,
   ): Promise<Outcome | NotFoundResult> =>
-    (await table.findById(id)) ? fn() : { notFound: true, ok: false };
+    (await table.read.one(byPrimaryKey(table, id)))
+      ? fn()
+      : { notFound: true, ok: false };
 
   /** Parse + validate the form, write the row (transactionally when
    * `afterWrite` is set, else the plain insert/update `fallback`), then run the
@@ -270,7 +273,7 @@ export const defineResource = <
     create,
     delete: deleteRow,
     fields: schema.fields,
-    loadOrNull: table.findById,
+    loadOrNull: (id) => table.read.one(byPrimaryKey(table, id)),
     parseInput,
     table,
     update,

--- a/test/features/admin/api-groups.test.ts
+++ b/test/features/admin/api-groups.test.ts
@@ -185,11 +185,11 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
     test("still creates when the read-back replica lags the just-committed write", async () => {
       // Regression (JSON API, shared crud write-back): after committing the row in
       // a transaction on the primary, the API read it back with a plain "read"-mode
-      // `findById`, which Turso can serve from a replica lagging the commit —
+      // plain read, which Turso can serve from a replica lagging the commit —
       // returning null and crashing on `row.id`. The read-back now uses the
       // primary-pinned `findByIdPrimary`. Stub the optional replica read to
       // miss the row — the create must still succeed.
-      const findByIdStub = stub(groups.table, "findById", () =>
+      const readStub = stub(groups.table.read, "one", () =>
         Promise.resolve(null),
       );
       try {
@@ -205,7 +205,7 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
           },
         );
       } finally {
-        findByIdStub.restore();
+        readStub.restore();
       }
     });
 
@@ -494,7 +494,9 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
         },
       );
 
-      expect((await groups.table.findById(group.id))?.max_attendees).toBe(12);
+      expect(
+        (await groups.table.read.one({ id: group.id }))?.max_attendees,
+      ).toBe(12);
     });
 
     test("returns 404 for non-existent group", async () => {
@@ -577,7 +579,7 @@ describeWithEnv("Admin API - Groups", { db: true }, () => {
         },
       );
 
-      const row = await groups.table.findById(group.id);
+      const row = await groups.table.read.one({ id: group.id });
       expect(row).toBeDefined();
     });
 

--- a/test/features/admin/api-holidays.test.ts
+++ b/test/features/admin/api-holidays.test.ts
@@ -266,7 +266,7 @@ describeWithEnv("Admin API - Holidays", { db: true }, () => {
       );
 
       // Holiday should still exist
-      const row = await holidays.table.findById(holiday.id);
+      const row = await holidays.table.read.one({ id: holiday.id });
       expect(row).not.toBeNull();
     });
 
@@ -328,7 +328,7 @@ describeWithEnv("Admin API - Holidays", { db: true }, () => {
       );
       expect(res.status).toBe(403);
       // The manager's delete was blocked, so the holiday still exists.
-      expect(await holidays.table.findById(holiday.id)).not.toBeNull();
+      expect(await holidays.table.read.one({ id: holiday.id })).not.toBeNull();
     });
   });
 });

--- a/test/features/admin/built-sites/scheduler.test.ts
+++ b/test/features/admin/built-sites/scheduler.test.ts
@@ -32,7 +32,7 @@ describeWithEnv(
       );
 
       expectFlash(response, "Scheduled maintenance key sent to the site.");
-      const key = (await builtSitesCrudTable.findById(site.id))
+      const key = (await builtSitesCrudTable.read.one({ id: site.id }))
         ?.scheduledTaskKey;
       expect(isScheduledTaskKey(key ?? "")).toBe(true);
     });
@@ -59,7 +59,7 @@ describeWithEnv(
         `/admin/built-sites/${site.id}/provision-scheduler`,
       );
       expectFlash(failed, "provider failed", false);
-      const retained = (await builtSitesCrudTable.findById(site.id))
+      const retained = (await builtSitesCrudTable.read.one({ id: site.id }))
         ?.scheduledTaskKey;
 
       const { response: retried } = await adminFormPost(

--- a/test/features/admin/built-sites/server.test.ts
+++ b/test/features/admin/built-sites/server.test.ts
@@ -499,7 +499,7 @@ describeWithEnv("server (admin built sites)", builtSitesTestEnv, () => {
       await deleteTestBuiltSite(site.id);
 
       const { builtSitesCrudTable } = await import("#shared/db/built-sites.ts");
-      const found = await builtSitesCrudTable.findById(site.id);
+      const found = await builtSitesCrudTable.read.one({ id: site.id });
       expect(found).toBeNull();
     });
 
@@ -519,18 +519,18 @@ describeWithEnv("server (admin built sites)", builtSitesTestEnv, () => {
       );
 
       const { builtSitesCrudTable } = await import("#shared/db/built-sites.ts");
-      const found = await builtSitesCrudTable.findById(site.id);
+      const found = await builtSitesCrudTable.read.one({ id: site.id });
       expect(found).not.toBeNull();
     });
 
-    test("table lookups preserve missing rows", async () => {
+    test("a list filter reads back only the sites that exist", async () => {
       const site = await createTestBuiltSite({ name: "Lookup Site" });
       const { builtSitesCrudTable } = await import("#shared/db/built-sites.ts");
       expect(
-        (await builtSitesCrudTable.findByIds([site.id, 999_999])).map(
-          (row) => row?.id ?? null,
+        (await builtSitesCrudTable.read.many({ id: [site.id, 999_999] })).map(
+          (row) => row.id,
         ),
-      ).toEqual([site.id, null]);
+      ).toEqual([site.id]);
     });
 
     test("name confirmation is case-insensitive", async () => {
@@ -644,7 +644,7 @@ describeWithEnv("server (admin built sites)", builtSitesTestEnv, () => {
       );
       expect(response.status).toBe(302);
       const { builtSitesCrudTable } = await import("#shared/db/built-sites.ts");
-      const updated = await builtSitesCrudTable.findById(site.id);
+      const updated = await builtSitesCrudTable.read.one({ id: site.id });
       expect(updated!.name).toBe("Keep Beta Renamed");
       expect(updated!.updates).toBe("beta");
     });

--- a/test/features/admin/modifiers/child-only-guard.test.ts
+++ b/test/features/admin/modifiers/child-only-guard.test.ts
@@ -155,9 +155,9 @@ describeWithEnv(
         'value="optional" selected',
         'value="Becomes add-on"',
       );
-      expect((await modifiersTable.findById(modifier.id))!.trigger).toBe(
-        "automatic",
-      );
+      expect(
+        (await modifiersTable.read.one({ id: modifier.id }))!.trigger,
+      ).toBe("automatic");
     });
 
     test("allows editing an active NON-opt-in child-scoped modifier (not an add-on)", async () => {
@@ -186,7 +186,7 @@ describeWithEnv(
         "Modifier updated",
         true,
       )(response);
-      expect((await modifiersTable.findById(modifier.id))!.name).toBe(
+      expect((await modifiersTable.read.one({ id: modifier.id }))!.name).toBe(
         "Auto child surcharge renamed",
       );
     });
@@ -215,9 +215,9 @@ describeWithEnv(
         "Modifier updated",
         true,
       )(response);
-      expect((await modifiersTable.findById(modifier.id))!.trigger).toBe(
-        "optional",
-      );
+      expect(
+        (await modifiersTable.read.one({ id: modifier.id }))!.trigger,
+      ).toBe("optional");
     });
 
     test("blocks scoping an opt-in add-on to a group of only children", async () => {

--- a/test/features/admin/owner-crud.test.ts
+++ b/test/features/admin/owner-crud.test.ts
@@ -234,7 +234,7 @@ describeWithEnv("owner CRUD handlers", { db: true }, () => {
     );
 
     expectRedirectWithFlash(path, "This holiday is protected", false)(response);
-    expect(await holidays.table.findById(holiday.id)).toEqual(holiday);
+    expect(await holidays.table.read.one({ id: holiday.id })).toEqual(holiday);
   });
 
   test("uses the configured identifier label for a mismatch", async () => {

--- a/test/features/admin/questions/questions.test.ts
+++ b/test/features/admin/questions/questions.test.ts
@@ -268,7 +268,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
 
       // Verify the question was updated
       const { questionsTable } = await import("#shared/db/questions/tables.ts");
-      const updated = await questionsTable.findById(id);
+      const updated = await questionsTable.read.one({ id: id });
       expect(updated!.text).toBe("After edit");
     });
 
@@ -287,7 +287,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
           });
         }),
       ).rejects.toThrow("feature enable failed");
-      expect((await questionsTable.findById(question.id))?.text).toBe(
+      expect((await questionsTable.read.one({ id: question.id }))?.text).toBe(
         "Before?",
       );
     });
@@ -336,7 +336,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         `/admin/questions/${q.id}`,
         "Question updated",
       )(response);
-      const updated = await questionsTable.findById(q.id);
+      const updated = await questionsTable.read.one({ id: q.id });
       expect(updated!.display_type).toBe("free_text");
       expect(updated!.text).toBe("Notes updated");
     });
@@ -348,7 +348,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
         display_type: "free_text",
         text: "Colour?",
       });
-      const updated = await questionsTable.findById(id);
+      const updated = await questionsTable.read.one({ id: id });
       expect(updated!.display_type).toBe("radio");
     });
 

--- a/test/integration/db/modifier-aggregates.test.ts
+++ b/test/integration/db/modifier-aggregates.test.ts
@@ -57,7 +57,7 @@ describeWithEnv(
       // defaults must make the modifier an active, automatic, whole-order rule
       // with no gates — exactly what the admin docs promise a fresh modifier is.
       const m = await makeModifier();
-      const stored = (await modifiersTable.findById(m.id))!;
+      const stored = (await modifiersTable.read.one({ id: m.id }))!;
       expect(stored).toMatchObject({
         active: true,
         code_index: null,
@@ -112,7 +112,7 @@ describeWithEnv(
     test("modifiersTable read exposes the trigger-maintained counts", async () => {
       const m = await makeModifier();
       await insertModifierUsage(m.id, 1, 3, 1500);
-      const reread = await modifiersTable.findById(m.id);
+      const reread = await modifiersTable.read.one({ id: m.id });
       expect(reread).toMatchObject({
         total_uses: 3,
         usage_count: 1,
@@ -273,7 +273,7 @@ describeWithEnv(
         usage_count: 4,
       });
 
-      const stale = (await modifiersTable.findById(m.id))!;
+      const stale = (await modifiersTable.read.one({ id: m.id }))!;
       expect(await getModifierAggregateRecalculation(stale)).toEqual({
         total_uses: { current: 8, recalculated: 5 },
         usage_count: { current: 4, recalculated: 2 },

--- a/test/integration/server/bookable-alone.test.ts
+++ b/test/integration/server/bookable-alone.test.ts
@@ -148,9 +148,9 @@ describeWithEnv(
           name: "Lone",
         });
         await updateTestListing(solo.id, { bookableAlone: false });
-        expect((await listingsTable.findById(solo.id))!.bookable_alone).toBe(
-          false,
-        );
+        expect(
+          (await listingsTable.read.one({ id: solo.id }))!.bookable_alone,
+        ).toBe(false);
       });
     });
   },

--- a/test/integration/server/group-packages/helpers.ts
+++ b/test/integration/server/group-packages/helpers.ts
@@ -7,8 +7,12 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { attendeesApi } from "#shared/db/attendees/api.ts";
-import { getGroupPackagePrices, groups } from "#shared/db/groups.ts";
-import type { ListingWithCount } from "#shared/types.ts";
+import {
+  getGroupById,
+  getGroupPackagePrices,
+  groups,
+} from "#shared/db/groups.ts";
+import type { Group, ListingWithCount } from "#shared/types.ts";
 import { expectFlashRedirect } from "#test-utils/assertions.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -96,6 +100,20 @@ export const postIsPackage = (group: {
     is_package: "1",
   });
 
+/** Assert a group edit POST was turned away by the package invariant, and hand
+ * back the group as the refused save left it. */
+export const expectPackageRefused = async (
+  group: { id: number },
+  response: Response,
+): Promise<Group> => {
+  await expectFlashRedirect(
+    `/admin/groups/${group.id}/edit`,
+    expect.stringContaining("Packages cannot contain"),
+    false,
+  )(response);
+  return (await getGroupById(group.id))!;
+};
+
 /** POST the edit form with is_package ticked and assert it was rejected by the
  * package invariant, leaving the flag clear. */
 export const expectPackageRejected = async (group: {
@@ -104,12 +122,8 @@ export const expectPackageRejected = async (group: {
   slug: string;
 }): Promise<void> => {
   const { response } = await postIsPackage(group);
-  await expectFlashRedirect(
-    `/admin/groups/${group.id}/edit`,
-    expect.stringContaining("Packages cannot contain"),
-    false,
-  )(response);
-  expect((await groups.table.findById(group.id))!.is_package).toBe(false);
+  const refused = await expectPackageRefused(group, response);
+  expect(refused.is_package).toBe(false);
 };
 
 /** POST the edit form with is_package ticked and assert it saved. */
@@ -120,7 +134,7 @@ export const expectPackageAccepted = async (group: {
 }): Promise<void> => {
   const { response } = await postIsPackage(group);
   expect(response.status).toBe(302);
-  expect((await groups.table.findById(group.id))!.is_package).toBe(true);
+  expect((await getGroupById(group.id))!.is_package).toBe(true);
 };
 
 /** POST add-listings with `listingId` to a package group and assert the package

--- a/test/integration/server/group-packages/membership.test.ts
+++ b/test/integration/server/group-packages/membership.test.ts
@@ -23,6 +23,7 @@ import {
   editFields,
   expectAddListingRejected,
   expectPackageAccepted,
+  expectPackageRefused,
   expectPackageRejected,
   member,
 } from "./helpers.ts";
@@ -65,14 +66,8 @@ describeWithEnv(
           is_package: "1",
         },
       );
-      await expectFlashRedirect(
-        `/admin/groups/${group.id}/edit`,
-        expect.stringContaining("Packages cannot contain"),
-        false,
-      )(response);
-      expect(
-        (await groups.table.findById(group.id))!.hide_package_listings,
-      ).toBe(false);
+      const refused = await expectPackageRefused(group, response);
+      expect(refused.hide_package_listings).toBe(false);
     });
 
     test("edit POST rejects is_package on a group whose member is another listing's child", async () => {

--- a/test/integration/server/group-packages/pricing.test.ts
+++ b/test/integration/server/group-packages/pricing.test.ts
@@ -63,7 +63,7 @@ describeWithEnv(
         true,
       )(response);
 
-      const saved = (await groups.table.findById(group.id))!;
+      const saved = (await groups.table.read.one({ id: group.id }))!;
       expect(saved.is_package).toBe(true);
       const prices = await getTestPackagePrices(group.id);
       expect(prices.get(a.id)).toBe(1250);
@@ -161,7 +161,7 @@ describeWithEnv(
         is_package: "1",
       });
       expect(
-        (await groups.table.findById(group.id))!.hide_package_listings,
+        (await groups.table.read.one({ id: group.id }))!.hide_package_listings,
       ).toBe(true);
     });
 
@@ -231,14 +231,16 @@ describeWithEnv(
         is_package: "1",
         [`package_price_${a.id}`]: "9.00",
       });
-      expect((await groups.table.findById(group.id))!.is_package).toBe(true);
+      expect((await groups.table.read.one({ id: group.id }))!.is_package).toBe(
+        true,
+      );
 
       // Re-submit without the checkbox: flag clears and overrides reset to 0.
       await adminFormPost(`/admin/groups/${group.id}/edit`, {
         ...editFields("Clr", "clr"),
         [`package_price_${a.id}`]: "9.00",
       });
-      const saved = (await groups.table.findById(group.id))!;
+      const saved = (await groups.table.read.one({ id: group.id }))!;
       expect(saved.is_package).toBe(false);
       expect((await getTestPackagePrices(group.id)).size).toBe(0);
     });

--- a/test/integration/server/group-packages/sold-guard.test.ts
+++ b/test/integration/server/group-packages/sold-guard.test.ts
@@ -41,7 +41,7 @@ describeWithEnv(
         },
       );
       expect(response.status).toBe(302);
-      const kept = (await groups.table.findById(group.id))!;
+      const kept = (await groups.table.read.one({ id: group.id }))!;
       expect(kept.is_package).toBe(true);
       expect(kept.hide_package_listings).toBe(true);
     });
@@ -59,7 +59,7 @@ describeWithEnv(
         { confirm_identifier: "Empty Kit" },
       );
       expect(response.status).toBe(302);
-      expect(await groups.table.findById(group.id)).toBeNull();
+      expect(await groups.table.read.one({ id: group.id })).toBeNull();
     });
 
     test("the groups API blocks deleting a sold hidden package until un-hidden", async () => {
@@ -79,7 +79,7 @@ describeWithEnv(
           );
         },
       );
-      expect(await groups.table.findById(group.id)).not.toBeNull();
+      expect(await groups.table.read.one({ id: group.id })).not.toBeNull();
 
       // After the explicit reveal, the API delete un-groups as before.
       await groups.table.update(group.id, { hidePackageListings: false });
@@ -93,7 +93,7 @@ describeWithEnv(
           expect(body.status).toBe("ok");
         },
       );
-      expect(await groups.table.findById(group.id)).toBeNull();
+      expect(await groups.table.read.one({ id: group.id })).toBeNull();
       expect(await loadListing(memberListing.id)).not.toBeNull();
     });
 

--- a/test/integration/server/groups/edit-delete.test.ts
+++ b/test/integration/server/groups/edit-delete.test.ts
@@ -252,7 +252,7 @@ describeWithEnv("server (admin groups) — edit & delete", { db: true }, () => {
         "#shared/db/listings/records.ts"
       );
 
-      expect(await groups.table.findById(group.id)).toBeNull();
+      expect(await groups.table.read.one({ id: group.id })).toBeNull();
       const existingListing = await getListingWithCount(listing.id);
       expect(existingListing).not.toBeNull();
       // Group delete prunes membership rows, leaving the listing ungrouped.
@@ -275,11 +275,11 @@ describeWithEnv("server (admin groups) — edit & delete", { db: true }, () => {
       const csrfToken = await testCsrfToken();
 
       const { groups } = await import("#shared/db/groups.ts");
-      const original = groups.table.findById.bind(groups.table);
+      const original = groups.table.read.one.bind(groups.table.read);
       let calls = 0;
-      const findByIdStub = stub(
-        groups.table,
-        "findById",
+      const readStub = stub(
+        groups.table.read,
+        "one",
         (...args: Parameters<typeof original>) => {
           calls++;
           return calls === 1 ? original(...args) : Promise.resolve(null);
@@ -299,7 +299,7 @@ describeWithEnv("server (admin groups) — edit & delete", { db: true }, () => {
           false,
         );
       } finally {
-        findByIdStub.restore();
+        readStub.restore();
       }
     });
   });

--- a/test/integration/server/holidays/entity-page.test.ts
+++ b/test/integration/server/holidays/entity-page.test.ts
@@ -109,7 +109,7 @@ describeWithEnv("holiday entity page", { db: true }, () => {
         "Holiday updated",
       )(response);
       const { holidays } = await import("#shared/db/holidays.ts");
-      expect(await holidays.table.findById(holiday.id)).toEqual({
+      expect(await holidays.table.read.one({ id: holiday.id })).toEqual({
         ...holiday,
         end_date: "2026-12-27",
       });
@@ -214,7 +214,7 @@ describeWithEnv("holiday entity page", { db: true }, () => {
       const holiday = await createTestHoliday({ name: "To Delete" });
       await deleteTestHoliday(holiday.id);
       const { holidays } = await import("#shared/db/holidays.ts");
-      expect(await holidays.table.findById(holiday.id)).toBeNull();
+      expect(await holidays.table.read.one({ id: holiday.id })).toBeNull();
     });
 
     test("rejects deletion with wrong name", async () => {
@@ -230,7 +230,7 @@ describeWithEnv("holiday entity page", { db: true }, () => {
         false,
       );
       const { holidays } = await import("#shared/db/holidays.ts");
-      expect(await holidays.table.findById(holiday.id)).not.toBeNull();
+      expect(await holidays.table.read.one({ id: holiday.id })).not.toBeNull();
     });
 
     test("name confirmation is case-insensitive", async () => {
@@ -240,7 +240,7 @@ describeWithEnv("holiday entity page", { db: true }, () => {
         { confirm_identifier: "christmas day" },
       );
       await expectFlashRedirect("/admin/holidays", "Holiday deleted")(response);
-      expect(await holidays.table.findById(holiday.id)).toBeNull();
+      expect(await holidays.table.read.one({ id: holiday.id })).toBeNull();
     });
 
     test("returns 404 for non-existent holiday", async () => {

--- a/test/integration/server/listings-create.test.ts
+++ b/test/integration/server/listings-create.test.ts
@@ -108,7 +108,7 @@ describeWithEnv("server listings > create", { db: true }, () => {
     test("still creates when the read-back replica lags the just-committed write", async () => {
       // The primary read-back succeeds even while an optional replica read
       // still misses the newly committed row.
-      const findByIdStub = stub(listingsTable, "findById", () =>
+      const readStub = stub(listingsTable.read, "one", () =>
         Promise.resolve(null),
       );
       try {
@@ -120,7 +120,7 @@ describeWithEnv("server listings > create", { db: true }, () => {
         });
         await expectFlashRedirect("/admin", "Listing created")(response);
       } finally {
-        findByIdStub.restore();
+        readStub.restore();
       }
 
       // The row really was written (the stub only affected the replica read path).

--- a/test/integration/server/listings-error-pages.test.ts
+++ b/test/integration/server/listings-error-pages.test.ts
@@ -168,25 +168,22 @@ describeWithEnv(
           name: "Listing For Delete Err",
         });
 
-        // Spy on listingsTable.findById: return the row on first call (so requireExists passes),
-        // but also delete the listing from DB so getListingWithCount (raw SQL) returns null.
-        const originalFindById = listingsTable.findById.bind(listingsTable);
-        const findByIdStub = stub(
-          listingsTable,
-          "findById",
-          async (id: unknown) => {
-            const row = await originalFindById(id as number);
-            if (row) {
-              // Delete the listing from DB so getListingWithCount returns null
-              await getDb().execute({
-                args: [id as number],
-                sql: "DELETE FROM listings WHERE id = ?",
-              });
-              invalidateListingsCache();
-            }
-            return row;
-          },
-        );
+        // Spy on the listing read: return the row on first call (so requireExists
+        // passes), but also delete the listing from DB so getListingWithCount
+        // (raw SQL) returns null.
+        const originalRead = listingsTable.read.one.bind(listingsTable.read);
+        const readStub = stub(listingsTable.read, "one", async (filter) => {
+          const row = await originalRead(filter);
+          if (row) {
+            // Delete the listing from DB so getListingWithCount returns null
+            await getDb().execute({
+              args: [row.id],
+              sql: "DELETE FROM listings WHERE id = ?",
+            });
+            invalidateListingsCache();
+          }
+          return row;
+        });
 
         try {
           // Send an update with empty name to trigger validation error
@@ -198,11 +195,11 @@ describeWithEnv(
               name: "",
             },
           );
-          // requireExists sees the row (first findById). Validation fails (empty name).
+          // requireExists sees the row (first read). Validation fails (empty name).
           // listingErrorPage calls getListingWithCount, but listing was deleted, so returns 404.
           expect(response.status).toBe(404);
         } finally {
-          findByIdStub.restore();
+          readStub.restore();
         }
       });
     });
@@ -215,10 +212,10 @@ describeWithEnv(
         });
 
         // handleAdminListingEditPost calls getListingWithCount (raw SQL), then
-        // updateResource.update which checks the nullable table.findById result.
+        // updateResource.update which checks the nullable by-key read.
         // Return null to simulate the listing being deleted
         // between the initial check and the update.
-        const findByIdStub2 = stub(listingsTable, "findById", () =>
+        const readStub2 = stub(listingsTable.read, "one", () =>
           Promise.resolve(null),
         );
 
@@ -234,7 +231,7 @@ describeWithEnv(
           );
           expect(response.status).toBe(404);
         } finally {
-          findByIdStub2.restore();
+          readStub2.restore();
         }
       });
     });

--- a/test/integration/server/logistics.test.ts
+++ b/test/integration/server/logistics.test.ts
@@ -199,7 +199,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
       );
 
       expect(response.status).toBe(503);
-      expect((await logisticsAgents.table.findById(id))!.name).toBe(
+      expect((await logisticsAgents.table.read.one({ id: id }))!.name).toBe(
         "Atomic van",
       );
       expect(await agentUsers.getIds(id)).toEqual([]);
@@ -244,7 +244,7 @@ describeWithEnv("server (admin logistics)", { db: true }, () => {
         "/admin/logistics",
         "Logistics agent deleted",
       )(response);
-      expect(await logisticsAgents.table.findById(id)).toBeNull();
+      expect(await logisticsAgents.table.read.one({ id: id })).toBeNull();
     });
 
     test("deleting an agent clears its booking references", async () => {

--- a/test/integration/test-utils/compat.test.ts
+++ b/test/integration/test-utils/compat.test.ts
@@ -66,7 +66,7 @@ describe("test-compat", () => {
       });
       await deleteTestGroup(group.id);
       const { groups } = await import("#shared/db/groups.ts");
-      expect(await groups.table.findById(group.id)).toBeNull();
+      expect(await groups.table.read.one({ id: group.id })).toBeNull();
     });
   });
 

--- a/test/shared/db/backup.test.ts
+++ b/test/shared/db/backup.test.ts
@@ -14,7 +14,6 @@ import {
 } from "#shared/db/backup.ts";
 import { exportTable } from "#shared/db/backup-snapshot.ts";
 import { getDb, queryAll } from "#shared/db/client.ts";
-import { listingsTable } from "#shared/db/listings/records.ts";
 import { SCHEMA } from "#shared/db/migrations/schema/index.ts";
 import { TRIGGERS } from "#shared/db/migrations/schema/triggers.ts";
 import {
@@ -24,7 +23,10 @@ import {
   SCHEMA_TABLE_NAMES,
 } from "#shared/db/migrations.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import {
+  createTestListing,
+  storedListingNames,
+} from "#test-utils/db-helpers/listings.ts";
 
 describeWithEnv("backup", { db: true }, () => {
   describe("splitStatements", () => {
@@ -243,9 +245,7 @@ describeWithEnv("backup", { db: true }, () => {
           await dumpWithFutureMigrations(["2099-01-01_from_the_future"]),
         ),
       ).rejects.toThrow("2099-01-01_from_the_future");
-      expect((await listingsTable.findAll()).map(({ name }) => name)).toEqual([
-        "Still here",
-      ]);
+      expect(await storedListingNames()).toEqual(["Still here"]);
     });
 
     test("explains every future migration and how to proceed", async () => {
@@ -281,9 +281,7 @@ describeWithEnv("backup", { db: true }, () => {
       const zip = await createBackupZip();
       const progress: Array<{ stage: string; statementCount: number }> = [];
       await restoreFromZip(zip, (event) => progress.push(event));
-      const listings = await listingsTable.findAll();
-      expect(listings.length).toBe(1);
-      expect(listings[0]!.name).toBe("Zip Restore Test");
+      expect(await storedListingNames()).toEqual(["Zip Restore Test"]);
       expect(progress.map(({ stage }) => stage)).toEqual([
         "checking",
         "resetting",
@@ -355,9 +353,7 @@ describeWithEnv("backup", { db: true }, () => {
           `Backup contains data for tables this app cannot restore: ${names}`,
         );
       }
-      expect((await listingsTable.findAll()).map(({ name }) => name)).toEqual([
-        "Still here",
-      ]);
+      expect(await storedListingNames()).toEqual(["Still here"]);
     });
 
     const sqlOf = (stmt: string | { sql: string }): string =>
@@ -397,9 +393,7 @@ describeWithEnv("backup", { db: true }, () => {
         executeStub.restore();
       }
 
-      const listings = await listingsTable.findAll();
-      expect(listings.length).toBe(1);
-      expect(listings[0]!.name).toBe("Stale Read Survivor");
+      expect(await storedListingNames()).toEqual(["Stale Read Survivor"]);
     });
 
     test("succeeds even when a schema snapshot still shows the pre-wipe tables", async () => {
@@ -447,9 +441,7 @@ describeWithEnv("backup", { db: true }, () => {
         batchStub.restore();
       }
 
-      const listings = await listingsTable.findAll();
-      expect(listings.length).toBe(1);
-      expect(listings[0]!.name).toBe("Snapshot Lag Survivor");
+      expect(await storedListingNames()).toEqual(["Snapshot Lag Survivor"]);
     });
   });
 });

--- a/test/shared/db/backup/restore.test.ts
+++ b/test/shared/db/backup/restore.test.ts
@@ -9,7 +9,6 @@ import {
 } from "#shared/db/backup.ts";
 import { exportTable } from "#shared/db/backup-snapshot.ts";
 import { getDb, queryAll, queryOne } from "#shared/db/client.ts";
-import { listingsTable } from "#shared/db/listings/records.ts";
 import { verifyCurrentAppSchema } from "#shared/db/migrations/schema-sync.ts";
 import { initDb } from "#shared/db/migrations.ts";
 import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
@@ -18,7 +17,10 @@ import {
   bookTestAttendee,
   decryptFirstAttendee,
 } from "#test-utils/db-helpers/attendees.ts";
-import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import {
+  createTestListing,
+  storedListingNames,
+} from "#test-utils/db-helpers/listings.ts";
 
 /**
  * Regression tests for restoring a backup taken before a column-dropping
@@ -167,7 +169,7 @@ describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
       "Backup without a manifest is missing required data for tables: settings, schema_migrations, attendee_statuses",
     );
 
-    expect((await listingsTable.findAll()).map(({ name }) => name)).toEqual([
+    expect(await storedListingNames()).toEqual([
       "From partial backup",
       "Must stay",
     ]);
@@ -183,9 +185,7 @@ describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
     }).catch((caught: unknown) => caught);
 
     expect(error).toEqual(new Error("progress stopped"));
-    expect((await listingsTable.findAll()).map(({ name }) => name)).toEqual([
-      "From backup",
-    ]);
+    expect(await storedListingNames()).toEqual(["From backup"]);
   });
 
   describe("backups taken before a column-dropping migration", () => {

--- a/test/shared/db/built-site-scheduler.test.ts
+++ b/test/shared/db/built-site-scheduler.test.ts
@@ -32,9 +32,9 @@ describeWithEnv("built-site scheduler keys", { db: true }, () => {
     );
     expect(raw?.site_data).not.toContain(TEST_SCHEDULED_KEY);
     expect(JSON.stringify(raw)).not.toContain(TEST_SCHEDULED_KEY);
-    expect((await builtSitesCrudTable.findById(row.id))?.scheduledTaskKey).toBe(
-      TEST_SCHEDULED_KEY,
-    );
+    expect(
+      (await builtSitesCrudTable.read.one({ id: row.id }))?.scheduledTaskKey,
+    ).toBe(TEST_SCHEDULED_KEY);
   });
 
   test("fails loudly when the built site does not exist", async () => {
@@ -54,7 +54,7 @@ describeWithEnv("built-site scheduler keys", { db: true }, () => {
     expect(first).toBe(second);
     expect(isScheduledTaskKey(first)).toBe(true);
     expect(
-      (await builtSitesCrudTable.findById(site.id))?.scheduledTaskKey,
+      (await builtSitesCrudTable.read.one({ id: site.id }))?.scheduledTaskKey,
     ).toBe(first);
   });
 
@@ -66,7 +66,7 @@ describeWithEnv("built-site scheduler keys", { db: true }, () => {
       builtSitesCrudTable.update(site.id, { name: "Edited child" }),
     ]);
 
-    const updated = await builtSitesCrudTable.findById(site.id);
+    const updated = await builtSitesCrudTable.read.one({ id: site.id });
     expect(updated?.name).toBe("Edited child");
     expect(isScheduledTaskKey(updated?.scheduledTaskKey ?? "")).toBe(true);
   });
@@ -83,7 +83,7 @@ describeWithEnv("built-site scheduler keys", { db: true }, () => {
       }),
     ]);
 
-    const updated = await builtSitesCrudTable.findById(site.id);
+    const updated = await builtSitesCrudTable.read.one({ id: site.id });
     expect(updated?.readOnlyFrom).toBe("2026-08-01T00:00:00.000Z");
     expect(updated?.renewalToken).toBe("renewal-token");
     expect(updated?.renewalTokenIndex).toBe("renewal-index");

--- a/test/shared/db/built-sites/assignment-renewal.test.ts
+++ b/test/shared/db/built-sites/assignment-renewal.test.ts
@@ -67,7 +67,7 @@ describeWithEnv("assignable built sites", { db: true }, () => {
       assignBuiltSite(site.id, 42, 7),
     ]);
 
-    expect(await builtSitesCrudTable.findById(site.id)).toMatchObject({
+    expect(await builtSitesCrudTable.read.one({ id: site.id })).toMatchObject({
       assignable: false,
       assignedAttendeeId: 42,
       assignedListingId: 7,
@@ -176,7 +176,7 @@ describeWithEnv("built-site renewal storage", { db: true }, () => {
     const row = await insertBuiltSite("Empty Index", "empty-index.b-cdn.net");
     await updateBuiltSiteRenewalState(row.id, { renewalTokenIndex: "" });
     expect(
-      (await builtSitesCrudTable.findById(row.id))?.renewalTokenIndex,
+      (await builtSitesCrudTable.read.one({ id: row.id }))?.renewalTokenIndex,
     ).toBe("");
   });
 
@@ -189,7 +189,7 @@ describeWithEnv("built-site renewal storage", { db: true }, () => {
     await updateBuiltSiteRenewalState(row.id, { renewalToken: "" });
 
     expect(
-      (await builtSitesCrudTable.findById(row.id))?.renewalToken,
+      (await builtSitesCrudTable.read.one({ id: row.id }))?.renewalToken,
     ).toBeNull();
   });
 });

--- a/test/shared/db/built-sites/core.test.ts
+++ b/test/shared/db/built-sites/core.test.ts
@@ -184,7 +184,7 @@ describeWithEnv("built-site storage", { db: true }, () => {
       "bunny",
       TEST_SCHEDULED_KEY,
     );
-    const site = await builtSitesCrudTable.findById(row.id);
+    const site = await builtSitesCrudTable.read.one({ id: row.id });
     expect(site?.scheduledTaskKey).toBe(TEST_SCHEDULED_KEY);
   });
 
@@ -215,6 +215,8 @@ describeWithEnv("built-site storage", { db: true }, () => {
         v: 1,
       }),
     });
-    expect((await builtSitesCrudTable.findById(row.id))?.renewalToken).toBe("");
+    expect(
+      (await builtSitesCrudTable.read.one({ id: row.id }))?.renewalToken,
+    ).toBe("");
   });
 });

--- a/test/shared/db/built-sites/crud.test.ts
+++ b/test/shared/db/built-sites/crud.test.ts
@@ -36,10 +36,30 @@ const siteFixture = (overrides: Partial<BuiltSite> = {}): BuiltSite => ({
 });
 
 describeWithEnv("built-sites CRUD table", { db: true }, () => {
-  test("findAll returns all built sites", async () => {
+  test("reads back every built site", async () => {
     await insertBuiltSite("Site A", "a.bunny.run");
     await insertBuiltSite("Site B", "b.bunny.run");
-    expect(await builtSitesCrudTable.findAll()).toHaveLength(2);
+    expect(await builtSitesCrudTable.read.many()).toHaveLength(2);
+  });
+
+  test("refuses to filter on fields kept inside the blob", () => {
+    // A site's name lives in the encrypted blob, not in a column, so no read
+    // can find a site by it — saying so is better than reading every site.
+    // Every such field is named, so the message is not a guessing game.
+    expect(() =>
+      builtSitesCrudTable.read.many({ name: "Site A", siteUrl: "a.example" }),
+    ).toThrow("Cannot filter built sites by name, siteUrl:");
+    // One such field is refused just the same — it must never fall through and
+    // quietly read every site.
+    expect(() => builtSitesCrudTable.read.many({ name: "Site A" })).toThrow(
+      "Cannot filter built sites by name:",
+    );
+  });
+
+  test("refuses to pick out some of a site's fields", () => {
+    expect(() => builtSitesCrudTable.read.pick(["name"])).toThrow(
+      "stored in one encrypted blob",
+    );
   });
 
   test("fromDb returns the row unchanged", async () => {
@@ -237,7 +257,7 @@ describeWithEnv("built-sites CRUD table", { db: true }, () => {
       builtSitesCrudTable.update(site.id, { name: "Renamed" }),
       builtSitesCrudTable.update(site.id, { siteUrl: "moved.bunny.run" }),
     ]);
-    expect(await builtSitesCrudTable.findById(site.id)).toMatchObject({
+    expect(await builtSitesCrudTable.read.one({ id: site.id })).toMatchObject({
       name: "Renamed",
       siteDataRevision: 2,
       siteUrl: "moved.bunny.run",

--- a/test/shared/db/chosen-columns/columns.test.ts
+++ b/test/shared/db/chosen-columns/columns.test.ts
@@ -36,6 +36,21 @@ describe("chosen table columns", () => {
     expect(chosen.columnsSql("row")).toBe("row.id, row.name");
   });
 
+  test("a read of the table's own rows also selects the row's key", () => {
+    // A column's read transform may name the row a bad value came from, so the
+    // key has to come back with it — but only when it was not chosen already,
+    // or the read would ask for the same column twice.
+    expect(chooseColumns(sampleTable, ["name"]).readColumnsSql()).toBe(
+      "name, id",
+    );
+    expect(chooseColumns(sampleTable, ["id", "name"]).readColumnsSql()).toBe(
+      "id, name",
+    );
+    expect(chooseColumns(sampleTable, ["name"]).readColumnsSql("row")).toBe(
+      "row.name, row.id",
+    );
+  });
+
   test("reads only the selected columns through their table transforms", async () => {
     const chosen = chooseColumns(sampleTable, ["id", "name", "active"]);
 

--- a/test/shared/db/groups.test.ts
+++ b/test/shared/db/groups.test.ts
@@ -82,13 +82,13 @@ describeWithEnv("db > groups", { db: true, triggers: true }, () => {
     });
 
   describe("CRUD", () => {
-    test("groups.table create, update, findById, deleteById", async () => {
+    test("groups.table create, update, read, deleteById", async () => {
       const created = await createTestGroup({
         name: "DB Group",
         slug: "db-group",
       });
 
-      const fetched = await groups.table.findById(created.id);
+      const fetched = await groups.table.read.one({ id: created.id });
       expect(fetched).not.toBeNull();
       expect(fetched?.name).toBe("DB Group");
       expect(fetched?.slug).toBe("db-group");
@@ -101,7 +101,7 @@ describeWithEnv("db > groups", { db: true, triggers: true }, () => {
       expect(updated?.terms_and_conditions).toBe("Terms");
 
       await groups.table.deleteById(created.id);
-      expect(await groups.table.findById(created.id)).toBeNull();
+      expect(await groups.table.read.one({ id: created.id })).toBeNull();
     });
 
     test("getAllGroups returns decrypted groups ordered by id", async () => {

--- a/test/shared/db/groups/contracts.test.ts
+++ b/test/shared/db/groups/contracts.test.ts
@@ -42,7 +42,7 @@ const insertMinimalGroup = async (name: string) => {
 describeWithEnv("db > group storage contracts", { db: true }, () => {
   test("omitted group flags default to false", async () => {
     const inserted = await insertMinimalGroup("Default Flags");
-    expect(await groups.table.findById(inserted.id)).toMatchObject({
+    expect(await groups.table.read.one({ id: inserted.id })).toMatchObject({
       hidden: false,
       hide_package_listings: false,
       is_package: false,

--- a/test/shared/db/questions/queries/crud.test.ts
+++ b/test/shared/db/questions/queries/crud.test.ts
@@ -37,7 +37,7 @@ describeWithEnv(
         const q = await createQuestion("Favourite colour?");
         expect(q.id).toBeGreaterThan(0);
 
-        const found = await questionsTable.findById(q.id);
+        const found = await questionsTable.read.one({ id: q.id });
         expect(found).not.toBeNull();
         expect(found!.text).toBe("Favourite colour?");
       });
@@ -45,7 +45,7 @@ describeWithEnv(
       test("updates a question", async () => {
         const q = await createQuestion("Old text");
         await questionsTable.update(q.id, { text: "New text" });
-        const found = await questionsTable.findById(q.id);
+        const found = await questionsTable.read.one({ id: q.id });
         expect(found!.text).toBe("New text");
       });
 
@@ -61,7 +61,7 @@ describeWithEnv(
 
         await deleteQuestion(q.id);
 
-        expect(await questionsTable.findById(q.id)).toBeNull();
+        expect(await questionsTable.read.one({ id: q.id })).toBeNull();
         expect(await getQuestionsForListing(listing.id)).toEqual([]);
         const answers = await getAttendeeAnswersBatch([attendee.id], {
           texts: false,

--- a/test/shared/db/questions/tables/question-delete.test.ts
+++ b/test/shared/db/questions/tables/question-delete.test.ts
@@ -63,7 +63,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
 
       // Verify it's gone
       const { questionsTable } = await import("#shared/db/questions/tables.ts");
-      const found = await questionsTable.findById(id);
+      const found = await questionsTable.read.one({ id: id });
       expect(found).toBeNull();
     });
 
@@ -83,7 +83,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       )(response);
 
       const { questionsTable } = await import("#shared/db/questions/tables.ts");
-      expect(await questionsTable.findById(id)).toBeNull();
+      expect(await questionsTable.read.one({ id: id })).toBeNull();
     });
 
     test("rejects deletion with wrong text", async () => {
@@ -103,7 +103,7 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
 
       // Verify still exists
       const { questionsTable } = await import("#shared/db/questions/tables.ts");
-      const found = await questionsTable.findById(id);
+      const found = await questionsTable.read.one({ id: id });
       expect(found).not.toBeNull();
     });
 

--- a/test/shared/db/table-reader/filters.test.ts
+++ b/test/shared/db/table-reader/filters.test.ts
@@ -5,14 +5,12 @@
  */
 
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { attributesTable } from "#shared/db/attributes.ts";
-import { rawListingsTable } from "#shared/db/listings/table.ts";
-import { readerFor } from "#shared/db/table-reader.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 
-describeWithEnv("db > table reader", { db: true }, () => {
-  const attributes = readerFor(attributesTable);
+describeWithEnv("db > table reader > filters", { db: true }, () => {
+  const attributes = attributesTable.read;
   const add = (name: string, sortOrder = 0) =>
     attributesTable.insert({ name, sortOrder });
 
@@ -94,16 +92,6 @@ describeWithEnv("db > table reader", { db: true }, () => {
     // refused as the call is made, before any query is built.
     expect(() => attributes.one({ name: "Sealed" })).toThrow(
       "Cannot filter attributes by name: it is stored in a different form",
-    );
-  });
-});
-
-describe("readerFor guards", () => {
-  test("refuses a table whose row is more than its stored columns", () => {
-    // listings works its image and day-price values out from other tables, so a
-    // whole-row read cannot return a whole Listing.
-    expect(() => readerFor(rawListingsTable)).toThrow(
-      "listings has values that are not stored columns",
     );
   });
 });

--- a/test/shared/db/table-reader/reads.test.ts
+++ b/test/shared/db/table-reader/reads.test.ts
@@ -1,13 +1,11 @@
 /**
- * Tests for a declared read (`select` / `selectOne` in
- * `src/shared/db/chosen-columns.ts`), which puts the chosen columns and their
- * table together with the shared filters, so an ordinary single-table read
- * needs no SQL of its own.
+ * Tests for the reads a table's reader runs (`src/shared/db/table-reader.ts`),
+ * which put the chosen columns and their table together with the shared
+ * filters, so an ordinary single-table read needs no SQL of its own.
  */
 
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { chooseColumns } from "#shared/db/chosen-columns.ts";
 import {
   listingOptionColumns,
   rawListingsTable,
@@ -17,16 +15,15 @@ import {
   getQueryLog,
   runWithQueryLogContext,
 } from "#shared/db/query-log.ts";
-import { equals, inList } from "#shared/db/where-clauses.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 
-describeWithEnv("db > chosen columns > declared reads", { db: true }, () => {
+describeWithEnv("db > table reader > reads", { db: true }, () => {
   test("reads every row when nothing is asked of it", async () => {
     const first = await createTestListing({ name: "Alpha" });
     const second = await createTestListing({ name: "Beta" });
 
-    const rows = await listingOptionColumns.select({ alias: "listing" });
+    const rows = await listingOptionColumns.many({}, { alias: "listing" });
 
     expect(rows.map(({ id }) => id).toSorted()).toEqual(
       [first.id, second.id].toSorted(),
@@ -37,10 +34,10 @@ describeWithEnv("db > chosen columns > declared reads", { db: true }, () => {
     const wanted = await createTestListing({ name: "Wanted" });
     await createTestListing({ name: "Unwanted" });
 
-    const rows = await listingOptionColumns.select({
-      alias: "listing",
-      where: equals("listing.id", wanted.id),
-    });
+    const rows = await listingOptionColumns.many(
+      { id: wanted.id },
+      { alias: "listing" },
+    );
 
     expect(rows.map(({ name }) => name)).toEqual(["Wanted"]);
   });
@@ -49,11 +46,10 @@ describeWithEnv("db > chosen columns > declared reads", { db: true }, () => {
     const first = await createTestListing({ name: "First" });
     const second = await createTestListing({ name: "Second" });
 
-    const rows = await listingOptionColumns.select({
-      alias: "listing",
-      limit: 1,
-      order: "listing.id DESC",
-    });
+    const rows = await listingOptionColumns.many(
+      {},
+      { alias: "listing", limit: 1, order: "listing.id DESC" },
+    );
 
     expect(rows.map(({ id }) => id)).toEqual([Math.max(first.id, second.id)]);
   });
@@ -62,16 +58,10 @@ describeWithEnv("db > chosen columns > declared reads", { db: true }, () => {
     const listing = await createTestListing({ name: "Only" });
 
     expect(
-      await listingOptionColumns.selectOne({
-        alias: "listing",
-        where: equals("listing.id", listing.id),
-      }),
+      await listingOptionColumns.one({ id: listing.id }, { alias: "listing" }),
     ).toMatchObject({ id: listing.id, name: "Only" });
     expect(
-      await listingOptionColumns.selectOne({
-        alias: "listing",
-        where: equals("listing.id", 999_999),
-      }),
+      await listingOptionColumns.one({ id: 999_999 }, { alias: "listing" }),
     ).toBeNull();
   });
 
@@ -80,14 +70,14 @@ describeWithEnv("db > chosen columns > declared reads", { db: true }, () => {
     // it can only do if the key came back with it — but the key is not part of
     // what the caller asked for, so it must not be handed back either.
     const listing = await createTestListing({ name: "Keyed" });
-    const nameOnly = chooseColumns(rawListingsTable, ["name"]);
+    const nameOnly = rawListingsTable.read.pick(["name"]);
 
     await runWithQueryLogContext(async () => {
       enableQueryLog();
-      const rows = await nameOnly.select({
-        alias: "listing",
-        where: equals("listing.id", listing.id),
-      });
+      const rows = await nameOnly.many(
+        { id: listing.id },
+        { alias: "listing" },
+      );
 
       // Only the selected columns count — the filter names the key too.
       const sql = getQueryLog()[0]?.sql ?? "";
@@ -102,18 +92,40 @@ describeWithEnv("db > chosen columns > declared reads", { db: true }, () => {
     await runWithQueryLogContext(async () => {
       enableQueryLog();
       expect(
-        await listingOptionColumns.select({
-          alias: "listing",
-          where: inList("listing.id", []),
-        }),
+        await listingOptionColumns.many({ id: [] }, { alias: "listing" }),
       ).toEqual([]);
       expect(
-        await listingOptionColumns.selectOne({
-          alias: "listing",
-          where: inList("listing.id", []),
-        }),
+        await listingOptionColumns.one({ id: [] }, { alias: "listing" }),
       ).toBeNull();
       expect(getQueryLog()).toEqual([]);
     });
+  });
+
+  test("clauses the row shape cannot say narrow the read too", async () => {
+    const wanted = await createTestListing({ name: "Wanted" });
+    const other = await createTestListing({ name: "Other" });
+
+    // Both must hold: the filter written as the row, and the clause written by
+    // hand. A read that dropped either would keep a listing it was not asked
+    // for, so each is checked by the read that only it rules out.
+    const bothHold = await listingOptionColumns.many(
+      { id: [wanted.id, other.id] },
+      {
+        alias: "listing",
+        where: [{ args: [wanted.id], clause: "listing.id = ?" }],
+      },
+    );
+    const clauseRulesOutEveryRow = await listingOptionColumns.many(
+      { id: [wanted.id, other.id] },
+      { alias: "listing", where: [{ args: [], clause: "listing.active = 0" }] },
+    );
+    const filterRulesOutTheRest = await listingOptionColumns.many(
+      { id: [wanted.id] },
+      { alias: "listing", where: [{ args: [], clause: "listing.active = 1" }] },
+    );
+
+    expect(bothHold.map(({ id }) => id)).toEqual([wanted.id]);
+    expect(clauseRulesOutEveryRow).toEqual([]);
+    expect(filterRulesOutTheRest.map(({ id }) => id)).toEqual([wanted.id]);
   });
 });

--- a/test/shared/db/table.test.ts
+++ b/test/shared/db/table.test.ts
@@ -193,7 +193,7 @@ describeWithEnv("db > table utilities", { db: true }, () => {
     expect(await table.readColumn("id", 7)).toBe(7);
   });
 
-  test("defineTable.findAll returns all rows", async () => {
+  test("defineTable reads back every row", async () => {
     const { col, defineTable } = await import("#shared/db/table.ts");
     const testTable = buildListingsTestTable<{ name: string }>(
       col,
@@ -211,30 +211,30 @@ describeWithEnv("db > table utilities", { db: true }, () => {
       thankYouUrl: "https://example.com",
     });
 
-    const rows = await testTable.findAll();
+    const rows = await testTable.read.many();
     expect(rows.length).toBe(2);
   });
 
-  test("defineTable resolves one id through the ordered many-id lookup", async () => {
+  test("defineTable reads one id and a list of them the same way", async () => {
     const { col, defineTable } = await import("#shared/db/table.ts");
     const first = await createTestListing({ name: "First" });
     const second = await createTestListing({ name: "Second" });
     const table = buildListingsTestTable<{ name: string }>(col, defineTable);
 
-    expect((await table.findById(second.id))?.id).toBe(second.id);
+    expect((await table.read.one({ id: second.id }))?.id).toBe(second.id);
     expect(
-      (await table.findByIds([second.id, first.id, second.id])).map(
-        (row) => row?.id,
-      ),
-    ).toEqual([second.id, first.id, second.id]);
+      (await table.read.many({ id: [second.id, first.id] }))
+        .map((row) => row.id)
+        .toSorted(),
+    ).toEqual([first.id, second.id].toSorted());
   });
 
   test("defineTable keeps optional misses nullable", async () => {
     const { col, defineTable } = await import("#shared/db/table.ts");
     const table = buildListingsTestTable<{ name: string }>(col, defineTable);
-    expect(await table.findById(999_999)).toBeNull();
+    expect(await table.read.one({ id: 999_999 })).toBeNull();
     expect(await table.findByIdPrimary!(999_999)).toBeNull();
-    expect(await table.findByIds([])).toEqual([]);
+    expect(await table.read.many({ id: [] })).toEqual([]);
   });
 
   test("defineTable.update with no changes returns existing row", async () => {
@@ -311,7 +311,7 @@ describeWithEnv("db > table utilities", { db: true }, () => {
     expect(row.unit_price).toBe(0);
     expect(row.webhook_url).toBeNull();
 
-    const fromDb = await testTable.findById(row.id);
+    const fromDb = await testTable.read.one({ id: row.id });
     expect(fromDb?.slug).toBe("test-listing");
   });
 
@@ -344,7 +344,7 @@ describeWithEnv("db > table utilities", { db: true }, () => {
     expect(row.key).toBe("test-key");
     expect(row.value).toBe("test-value");
 
-    const fetched = await kvTable.findById("test-key");
+    const fetched = await kvTable.read.one({ key: "test-key" });
     expect(fetched).not.toBeNull();
     expect(fetched?.value).toBe("test-value");
   });

--- a/test/shared/rest/crud-api.test.ts
+++ b/test/shared/rest/crud-api.test.ts
@@ -31,7 +31,7 @@ const makeRoutes = (
   config: Partial<CrudApiConfig<Row, Input>> = {},
 ): Record<string, unknown> =>
   defineCrudApi<Row, Input>({
-    getAll: () => table.findAll(),
+    getAll: () => table.read.many(),
     name: "widgets",
     nameField: "name",
     singular: "Widget",
@@ -139,7 +139,7 @@ describeWithEnv("defineCrudApi", { db: true }, () => {
     expect(await response.json()).toEqual({
       widget: { hydrated: "row:1", id: 1 },
     });
-    expect(await table.findById(1)).toEqual({ id: 1, name: "Created" });
+    expect(await table.read.one({ id: 1 })).toEqual({ id: 1, name: "Created" });
     expect(hydrationCalls).toEqual([[1]]);
     const entry = (await getAllActivityLog()).find(
       (item) => item.message === "Widget 'Created' created",
@@ -201,7 +201,7 @@ describeWithEnv("defineCrudApi", { db: true }, () => {
     expect(await response.json()).toEqual({
       widget: { id: row.id, name: "Updated" },
     });
-    expect(await table.findById(row.id)).toEqual({
+    expect(await table.read.one({ id: row.id })).toEqual({
       id: row.id,
       name: "Updated",
     });
@@ -221,7 +221,7 @@ describeWithEnv("defineCrudApi", { db: true }, () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "ok" });
-    expect(await table.findById(row.id)).toBeNull();
+    expect(await table.read.one({ id: row.id })).toBeNull();
     expect(await wasActivityLogged("Widget 'Delete me' deleted")).toBe(true);
   });
 
@@ -247,7 +247,7 @@ describeWithEnv("defineCrudApi", { db: true }, () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "ok" });
     expect(deleted).toEqual([row.id]);
-    expect(await table.findById(row.id)).toBeNull();
+    expect(await table.read.one({ id: row.id })).toBeNull();
   });
 
   test("PUT returns 404 when the row vanishes before its write reads back", async () => {

--- a/test/shared/rest/resource.test.ts
+++ b/test/shared/rest/resource.test.ts
@@ -77,7 +77,7 @@ const expectRowExists = async (
   id: number,
   exists: boolean,
 ): Promise<void> => {
-  const row = await resource.table.findById(id);
+  const row = await resource.table.read.one({ id: id });
   exists ? expect(row).not.toBeNull() : expect(row).toBeNull();
 };
 
@@ -345,7 +345,7 @@ describeWithEnv("rest/resource - additional coverage", { db: true }, () => {
       expect(deletedId).toBe(1);
 
       // Verify row was actually deleted
-      const row = await table.findById(1);
+      const row = await table.read.one({ id: 1 });
       expect(row).toBeNull();
     });
   });

--- a/test/shared/rest/write-entity.test.ts
+++ b/test/shared/rest/write-entity.test.ts
@@ -64,7 +64,7 @@ describe("writeEntity", () => {
     expect(joinIds).toEqual([1]);
     // afterCommit ran once with the written row's id, after the read-back.
     expect(afterCommitIds).toEqual([1]);
-    expect(await table.findById(1)).toEqual({ id: 1, name: "row" });
+    expect(await table.read.one({ id: 1 })).toEqual({ id: 1, name: "row" });
   });
 
   test("runs every join write in order, all inside the one transaction", async () => {
@@ -111,7 +111,7 @@ describe("writeEntity", () => {
 
     // The row write rolled back with the failed join write; nothing persisted,
     // and the post-commit hook never ran.
-    expect(await table.findById(1)).toBeNull();
+    expect(await table.read.one({ id: 1 })).toBeNull();
     expect(afterCommitRan).toBe(false);
   });
 

--- a/test/shared/site-scheduler.test.ts
+++ b/test/shared/site-scheduler.test.ts
@@ -40,7 +40,8 @@ describeWithEnv(
         ok: false,
       });
       expect(
-        (await builtSitesCrudTable.findById(child.id))?.scheduledTaskKey,
+        (await builtSitesCrudTable.read.one({ id: child.id }))
+          ?.scheduledTaskKey,
       ).toBeNull();
     });
 
@@ -52,11 +53,11 @@ describeWithEnv(
 
     test("reuses the primary key when a replica read is stale", async () => {
       const child = await site();
-      const stale = await builtSitesCrudTable.findById(child.id);
+      const stale = await builtSitesCrudTable.read.one({ id: child.id });
       const key = await ensureBuiltSiteSchedulerKey(child.id);
       const pushed: string[] = [];
       stubs.push(
-        stub(builtSitesCrudTable, "findById", () => Promise.resolve(stale)),
+        stub(builtSitesCrudTable.read, "one", () => Promise.resolve(stale)),
         stub(bunnyHostingProvider, "getSecretNames", () =>
           Promise.resolve({ ok: true, value: ["SCHEDULED_TASK_KEY"] }),
         ),
@@ -104,11 +105,12 @@ describeWithEnv(
       stubBunnySchedulerSecrets(stubs, [], { error: "host down", ok: false });
 
       expect((await provisionSiteScheduler(child.id)).ok).toBe(false);
-      const first = (await builtSitesCrudTable.findById(child.id))
+      const first = (await builtSitesCrudTable.read.one({ id: child.id }))
         ?.scheduledTaskKey;
       expect((await provisionSiteScheduler(child.id)).ok).toBe(false);
       expect(
-        (await builtSitesCrudTable.findById(child.id))?.scheduledTaskKey,
+        (await builtSitesCrudTable.read.one({ id: child.id }))
+          ?.scheduledTaskKey,
       ).toBe(first);
     });
 

--- a/test/specs/support/bundles.ts
+++ b/test/specs/support/bundles.ts
@@ -200,7 +200,7 @@ export const organiserRevealsParts: ActOnOneThing = async (world, name) => {
 
 /** The bundle as the site has it now, or nothing if it is gone. */
 const storedBundleOrNull = (world: TicketsWorld, name: string) =>
-  groups.table.findById(bundleNamed(world, name).id);
+  groups.table.read.one({ id: bundleNamed(world, name).id });
 
 /** Whether the site is still selling this as one bundle. */
 export const isStillABundle = async (

--- a/test/test-utils/db-helpers/built-sites.ts
+++ b/test/test-utils/db-helpers/built-sites.ts
@@ -84,7 +84,9 @@ export const updateTestBuiltSite = async (
   updates: Partial<BuiltSiteFormInput>,
 ): Promise<BuiltSite> => {
   const { builtSitesCrudTable } = await import("#shared/db/built-sites.ts");
-  const existing = (await builtSitesCrudTable.findById(siteId)) as BuiltSite;
+  const existing = (await builtSitesCrudTable.read.one({
+    id: siteId,
+  })) as BuiltSite;
 
   const assignable = updates.assignable ?? existing.assignable;
   return withBuilderEnabled(() =>
@@ -100,7 +102,7 @@ export const updateTestBuiltSite = async (
         ...(assignable ? { assignable: "1" } : {}),
       },
       async () => {
-        const updated = await builtSitesCrudTable.findById(siteId);
+        const updated = await builtSitesCrudTable.read.one({ id: siteId });
         return updated as BuiltSite;
       },
       "update built site",
@@ -110,7 +112,9 @@ export const updateTestBuiltSite = async (
 
 export const deleteTestBuiltSite = async (siteId: number): Promise<void> => {
   const { builtSitesCrudTable } = await import("#shared/db/built-sites.ts");
-  const existing = (await builtSitesCrudTable.findById(siteId)) as BuiltSite;
+  const existing = (await builtSitesCrudTable.read.one({
+    id: siteId,
+  })) as BuiltSite;
 
   return withBuilderEnabled(() =>
     doAuthenticatedFormRequest(

--- a/test/test-utils/db-helpers/groups.ts
+++ b/test/test-utils/db-helpers/groups.ts
@@ -63,7 +63,7 @@ export const updateTestGroup = async (
   updates: Partial<Omit<GroupInput, "slugIndex">>,
 ): Promise<Group> => {
   const { groups } = await import("#shared/db/groups.ts");
-  const existing = (await groups.table.findById(groupId)) as Group;
+  const existing = (await groups.table.read.one({ id: groupId })) as Group;
 
   const hidden = updates.hidden ?? existing.hidden;
   const isPackage = updates.isPackage ?? existing.is_package;
@@ -80,7 +80,7 @@ export const updateTestGroup = async (
       ...(isPackage ? { is_package: "1" } : {}),
     },
     async () => {
-      const updated = await groups.table.findById(groupId);
+      const updated = await groups.table.read.one({ id: groupId });
       return updated as Group;
     },
     "update group",
@@ -89,7 +89,7 @@ export const updateTestGroup = async (
 
 export const deleteTestGroup = async (groupId: number): Promise<void> => {
   const { groups } = await import("#shared/db/groups.ts");
-  const existing = (await groups.table.findById(groupId)) as Group;
+  const existing = (await groups.table.read.one({ id: groupId })) as Group;
 
   return doAuthenticatedFormRequest(
     `/admin/groups/${groupId}/delete`,

--- a/test/test-utils/db-helpers/holidays.ts
+++ b/test/test-utils/db-helpers/holidays.ts
@@ -32,7 +32,9 @@ export const updateTestHoliday = async (
   updates: Partial<HolidayInput>,
 ): Promise<Holiday> => {
   const { holidays } = await import("#shared/db/holidays.ts");
-  const existing = (await holidays.table.findById(holidayId)) as Holiday;
+  const existing = (await holidays.table.read.one({
+    id: holidayId,
+  })) as Holiday;
 
   return doAuthenticatedFormRequest(
     `/admin/holidays/${holidayId}/edit`,
@@ -42,7 +44,7 @@ export const updateTestHoliday = async (
       start_date: updates.startDate ?? existing.start_date,
     },
     async () => {
-      const updated = await holidays.table.findById(holidayId);
+      const updated = await holidays.table.read.one({ id: holidayId });
       return updated as Holiday;
     },
     "update holiday",
@@ -51,7 +53,9 @@ export const updateTestHoliday = async (
 
 export const deleteTestHoliday = async (holidayId: number): Promise<void> => {
   const { holidays } = await import("#shared/db/holidays.ts");
-  const existing = (await holidays.table.findById(holidayId)) as Holiday;
+  const existing = (await holidays.table.read.one({
+    id: holidayId,
+  })) as Holiday;
 
   return doAuthenticatedFormRequest(
     `/admin/holidays/${holidayId}/delete`,

--- a/test/test-utils/db-helpers/listings.ts
+++ b/test/test-utils/db-helpers/listings.ts
@@ -1,5 +1,8 @@
 import type { ListingInput } from "#shared/catalog-fields/fields.ts";
-import { getListingWithCount } from "#shared/db/listings/records.ts";
+import {
+  getListingWithCount,
+  listingsTable,
+} from "#shared/db/listings/records.ts";
 import type { Listing, ListingWithCount } from "#shared/types.ts";
 import {
   resolveTestGroupIds,
@@ -171,3 +174,10 @@ export const bookableStartDates = async (
     await getActiveHolidays(),
   );
 };
+
+/** The name of every listing now in the database. What a backup or restore test
+ * checks to see which listings survived. */
+export const storedListingNames = async (): Promise<string[]> =>
+  (await listingsTable.read.pick(["id", "name"]).many()).map(
+    ({ name }) => name,
+  );


### PR DESCRIPTION
## What changed

Reading a table from the database had grown three ways of saying the same thing, so someone writing a new query had several equally sensible-looking options to choose between. This makes it one.

Every table now carries a reader, and that reader is the whole of an ordinary read:

```ts
table.read.one({ id })                    // one row, every stored column
table.read.many({ id: [1, 2] })           // the rows those ids name
table.read.pick(["id", "name"]).many()    // only the columns you name
```

Which rows to keep is written as the row itself. A column that does not exist, or a value of the wrong type, is caught while the code is being written instead of by the database at run time. Filters the row shape cannot express — a subquery, a comparison, a rule built from the site's own settings — are passed alongside it, and a row has to pass both.

The set of columns a read names is now only a decoder: it says which columns a read must select, and turns the values that come back into a row. Plain reads and reads that join across tables share the same set, so the two can never end up meaning different columns.

Removed: the table's old `findById`, `findByIds` and `findAll`. Every caller moved over in this change; nothing was left behind as a wrapper. Reading a row back on the primary right after writing it (`findByIdPrimary`) is unchanged — that one genuinely cannot go through a normal read.

## Why it matters

Two real improvements fell out of having one path instead of three:

- **A read is checked against the table it reads.** Built sites keep most of their details inside a single encrypted blob rather than in columns. Asking for a site by its name used to be accepted and quietly return every site; it now says plainly that a name is not something a site can be found by.
- **Looking a group up by id was written out five separate times.** It is one shared read now, so the five places cannot drift apart.

## Testing

`deno task precommit` passes: lint, typecheck, duplicate check, copy check, edge build, and the full suite at 100% coverage.

Mutation testing on all three rewritten modules — the reader, the column decoder, and the built-sites façade — kills 100% of mutants. Three test gaps that surfaced along the way are closed: reads that combine both kinds of filter, the key a narrow read has to fetch alongside the columns it was asked for, and the two refusals the built-sites façade makes.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145jX1UQn15ZvXtkoqNz1pe)_