### PR TITLE
Only strip the UUID prefix from Bunny lite hostnames, and keep the freshness helper private

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1588,9 +1588,12 @@ ones that noticed, because they are the ones that assert a failure. Worth
 looking at whether ports should be handed out so that no two tests in a run can
 ever receive the same one.
 
-It has since been seen once more, in `test/scripts/stripe-mock/lifecycle.test.ts`
+It has since been seen more, in `test/scripts/stripe-mock/lifecycle.test.ts`
 ("stops trying once the mock has been started as many times as asked", on CI for
-PR #1968), with a second symptom worth knowing about. That test counts how many
+PR #1968, and "gives a mock time to shut itself down before killing it", on CI
+for PR #2032 — the latter now hardened: the fixture notes when it wins its
+port, and the test retries on a fresh port when that note is missing), with a
+second symptom worth knowing about. That test counts how many
 times the fake mock was started and expects one start per try asked for. A try
 whose freshly picked port already has something listening on it is abandoned
 *before* the mock is started, so the count comes up short and the test fails —

--- a/src/shared/db/backup-storage.ts
+++ b/src/shared/db/backup-storage.ts
@@ -18,13 +18,15 @@ export const isRemoteDatabase = (): boolean =>
  * are filed under "local", so backups never land in a nameless folder.
  */
 export const dbName = (url: string = requireEnv("DB_URL")): string => {
-  const host = databaseHostFor(url);
-  if (host === "local") return "local";
+  if (databaseHostFor(url) === "local") return "local";
 
-  const first = new URL(url).hostname.split(".")[0]!;
-  if (host !== "bunny") return first;
+  const { hostname } = new URL(url);
+  const first = hostname.split(".")[0]!;
 
-  // Bunny DB hostnames: {uuid}-{name}.lite.bunnydb.net — drop the UUID prefix
+  // Only Bunny's lite connection addresses carry a UUID prefix to drop
+  // ({uuid}-{name}.lite.bunnydb.net); every other remote host keeps its
+  // full first hostname segment.
+  if (!hostname.endsWith(".lite.bunnydb.net")) return first;
   const dashIdx = first.indexOf("-");
   return dashIdx === -1 ? first : first.slice(dashIdx + 1);
 };
@@ -70,7 +72,7 @@ const BACKUP_CLOCK_SKEW_MS = 5 * 60 * 1000;
 /** True when a backup taken at `takenAtMs` satisfies the freshness gate at
  *  `nowMs`: younger than `maxAgeMs`, and no further ahead of the clock than
  *  the skew allowance. */
-export const backupIsFresh = (
+const backupIsFresh = (
   takenAtMs: number,
   nowMs: number,
   maxAgeMs: number,

--- a/test/scripts/stripe-mock/fixtures.ts
+++ b/test/scripts/stripe-mock/fixtures.ts
@@ -79,10 +79,14 @@ export const writeSlowToListenMock = async (
 /**
  * A mock that takes a moment to shut down when asked politely, and leaves a
  * note behind once it has. No note means it was killed before it could finish.
+ * It also notes when it wins its port: no bound note means the mock never got
+ * to run at all (something else took the port), which is a different story
+ * from being killed too early.
  */
 export const writeSlowToStopMock = async (
   paths: TestStripeMockPaths,
   notePath: string,
+  boundNotePath: string,
   shutdownMs = 200,
 ): Promise<void> => {
   await Deno.writeTextFile(
@@ -91,9 +95,9 @@ export const writeSlowToStopMock = async (
       "#!/bin/sh",
       `exec perl -MIO::Socket::INET -e '$SIG{TERM}=sub{ select(undef,undef,undef,${
         shutdownMs / 1000
-      }); open(my $fh, ">", $ARGV[2]); close $fh; exit 0 }; my $socket=IO::Socket::INET->new(LocalAddr=>"127.0.0.1", LocalPort=>$ARGV[1], Proto=>"tcp", Listen=>5, Reuse=>1) or die $!; while (1) { my $client=$socket->accept(); close $client if $client; }' -- "$@" ${shellQuote(
+      }); open(my $fh, ">", $ARGV[2]); close $fh; exit 0 }; my $socket=IO::Socket::INET->new(LocalAddr=>"127.0.0.1", LocalPort=>$ARGV[1], Proto=>"tcp", Listen=>5, Reuse=>1) or die $!; open(my $bound, ">", $ARGV[3]); close $bound; while (1) { my $client=$socket->accept(); close $client if $client; }' -- "$@" ${shellQuote(
         notePath,
-      )}`,
+      )} ${shellQuote(boundNotePath)}`,
     ].join("\n"),
   );
   await makeExecutable(paths.binaryPath);

--- a/test/scripts/stripe-mock/lifecycle.test.ts
+++ b/test/scripts/stripe-mock/lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   expectPortAvailable,
   expectPortOpen,
   expectStripeMockFails,
+  retryWhilePortTaken,
   withHeldPort,
   withUnusedPort,
 } from "#test/test-utils/stripe-mock/ports.ts";
@@ -94,26 +95,54 @@ describe("starting stripe-mock", () => {
 
   test("gives a mock time to shut itself down before killing it", async () => {
     await withTempStripeMockPaths(async (paths) => {
-      const note = join(paths.binDir, "stopped-cleanly");
-      await writeSlowToStopMock(paths, note);
+      let round = 0;
+      await retryWhilePortTaken(async () => {
+        // Fresh notes each round, so a leftover from an earlier stolen-port
+        // round can never speak for this one.
+        round += 1;
+        const note = join(paths.binDir, `stopped-cleanly-${round}`);
+        const bound = join(paths.binDir, `bound-${round}`);
+        await writeSlowToStopMock(paths, note, bound);
 
-      await withUnusedPort(async (port) => {
-        const stripeMock = await startStripeMock({
-          budgetMs: 1000,
-          delayMs: 10,
-          paths,
-          port,
-          // Far longer than the mock's shutdown, so a busy machine cannot make
-          // this read as an impatient stopper. A CI runner under two parallel
-          // suite runs has starved the mock past 10 seconds, so the allowance
-          // is generous — a healthy stop returns on exit, never on this timer.
-          stopTimeoutMs: 60_000,
+        let portWasTaken = false;
+        await withUnusedPort(async (port) => {
+          let stripeMock: Awaited<ReturnType<typeof startStripeMock>>;
+          try {
+            stripeMock = await startStripeMock({
+              budgetMs: 1000,
+              delayMs: 10,
+              paths,
+              port,
+              // Far longer than the mock's shutdown, so a busy machine cannot
+              // make this read as an impatient stopper. A CI runner under two
+              // parallel suite runs has starved the mock past 10 seconds, so
+              // the allowance is generous — a healthy stop returns on exit,
+              // never on this timer.
+              stopTimeoutMs: 60_000,
+            });
+          } catch (error) {
+            if (!String(error).includes(STRIPE_MOCK_FAILED_TO_START)) {
+              throw error;
+            }
+            // Our mock lost its port to another test between picking it and
+            // binding it, so it died without ever listening. Try again.
+            portWasTaken = true;
+            return;
+          }
+          if (!(await pathExists(bound))) {
+            // The start found something else already listening and adopted
+            // it — our mock never ran, so there is nothing to judge here.
+            await stripeMock.stop();
+            portWasTaken = true;
+            return;
+          }
+          await expectPortOpen(port);
+
+          await stripeMock.stop();
+
+          expect(await pathExists(note)).toBe(true);
         });
-        await expectPortOpen(port);
-
-        await stripeMock.stop();
-
-        expect(await pathExists(note)).toBe(true);
+        return portWasTaken;
       });
     });
   });

--- a/test/scripts/stripe-mock/lifecycle.test.ts
+++ b/test/scripts/stripe-mock/lifecycle.test.ts
@@ -95,6 +95,31 @@ describe("starting stripe-mock", () => {
 
   test("gives a mock time to shut itself down before killing it", async () => {
     await withTempStripeMockPaths(async (paths) => {
+      // Starts our mock on the port, or null when the start reports failure —
+      // our mock lost the port to another test between picking and binding
+      // it, so it died without ever listening. Any other error still throws.
+      const startOnPortOrNull = async (port: number) => {
+        try {
+          return await startStripeMock({
+            budgetMs: 1000,
+            delayMs: 10,
+            paths,
+            port,
+            // Far longer than the mock's shutdown, so a busy machine cannot
+            // make this read as an impatient stopper. A CI runner under two
+            // parallel suite runs has starved the mock past 10 seconds, so
+            // the allowance is generous — a healthy stop returns on exit,
+            // never on this timer.
+            stopTimeoutMs: 60_000,
+          });
+        } catch (error) {
+          if (!String(error).includes(STRIPE_MOCK_FAILED_TO_START)) {
+            throw error;
+          }
+          return null;
+        }
+      };
+
       let round = 0;
       await retryWhilePortTaken(async () => {
         // Fresh notes each round, so a leftover from an earlier stolen-port
@@ -106,33 +131,11 @@ describe("starting stripe-mock", () => {
 
         let portWasTaken = false;
         await withUnusedPort(async (port) => {
-          let stripeMock: Awaited<ReturnType<typeof startStripeMock>>;
-          try {
-            stripeMock = await startStripeMock({
-              budgetMs: 1000,
-              delayMs: 10,
-              paths,
-              port,
-              // Far longer than the mock's shutdown, so a busy machine cannot
-              // make this read as an impatient stopper. A CI runner under two
-              // parallel suite runs has starved the mock past 10 seconds, so
-              // the allowance is generous — a healthy stop returns on exit,
-              // never on this timer.
-              stopTimeoutMs: 60_000,
-            });
-          } catch (error) {
-            if (!String(error).includes(STRIPE_MOCK_FAILED_TO_START)) {
-              throw error;
-            }
-            // Our mock lost its port to another test between picking it and
-            // binding it, so it died without ever listening. Try again.
-            portWasTaken = true;
-            return;
-          }
-          if (!(await pathExists(bound))) {
-            // The start found something else already listening and adopted
-            // it — our mock never ran, so there is nothing to judge here.
-            await stripeMock.stop();
+          const stripeMock = await startOnPortOrNull(port);
+          // No bound note means our mock never got the port: the start found
+          // something else already listening and adopted it. Ask again.
+          if (stripeMock === null || !(await pathExists(bound))) {
+            await stripeMock?.stop();
             portWasTaken = true;
             return;
           }

--- a/test/shared/db/backup-storage.test.ts
+++ b/test/shared/db/backup-storage.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import {
   BACKUP_REQUIRED_WITHIN_MS,
   backupDir,
-  backupIsFresh,
   backupKey,
   backupLeaf,
   backupTimestamp,
@@ -71,11 +71,17 @@ describeWithEnv("backup storage", { db: true }, () => {
     });
 
     test("keeps the full first segment for hosts it does not recognise", () => {
-      // Only Bunny hostnames carry a UUID prefix to drop. Stripping the first
-      // dashed part from other hosts would file distinct databases in one
-      // folder — "alpha-db" and "beta-db" must not both become "db".
+      // Only Bunny's lite hostnames carry a UUID prefix to drop. Stripping
+      // the first dashed part from other hosts would file distinct databases
+      // in one folder — "alpha-db" and "beta-db" must not both become "db".
       expect(dbName("https://alpha-db.example.com")).toBe("alpha-db");
       expect(dbName("https://beta-db.example.com")).toBe("beta-db");
+    });
+
+    test("keeps the full first segment for a Bunny hostname outside the lite shape", () => {
+      // Only {uuid}-{name}.lite.bunnydb.net addresses carry a UUID prefix;
+      // any other Bunny-owned hostname must not lose its first dashed part.
+      expect(dbName("libsql://alpha-db.bunnydb.net")).toBe("alpha-db");
     });
 
     test("returns the full segment for a Bunny hostname with no dash", () => {
@@ -183,34 +189,45 @@ describeWithEnv("backup storage", { db: true }, () => {
     });
   });
 
-  describe("backupIsFresh", () => {
+  describe("hasRecentBackup", () => {
+    const seedBackup = (when: Date) =>
+      uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp(when)));
+
     const MAX = BACKUP_REQUIRED_WITHIN_MS;
-    const NOW = 1_700_000_000_000;
+    const NOW = new Date("2024-06-01T12:00:00.000Z").getTime();
     // Deliberately restates the documented five-minute skew allowance rather
     // than importing it, so changing the allowance is a conscious test edit.
     const SKEW = 5 * 60 * 1000;
 
-    test("fresh from the moment it is taken until the window closes", () => {
-      expect(backupIsFresh(NOW, NOW, MAX)).toBe(true);
-      expect(backupIsFresh(NOW - MAX + 1, NOW, MAX)).toBe(true);
+    // Pins the clock at NOW so the freshness boundaries are exact.
+    const gateWithBackupAt = async (takenAtMs: number): Promise<boolean> => {
+      using _time = new FakeTime(NOW);
+      using tmpDir = tempDir();
+      using _env = withEnv({ LOCAL_STORAGE_PATH: tmpDir.path });
+      await seedBackup(new Date(takenAtMs));
+      return await hasRecentBackup();
+    };
+
+    test("fresh from the moment it is taken until the window closes", async () => {
+      expect(await gateWithBackupAt(NOW)).toBe(true);
+      expect(await gateWithBackupAt(NOW - MAX + 1)).toBe(true);
     });
 
-    test("no longer fresh exactly at the window edge", () => {
-      expect(backupIsFresh(NOW - MAX, NOW, MAX)).toBe(false);
+    test("no longer fresh exactly at the window edge", async () => {
+      expect(await gateWithBackupAt(NOW - MAX)).toBe(false);
     });
 
-    test("tolerates a timestamp ahead of the clock up to the skew allowance", () => {
-      expect(backupIsFresh(NOW + SKEW, NOW, MAX)).toBe(true);
+    test("tolerates a backup dated ahead of the clock up to the skew allowance", async () => {
+      // Out-of-band backups come from machines whose clocks can run a
+      // little ahead; a just-taken backup must still open the gate.
+      expect(await gateWithBackupAt(NOW + SKEW)).toBe(true);
     });
 
-    test("rejects a timestamp further ahead than the skew allowance", () => {
-      expect(backupIsFresh(NOW + SKEW + 1, NOW, MAX)).toBe(false);
+    test("rejects a backup dated further ahead than the skew allowance", async () => {
+      // A wrongly future-dated file must not satisfy the gate — a negative
+      // age is not a young age.
+      expect(await gateWithBackupAt(NOW + SKEW + 1)).toBe(false);
     });
-  });
-
-  describe("hasRecentBackup", () => {
-    const seedBackup = (when: Date) =>
-      uploadRaw(new Uint8Array([1]), backupKey(backupTimestamp(when)));
 
     test("true when a backup is within the freshness window", async () => {
       using tmpDir = tempDir();
@@ -257,24 +274,6 @@ describeWithEnv("backup storage", { db: true }, () => {
         true,
       );
       expect(await hasRecentBackup(60 * 60 * 1000, "tickets")).toBe(false);
-    });
-
-    test("a backup dated far in the future is not fresh", async () => {
-      // A wrongly future-dated file must not satisfy the gate — a negative
-      // age is not a young age.
-      using tmpDir = tempDir();
-      using _env = withEnv({ LOCAL_STORAGE_PATH: tmpDir.path });
-      await seedBackup(new Date(Date.now() + 24 * 60 * 60 * 1000));
-      expect(await hasRecentBackup()).toBe(false);
-    });
-
-    test("a backup dated slightly ahead of us still counts (clock skew)", async () => {
-      // Out-of-band backups come from machines whose clocks can run a
-      // little ahead; a just-taken backup must still open the gate.
-      using tmpDir = tempDir();
-      using _env = withEnv({ LOCAL_STORAGE_PATH: tmpDir.path });
-      await seedBackup(new Date(Date.now() + 60_000));
-      expect(await hasRecentBackup()).toBe(true);
     });
 
     test("false when no backups exist", async () => {


### PR DESCRIPTION
Follow-ups from the Codex review of PR #2031 (which merged before these could ride along), plus a fix for the flaky test its CI run surfaced.

## What changed

**`dbName` strips the UUID prefix only from Bunny's lite connection addresses** (`{uuid}-{name}.lite.bunnydb.net`). PR #2031 keyed the stripping off the app-wide "is this host Bunny?" classification, which covers every `.bunnydb.net` hostname — so two hypothetical databases at `alpha-db.bunnydb.net` and `beta-db.bunnydb.net` would still have collapsed into one `db/` backup folder. The check now matches the exact lite hostname shape; every other Bunny-owned hostname keeps its full first segment like any other remote host. A regression test covers the non-lite Bunny case.

**`backupIsFresh` is module-private again.** Production only calls it inside `hasRecentBackup`, so the export served tests alone — exactly the test-only-export shape the repo rules say to remove. The freshness boundary tests (window edge, five-minute clock-skew allowance edge) now drive `hasRecentBackup` itself with a pinned `FakeTime` clock and real seeded backup files, which proves the same boundaries through the production read path.

**The slow-shutdown stripe-mock test retries when another test steals its port.** This PR's first CI run failed on `gives a mock time to shut itself down before killing it` — the known port-stealing race recorded in TODO.md, not a shutdown bug. The fixture now leaves a note once it wins its port; when that note is missing the mock never ran (the start adopted an intruder or lost the bind race), so the test asks again on a fresh port — the same recipe `expectStartFails` already uses. A missing stopped-cleanly note with the bound note present still fails, which is the real regression the test exists to catch.

## Tests

- All 50 backup-storage module tests pass; mutation score stays 58/58 with no recorded equivalents.
- All 76 stripe-mock script tests pass.
- The dead-export scanner, Biome strict lint, jscpd, and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ehWXhDVAmSZFkKWVo4grA