### PR TITLE
Read through the table wherever the table can answer

### DIFF
--- a/src/shared/db/activityLog.ts
+++ b/src/shared/db/activityLog.ts
@@ -28,7 +28,6 @@ import type {
 } from "#shared/crypto/sealed.ts";
 import {
   execute,
-  queryAll,
   queryBatch,
   resultRows,
   type TxScope,
@@ -36,10 +35,8 @@ import {
 import { idAndCreatedSchema } from "#shared/db/common-schema.ts";
 import { decryptListingWithCount } from "#shared/db/listings/records.ts";
 import { listingReader } from "#shared/db/listings/select.ts";
-import { readRows } from "#shared/db/read.ts";
 import { CONFIG_KEYS, settings } from "#shared/db/settings.ts";
 import { col, defineTable } from "#shared/db/table.ts";
-import { equals } from "#shared/db/where-clauses.ts";
 import { nowIso } from "#shared/now.ts";
 import { requireRequestPrivateKey } from "#shared/session-private-key.ts";
 import type { ListingWithCount } from "#shared/types.ts";
@@ -93,6 +90,17 @@ export const activityLogTable = defineTable<
   },
 });
 const ACTIVITY_LOG_COLUMNS = activityLogTable.columns.join(", ");
+
+/** The whole stored entry — what every log read selects. */
+const logEntries = activityLogTable.read;
+
+/**
+ * Newest first, by id rather than by created: id is AUTOINCREMENT so it rises
+ * with created (newest row = highest id) but, being the rowid, it is served
+ * straight from the primary key / idx_activity_log_listing_id without a sort
+ * over the unbounded log table.
+ */
+const NEWEST_FIRST = { order: "id DESC" };
 
 /**
  * Decrypt a stored log message, routing by format prefix: owner-key (hybrid)
@@ -187,18 +195,11 @@ const queryActivityLog = async (
   limit: number,
 ): Promise<ActivityLogEntry[]> =>
   decryptLogRows(
-    await readRows<StoredActivityLogEntry>({
-      columns: ACTIVITY_LOG_COLUMNS,
-      from: "activity_log",
-      limit,
-      // Order by id DESC, not created DESC: id is AUTOINCREMENT so it is
-      // co-monotonic with created (newest row = highest id) but, being the
-      // rowid, it is served straight from the primary key /
-      // idx_activity_log_listing_id without a sort over the unbounded log table.
-      order: "id DESC",
+    await logEntries.many(
       // A null listing means "every listing", which is no filter at all.
-      where: equals("listing_id", listingId ?? undefined),
-    }),
+      listingId === null ? {} : { listing_id: listingId },
+      { ...NEWEST_FIRST, limit },
+    ),
   );
 
 /**
@@ -224,9 +225,9 @@ export const getAttendeeActivityLog = async (
   limit = 100,
 ): Promise<ActivityLogEntry[]> =>
   decryptLogRows(
-    await queryAll<StoredActivityLogEntry>(
-      `SELECT ${ACTIVITY_LOG_COLUMNS} FROM activity_log WHERE attendee_id = ? ORDER BY id DESC LIMIT ?`,
-      [attendeeId, limit],
+    await logEntries.many(
+      { attendee_id: attendeeId },
+      { ...NEWEST_FIRST, limit },
     ),
   );
 
@@ -246,10 +247,7 @@ export const getListingWithActivityLogOrNull = async (
 ): Promise<ListingWithActivityLog | null> => {
   const results = await queryBatch([
     listingReader.statement({ where: { ids: [listingId] } }),
-    {
-      args: [listingId, limit],
-      sql: `SELECT ${ACTIVITY_LOG_COLUMNS} FROM activity_log WHERE listing_id = ? ORDER BY id DESC LIMIT ?`,
-    },
+    logEntries.statement({ listing_id: listingId }, { ...NEWEST_FIRST, limit }),
   ]);
 
   const listingRow = resultRows<ListingWithCount>(results[0]!)[0];

--- a/src/shared/db/attendee-statuses.ts
+++ b/src/shared/db/attendee-statuses.ts
@@ -115,11 +115,16 @@ export const requirePaidDefaultStatus: () => Promise<AttendeeStatus> =
 export const requirePublicStatusId = async (): Promise<number> =>
   (await requirePublicDefaultStatus()).id;
 
-type DefaultRow = {
-  is_paid_default: number;
-  is_public_default: number;
-  sort_order: number;
-};
+/** The three columns a status write reads back about itself, opened by the
+ * table — so the two default flags arrive as the booleans they are declared
+ * to be, not as the 1/0 the database stores. */
+const statusDefaults = attendeeStatuses.table.read.pick([
+  "is_paid_default",
+  "is_public_default",
+  "sort_order",
+]);
+
+type DefaultRow = NonNullable<Awaited<ReturnType<typeof statusDefaults.one>>>;
 
 const executeStatusWrite = async (
   tx: TxScope,
@@ -132,14 +137,9 @@ const getCurrentDefaults = async (
   tx: TxScope,
   id: number,
 ): Promise<DefaultRow> => {
-  const current = resultRows<DefaultRow>(
-    await tx.execute({
-      args: [id],
-      sql: `SELECT status.is_public_default, status.is_paid_default, status.sort_order
-              FROM attendee_statuses AS status
-             WHERE status.id = ?`,
-    }),
-  )[0];
+  const [current] = await statusDefaults.readAll(
+    resultRows(await tx.execute(statusDefaults.statement({ id }))),
+  );
   if (!current) throw new Error(`Attendee status ${id} does not exist`);
   return current;
 };
@@ -148,10 +148,10 @@ const defaultChangeError = (
   current: DefaultRow,
   input: AttendeeStatusWriteInput,
 ): AttendeeStatusSaveError | null => {
-  if (current.is_public_default === 1 && !input.isPublicDefault) {
+  if (current.is_public_default && !input.isPublicDefault) {
     return "public_default_required";
   }
-  return current.is_paid_default === 1 && !input.isPaidDefault
+  return current.is_paid_default && !input.isPaidDefault
     ? "paid_default_required"
     : null;
 };
@@ -228,10 +228,10 @@ const deleteStatus = (
              LIMIT 1`,
     });
     if (anotherStatus.rows.length === 0) return errorResult("last_status");
-    if (status.is_public_default === 1) {
+    if (status.is_public_default) {
       return errorResult("public_default");
     }
-    if (status.is_paid_default === 1) return errorResult("paid_default");
+    if (status.is_paid_default) return errorResult("paid_default");
 
     const attendee = await tx.execute({
       args: [id],

--- a/src/shared/db/built-sites.ts
+++ b/src/shared/db/built-sites.ts
@@ -149,17 +149,27 @@ const firstOf = async <Item>(items: Promise<Item[]>): Promise<Item | null> => {
   return first;
 };
 
+/** A built site is only ever handed back whole and already opened: its fields
+ * live in one encrypted blob, so there is no half of a site to give out and no
+ * raw row a caller could make sense of. */
+const refuseUnopened = (): never => {
+  throw new Error(
+    "A built site's fields are stored in one encrypted blob, so a read can only hand back whole, opened sites. Read the whole site.",
+  );
+};
+
 const builtSiteReads: TableReader<BuiltSite> = {
+  exists: (filter, options) =>
+    rawBuiltSitesTable.read.exists(rawFilter(filter), options),
   // The filter is checked before anything is awaited, so a field that is not a
   // column fails at the call rather than in a rejected promise later.
   many: (filter, options) => readSites(rawFilter(filter), options),
   one: (filter, options) =>
     firstOf(readSites(rawFilter(filter), { ...options, limit: 1 })),
-  pick: () => {
-    throw new Error(
-      "A built site's fields are stored in one encrypted blob, so a read cannot pick out some of them. Read the whole site.",
-    );
-  },
+  // Both of these would hand back something that is not an opened site — some
+  // of its columns, or rows nobody has parsed the blob out of.
+  pick: refuseUnopened,
+  statement: refuseUnopened,
 };
 
 export const findBuiltSiteByIdPrimary = async (

--- a/src/shared/db/email-templates.ts
+++ b/src/shared/db/email-templates.ts
@@ -8,7 +8,7 @@
  */
 
 import type { OwnerKeyEncrypted } from "#shared/crypto/sealed.ts";
-import { countRows, queryAll } from "#shared/db/client.ts";
+import { countRows } from "#shared/db/client.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
 import { col } from "#shared/db/table.ts";
 
@@ -33,7 +33,9 @@ const emailTemplatesTable = defineIdTable<
 
 /** Every template, newest first (the admin templates list). */
 export const getAllRawEmailTemplates = (): Promise<RawEmailTemplate[]> =>
-  queryAll("SELECT id, subject, body FROM email_templates ORDER BY id DESC");
+  emailTemplatesTable.read
+    .pick(["id", "subject", "body"])
+    .many({}, { order: "id DESC" });
 
 export const getRawEmailTemplate = (
   id: number,

--- a/src/shared/db/groups.ts
+++ b/src/shared/db/groups.ts
@@ -52,7 +52,7 @@ import {
   type ListingRecordRow,
   listingReader,
 } from "#shared/db/listings/select.ts";
-import { envNameSource, queryAndMap, rowsByIds } from "#shared/db/query.ts";
+import { envNameSource, rowsByIds } from "#shared/db/query.ts";
 import { isSlugTakenAnywhere } from "#shared/db/slug-registry.ts";
 import { equals, inList } from "#shared/db/where-clauses.ts";
 import {
@@ -97,21 +97,11 @@ const packageDisplayColumns = rawGroupsTable.read.pick([
 ]);
 
 /** Execute a query and decrypt the resulting group rows */
-const queryGroups = queryAndMap<Group, Group>((row) =>
-  rawGroupsTable.fromDb(row),
-);
-const GROUP_COLUMNS = rawGroupsTable.columns
-  .map((column) => `groupRecord.${column}`)
-  .join(", ");
-
 export const groups = cachedEntityTable<Group, GroupInput>(
   "groups",
   rawGroupsTable,
   {
-    fetchAll: () =>
-      queryGroups(
-        `SELECT ${GROUP_COLUMNS} FROM groups AS groupRecord ORDER BY groupRecord.id ASC`,
-      ),
+    fetchAll: () => rawGroupsTable.read.many({}, { order: "id ASC" }),
     idOf: (g) => g.id,
     keyOf: (g) => g.slug_index,
     ttlMs: GROUPS_CACHE_TTL_MS,

--- a/src/shared/db/questions/attendee-answers/save.ts
+++ b/src/shared/db/questions/attendee-answers/save.ts
@@ -18,6 +18,7 @@ import {
   internStringRows,
   prepareStringRows,
 } from "#shared/db/questions/strings.ts";
+import { answersTable, questionsTable } from "#shared/db/questions/tables.ts";
 
 export type AttendeeAnswerSet = {
   answerIds: number[];
@@ -41,10 +42,11 @@ const questionIdsByAnswerIdTx = async (
 ): Promise<Map<number, number>> => {
   if (answerIds.length === 0) return new Map();
   const rows = resultRows<{ id: number; question_id: number }>(
-    await tx.execute({
-      args: answerIds,
-      sql: `SELECT answer.id, answer.question_id FROM answers AS answer WHERE answer.id IN (${inPlaceholders(answerIds)})`,
-    }),
+    await tx.execute(
+      answersTable.read
+        .pick(["id", "question_id"])
+        .statement({ id: answerIds }),
+    ),
   );
   return fieldById("question_id")(rows);
 };
@@ -91,10 +93,9 @@ const existingQuestionIdsTx = async (
 ): Promise<Set<number>> => {
   if (questionIds.length === 0) return new Set();
   const rows = resultRows<{ id: number }>(
-    await tx.execute({
-      args: questionIds,
-      sql: `SELECT id FROM questions WHERE id IN (${inPlaceholders(questionIds)})`,
-    }),
+    await tx.execute(
+      questionsTable.read.pick(["id"]).statement({ id: questionIds }),
+    ),
   );
   return new Set(rows.map((row) => row.id));
 };

--- a/src/shared/db/site-page-items.ts
+++ b/src/shared/db/site-page-items.ts
@@ -13,7 +13,6 @@ import { registerTableInvalidation } from "#shared/cache-registry.ts";
 import {
   execute,
   executeBatch,
-  inPlaceholders,
   queryAll,
   resultRows,
   type SqlStatement,
@@ -25,6 +24,7 @@ import {
   deleteByItemStatement,
 } from "#shared/db/images.ts";
 import { defineOrderedCollection } from "#shared/db/ordered-collection.ts";
+import { existingSitePageIdsStatement } from "#shared/db/site-pages.ts";
 import { requestCache } from "#shared/request-cache.ts";
 import {
   pageParentMapFromEdges,
@@ -120,10 +120,7 @@ const addPageItemInTransaction: PageItemChangeInTransaction<boolean> = async (
     ...new Set([pageId, ...(itemType === "page" ? [itemId] : [])]),
   ];
   const pageRows = resultRows<{ id: number }>(
-    await tx.execute({
-      args: requiredIds,
-      sql: `SELECT id FROM site_pages WHERE id IN (${inPlaceholders(requiredIds)})`,
-    }),
+    await tx.execute(existingSitePageIdsStatement(requiredIds)),
   );
   if (pageRows.length !== requiredIds.length) return false;
   // Duplicate edge (the unique (page_id, item_type, item_id) key): checked

--- a/src/shared/db/site-pages.ts
+++ b/src/shared/db/site-pages.ts
@@ -13,7 +13,11 @@
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex } from "#shared/crypto/sealed.ts";
-import { type TxScope, useTransaction } from "#shared/db/client.ts";
+import {
+  type SqlStatement,
+  type TxScope,
+  useTransaction,
+} from "#shared/db/client.ts";
 import { idAndEncryptedSlugSchema } from "#shared/db/common-schema.ts";
 import { encryptedNameAndSeoSchema } from "#shared/db/content-columns.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
@@ -70,6 +74,15 @@ export const sitePageOrder = defineOrderedCollection({
   key: "id",
   table: "site_pages",
 });
+
+const sitePageIdColumn = rawSitePagesTable.read.pick(["id"]);
+
+/** Which of `ids` name a page that is really there — as a statement, so a
+ * caller can ask inside its own write transaction and have the answer hold
+ * for the writes it makes next. */
+export const existingSitePageIdsStatement = (
+  ids: readonly number[],
+): SqlStatement => sitePageIdColumn.statement({ id: ids });
 
 /** One full page by blind-index slug lookup (the `/page/:slug` read). */
 export const getSitePageBySlugIndex = (

--- a/src/shared/db/table-reader.ts
+++ b/src/shared/db/table-reader.ts
@@ -14,6 +14,7 @@
  */
 
 import type { InValue } from "@libsql/client";
+import { once } from "#fp";
 import {
   type ChosenColumns,
   type ChosenRow,
@@ -22,7 +23,13 @@ import {
   type ReadableTable,
   type StoredRowOf,
 } from "#shared/db/chosen-columns.ts";
-import { type Read, readOneRow, readRows } from "#shared/db/read.ts";
+import type { SqlStatement } from "#shared/db/client.ts";
+import {
+  type Read,
+  readOneRow,
+  readRows,
+  readStatement,
+} from "#shared/db/read.ts";
 import type { TableSchema } from "#shared/db/table.ts";
 import { equals, inList, type WhereClause } from "#shared/db/where-clauses.ts";
 
@@ -60,18 +67,25 @@ export type RowOptions = {
 /**
  * Turn a filter written as a row into the shared clause vocabulary.
  *
- * A column stored in a different form from the value the caller holds — an
- * encrypted one — cannot be compared against that value: the database would
- * match plaintext against ciphertext and quietly find nothing. That is refused
- * rather than answered wrongly. Such a value is found by the column that
- * carries its one-way code, which is stored as it is written.
+ * Two kinds of column are refused rather than answered wrongly. One the table
+ * does not store — a value worked out from another table — is not there to be
+ * compared against, so the database would fail on a column it has never heard
+ * of. One stored in a different form from the value the caller holds — an
+ * encrypted one — would match plaintext against ciphertext and quietly find
+ * nothing; such a value is found by the column carrying its one-way code,
+ * which is stored as it is written.
  */
 const filterClauses = <Row>(
-  table: { name: string; schema: TableSchema<Row> },
+  table: { columns: readonly string[]; name: string; schema: TableSchema<Row> },
   filter: RowFilter<Row>,
   alias: string | undefined,
 ): WhereClause[] =>
   Object.entries(filter).flatMap(([column, value]) => {
+    if (!table.columns.includes(column)) {
+      throw new Error(
+        `Cannot filter ${table.name} by ${column}: it is not one of its columns. A value worked out from another table cannot be compared against.`,
+      );
+    }
     if (table.schema[column as keyof Row]?.write !== undefined) {
       throw new Error(
         `Cannot filter ${table.name} by ${column}: it is stored in a different form from the value you have. Filter on the column holding its one-way code instead.`,
@@ -96,6 +110,11 @@ export type Rows<Row, Selected = Row> = {
     filter?: RowFilter<Row>,
     options?: RowOptions,
   ) => Promise<Selected | null>;
+  /** The same read as a statement, for a caller that must run it somewhere
+   * this reader cannot reach: inside an open transaction, or as one leg of a
+   * batch. The rows it returns are opened with {@link ChosenColumns.readAll},
+   * the same way this reader opens its own. */
+  statement: (filter?: RowFilter<Row>, options?: RowOptions) => SqlStatement;
 };
 
 /**
@@ -118,6 +137,15 @@ export type Selection<Row, Columns extends ColumnNames<Row>> = ChosenColumns<
  * too. A read that wants them says so in its own SQL.
  */
 export type TableReader<Row> = Rows<Row> & {
+  /**
+   * Whether any row passes the filter, read as narrowly as that question
+   * allows: the row's own key, capped at one row. Nothing else is fetched, so
+   * nothing else is decrypted to answer a yes-or-no — and unlike a whole-row
+   * read, a table that works some of its values out from other tables can
+   * still answer it.
+   */
+  exists: (filter?: RowFilter<Row>, options?: RowOptions) => Promise<boolean>;
+
   /** The same reads over a narrower set of columns — nothing else is selected,
    * so nothing else is fetched or decrypted. */
   pick: <const Columns extends ColumnNames<Row>>(
@@ -166,6 +194,8 @@ const selectionOf = <Row, Columns extends ColumnNames<Row>>(
     ...chosen,
     many: (filter = {}, options = {}) => rowsOf(readFor(filter, options)),
     one: (filter = {}, options = {}) => rowOf(readFor(filter, options)),
+    statement: (filter = {}, options = {}) =>
+      readStatement(readFor(filter, options)),
   };
 };
 
@@ -179,12 +209,39 @@ export const readerFor = <Row>(table: ReadableTable<Row>): TableReader<Row> => {
   ): Selection<Row, Columns> =>
     selectionOf(table, chooseColumns(table, columns));
 
-  // A table's declared columns are exactly the keys of its row, and a table
-  // with no columns cannot be declared — so this is the whole stored row.
-  const whole = pick(table.columns as unknown as ColumnNames<Row>) as Rows<
-    Row,
-    Row
-  >;
+  // A whole-row read can only promise the whole row when the row IS the
+  // table's stored columns. A table that works some of its values out from
+  // other tables has more in its row than it stores, so a read of every column
+  // would still be missing some and the promise would be a lie. Only the
+  // whole-row reads are refused — `pick` is how such a table is read — so the
+  // check waits until a whole-row read is actually asked for.
+  const whole = once((): Rows<Row, Row> => {
+    const workedOut = Object.keys(table.schema).filter(
+      (column) => table.schema[column as keyof Row]?.projected,
+    );
+    if (workedOut.length > 0) {
+      throw new Error(
+        `${table.name} has values that are not stored columns (${workedOut.join(", ")}), so a whole-row read cannot return them. Name the columns you want with read.pick instead.`,
+      );
+    }
+    // A table's declared columns are exactly the keys of its row, and a table
+    // with no columns cannot be declared — so this is the whole stored row.
+    return pick(table.columns as unknown as ColumnNames<Row>) as Rows<Row, Row>;
+  });
 
-  return { ...whole, pick };
+  // Every existence check reads the same one column, so the set is built once.
+  const key = once(() =>
+    pick([table.primaryKey] as unknown as ColumnNames<Row>),
+  );
+
+  return {
+    // Reading one row already caps the read at one, so this asks for nothing
+    // beyond the key column itself.
+    exists: async (filter, options) =>
+      (await key().one(filter, options)) !== null,
+    many: (filter, options) => whole().many(filter, options),
+    one: (filter, options) => whole().one(filter, options),
+    pick,
+    statement: (filter, options) => whole().statement(filter, options),
+  };
 };

--- a/src/shared/rest/resource.ts
+++ b/src/shared/rest/resource.ts
@@ -188,12 +188,14 @@ export const defineResource = <
       config.validateValues,
     );
 
-  /** Run `fn` only when the row exists; otherwise report not found. */
+  /** Run `fn` only when the row exists; otherwise report not found. Asking
+   * whether the row is there fetches only its key: the whole row would be
+   * decrypted just to be thrown away. */
   const withExistingRow = async <Outcome>(
     id: InValue,
     fn: () => Promise<Outcome>,
   ): Promise<Outcome | NotFoundResult> =>
-    (await table.read.one(byPrimaryKey(table, id)))
+    (await table.read.exists(byPrimaryKey(table, id)))
       ? fn()
       : { notFound: true, ok: false };
 

--- a/test/integration/server/bookable-alone.test.ts
+++ b/test/integration/server/bookable-alone.test.ts
@@ -149,7 +149,9 @@ describeWithEnv(
         });
         await updateTestListing(solo.id, { bookableAlone: false });
         expect(
-          (await listingsTable.read.one({ id: solo.id }))!.bookable_alone,
+          (await listingsTable.read.pick(["bookable_alone"]).one({
+            id: solo.id,
+          }))!.bookable_alone,
         ).toBe(false);
       });
     });

--- a/test/integration/server/groups/edit-delete.test.ts
+++ b/test/integration/server/groups/edit-delete.test.ts
@@ -274,16 +274,11 @@ describeWithEnv("server (admin groups) — edit & delete", { db: true }, () => {
       const cookie = await testCookie();
       const csrfToken = await testCsrfToken();
 
+      // The confirm page still loads the group; by the time the delete itself
+      // checks the row is there, it has gone.
       const { groups } = await import("#shared/db/groups.ts");
-      const original = groups.table.read.one.bind(groups.table.read);
-      let calls = 0;
-      const readStub = stub(
-        groups.table.read,
-        "one",
-        (...args: Parameters<typeof original>) => {
-          calls++;
-          return calls === 1 ? original(...args) : Promise.resolve(null);
-        },
+      const readStub = stub(groups.table.read, "exists", () =>
+        Promise.resolve(false),
       );
 
       try {

--- a/test/integration/server/listings-create.test.ts
+++ b/test/integration/server/listings-create.test.ts
@@ -108,6 +108,8 @@ describeWithEnv("server listings > create", { db: true }, () => {
     test("still creates when the read-back replica lags the just-committed write", async () => {
       // The primary read-back succeeds even while an optional replica read
       // still misses the newly committed row.
+      // The optional replica read misses the row; the primary read-back the
+      // create path actually uses must still find it.
       const readStub = stub(listingsTable.read, "one", () =>
         Promise.resolve(null),
       );

--- a/test/integration/server/listings-error-pages.test.ts
+++ b/test/integration/server/listings-error-pages.test.ts
@@ -168,21 +168,23 @@ describeWithEnv(
           name: "Listing For Delete Err",
         });
 
-        // Spy on the listing read: return the row on first call (so requireExists
-        // passes), but also delete the listing from DB so getListingWithCount
-        // (raw SQL) returns null.
-        const originalRead = listingsTable.read.one.bind(listingsTable.read);
-        const readStub = stub(listingsTable.read, "one", async (filter) => {
-          const row = await originalRead(filter);
-          if (row) {
+        // Spy on the existence check: say the listing is there (so requireExists
+        // passes), but delete it from the DB on the way past so
+        // getListingWithCount (raw SQL) returns null.
+        const originalExists = listingsTable.read.exists.bind(
+          listingsTable.read,
+        );
+        const readStub = stub(listingsTable.read, "exists", async (filter) => {
+          const found = await originalExists(filter);
+          if (found) {
             // Delete the listing from DB so getListingWithCount returns null
             await getDb().execute({
-              args: [row.id],
+              args: [Number(filter?.id)],
               sql: "DELETE FROM listings WHERE id = ?",
             });
             invalidateListingsCache();
           }
-          return row;
+          return found;
         });
 
         try {
@@ -195,7 +197,7 @@ describeWithEnv(
               name: "",
             },
           );
-          // requireExists sees the row (first read). Validation fails (empty name).
+          // requireExists sees the row (first check). Validation fails (empty name).
           // listingErrorPage calls getListingWithCount, but listing was deleted, so returns 404.
           expect(response.status).toBe(404);
         } finally {
@@ -212,11 +214,11 @@ describeWithEnv(
         });
 
         // handleAdminListingEditPost calls getListingWithCount (raw SQL), then
-        // updateResource.update which checks the nullable by-key read.
+        // updateResource.update which checks whether the row is still there.
         // Return null to simulate the listing being deleted
         // between the initial check and the update.
-        const readStub2 = stub(listingsTable.read, "one", () =>
-          Promise.resolve(null),
+        const readStub2 = stub(listingsTable.read, "exists", () =>
+          Promise.resolve(false),
         );
 
         try {

--- a/test/shared/db/attendee-statuses.test.ts
+++ b/test/shared/db/attendee-statuses.test.ts
@@ -76,6 +76,65 @@ describeWithEnv("db > attendee statuses", { db: true }, () => {
     expect(seed.sort_order).toBe(0);
   });
 
+  test("the seeded status is the word an operator sees", async () => {
+    // The name is what an attendee's status reads as until anyone renames it,
+    // so it has to be a real word rather than blank.
+    expect(DEFAULT_ATTENDEE_STATUS_NAME).toBe("Confirmed");
+  });
+
+  test("saving a status that is not a default leaves it alone", async () => {
+    const other = await attendeeStatuses.table.insert({
+      name: "Waitlist",
+      sortOrder: 1,
+    });
+
+    // It holds neither default, and is not being asked to take one, so there
+    // is nothing to refuse — only a status giving a default UP is refused.
+    const saved = await attendeeStatusWrites.save(
+      other.id,
+      statusInput("Waitlist renamed"),
+    );
+
+    expect(saved.ok).toBe(true);
+    expect((await getAttendeeStatus(other.id))?.name).toBe("Waitlist renamed");
+  });
+
+  test("a default status may be saved while keeping its defaults", async () => {
+    const seed = (await attendeeStatuses.getAll())[0]!;
+
+    // Keeping a default is not giving it up, so this must save rather than be
+    // refused for leaving the site without one.
+    const saved = await attendeeStatusWrites.save(
+      seed.id,
+      statusInput("Still confirmed", {
+        isPaidDefault: true,
+        isPublicDefault: true,
+      }),
+    );
+
+    expect(saved.ok).toBe(true);
+    expect((await getAttendeeStatus(seed.id))?.name).toBe("Still confirmed");
+  });
+
+  test("a new status taking the defaults takes them off the old one", async () => {
+    const seed = (await attendeeStatuses.getAll())[0]!;
+
+    const created = await attendeeStatusWrites.save(
+      null,
+      statusInput("Now the default", {
+        isPaidDefault: true,
+        isPublicDefault: true,
+      }),
+    );
+
+    expect(created.ok).toBe(true);
+    // Two statuses claiming the same default is the state this must never
+    // leave behind — the old one gives them up as the new one takes them.
+    const previous = await getAttendeeStatus(seed.id);
+    expect(previous?.is_public_default).toBe(false);
+    expect(previous?.is_paid_default).toBe(false);
+  });
+
   test("required default status lookups return the seed", async () => {
     const [pub, paid] = await Promise.all([
       requirePublicDefaultStatus(),

--- a/test/shared/db/built-sites/crud.test.ts
+++ b/test/shared/db/built-sites/crud.test.ts
@@ -56,9 +56,14 @@ describeWithEnv("built-sites CRUD table", { db: true }, () => {
     );
   });
 
-  test("refuses to pick out some of a site's fields", () => {
+  test("refuses to hand back anything but a whole, opened site", () => {
+    // Some of its columns, or a statement whose rows nobody has opened, would
+    // both be a site the caller cannot actually read.
     expect(() => builtSitesCrudTable.read.pick(["name"])).toThrow(
-      "stored in one encrypted blob",
+      "can only hand back whole, opened sites",
+    );
+    expect(() => builtSitesCrudTable.read.statement({ id: 1 })).toThrow(
+      "can only hand back whole, opened sites",
     );
   });
 

--- a/test/shared/db/table-reader/filters.test.ts
+++ b/test/shared/db/table-reader/filters.test.ts
@@ -7,7 +7,10 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { attributesTable } from "#shared/db/attributes.ts";
+import { rawListingsTable } from "#shared/db/listings/table.ts";
+import { col, defineTable } from "#shared/db/table.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 
 describeWithEnv("db > table reader > filters", { db: true }, () => {
   const attributes = attributesTable.read;
@@ -84,6 +87,13 @@ describeWithEnv("db > table reader > filters", { db: true }, () => {
     expect(row).toEqual({ name: "Filtered" });
   });
 
+  test("existence is a yes-or-no, not a row", async () => {
+    const made = await add("There");
+
+    expect(await attributes.exists({ id: made.id })).toBe(true);
+    expect(await attributes.exists({ id: made.id + 1000 })).toBe(false);
+  });
+
   test("refuses to filter on a column stored in another form", async () => {
     await add("Sealed");
 
@@ -95,3 +105,59 @@ describeWithEnv("db > table reader > filters", { db: true }, () => {
     );
   });
 });
+
+describeWithEnv(
+  "db > table reader > a table with worked-out values",
+  { db: true },
+  () => {
+    // listings works its image values out from other tables: they are in a
+    // Listing, but they are not columns of `listings`.
+    test("refuses even a single worked-out value", () => {
+      // One is enough to make a whole-row read a lie, so the refusal must not
+      // wait for a second.
+      const oneWorkedOut = defineTable<
+        { id: number; worked_out: string },
+        never
+      >({
+        name: "attributes",
+        primaryKey: "id",
+        schema: {
+          id: col.generated<number>(),
+          worked_out: col.projected<string>(() => "from elsewhere"),
+        },
+      });
+
+      expect(() => oneWorkedOut.read.many()).toThrow(
+        "attributes has values that are not stored columns (worked_out)",
+      );
+    });
+
+    test("refuses a whole-row read it could not answer honestly", () => {
+      // Every value it could not have returned is named, and named apart, so
+      // the reader is told exactly what to ask for instead.
+      const refusal =
+        "listings has values that are not stored columns (image_alt_text, image_thumb_url, image_url, day_prices)";
+
+      expect(() => rawListingsTable.read.many()).toThrow(refusal);
+      expect(() => rawListingsTable.read.one({ id: 1 })).toThrow(refusal);
+    });
+
+    test("refuses a filter naming a value it does not store", () => {
+      // Without this the read would reach the database as
+      // `WHERE image_url = ?` and fail there on a column listings has never
+      // had — a mistake worth catching as the call is made.
+      expect(() =>
+        rawListingsTable.read.pick(["id"]).many({ image_url: "x" }),
+      ).toThrow(
+        "Cannot filter listings by image_url: it is not one of its columns",
+      );
+    });
+
+    test("still answers whether a row is there", async () => {
+      const listing = await createTestListing({ name: "Findable" });
+
+      expect(await rawListingsTable.read.exists({ id: listing.id })).toBe(true);
+      expect(await rawListingsTable.read.exists({ id: 999_999 })).toBe(false);
+    });
+  },
+);

--- a/test/shared/db/table-reader/reads.test.ts
+++ b/test/shared/db/table-reader/reads.test.ts
@@ -6,6 +6,7 @@
 
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { getDb, resultRows } from "#shared/db/client.ts";
 import {
   listingOptionColumns,
   rawListingsTable,
@@ -99,6 +100,22 @@ describeWithEnv("db > table reader > reads", { db: true }, () => {
       ).toBeNull();
       expect(getQueryLog()).toEqual([]);
     });
+  });
+
+  test("hands out the same read as a statement, to run elsewhere", async () => {
+    const wanted = await createTestListing({ name: "Batched" });
+    await createTestListing({ name: "Other" });
+
+    // A caller inside its own transaction runs the statement itself, and opens
+    // the rows with the very same chosen set — so it cannot drift from what
+    // `many` would have read.
+    const statement = listingOptionColumns.statement({ id: wanted.id });
+    const rows = await listingOptionColumns.readAll(
+      resultRows(await getDb().execute(statement)),
+    );
+
+    expect(rows).toEqual(await listingOptionColumns.many({ id: wanted.id }));
+    expect(rows.map(({ id }) => id)).toEqual([wanted.id]);
   });
 
   test("clauses the row shape cannot say narrow the read too", async () => {


### PR DESCRIPTION
Follow-up to #2015. It fixes two things review found in that change, and then moves across the reads that were waiting on the fix.

## Two reads a table could not answer honestly

Both were caught by Codex on #2015, and both are right.

**A filter could name something the table does not store.** A listing's image values are worked out from another table — they are part of a listing, but not columns of `listings`. The filter accepted them anyway, and the read reached the database asking for a column it has never had. The filter now checks each column against the table, the same check that choosing columns already made, so this is caught as the call is written.

**A whole-row read promised more than it selected.** It said it returned a whole listing while selecting only stored columns, so a listing came back with its image values missing even though its type says they are there. The refusal for those tables is back.

I dropped that refusal in #2015 believing it could not survive, because the shared admin CRUD path reads any table by key and would have hit it on a normal listing edit. That was wrong about what the CRUD path needs: it only asks *whether the row is there* and throws the row away. It now asks a new `read.exists`, which fetches just the key — so a table with worked-out values answers it fine, and every other table stops decrypting a full row to answer a yes-or-no.

## Reads that can now go through the table

A read can also be handed out as a statement, for the callers this reader could not reach: ones that must run inside an already-open write transaction, or as one leg of a batch. Those had all kept hand-written SQL, with column lists nothing checked against the table.

Nine reads moved across:

- The site-page and question existence checks that run inside their own write transactions
- The activity log — three reads folded onto one declared order, one of them a leg of a batch
- Email templates, and the groups cache
- The status defaults a status write reads back about itself, which now arrive as the booleans they are declared to be rather than as 1 and 0

## Testing

`deno task precommit` passes: lint, typecheck, duplicate check, copy check, edge build, full suite at 100% coverage.

Both fixes have a regression test that reproduces the reported case, each confirmed to fail with its fix removed. Mutation testing kills every mutant of the reader (19/19) and of attendee-statuses (71/71) — the latter including four gaps in the status default rules that predate this change: keeping a default while renaming, saving a status that holds no default, and a new default status taking the flags off the old one. Mutation testing also found genuinely dead code in my own new `exists`, since removed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145jX1UQn15ZvXtkoqNz1pe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary data retrieval during existence checks and common database reads.
  * Improved efficiency for activity logs, groups, email templates, and related records while preserving existing ordering and limits.

* **Reliability**
  * Improved handling of partially selected or unavailable data during database operations.
  * Strengthened validation for attendee statuses and site-related records.

* **Bug Fixes**
  * Improved consistency of missing-record handling, including clearer not-found responses in race-condition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->