### PR TITLE
Fix backup folder naming and freshness edge cases; strengthen the admin debug tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1076,28 +1076,6 @@ state.
 
 ---
 
-## Backup storage edge cases
-
-*Origin: CodeRabbit review of PR #1837.*
-
-PR #1837 only moves the existing backup storage helpers out of
-`src/shared/db/backup.ts`; it deliberately preserves their behavior. These
-possible behavior changes need separate decisions and regression tests:
-
-- **Keep every database namespace non-empty and distinct.** `dbName` in
-  `src/shared/db/backup-storage.ts` returns an empty name for a parseable local
-  `file:` URL and strips the first dashed part from non-Bunny hostnames. Decide
-  the supported URL schemes and hostnames, return a named local folder for local
-  URLs, and only remove Bunny DB's UUID prefix for `.lite.bunnydb.net`. Start
-  with tests for `file:database.db` and two distinct dashed HTTPS hostnames.
-- **Reject future-dated backups from the update gate.** `hasRecentBackup` in
-  `src/shared/db/backup-storage.ts` treats every future timestamp as recent
-  because its age is negative. Decide how much clock skew is acceptable, then
-  require a non-negative age (or a documented tolerance) before applying the
-  maximum age. Add a test with a future backup filename.
-
----
-
 ## Checkout stage attendee cleanup
 
 *Origin: Codex review of PR #1840.*

--- a/TODO.md
+++ b/TODO.md
@@ -1166,50 +1166,6 @@ of scope for #1873, and a starting point.*
   helpers to prove parity with the inline implementation.
 ---
 
-## Admin debug test coverage follow-ups
-
-*Origin: CodeRabbit review of PR #1875 ("Move admin debug tests and add a
-template rendering test"). PR #1875 is test-only: it `git mv`s
-`test/lib/server-debug*.test.ts` into `test/features/admin/debug/`, extracts
-shared state into `test/test-utils/debug.ts`, and adds a direct-rendering test.
-CodeRabbit raised two findings that are valid as code-quality observations but
-out of scope for that PR's brief — recorded here for a follow-up.*
-
-- **Inspect the Sentry test envelope, not only the request count.** In
-  `test/features/admin/debug/sentry.test.ts` (around lines 63-68), the
-  "sends a tagged test error and confirms delivery" test stubs `fetch` with the
-  shared `stubFetch` helper and asserts only that one request was made. It does
-  not prove the emitted event is tagged or carries the intended test-error
-  message. Replace the shared stub with a local fetch recorder inside that test,
-  then assert the captured Sentry envelope body contains the literal message
-  `"Test Sentry notification from the admin debug page."` and the
-  `source=admin-debug` / `test=true` tags (the literal values
-  `src/shared/sentry.ts` `sendSentryTest` writes today — keep them in sync with
-  that source when the follow-up lands). Retain the existing request-count,
-  redirect, and flash assertions. Starting point: read `sendSentryTest` in
-  `src/shared/sentry.ts` (lines ~74-101) to confirm the exact envelope values,
-  then look at `test/test-utils/fetch-stub.ts` to see what the shared stub
-  exposes today.
-- **Assert semantic debug sections, not CSS-class counts.** In
-  `test/ui/templates/admin/debug/rendering.test.tsx` (around lines 38-40), the
-  "keeps the debug navigation and section structure" test asserts the page
-  contains exactly 3 `class="prose"` and 13 `class="table-scroll"` occurrences.
-  Those counts couple the test to presentation wrappers, so a layout change can
-  fail it without changing page behaviour. PR #1875 carried these counts in
-  because the brief explicitly asked for them as the current-main contract; a
-  follow-up can replace them with assertions on the rendered section headings.
-  Keep the `href="/admin/debug"` link assertion. Maintain the expected heading
-  set as an explicit literal list inside the test (`t("debug.section.build")`,
-  `t("debug.section.runtime")`, etc.) — do **not** derive it from
-  `DEBUG_SECTIONS` in `src/ui/templates/admin/debug.tsx`: deriving the oracle
-  from the same source list the template renders against lets a removed or
-  renamed section pass undetected when both the rendering and the oracle shift
-  in lockstep. An independent literal list makes a section addition/removal/rename
-  a deliberate test review, which is the only way the test catches the failure
-  mode it is meant to catch.
-
----
-
 ## Recover paid SumUp checkouts without a webhook or redirect
 
 *Origin: follow-up to the SumUp provider work, surfaced 2026-07-25 while

--- a/src/shared/db/backup-storage.ts
+++ b/src/shared/db/backup-storage.ts
@@ -65,7 +65,7 @@ export const BACKUP_REQUIRED_WITHIN_MS = 60 * 60 * 1000;
  * a little ahead of ours; anything further ahead than this is not fresh, so a
  * wrongly future-dated file cannot satisfy the gate forever. Five minutes.
  */
-export const BACKUP_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const BACKUP_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
 /** True when a backup taken at `takenAtMs` satisfies the freshness gate at
  *  `nowMs`: younger than `maxAgeMs`, and no further ahead of the clock than

--- a/src/shared/db/backup-storage.ts
+++ b/src/shared/db/backup-storage.ts
@@ -12,23 +12,21 @@ export const isRemoteDatabase = (): boolean =>
 /**
  * Extract a short database name from DB_URL for use in backup filenames.
  * e.g. "libsql://01KFXB...-tickets-spencer.lite.bunnydb.net/" → "tickets-spencer"
- * For Turso URLs the full first hostname segment is used as-is (it is already
- * the unique database identity: "{db-name}-{org}.turso.io").
- * Falls back to "local" for non-remote or unparseable URLs.
+ * Only Bunny DB hostnames carry a UUID prefix to drop; every other remote host
+ * keeps its full first hostname segment (for Turso that is already the unique
+ * database identity: "{db-name}-{org}.turso.io"). Local and unparseable URLs
+ * are filed under "local", so backups never land in a nameless folder.
  */
 export const dbName = (url: string = requireEnv("DB_URL")): string => {
-  if (!URL.canParse(url)) return "local";
+  const host = databaseHostFor(url);
+  if (host === "local") return "local";
 
-  const host = new URL(url).hostname;
-  const first = host.split(".")[0]!;
-
-  // Turso hostnames: {db-name}-{org}.turso.io — the full first segment is unique
-  if (host.endsWith(".turso.io")) return first;
+  const first = new URL(url).hostname.split(".")[0]!;
+  if (host !== "bunny") return first;
 
   // Bunny DB hostnames: {uuid}-{name}.lite.bunnydb.net — drop the UUID prefix
   const dashIdx = first.indexOf("-");
-  if (dashIdx === -1) return first;
-  return first.slice(dashIdx + 1);
+  return dashIdx === -1 ? first : first.slice(dashIdx + 1);
 };
 
 /**
@@ -60,6 +58,26 @@ export const backupTimestamp = (date = new Date()): string =>
  * database was taken within this window. One hour.
  */
 export const BACKUP_REQUIRED_WITHIN_MS = 60 * 60 * 1000;
+
+/**
+ * How far ahead of our clock a backup's timestamp may sit and still count as
+ * fresh. Out-of-band backups are taken on other machines whose clocks can run
+ * a little ahead of ours; anything further ahead than this is not fresh, so a
+ * wrongly future-dated file cannot satisfy the gate forever. Five minutes.
+ */
+export const BACKUP_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+/** True when a backup taken at `takenAtMs` satisfies the freshness gate at
+ *  `nowMs`: younger than `maxAgeMs`, and no further ahead of the clock than
+ *  the skew allowance. */
+export const backupIsFresh = (
+  takenAtMs: number,
+  nowMs: number,
+  maxAgeMs: number,
+): boolean => {
+  const age = nowMs - takenAtMs;
+  return age >= -BACKUP_CLOCK_SKEW_MS && age < maxAgeMs;
+};
 
 /** ISO-8601-ish timestamp as it appears in a backup filename (":"/"." → "-"),
  *  with the date/time pieces captured so parseBackupTime can rebuild the real
@@ -110,7 +128,7 @@ export const hasRecentBackup = async (
     // pruneOldBackups).
     if (!isBackupPath(file)) continue;
     const ms = parseBackupTime(file);
-    if (ms !== null && now - ms < maxAgeMs) return true;
+    if (ms !== null && backupIsFresh(ms, now, maxAgeMs)) return true;
   }
   return false;
 };

--- a/test/features/admin/debug/sentry.test.ts
+++ b/test/features/admin/debug/sentry.test.ts
@@ -61,10 +61,35 @@ describeWithEnv("server (admin Sentry test)", { db: true }, () => {
   });
 
   test("sends a tagged test error and confirms delivery", async () => {
-    const { requests, response } = await sendAcceptedSentryTest();
-    expectDebugRedirect(response);
-    expectFlash(response, "Sentry test sent.");
-    expect(requests).toBe(1);
+    using _env = withEnv({ SENTRY_URL: SENTRY_DSN });
+    const envelopes: string[] = [];
+    using _fetchStub = stubFetch((_url, init) => {
+      const body = init?.body;
+      if (body === undefined || body === null) {
+        throw new Error("Sentry request had no body");
+      }
+      envelopes.push(
+        typeof body === "string"
+          ? body
+          : new TextDecoder().decode(body as BufferSource),
+      );
+      return new Response(null, { status: 200 });
+    });
+    try {
+      const { response } = await adminFormPost("/admin/debug/sentry");
+      expectDebugRedirect(response);
+      expectFlash(response, "Sentry test sent.");
+      // The exact values sendSentryTest (src/shared/sentry.ts) writes today —
+      // keep these literals in sync with that source.
+      expect(envelopes).toHaveLength(1);
+      expect(envelopes[0]).toContain(
+        "Test Sentry notification from the admin debug page.",
+      );
+      expect(envelopes[0]).toContain('"source":"admin-debug"');
+      expect(envelopes[0]).toContain('"test":"true"');
+    } finally {
+      resetSentry();
+    }
   });
 
   test("sends the diagnostic while the site is read-only", async () => {

--- a/test/shared/db/backup-storage.test.ts
+++ b/test/shared/db/backup-storage.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
-  BACKUP_CLOCK_SKEW_MS,
   BACKUP_REQUIRED_WITHIN_MS,
   backupDir,
   backupIsFresh,
@@ -187,6 +186,9 @@ describeWithEnv("backup storage", { db: true }, () => {
   describe("backupIsFresh", () => {
     const MAX = BACKUP_REQUIRED_WITHIN_MS;
     const NOW = 1_700_000_000_000;
+    // Deliberately restates the documented five-minute skew allowance rather
+    // than importing it, so changing the allowance is a conscious test edit.
+    const SKEW = 5 * 60 * 1000;
 
     test("fresh from the moment it is taken until the window closes", () => {
       expect(backupIsFresh(NOW, NOW, MAX)).toBe(true);
@@ -198,13 +200,11 @@ describeWithEnv("backup storage", { db: true }, () => {
     });
 
     test("tolerates a timestamp ahead of the clock up to the skew allowance", () => {
-      expect(backupIsFresh(NOW + BACKUP_CLOCK_SKEW_MS, NOW, MAX)).toBe(true);
+      expect(backupIsFresh(NOW + SKEW, NOW, MAX)).toBe(true);
     });
 
     test("rejects a timestamp further ahead than the skew allowance", () => {
-      expect(backupIsFresh(NOW + BACKUP_CLOCK_SKEW_MS + 1, NOW, MAX)).toBe(
-        false,
-      );
+      expect(backupIsFresh(NOW + SKEW + 1, NOW, MAX)).toBe(false);
     });
   });
 

--- a/test/shared/db/backup-storage.test.ts
+++ b/test/shared/db/backup-storage.test.ts
@@ -1,8 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  BACKUP_CLOCK_SKEW_MS,
   BACKUP_REQUIRED_WITHIN_MS,
   backupDir,
+  backupIsFresh,
   backupKey,
   backupLeaf,
   backupTimestamp,
@@ -62,6 +64,23 @@ describeWithEnv("backup storage", { db: true }, () => {
       expect(dbName("libsql://01ABC-client-acme.lite.bunnydb.net/")).toBe(
         "client-acme",
       );
+    });
+
+    test("files a parseable local file: URL under 'local'", () => {
+      // An empty name would put backups under a bare "/" folder.
+      expect(dbName("file:database.db")).toBe("local");
+    });
+
+    test("keeps the full first segment for hosts it does not recognise", () => {
+      // Only Bunny hostnames carry a UUID prefix to drop. Stripping the first
+      // dashed part from other hosts would file distinct databases in one
+      // folder — "alpha-db" and "beta-db" must not both become "db".
+      expect(dbName("https://alpha-db.example.com")).toBe("alpha-db");
+      expect(dbName("https://beta-db.example.com")).toBe("beta-db");
+    });
+
+    test("returns the full segment for a Bunny hostname with no dash", () => {
+      expect(dbName("libsql://tickets.lite.bunnydb.net")).toBe("tickets");
     });
   });
 
@@ -165,6 +184,30 @@ describeWithEnv("backup storage", { db: true }, () => {
     });
   });
 
+  describe("backupIsFresh", () => {
+    const MAX = BACKUP_REQUIRED_WITHIN_MS;
+    const NOW = 1_700_000_000_000;
+
+    test("fresh from the moment it is taken until the window closes", () => {
+      expect(backupIsFresh(NOW, NOW, MAX)).toBe(true);
+      expect(backupIsFresh(NOW - MAX + 1, NOW, MAX)).toBe(true);
+    });
+
+    test("no longer fresh exactly at the window edge", () => {
+      expect(backupIsFresh(NOW - MAX, NOW, MAX)).toBe(false);
+    });
+
+    test("tolerates a timestamp ahead of the clock up to the skew allowance", () => {
+      expect(backupIsFresh(NOW + BACKUP_CLOCK_SKEW_MS, NOW, MAX)).toBe(true);
+    });
+
+    test("rejects a timestamp further ahead than the skew allowance", () => {
+      expect(backupIsFresh(NOW + BACKUP_CLOCK_SKEW_MS + 1, NOW, MAX)).toBe(
+        false,
+      );
+    });
+  });
+
   describe("hasRecentBackup", () => {
     const seedBackup = (when: Date) =>
       uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp(when)));
@@ -214,6 +257,24 @@ describeWithEnv("backup storage", { db: true }, () => {
         true,
       );
       expect(await hasRecentBackup(60 * 60 * 1000, "tickets")).toBe(false);
+    });
+
+    test("a backup dated far in the future is not fresh", async () => {
+      // A wrongly future-dated file must not satisfy the gate — a negative
+      // age is not a young age.
+      using tmpDir = tempDir();
+      using _env = withEnv({ LOCAL_STORAGE_PATH: tmpDir.path });
+      await seedBackup(new Date(Date.now() + 24 * 60 * 60 * 1000));
+      expect(await hasRecentBackup()).toBe(false);
+    });
+
+    test("a backup dated slightly ahead of us still counts (clock skew)", async () => {
+      // Out-of-band backups come from machines whose clocks can run a
+      // little ahead; a just-taken backup must still open the gate.
+      using tmpDir = tempDir();
+      using _env = withEnv({ LOCAL_STORAGE_PATH: tmpDir.path });
+      await seedBackup(new Date(Date.now() + 60_000));
+      expect(await hasRecentBackup()).toBe(true);
     });
 
     test("false when no backups exist", async () => {

--- a/test/ui/templates/admin/debug/rendering.test.tsx
+++ b/test/ui/templates/admin/debug/rendering.test.tsx
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { t } from "#i18n";
+import { escapeHtml } from "#shared/jsx/escape-html.ts";
 import {
   adminDebugPage,
   SENTRY_TEST_FORM_ID,
@@ -32,12 +33,29 @@ const expectBadgeRow = (
 };
 
 describe("admin debug template rendering", () => {
-  test("keeps the debug navigation and section structure", () => {
+  test("keeps the debug navigation and every section heading", () => {
     const html = adminDebugPage(debugOwnerSession, makeDebugState());
 
     expect(html).toContain('href="/admin/debug"');
-    expect([...html.matchAll(/class="prose"/g)]).toHaveLength(2);
-    expect([...html.matchAll(/class="table-scroll"/g)]).toHaveLength(12);
+    // An independent literal list — deliberately not derived from the
+    // template's own section table, so a dropped or renamed section fails
+    // here instead of shifting both sides in lockstep.
+    const sectionKeys = [
+      "debug.section.build",
+      "debug.section.runtime",
+      "debug.section.site",
+      "debug.section.availability",
+      "debug.section.apple_wallet",
+      "debug.section.google_wallet",
+      "debug.section.payments",
+      "common.email",
+      "debug.section.notifications",
+      "debug.section.bunny",
+      "debug.section.database_domain",
+      "debug.section.limits",
+    ] as const;
+    const headings = [...html.matchAll(/<h2>(.*?)<\/h2>/g)].map((m) => m[1]);
+    expect(headings).toEqual(sectionKeys.map((key) => escapeHtml(t(key))));
   });
 
   test("shows every missing value in its own row", () => {


### PR DESCRIPTION
Knocks out two small TODO sections, each deleted from `TODO.md` in full.

## Backup storage edge cases (from the PR #1837 review)

**Every database now gets a proper, distinct backup folder.** `dbName` used to return an empty name for a parseable local `file:` URL (filing backups under a bare `/`), and it stripped the first dashed part from *every* hostname — so two different databases at `alpha-db.example.com` and `beta-db.example.com` would both be filed under `db`. It now reads the host kind from the shared `databaseHostFor` helper: local and unparseable URLs are filed under `local`, only Bunny DB hostnames have their UUID prefix dropped, and every other host keeps its full first hostname segment. Bunny and Turso names come out exactly as before.

**A backup dated in the future no longer counts as fresh forever.** The update gate blocks upgrades unless a backup was taken within the last hour, but `hasRecentBackup` only checked `now - takenAt < maxAge` — a wrongly future-dated file has a negative age, so it passed that check permanently. The freshness rule now lives in a pure `backupIsFresh` function that also rejects any timestamp more than five minutes ahead of the clock. The five-minute allowance keeps a just-taken backup valid when it was made on another machine whose clock runs slightly ahead; the allowance itself stays private to the module, and the tests restate it as their own literal so changing it is a conscious test edit.

Regression tests for all three broken cases were written first and confirmed failing before the fix, plus deterministic boundary tests on the pure `backupIsFresh`. Mutation score on the module: 58/58 killed.

## Admin debug test follow-ups (from the PR #1875 review)

Both are test-only assertion strengthenings:

- The admin Sentry test now records the envelope the page actually sends and checks the test message and its `source`/`test` tags, instead of only counting that one request happened.
- The debug page structure test now asserts the exact ordered list of section headings — an independent literal list, so a dropped, renamed, or added section is a conscious test edit — instead of counting presentation CSS classes. Writing that list immediately surfaced the Email section, which the old class counts said nothing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ehWXhDVAmSZFkKWVo4grA