### PR TITLE
Cap the session cache so junk cookies cannot grow it forever

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,11 +53,6 @@ operators own the risk of choosing deliberately hostile third-party endpoints.
   context into the shared request handler so production rate limits do not fall
   back to one global bucket. Add direct entrypoint tests that prove two client
   IPs do not share a limiter row.
-- **Bound the invalid-session cache.** `src/features/auth.ts` negative-caches
-  arbitrary invalid session cookies in process memory. Give that cache a size
-  cap or time-based sweep that removes entries without waiting for the same bad
-  token to be seen again, and test that unique junk cookies cannot grow it
-  without bound.
 - **Stop cross-origin redirects from replaying secrets or PII.** The shared
   fetch path in `src/shared/safe-fetch.ts` is used by registration webhooks and
   SMS delivery. Do not let a cross-origin redirect replay attendee data,

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -464,14 +464,23 @@ export type TtlCache<K, V> = {
   size: () => number;
 };
 
+/** How many entries a ttlCache may hold before the oldest is dropped. Caches
+ * built on it are best-effort, so dropping an entry only costs a re-fetch —
+ * the cap is what stops attacker-chosen keys (e.g. unique junk session
+ * cookies) growing the map without bound. */
+export const TTL_CACHE_MAX_ENTRIES = 1000;
+
 /**
  * Create a TTL (Time-To-Live) cache.
  * Entries expire after ttlMs milliseconds.
  * Accepts an optional clock function for testing.
+ * Holds at most maxEntries entries: storing a new key at the cap drops the
+ * oldest-stored entry first.
  */
 export const ttlCache = <K, V>(
   ttlMs: number,
   now: () => number = Date.now,
+  maxEntries: number = TTL_CACHE_MAX_ENTRIES,
 ): TtlCache<K, V> => {
   const cache = new Map<K, { value: V; cachedAt: number }>();
   return {
@@ -488,6 +497,11 @@ export const ttlCache = <K, V>(
       return entry.value;
     },
     set: (key: K, value: V): void => {
+      if (cache.size >= maxEntries && !cache.has(key)) {
+        // The Map keeps insertion order, so the first key is the oldest entry.
+        const oldest = cache.keys().next();
+        if (!oldest.done) cache.delete(oldest.value);
+      }
       cache.set(key, { cachedAt: now(), value });
     },
     size: (): number => cache.size,

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -464,23 +464,21 @@ export type TtlCache<K, V> = {
   size: () => number;
 };
 
-/** How many entries a ttlCache may hold before the oldest is dropped. Caches
- * built on it are best-effort, so dropping an entry only costs a re-fetch —
- * the cap is what stops attacker-chosen keys (e.g. unique junk session
- * cookies) growing the map without bound. */
-export const TTL_CACHE_MAX_ENTRIES = 1000;
-
 /**
  * Create a TTL (Time-To-Live) cache.
  * Entries expire after ttlMs milliseconds.
  * Accepts an optional clock function for testing.
- * Holds at most maxEntries entries: storing a new key at the cap drops the
- * oldest-stored entry first.
+ * Give maxEntries a value to bound the cache: storing a new key at the cap
+ * drops the oldest-stored entry first. Bound any cache whose keys can be
+ * chosen from outside (e.g. unknown session cookies), so a flood of unique
+ * keys cannot grow it without limit. Leave it unset for caches whose keyspace
+ * our own data already bounds — the keyed entity caches rely on holding every
+ * row of their table.
  */
 export const ttlCache = <K, V>(
   ttlMs: number,
   now: () => number = Date.now,
-  maxEntries: number = TTL_CACHE_MAX_ENTRIES,
+  maxEntries?: number,
 ): TtlCache<K, V> => {
   const cache = new Map<K, { value: V; cachedAt: number }>();
   return {
@@ -497,8 +495,10 @@ export const ttlCache = <K, V>(
       return entry.value;
     },
     set: (key: K, value: V): void => {
-      if (cache.size >= maxEntries && !cache.has(key)) {
-        // The Map keeps insertion order, so the first key is the oldest entry.
+      // Deleting first re-inserts a refreshed key at the newest position, so
+      // the Map's first key is always the oldest-stored entry.
+      cache.delete(key);
+      if (maxEntries !== undefined && cache.size >= maxEntries) {
         const oldest = cache.keys().next();
         if (!oldest.done) cache.delete(oldest.value);
       }

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -29,7 +29,7 @@ import type { Session } from "#shared/types.ts";
  * without bound.
  */
 const SESSION_CACHE_TTL_MS = 10_000;
-export const SESSION_CACHE_MAX_ENTRIES = 1000;
+const SESSION_CACHE_MAX_ENTRIES = 1000;
 const sessionCache = ttlCache<string, Session | null>(
   SESSION_CACHE_TTL_MS,
   () => Date.now(),

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -2,6 +2,7 @@
  * Sessions table operations
  */
 
+import { ttlCache } from "#fp";
 import {
   type CacheInvalidation,
   registerCache,
@@ -23,41 +24,35 @@ import type { Session } from "#shared/types.ts";
 /**
  * Session cache with TTL (10 seconds)
  * Reduces DB queries for repeated session lookups within the TTL window.
- * Cache entries: { session, cachedAt }
+ * The entry cap matters here: misses are cached too (a null entry per unknown
+ * token), so without it a flood of unique junk cookies would grow the map
+ * without bound.
  */
 const SESSION_CACHE_TTL_MS = 10_000;
-type CacheEntry = { session: Session | null; cachedAt: number };
-const sessionCache = new Map<string, CacheEntry>();
+const sessionCache = ttlCache<string, Session | null>(
+  SESSION_CACHE_TTL_MS,
+  () => Date.now(),
+);
 const primaryRefill = createPrimaryCacheRefill();
 
-registerCache(() => ({ entries: sessionCache.size, name: "sessions" }));
+registerCache(() => ({ entries: sessionCache.size(), name: "sessions" }));
 
 /**
  * Get cached session if still valid
  */
 const getCachedSession = (token: string): Session | null | undefined => {
   const entry = sessionCache.get(token);
-  if (!entry) return;
-
-  if (Date.now() - entry.cachedAt > SESSION_CACHE_TTL_MS) {
-    sessionCache.delete(token);
-    return;
-  }
-
-  // Also check if the session itself has expired
-  if (entry.session && Date.now() > entry.session.expires) {
-    sessionCache.delete(token);
-    return;
-  }
-
-  return entry.session;
+  // A session that expired mid-window is a miss: the DB read that follows
+  // overwrites the entry, so it is not served again.
+  if (entry && Date.now() > entry.expires) return;
+  return entry;
 };
 
 /**
  * Cache a session lookup result
  */
 const cacheSession = (token: string, session: Session | null): void => {
-  sessionCache.set(token, { cachedAt: Date.now(), session });
+  sessionCache.set(token, session);
 };
 
 /**

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -29,9 +29,11 @@ import type { Session } from "#shared/types.ts";
  * without bound.
  */
 const SESSION_CACHE_TTL_MS = 10_000;
+export const SESSION_CACHE_MAX_ENTRIES = 1000;
 const sessionCache = ttlCache<string, Session | null>(
   SESSION_CACHE_TTL_MS,
   () => Date.now(),
+  SESSION_CACHE_MAX_ENTRIES,
 );
 const primaryRefill = createPrimaryCacheRefill();
 

--- a/test/fp/caches.test.ts
+++ b/test/fp/caches.test.ts
@@ -7,6 +7,7 @@ import {
   firstMatch,
   lazyRef,
   once,
+  TTL_CACHE_MAX_ENTRIES,
   ttlCache,
 } from "#fp";
 
@@ -257,6 +258,40 @@ describe("fp caches and resources", () => {
       expect(cache.get("q")).toBe(2);
       cache.clear();
       expect(cache.size()).toBe(0);
+    });
+
+    test("drops the oldest entry when a new key arrives at the cap", () => {
+      const cache = ttlCache<string, number>(1000, () => 0, 2);
+      cache.set("first", 1);
+      cache.set("second", 2);
+      cache.set("third", 3);
+      expect(cache.size()).toBe(2);
+      expect(cache.get("first")).toBe(undefined);
+      expect(cache.get("second")).toBe(2);
+      expect(cache.get("third")).toBe(3);
+    });
+
+    test("re-storing a known key at the cap evicts nothing", () => {
+      const cache = ttlCache<string, number>(1000, () => 0, 2);
+      cache.set("keep", 1);
+      cache.set("update", 2);
+      cache.set("update", 20);
+      expect(cache.size()).toBe(2);
+      expect(cache.get("keep")).toBe(1);
+      expect(cache.get("update")).toBe(20);
+    });
+
+    test("holds no more than the default cap of entries", () => {
+      const cache = ttlCache<number, number>(1000, () => 0);
+      for (let i = 0; i < TTL_CACHE_MAX_ENTRIES + 10; i++) {
+        cache.set(i, i);
+      }
+      expect(cache.size()).toBe(TTL_CACHE_MAX_ENTRIES);
+      // The newest entries survive; the earliest were dropped to make room.
+      expect(cache.get(0)).toBe(undefined);
+      expect(cache.get(TTL_CACHE_MAX_ENTRIES + 9)).toBe(
+        TTL_CACHE_MAX_ENTRIES + 9,
+      );
     });
   });
 

--- a/test/fp/caches.test.ts
+++ b/test/fp/caches.test.ts
@@ -7,7 +7,6 @@ import {
   firstMatch,
   lazyRef,
   once,
-  TTL_CACHE_MAX_ENTRIES,
   ttlCache,
 } from "#fp";
 
@@ -281,17 +280,26 @@ describe("fp caches and resources", () => {
       expect(cache.get("update")).toBe(20);
     });
 
-    test("holds no more than the default cap of entries", () => {
+    test("a refreshed entry is not the one evicted at the cap", () => {
+      const cache = ttlCache<string, number>(1000, () => 0, 2);
+      cache.set("refreshed", 1);
+      cache.set("stale", 2);
+      // Storing an existing key again makes it the newest entry, so the next
+      // eviction takes the other one.
+      cache.set("refreshed", 10);
+      cache.set("new", 3);
+      expect(cache.get("stale")).toBe(undefined);
+      expect(cache.get("refreshed")).toBe(10);
+      expect(cache.get("new")).toBe(3);
+    });
+
+    test("grows without limit when no cap is given", () => {
       const cache = ttlCache<number, number>(1000, () => 0);
-      for (let i = 0; i < TTL_CACHE_MAX_ENTRIES + 10; i++) {
+      for (let i = 0; i < 1010; i++) {
         cache.set(i, i);
       }
-      expect(cache.size()).toBe(TTL_CACHE_MAX_ENTRIES);
-      // The newest entries survive; the earliest were dropped to make room.
-      expect(cache.get(0)).toBe(undefined);
-      expect(cache.get(TTL_CACHE_MAX_ENTRIES + 9)).toBe(
-        TTL_CACHE_MAX_ENTRIES + 9,
-      );
+      expect(cache.size()).toBe(1010);
+      expect(cache.get(0)).toBe(0);
     });
   });
 

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -2,7 +2,6 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
-import { TTL_CACHE_MAX_ENTRIES } from "#fp";
 import {
   getAllCacheStats,
   invalidateCachesForTable,
@@ -16,6 +15,7 @@ import {
   deleteSession,
   getAllSessions,
   getSession,
+  SESSION_CACHE_MAX_ENTRIES,
 } from "#shared/db/sessions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { withEnv } from "#test-utils/env.ts";
@@ -243,13 +243,13 @@ describeWithEnv("db > sessions", { db: true }, () => {
   test("unique invalid tokens cannot grow the session cache without bound", async () => {
     invalidateCachesForTable("sessions");
 
-    const probes = TTL_CACHE_MAX_ENTRIES + 100;
+    const probes = SESSION_CACHE_MAX_ENTRIES + 100;
     for (let i = 0; i < probes; i++) {
       expect(await getSession(`junk-cookie-${i}`)).toBeNull();
     }
 
     const stat = getAllCacheStats().find((s) => s.name === "sessions");
-    expect(stat?.entries).toBeLessThanOrEqual(TTL_CACHE_MAX_ENTRIES);
+    expect(stat?.entries).toBeLessThanOrEqual(SESSION_CACHE_MAX_ENTRIES);
   });
 
   test("registers a 'sessions' cache stat reflecting cached entries", async () => {

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -15,7 +15,6 @@ import {
   deleteSession,
   getAllSessions,
   getSession,
-  SESSION_CACHE_MAX_ENTRIES,
 } from "#shared/db/sessions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { withEnv } from "#test-utils/env.ts";
@@ -243,13 +242,16 @@ describeWithEnv("db > sessions", { db: true }, () => {
   test("unique invalid tokens cannot grow the session cache without bound", async () => {
     invalidateCachesForTable("sessions");
 
-    const probes = SESSION_CACHE_MAX_ENTRIES + 100;
+    // The bound this test pins is the session cache's documented contract:
+    // at most 1,000 entries (SESSION_CACHE_MAX_ENTRIES in sessions.ts).
+    const cap = 1000;
+    const probes = cap + 100;
     for (let i = 0; i < probes; i++) {
       expect(await getSession(`junk-cookie-${i}`)).toBeNull();
     }
 
     const stat = getAllCacheStats().find((s) => s.name === "sessions");
-    expect(stat?.entries).toBeLessThanOrEqual(SESSION_CACHE_MAX_ENTRIES);
+    expect(stat?.entries).toBeLessThanOrEqual(cap);
   });
 
   test("registers a 'sessions' cache stat reflecting cached entries", async () => {

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -174,6 +174,11 @@ describeWithEnv("db > sessions", { db: true }, () => {
     );
     expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-old");
 
+    // Midway through the window the entry is still served, so the TTL is a
+    // real span of time, not just "the same instant".
+    time.now = start + 5000;
+    expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-old");
+
     // Past the 10s TTL: the cache entry expires and the DB is re-read.
     time.now = start + 11000;
     expect((await getSession("ttl-requery"))?.csrf_token).toBe("csrf-new");

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -250,8 +250,10 @@ describeWithEnv("db > sessions", { db: true }, () => {
       expect(await getSession(`junk-cookie-${i}`)).toBeNull();
     }
 
+    // Exactly the cap: more would mean unbounded growth, fewer would mean
+    // the cache holds less than its documented contract.
     const stat = getAllCacheStats().find((s) => s.name === "sessions");
-    expect(stat?.entries).toBeLessThanOrEqual(cap);
+    expect(stat?.entries).toBe(cap);
   });
 
   test("registers a 'sessions' cache stat reflecting cached entries", async () => {

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
+import { TTL_CACHE_MAX_ENTRIES } from "#fp";
 import {
   getAllCacheStats,
   invalidateCachesForTable,
@@ -232,6 +233,18 @@ describeWithEnv("db > sessions", { db: true }, () => {
     const kept = await getSession("keep");
     expect(kept).not.toBeNull();
     expect(kept?.csrf_token).toBe("csrf-keep");
+  });
+
+  test("unique invalid tokens cannot grow the session cache without bound", async () => {
+    invalidateCachesForTable("sessions");
+
+    const probes = TTL_CACHE_MAX_ENTRIES + 100;
+    for (let i = 0; i < probes; i++) {
+      expect(await getSession(`junk-cookie-${i}`)).toBeNull();
+    }
+
+    const stat = getAllCacheStats().find((s) => s.name === "sessions");
+    expect(stat?.entries).toBeLessThanOrEqual(TTL_CACHE_MAX_ENTRIES);
   });
 
   test("registers a 'sessions' cache stat reflecting cached entries", async () => {


### PR DESCRIPTION
Closes the "Bound the invalid-session cache" item from TODO.md.

## What was wrong

The session lookup keeps a small in-memory cache so repeated reads of the same login cookie skip the database for ten seconds. It also remembers lookups that found nothing — one entry per unknown cookie. Nothing limited how many entries it could hold, so a flood of made-up cookies could grow that memory without bound. Old entries were only removed when the exact same cookie was looked up again, which junk cookies never are.

(The TODO item pointed at `src/features/auth.ts`, but the unbounded cache turned out to live in `src/shared/db/sessions.ts` — the auth-layer cache is per-request and cannot grow across requests.)

## What changed

- The shared `ttlCache` helper in `src/fp.ts` can now be given a cap: storing a new key at the cap drops the oldest-stored entry first, and storing a known key again moves it to the newest position so a fresh value is never the one dropped. The cap is opt-in — a cache without one behaves exactly as before, which the keyed entity caches rely on.
- The session cache in `src/shared/db/sessions.ts` was hand-rolling the exact same TTL logic, so it now uses the shared `ttlCache` with a 1,000-entry cap — one mechanism, less code, and the bound comes with it. These caches are best-effort, so dropping an entry only costs a re-fetch.

## Tests

- The regression: looking up 1,100 unique junk cookies leaves the session cache holding exactly its 1,000-entry cap (written first and confirmed failing at 1,100 entries before the fix).
- New `ttlCache` tests: the oldest entry is dropped at the cap, re-storing a known key evicts nothing, a refreshed entry is never the one evicted, and an uncapped cache stays unbounded.
- A strengthened session test proves cached entries are served for the whole ten-second window, not just the same instant.

`deno task precommit` passes, and `deno task mutation` kills every mutant in both changed modules (`src/fp.ts` and `src/shared/db/sessions.ts`).

TODO.md is updated: the completed item is removed.

All three Codex review points were addressed: the cap became opt-in so large entity tables cannot lose valid lookups, eviction order now respects refreshed entries, and the cap constant stays private to the session module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ehWXhDVAmSZFkKWVo4grA