### PR TITLE
Prove a guessed promo code tells the customer nothing

### DIFF
--- a/specs/payments/booking-with-a-discount-code.feature
+++ b/specs/payments/booking-with-a-discount-code.feature
@@ -62,6 +62,7 @@ Feature: A customer books with a discount code
       When a customer asks the price of a Pottery place with the code "TENOFF"
       Then the summary total is 10.00
       And the summary shows no discount line
+      And the summary never names "TENOFF"
 
   @rule:payments.the-books-remember-what-a-code-was-used-for
   @surface:webhook

--- a/specs/payments/booking-with-a-discount-code.feature
+++ b/specs/payments/booking-with-a-discount-code.feature
@@ -63,6 +63,7 @@ Feature: A customer books with a discount code
       Then the summary total is 10.00
       And the summary shows no discount line
       And the summary never names "TENOFF"
+      And the summary reads exactly as it does for a Pottery place with no code
 
   @rule:payments.the-books-remember-what-a-code-was-used-for
   @surface:webhook

--- a/test/specs/steps/discount-codes.ts
+++ b/test/specs/steps/discount-codes.ts
@@ -105,6 +105,13 @@ Then("the summary shows no discount line", function (this: TicketsWorld): void {
   expect(priceSummary(this)).not.toContain("-£");
 });
 
+Then(
+  "the summary never names {string}",
+  function (this: TicketsWorld, code: string): void {
+    expect(priceSummary(this)).not.toContain(code);
+  },
+);
+
 When(
   "a customer books a {word} place with the code {string} and pays",
   codeJourney(customerPaysWithCode),

--- a/test/specs/steps/discount-codes.ts
+++ b/test/specs/steps/discount-codes.ts
@@ -11,6 +11,7 @@ import {
   expectDiscountLine,
   organiserCreatesCode,
   priceSummary,
+  quoteFor,
   summaryTotal,
 } from "#test/specs/support/discount-codes.ts";
 import { sellPlacesAt } from "#test/specs/support/money.ts";
@@ -109,6 +110,15 @@ Then(
   "the summary never names {string}",
   function (this: TicketsWorld, code: string): void {
     expect(priceSummary(this)).not.toContain(code);
+  },
+);
+
+Then(
+  "the summary reads exactly as it does for a {word} place with no code",
+  async function (this: TicketsWorld, listing: string): Promise<void> {
+    // Word for word the same answer as someone who typed nothing gets: not
+    // even a general "we don't know that code" can hide in the difference.
+    expect(priceSummary(this)).toBe(await quoteFor(this, listing, ""));
   },
 );
 

--- a/test/specs/support/discount-codes.ts
+++ b/test/specs/support/discount-codes.ts
@@ -15,7 +15,10 @@ import { fillInAndSend } from "#test/specs/support/form-controls.ts";
 import { listingNamed } from "#test/specs/support/listings.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
 import { openBookingPage } from "#test/specs/support/public-booking.ts";
-import type { TicketsWorld } from "#test/specs/support/world.ts";
+import {
+  requiredWorldValue,
+  type TicketsWorld,
+} from "#test/specs/support/world.ts";
 import { completePaidCheckout } from "#test-utils/order-journey.ts";
 import { setupStripe } from "#test-utils/settings.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
@@ -89,7 +92,9 @@ const fromBookingPage =
   };
 
 /** The customer fills the booking page in with a code and presses the page's
- * own "Show total" button. What came back is kept for the summary steps. */
+ * own "Show total" button. Only the summary table is kept: the form around it
+ * still holds whatever the customer typed, which is not the site telling them
+ * anything about it. */
 export const customerAsksPrice = fromBookingPage(
   async (world, browser, code) => {
     await fillInAndSend(
@@ -97,7 +102,16 @@ export const customerAsksPrice = fromBookingPage(
       { ...CUSTOMER, promo_code: code },
       "Show total",
     );
-    world.things.remember("told", "price summary", browser.currentHtml);
+    world.things.remember(
+      "told",
+      "price summary",
+      requiredWorldValue(
+        browser.currentHtml.match(
+          /<table class="order-summary">[\s\S]*?<\/table>/,
+        )?.[0],
+        "the price summary",
+      ),
+    );
   },
 );
 

--- a/test/specs/support/discount-codes.ts
+++ b/test/specs/support/discount-codes.ts
@@ -18,6 +18,7 @@ import { openBookingPage } from "#test/specs/support/public-booking.ts";
 import {
   keepsAnswerAs,
   requiredWorldValue,
+  type StoryJourney,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
 import { completePaidCheckout } from "#test-utils/order-journey.ts";
@@ -109,15 +110,20 @@ const askForTotal = async (
   return browser.currentHtml;
 };
 
+/** What every customer journey here is told: which listing, and the code the
+ * customer typed into the box (empty when they typed none). */
+type APlaceAndACode = [listingName: string, code: string];
+
 /** What the site answers when a place's price is asked for with a code — or,
  * with the code left empty, without one. */
-export const quoteFor = fromBookingPage((_world, browser, code) =>
-  askForTotal(browser, code),
+export const quoteFor: StoryJourney<APlaceAndACode, string> = fromBookingPage(
+  (_world, browser, code) => askForTotal(browser, code),
 );
 
 /** The customer asks what a place costs with the code they hold, and keeps
  * the answer for the story to read. */
-export const customerAsksPrice = keepsAnswerAs("price summary", quoteFor);
+export const customerAsksPrice: StoryJourney<APlaceAndACode, void> =
+  keepsAnswerAs("price summary", quoteFor);
 
 /** The summary the customer was last shown. */
 export const priceSummary = (world: TicketsWorld): string =>
@@ -135,8 +141,8 @@ export const summaryTotal = (world: TicketsWorld): string => {
 /** The customer books with a code and pays. The booking page's own form
  * builds the checkout, and the payment completes through the provider — so
  * the code the customer typed is the one the books record. */
-export const customerPaysWithCode = fromBookingPage(
-  async (_world, browser, code) => {
+export const customerPaysWithCode: StoryJourney<APlaceAndACode, void> =
+  fromBookingPage(async (_world, browser, code) => {
     const captured: { intent: unknown } = { intent: null };
     const sessionId = "cs_discount_code";
     const checkoutStub = stub(
@@ -166,8 +172,7 @@ export const customerPaysWithCode = fromBookingPage(
       captured.intent as Parameters<typeof completePaidCheckout>[0],
       sessionId,
     );
-  },
-);
+  });
 
 /** The exact money words the story's own numbers come to, e.g. "£9.00". */
 export const asMoney = (pounds: string): string =>

--- a/test/specs/support/discount-codes.ts
+++ b/test/specs/support/discount-codes.ts
@@ -16,6 +16,7 @@ import { listingNamed } from "#test/specs/support/listings.ts";
 import { minorUnits } from "#test/specs/support/money.ts";
 import { openBookingPage } from "#test/specs/support/public-booking.ts";
 import {
+  keepsAnswerAs,
   requiredWorldValue,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
@@ -71,18 +72,18 @@ const CUSTOMER = { email: "quoter@example.com", name: "Quote Asker" };
  * stands ready, the page is opened, and the rest is what the journey does
  * with the code the customer holds. */
 const fromBookingPage =
-  (
+  <Answer>(
     journey: (
       world: TicketsWorld,
       browser: TestBrowser,
       code: string,
-    ) => Promise<void>,
+    ) => Promise<Answer>,
   ) =>
   async (
     world: TicketsWorld,
     listingName: string,
     code: string,
-  ): Promise<void> => {
+  ): Promise<Answer> => {
     await setupStripe();
     return journey(
       world,
@@ -91,29 +92,32 @@ const fromBookingPage =
     );
   };
 
-/** The customer fills the booking page in with a code and presses the page's
- * own "Show total" button. Only the summary table is kept: the form around it
- * still holds whatever the customer typed, which is not the site telling them
- * anything about it. */
-export const customerAsksPrice = fromBookingPage(
-  async (world, browser, code) => {
-    await fillInAndSend(
-      browser,
-      { ...CUSTOMER, promo_code: code },
-      "Show total",
-    );
-    world.things.remember(
-      "told",
-      "price summary",
-      requiredWorldValue(
-        browser.currentHtml.match(
-          /<table class="order-summary">[\s\S]*?<\/table>/,
-        )?.[0],
-        "the price summary",
-      ),
-    );
-  },
+/** Fill the booking page in with a code and press its own "Show total"
+ * button. What comes back is the site's whole answer, kept as sent — a word
+ * beside the table is as much a disclosure as a word inside it. */
+const askForTotal = async (
+  browser: TestBrowser,
+  code: string,
+): Promise<string> => {
+  await fillInAndSend(browser, { ...CUSTOMER, promo_code: code }, "Show total");
+  // A quote with no table is the site refusing to total the order, so the
+  // story stops here rather than reading a refusal as a summary.
+  requiredWorldValue(
+    browser.currentHtml.match(/<table class="order-summary">/)?.[0],
+    "the price summary",
+  );
+  return browser.currentHtml;
+};
+
+/** What the site answers when a place's price is asked for with a code — or,
+ * with the code left empty, without one. */
+export const quoteFor = fromBookingPage((_world, browser, code) =>
+  askForTotal(browser, code),
 );
+
+/** The customer asks what a place costs with the code they hold, and keeps
+ * the answer for the story to read. */
+export const customerAsksPrice = keepsAnswerAs("price summary", quoteFor);
 
 /** The summary the customer was last shown. */
 export const priceSummary = (world: TicketsWorld): string =>

--- a/test/specs/support/site-pages.ts
+++ b/test/specs/support/site-pages.ts
@@ -18,6 +18,7 @@ import {
   type ActOnOneThing,
   type AsksAboutOneThing,
   asksIfThereIs,
+  keepsAnswerAs,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
 import { adminFormPost } from "#test-utils/session.ts";
@@ -171,17 +172,10 @@ export const ownerTakesPageDown: TakesOneThingDown = takesDownFromList(
 
 /** The owner tries to take a page down, and what they were told is kept for
  * the step that reads it back. */
-export const ownerTriesToTakePageDown = async (
-  world: TicketsWorld,
-  name: string,
-  typed: string,
-): Promise<void> => {
-  world.things.remember(
-    "told",
-    OWNER,
-    await ownerTakesPageDown(world, name, typed),
-  );
-};
+export const ownerTriesToTakePageDown = keepsAnswerAs(
+  OWNER,
+  ownerTakesPageDown,
+);
 
 /** What the owner was told the last time they wrote a page. */
 export const whatOwnerWasTold = (world: TicketsWorld): string =>

--- a/test/specs/support/site-pages.ts
+++ b/test/specs/support/site-pages.ts
@@ -19,6 +19,7 @@ import {
   type AsksAboutOneThing,
   asksIfThereIs,
   keepsAnswerAs,
+  type StoryJourney,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
 import { adminFormPost } from "#test-utils/session.ts";
@@ -172,10 +173,10 @@ export const ownerTakesPageDown: TakesOneThingDown = takesDownFromList(
 
 /** The owner tries to take a page down, and what they were told is kept for
  * the step that reads it back. */
-export const ownerTriesToTakePageDown = keepsAnswerAs(
-  OWNER,
-  ownerTakesPageDown,
-);
+export const ownerTriesToTakePageDown: StoryJourney<
+  [name: string, typed: string],
+  void
+> = keepsAnswerAs(OWNER, ownerTakesPageDown);
 
 /** What the owner was told the last time they wrote a page. */
 export const whatOwnerWasTold = (world: TicketsWorld): string =>

--- a/test/specs/support/world.test.ts
+++ b/test/specs/support/world.test.ts
@@ -8,8 +8,10 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { namedThings } from "#test/specs/support/memory.ts";
 import {
   asksIfThereIs,
+  keepsAnswerAs,
   stillThere,
   type TicketsWorld,
   theBooking,
@@ -79,6 +81,29 @@ describe("the story's shared lookups", () => {
       });
       await asks(worldWith({}), "Parking");
       expect(asked).toEqual(["Parking"]);
+    });
+  });
+
+  describe("keeping what a journey answered", () => {
+    const worldRemembering = (): TicketsWorld =>
+      worldWith({ things: namedThings() });
+
+    test("keeps the answer under the name the story reads it by", async () => {
+      const world = worldRemembering();
+      await keepsAnswerAs("price summary", () => Promise.resolve("£9.00"))(
+        world,
+      );
+      expect(world.things.require("told", "price summary")).toBe("£9.00");
+    });
+
+    test("hands the journey the world and everything after it", async () => {
+      const given: unknown[] = [];
+      const world = worldRemembering();
+      await keepsAnswerAs("page", (...args: unknown[]) => {
+        given.push(...args);
+        return Promise.resolve("gone");
+      })(world, "Directions", "directions");
+      expect(given).toEqual([world, "Directions", "directions"]);
     });
   });
 });

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -169,15 +169,23 @@ export const addDatabaseCleanup = (
   world.cleanup.add(clearEncryptionKey, cleanupDb);
 };
 
+/** Something a story does to the site: told the world it works in and
+ * whatever else that journey needs, answering with words — a price summary,
+ * what the site said — or with nothing at all. */
+export type StoryJourney<Args extends unknown[], Answer> = (
+  world: TicketsWorld,
+  ...args: Args
+) => Promise<Answer>;
+
 /** Wrap a journey that answers with words, so the answer is kept under the
  * name the story reads it back by. The journey itself stays about doing the
  * thing; remembering what came back is this one step's job. */
 export const keepsAnswerAs =
   <Args extends unknown[]>(
     name: string,
-    journey: (world: TicketsWorld, ...args: Args) => Promise<string>,
-  ) =>
-  async (world: TicketsWorld, ...args: Args): Promise<void> => {
+    journey: StoryJourney<Args, string>,
+  ): StoryJourney<Args, void> =>
+  async (world, ...args) => {
     world.things.remember("told", name, await journey(world, ...args));
   };
 

--- a/test/specs/support/world.ts
+++ b/test/specs/support/world.ts
@@ -169,6 +169,18 @@ export const addDatabaseCleanup = (
   world.cleanup.add(clearEncryptionKey, cleanupDb);
 };
 
+/** Wrap a journey that answers with words, so the answer is kept under the
+ * name the story reads it back by. The journey itself stays about doing the
+ * thing; remembering what came back is this one step's job. */
+export const keepsAnswerAs =
+  <Args extends unknown[]>(
+    name: string,
+    journey: (world: TicketsWorld, ...args: Args) => Promise<string>,
+  ) =>
+  async (world: TicketsWorld, ...args: Args): Promise<void> => {
+    world.things.remember("told", name, await journey(world, ...args));
+  };
+
 export const requiredWorldValue = <Value>(
   value: Value | null | undefined,
   name: string,


### PR DESCRIPTION
Follow-up to #2017, from a Codex review point on that pull request.

## The gap

The discount-code story has a rule saying a code that matches nothing buys nothing **and** gives nothing away — someone guessing at codes should not be able to tell a real one from a made-up one. The story only checked that no negative amount appeared on the price summary, so three ways of breaking that rule would still have passed:

- a discount row named after the guess but worth £0.00,
- a message naming the guess ("we don't know TENOFF"), and
- a general message that never names it ("that code was not found").

All three tell a guesser whether they were close.

## What this changes

The quote step keeps the site's whole answer to "Show total", and insists that answer holds a summary table — so a refusal to quote can never be read as a summary. Two new steps then close the rule:

```gherkin
When a customer asks the price of a Pottery place with the code "TENOFF"
Then the summary total is 10.00
And the summary shows no discount line
And the summary never names "TENOFF"
And the summary reads exactly as it does for a Pottery place with no code
```

The last step asks the same price again with the code box left empty and demands the two answers match word for word. Nothing a guesser could read anything into survives that.

I checked the comparison fails for the right reason: with the site temporarily emitting "That code was not found" only when an unmatched code was typed, the total, no-discount-line and never-names steps all still passed — only the new step failed.

## A merge along the way

Two helpers were doing the same job in different words: one ran a price quote and kept the answer, another ran a page deletion and kept the answer. They are now a single `keepsAnswerAs` in the shared story support, which turned both call sites into one line each. It carries its own direct unit tests, because a story is never allowed to be the only thing covering a line here.

No behaviour changed and no site code was touched — this only makes an existing rule provable.

## Checks

Full precommit green: typecheck, lint, duplication at zero, copy checks, edge build, and the whole suite with 100% line and branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199Psv4jd85ZgQst3nGYXA7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or ignored discount codes no longer appear in booking summaries.
  * Invalid discount codes now produce the same summary as a booking without a discount code.

* **Tests**
  * Added coverage for discount-code handling and summary consistency.
  * Expanded journey tests to verify response preservation and stored results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->