### PR TITLE
Count rate-limit attempts in one atomic statement per limiter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,29 @@
 # TODO — remaining follow-ups
 
+## Numbered SQL parameters — adopt the pattern beyond the limiters (from PR #2040)
+
+PR #2040 rewrote the two rate-limiter upserts (`src/shared/db/login-attempts.ts`,
+`src/shared/db/token-attempts.ts`) to use SQLite's numbered parameters
+(`?1`..`?6`), with each number given a named fragment constant (`NOW`,
+`TOKEN_LIMIT`, …) that the SQL template interpolates. That turned a 25-slot
+repeated positional args array into one value per meaning. Follow-ups:
+
+- **Sweep other multi-use statements.** Any statement that binds the same value
+  more than once is a candidate — look for args arrays that repeat a variable
+  (e.g. correlated subqueries in `src/shared/db/prune.ts` whose cutoff is bound
+  twice, and the bigger hand-built statements under `src/shared/db/`). Plain
+  single-use `?` statements are fine as they are.
+- **Consider a small define-style helper.** Something like
+  `defineStatement({ ip: v.string(), now: v.number() }, (p) => sql\`... ${p.ip}
+  ...\`)` could hand back `{ sql, bind({ip, now}) }` so the parameter order
+  lives in one place and callers pass an object instead of an ordered array —
+  the same schema-first shape as `defineTable`/`defineForm`. Only worth it if
+  the sweep finds enough call sites; two files may not justify the machinery.
+- Starting point: the fragment-constant pattern at the top of
+  `src/shared/db/token-attempts.ts`.
+
+---
+
 This file tracks work that was planned but **not yet done** when the root-level
 planning/design docs were retired (they had served their purpose once the bulk
 of each feature shipped). Each section is written to stand on its own — you

--- a/TODO.md
+++ b/TODO.md
@@ -39,15 +39,6 @@ current trust model. They assume Bunny Edge remains the production runtime,
 site owners are trusted with their own content and integrations, and deployment
 operators own the risk of choosing deliberately hostile third-party endpoints.
 
-- **Make rate-limit writes atomic and bounded.** `src/shared/db/login-attempts.ts`
-  and `src/shared/db/token-attempts.ts` update shared rows with read-then-write
-  sequences, so concurrent attempts can lose increments, and below-threshold
-  rows are not pruned. Fold the login, API-key, booking, address-lookup, and
-  token limiters onto one atomic update/prune shape, with regression tests that
-  drive concurrent attempts. (The expired-lockout cleanup race in
-  `src/shared/db/attempt-lockout.ts` is fixed: the delete is conditional on the
-  observed `locked_until`, so a fresh lockout survives cleanup —
-  `test/shared/db/attempt-lockout.test.ts` proves it.)
 - **Preserve the client IP in production request scopes.** `src/edge.ts`,
   `src/deploy.ts`, and `src/serve-app.ts` should carry the platform connection
   context into the shared request handler so production rate limits do not fall

--- a/src/shared/db/attempt-lockout.ts
+++ b/src/shared/db/attempt-lockout.ts
@@ -1,13 +1,46 @@
 /**
  * Shared pieces of the per-IP attempt tables (`login_attempts`,
  * `token_attempts`). Both key their rows by a hashed IP and lock the IP out
- * until a timestamp, so the lockout check (with expired-row cleanup) and the
- * row clear live here once; each table keeps its own counting rules.
+ * until a timestamp, so the lockout check (with expired-row cleanup), the
+ * atomic attempt recorder, and the row clear live here once; each table keeps
+ * its own counting rules inside its own single-statement upsert.
  */
 
+import type { InValue } from "@libsql/client";
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { deleteByField, execute } from "#shared/db/client.ts";
+import {
+  deleteByField,
+  execute,
+  executeReturningRow,
+  queryOne,
+} from "#shared/db/client.ts";
 import { nowMs } from "#shared/now.ts";
+
+type StoredLockout = { locked_until: number | null };
+
+/** Build a limiter's attempt recorder from its single-statement upsert. The
+ * statement must count the attempt AND decide the lockout inside the database
+ * (`INSERT … ON CONFLICT … RETURNING locked_until`), so two attempts arriving
+ * at once can never lose a count the way a read-then-write sequence could.
+ * The recorder returns true when the IP is now locked out. */
+export const makeAttemptRecorder =
+  (sql: string): ((args: InValue[]) => Promise<boolean>) =>
+  async (args: InValue[]): Promise<boolean> =>
+    (await executeReturningRow<StoredLockout>(sql, args)).locked_until !== null;
+
+/** Whether the IP's row in an attempts table holds an active lockout. Reads
+ * only the lockout column; a missing row (no attempts yet) reads as not
+ * limited, and an expired lockout is cleaned up on the way. */
+export const isIpLockedOut = async (
+  table: string,
+  hashedIp: string,
+): Promise<boolean> => {
+  const row = await queryOne<StoredLockout>(
+    `SELECT locked_until FROM ${table} WHERE ip = ?`,
+    [hashedIp],
+  );
+  return lockoutActive(table, hashedIp, row?.locked_until);
+};
 
 /** Build the "forget this IP" action for an attempts table: delete the IP's
  * row (found by its one-way hash). Used on success so legitimate users leave

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -771,6 +771,18 @@ export const useTransaction = <T>(
   transaction === undefined ? withTransaction(work) : work(transaction);
 
 /**
+ * Run a write that ends in `RETURNING` and read back the row it wrote. A
+ * write that returns no row means nothing was written — fail there, loudly.
+ */
+export const executeReturningRow = async <T>(
+  ...[sql, args]: SqlWithArgs
+): Promise<T> => {
+  const row = firstRowOrNull<T>(await execute(sql, args));
+  if (row === null) throw new Error(`Write returned no row: ${sql}`);
+  return row;
+};
+
+/**
  * The key of the row an `INSERT … RETURNING` wrote, read from the row itself
  * rather than from the driver's optional `lastInsertRowid`. Every generated key
  * is a positive integer, so anything else means nothing downstream can be keyed

--- a/src/shared/db/login-attempts.ts
+++ b/src/shared/db/login-attempts.ts
@@ -5,79 +5,66 @@
  * abuse-prone entry points (e.g. public booking). Each call site namespaces its
  * counters with a `prefix` so they never collide — a booking flood can't lock
  * anyone out of logging in, and vice versa. Rows whose lockout has expired are
- * removed on the next check and by database pruning; counter-only rows (no
- * lockout) are left to be overwritten by the next attempt from that IP.
+ * removed on the next check and by database pruning; counter-only rows carry a
+ * `last_attempt` stamp so pruning can remove the stale ones.
  */
 
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { clearAttemptsFor, lockoutActive } from "#shared/db/attempt-lockout.ts";
-import { execute, queryOne } from "#shared/db/client.ts";
+import {
+  clearAttemptsFor,
+  isIpLockedOut,
+  makeAttemptRecorder,
+} from "#shared/db/attempt-lockout.ts";
 import { LOGIN_LOCKOUT_MS, MAX_LOGIN_ATTEMPTS } from "#shared/limits.ts";
 import { nowMs } from "#shared/now.ts";
 
-type LoginAttemptRow = { attempts: number; locked_until: number | null };
+/** One statement counts the attempt and applies the lockout: the VALUES arm
+ * covers an IP's first attempt, the conflict arm every later one, and both
+ * decide the lockout inside the database — concurrent attempts each land as
+ * their own increment instead of overwriting a shared read. */
+const RECORD_ATTEMPT_SQL = `
+  INSERT INTO login_attempts (ip, attempts, locked_until, last_attempt)
+  VALUES (?, 1, CASE WHEN 1 >= ? THEN ? ELSE NULL END, ?)
+  ON CONFLICT (ip) DO UPDATE SET
+    attempts = login_attempts.attempts + 1,
+    locked_until = CASE
+      WHEN login_attempts.attempts + 1 >= ? THEN ?
+      ELSE NULL
+    END,
+    last_attempt = ?
+  RETURNING locked_until`;
 
-/** Hash the prefixed IP and query its attempt row, then apply the handler */
-const withHashedIpAttempts = async <T>(
-  ip: string,
-  prefix: string,
-  handler: (hashedIp: string, row: LoginAttemptRow | null) => Promise<T>,
-): Promise<T> => {
-  const hashedIp = await hmacHash(`${prefix}${ip}`);
-  const row = await queryOne<LoginAttemptRow>(
-    "SELECT attempts, locked_until FROM login_attempts WHERE ip = ?",
-    [hashedIp],
-  );
-  return handler(hashedIp, row);
-};
-
-/** Check if lockout is active, resetting expired locks. A missing row (no
- * attempts yet) reads as not limited. */
-const checkLockout = (
-  hashedIp: string,
-  row: LoginAttemptRow | null,
-): Promise<boolean> =>
-  lockoutActive("login_attempts", hashedIp, row?.locked_until);
-
-/** Build an attempt recorder with the given threshold/lockout window. */
-const makeRecordAttempt =
-  (maxAttempts: number, lockoutMs: number) =>
-  async (hashedIp: string, row: LoginAttemptRow | null): Promise<boolean> => {
-    const newAttempts = (row?.attempts ?? 0) + 1;
-
-    if (newAttempts >= maxAttempts) {
-      const lockedUntil = nowMs() + lockoutMs;
-      await execute(
-        "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)",
-        [hashedIp, newAttempts, lockedUntil],
-      );
-      return true;
-    }
-
-    await execute(
-      "INSERT OR REPLACE INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, NULL)",
-      [hashedIp, newAttempts],
-    );
-    return false;
-  };
+const recordAttempt = makeAttemptRecorder(RECORD_ATTEMPT_SQL);
 
 /**
  * Check whether an IP (namespaced by `prefix`) is currently locked out.
  */
-const isIpRateLimited = (ip: string, prefix: string): Promise<boolean> =>
-  withHashedIpAttempts(ip, prefix, checkLockout);
+const isIpRateLimited = async (ip: string, prefix: string): Promise<boolean> =>
+  isIpLockedOut("login_attempts", await hmacHash(`${prefix}${ip}`));
 
 /**
  * Record one attempt for an IP (namespaced by `prefix`), locking it out for
  * `lockoutMs` once `maxAttempts` is reached. Returns true if now locked.
  */
-const recordIpAttempt = (
+const recordIpAttempt = async (
   ip: string,
   prefix: string,
   maxAttempts: number,
   lockoutMs: number,
-): Promise<boolean> =>
-  withHashedIpAttempts(ip, prefix, makeRecordAttempt(maxAttempts, lockoutMs));
+): Promise<boolean> => {
+  const hashedIp = await hmacHash(`${prefix}${ip}`);
+  const current = nowMs();
+  const lockedUntil = current + lockoutMs;
+  return recordAttempt([
+    hashedIp,
+    maxAttempts,
+    lockedUntil,
+    current,
+    maxAttempts,
+    lockedUntil,
+    current,
+  ]);
+};
 
 /**
  * Build a namespaced per-IP limiter: `isLimited` checks the lockout,

--- a/src/shared/db/login-attempts.ts
+++ b/src/shared/db/login-attempts.ts
@@ -21,17 +21,19 @@ import { nowMs } from "#shared/now.ts";
 /** One statement counts the attempt and applies the lockout: the VALUES arm
  * covers an IP's first attempt, the conflict arm every later one, and both
  * decide the lockout inside the database — concurrent attempts each land as
- * their own increment instead of overwriting a shared read. */
+ * their own increment instead of overwriting a shared read.
+ * Numbered parameters: ?1 hashed IP · ?2 the attempt limit · ?3 the lockout
+ * deadline · ?4 now. */
 const RECORD_ATTEMPT_SQL = `
   INSERT INTO login_attempts (ip, attempts, locked_until, last_attempt)
-  VALUES (?, 1, CASE WHEN 1 >= ? THEN ? ELSE NULL END, ?)
+  VALUES (?1, 1, CASE WHEN 1 >= ?2 THEN ?3 ELSE NULL END, ?4)
   ON CONFLICT (ip) DO UPDATE SET
     attempts = login_attempts.attempts + 1,
     locked_until = CASE
-      WHEN login_attempts.attempts + 1 >= ? THEN ?
+      WHEN login_attempts.attempts + 1 >= ?2 THEN ?3
       ELSE NULL
     END,
-    last_attempt = ?
+    last_attempt = ?4
   RETURNING locked_until`;
 
 const recordAttempt = makeAttemptRecorder(RECORD_ATTEMPT_SQL);
@@ -54,16 +56,8 @@ const recordIpAttempt = async (
 ): Promise<boolean> => {
   const hashedIp = await hmacHash(`${prefix}${ip}`);
   const current = nowMs();
-  const lockedUntil = current + lockoutMs;
-  return recordAttempt([
-    hashedIp,
-    maxAttempts,
-    lockedUntil,
-    current,
-    maxAttempts,
-    lockedUntil,
-    current,
-  ]);
+  // One value per numbered parameter, in ?1..?4 order.
+  return recordAttempt([hashedIp, maxAttempts, current + lockoutMs, current]);
 };
 
 /**

--- a/src/shared/db/migrations/2026-08-04_login_attempt_stamp.ts
+++ b/src/shared/db/migrations/2026-08-04_login_attempt_stamp.ts
@@ -1,0 +1,19 @@
+import { schemaMigration } from "./define.ts";
+
+export default schemaMigration(
+  "2026-08-04_login_attempt_stamp",
+  "Track when each login-attempt row was last touched.",
+  {
+    columns: { login_attempts: ["last_attempt"] },
+    indexes: ["idx_login_attempts_last_attempt"],
+  },
+  async ({ getDb }) => {
+    // Rows written before this release have no stamp. Start their clock at
+    // the migration, so existing counters age out one retention period from
+    // now instead of being pruned on the first maintenance run.
+    await getDb().execute({
+      args: [Date.now()],
+      sql: "UPDATE login_attempts SET last_attempt = ? WHERE last_attempt = 0",
+    });
+  },
+);

--- a/src/shared/db/migrations/registry.ts
+++ b/src/shared/db/migrations/registry.ts
@@ -397,6 +397,10 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     "2026-07-26_payment_records",
     () => import("./2026-07-26_payment_records.ts"),
   ),
+  entry(
+    "2026-08-04_login_attempt_stamp",
+    () => import("./2026-08-04_login_attempt_stamp.ts"),
+  ),
 ];
 /* jscpd:ignore-end */
 

--- a/src/shared/db/migrations/schema/tables-core.ts
+++ b/src/shared/db/migrations/schema/tables-core.ts
@@ -280,11 +280,16 @@ export const coreTables: [name: string, table: Table][] = [
         ["ip", "TEXT PRIMARY KEY"],
         ["attempts", "INTEGER NOT NULL DEFAULT 0"],
         ["locked_until", "INTEGER"],
+        ["last_attempt", "INTEGER NOT NULL DEFAULT 0"],
       ],
       indexes: [
         {
           columns: ["locked_until"],
           name: "idx_login_attempts_locked_until",
+        },
+        {
+          columns: ["last_attempt"],
+          name: "idx_login_attempts_last_attempt",
         },
       ],
     },

--- a/src/shared/db/migrations/schema/version.ts
+++ b/src/shared/db/migrations/schema/version.ts
@@ -1,6 +1,7 @@
 /** Schema version label and the migrations bookkeeping table name. */
 
-export const LATEST_UPDATE = "Add the tables one payment record lives in.";
+export const LATEST_UPDATE =
+  "Track when each login-attempt row was last touched.";
 
 export const SCHEMA_MIGRATIONS_TABLE = "schema_migrations";
 export const LATEST_DB_UPDATE_KEY = "latest_db_update";

--- a/src/shared/db/prune.ts
+++ b/src/shared/db/prune.ts
@@ -91,8 +91,9 @@ const pruneStatements = (): PruneStatement[] => [
   ]),
   boundedDelete(
     "login_attempts",
-    "locked_until IS NOT NULL AND locked_until < ?",
-    [nowMs() - PRUNE_LOGINS_RETENTION_MS],
+    `(locked_until IS NOT NULL AND locked_until < ?)
+        OR (locked_until IS NULL AND last_attempt < ?)`,
+    [nowMs() - PRUNE_LOGINS_RETENTION_MS, nowMs() - PRUNE_LOGINS_RETENTION_MS],
   ),
   boundedDelete("token_attempts", "last_attempt < ?", [
     nowMs() - PRUNE_TOKENS_RETENTION_MS,

--- a/src/shared/db/token-attempts.ts
+++ b/src/shared/db/token-attempts.ts
@@ -8,7 +8,9 @@
  *
  * Data stored per IP (hashed):
  *   - recent_tokens: JSON array of hashed tokens in the current window (max
- *     MAX_TOKEN_404S entries; cleared to "[]" once locked).
+ *     MAX_TOKEN_404S entries; cleared to "[]" once locked). Only ever written
+ *     by the single recording statement below, which merges inside the
+ *     database — the stored set is never read back into JS.
  *   - window_start: ms-epoch when the current counting window began. When
  *     now - window_start exceeds TOKEN_WINDOW_MS the window tumbles and the
  *     counter resets.
@@ -21,43 +23,71 @@
  */
 
 /* jscpd:ignore-start */
-import * as v from "valibot";
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { clearAttemptsFor, lockoutActive } from "#shared/db/attempt-lockout.ts";
-import { execute, queryOne } from "#shared/db/client.ts";
+import {
+  clearAttemptsFor,
+  isIpLockedOut,
+  makeAttemptRecorder,
+} from "#shared/db/attempt-lockout.ts";
 import {
   MAX_TOKEN_404S,
   TOKEN_LOCKOUT_MS,
   TOKEN_WINDOW_MS,
 } from "#shared/limits.ts";
 import { nowMs } from "#shared/now.ts";
-import { defineStoredJson } from "#shared/validation/stored-json.ts";
 
 /* jscpd:ignore-end */
 
-type TokenAttemptRow = {
-  recent_tokens: string;
-  locked_until: number | null;
-  window_start: number;
-};
+/** The stored tokens that still count: the saved set while the window is
+ * live, an empty set once the window has tumbled. Params: now, window ms. */
+const LIVE_TOKENS = `CASE
+  WHEN ? - token_attempts.window_start > ? THEN '[]'
+  ELSE token_attempts.recent_tokens
+END`;
 
-const recentTokensJson = defineStoredJson(v.array(v.string()));
+/** The live tokens and this request's tokens as one set (UNION removes
+ * duplicates, so retries of a known token never grow the set).
+ * Params: now, window ms, new-tokens JSON. */
+const UNION_TOKENS = `(
+  SELECT value FROM json_each(${LIVE_TOKENS})
+  UNION
+  SELECT value FROM json_each(?)
+) AS hashedToken`;
 
-const readRow = (hashedIp: string): Promise<TokenAttemptRow | null> =>
-  queryOne<TokenAttemptRow>(
-    "SELECT recent_tokens, locked_until, window_start FROM token_attempts WHERE ip = ?",
-    [hashedIp],
-  );
+const MERGED_COUNT = `(SELECT count(*) FROM ${UNION_TOKENS})`;
+const MERGED_JSON = `(SELECT json_group_array(hashedToken.value) FROM ${UNION_TOKENS})`;
+
+/** One statement tumbles the window, merges the new tokens, and applies the
+ * lockout — all inside the database, so two failures arriving at once can
+ * never lose each other's tokens. Once the merged set reaches the limit the
+ * stored set is cleared to "[]" (no fingerprint kept while locked). */
+const RECORD_FAILURE_SQL = `
+  INSERT INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt)
+  VALUES (
+    ?,
+    CASE WHEN json_array_length(?) >= ? THEN '[]' ELSE ? END,
+    CASE WHEN json_array_length(?) >= ? THEN ? ELSE NULL END,
+    ?,
+    ?
+  )
+  ON CONFLICT (ip) DO UPDATE SET
+    recent_tokens = CASE WHEN ${MERGED_COUNT} >= ? THEN '[]' ELSE ${MERGED_JSON} END,
+    locked_until = CASE WHEN ${MERGED_COUNT} >= ? THEN ? ELSE NULL END,
+    window_start = CASE
+      WHEN ? - token_attempts.window_start > ? THEN ?
+      ELSE token_attempts.window_start
+    END,
+    last_attempt = ?
+  RETURNING locked_until`;
+
+const recordFailure = makeAttemptRecorder(RECORD_FAILURE_SQL);
 
 /**
  * Check if IP is currently locked out of token URLs.
  * Clears expired lockouts so the next attempt starts fresh.
  */
-export const isTokenRateLimited = async (ip: string): Promise<boolean> => {
-  const hashedIp = await hmacHash(ip);
-  const row = await readRow(hashedIp);
-  return lockoutActive("token_attempts", hashedIp, row?.locked_until);
-};
+export const isTokenRateLimited = async (ip: string): Promise<boolean> =>
+  isIpLockedOut("token_attempts", await hmacHash(ip));
 
 /**
  * Record one or more failed token lookups (404) for an IP.
@@ -73,40 +103,44 @@ export const recordTokenFailure = async (
 
   const hashedIp = await hmacHash(ip);
   const hashedTokens = await Promise.all(tokens.map((t) => hmacHash(t)));
-  const row = await readRow(hashedIp);
-  const currentMs = nowMs();
+  const newTokensJson = JSON.stringify([...new Set(hashedTokens)]);
+  const current = nowMs();
+  const lockedUntil = current + TOKEN_LOCKOUT_MS;
 
-  const windowValid = row && currentMs - row.window_start <= TOKEN_WINDOW_MS;
-  const windowStart = windowValid ? row.window_start : currentMs;
-  const existing = windowValid
-    ? recentTokensJson.read(
-        row.recent_tokens,
-        `token_attempts.recent_tokens for ${hashedIp}`,
-      )
-    : [];
-
-  const merged = new Set(existing);
-  for (const h of hashedTokens) merged.add(h);
-
-  if (merged.size >= MAX_TOKEN_404S) {
-    const lockedUntil = currentMs + TOKEN_LOCKOUT_MS;
-    await execute(
-      "INSERT OR REPLACE INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt) VALUES (?, ?, ?, ?, ?)",
-      [hashedIp, "[]", lockedUntil, currentMs, currentMs],
-    );
-    return true;
-  }
-
-  await execute(
-    "INSERT OR REPLACE INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt) VALUES (?, ?, NULL, ?, ?)",
-    [
-      hashedIp,
-      recentTokensJson.write([...merged], "token_attempts.recent_tokens"),
-      windowStart,
-      currentMs,
-    ],
-  );
-  return false;
+  return recordFailure([
+    hashedIp,
+    // VALUES recent_tokens: a big enough first burst locks immediately
+    newTokensJson,
+    MAX_TOKEN_404S,
+    newTokensJson,
+    // VALUES locked_until
+    newTokensJson,
+    MAX_TOKEN_404S,
+    lockedUntil,
+    // VALUES window_start, last_attempt
+    current,
+    current,
+    // SET recent_tokens: merged count, limit, merged set
+    current,
+    TOKEN_WINDOW_MS,
+    newTokensJson,
+    MAX_TOKEN_404S,
+    current,
+    TOKEN_WINDOW_MS,
+    newTokensJson,
+    // SET locked_until: merged count, limit, lockout deadline
+    current,
+    TOKEN_WINDOW_MS,
+    newTokensJson,
+    MAX_TOKEN_404S,
+    lockedUntil,
+    // SET window_start: tumble to now when the old window has passed
+    current,
+    TOKEN_WINDOW_MS,
+    current,
+    // SET last_attempt
+    current,
+  ]);
 };
 
 /**

--- a/src/shared/db/token-attempts.ts
+++ b/src/shared/db/token-attempts.ts
@@ -60,7 +60,9 @@ const MERGED_JSON = `(SELECT json_group_array(hashedToken.value) FROM ${UNION_TO
 /** One statement tumbles the window, merges the new tokens, and applies the
  * lockout — all inside the database, so two failures arriving at once can
  * never lose each other's tokens. Once the merged set reaches the limit the
- * stored set is cleared to "[]" (no fingerprint kept while locked). */
+ * stored set is cleared to "[]" (no fingerprint kept while locked). While a
+ * lockout is active, both arms keep it: a straggling failure that queued
+ * behind the locking one must not restart the count and drop the lock. */
 const RECORD_FAILURE_SQL = `
   INSERT INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt)
   VALUES (
@@ -71,8 +73,16 @@ const RECORD_FAILURE_SQL = `
     ?
   )
   ON CONFLICT (ip) DO UPDATE SET
-    recent_tokens = CASE WHEN ${MERGED_COUNT} >= ? THEN '[]' ELSE ${MERGED_JSON} END,
-    locked_until = CASE WHEN ${MERGED_COUNT} >= ? THEN ? ELSE NULL END,
+    recent_tokens = CASE
+      WHEN token_attempts.locked_until > ? THEN token_attempts.recent_tokens
+      WHEN ${MERGED_COUNT} >= ? THEN '[]'
+      ELSE ${MERGED_JSON}
+    END,
+    locked_until = CASE
+      WHEN token_attempts.locked_until > ? THEN token_attempts.locked_until
+      WHEN ${MERGED_COUNT} >= ? THEN ?
+      ELSE NULL
+    END,
     window_start = CASE
       WHEN ? - token_attempts.window_start > ? THEN ?
       ELSE token_attempts.window_start
@@ -120,7 +130,8 @@ export const recordTokenFailure = async (
     // VALUES window_start, last_attempt
     current,
     current,
-    // SET recent_tokens: merged count, limit, merged set
+    // SET recent_tokens: active-lock guard, merged count, limit, merged set
+    current,
     current,
     TOKEN_WINDOW_MS,
     newTokensJson,
@@ -128,7 +139,8 @@ export const recordTokenFailure = async (
     current,
     TOKEN_WINDOW_MS,
     newTokensJson,
-    // SET locked_until: merged count, limit, lockout deadline
+    // SET locked_until: active-lock guard, merged count, limit, deadline
+    current,
     current,
     TOKEN_WINDOW_MS,
     newTokensJson,

--- a/src/shared/db/token-attempts.ts
+++ b/src/shared/db/token-attempts.ts
@@ -38,24 +38,35 @@ import { nowMs } from "#shared/now.ts";
 
 /* jscpd:ignore-end */
 
+/** The numbered parameters every fragment below shares:
+ *  ?1 hashed IP · ?2 this request's tokens as a JSON array · ?3 the distinct-
+ *  token limit · ?4 the lockout deadline · ?5 now · ?6 the window length. */
+const IP = "?1";
+const NEW_TOKENS = "?2";
+const TOKEN_LIMIT = "?3";
+const LOCK_DEADLINE = "?4";
+const NOW = "?5";
+const WINDOW_MS = "?6";
+
 /** The stored tokens that still count: the saved set while the window is
- * live, an empty set once the window has tumbled. Params: now, window ms. */
+ * live, an empty set once the window has tumbled. */
 const LIVE_TOKENS = `CASE
-  WHEN ? - token_attempts.window_start > ? THEN '[]'
+  WHEN ${NOW} - token_attempts.window_start > ${WINDOW_MS} THEN '[]'
   ELSE token_attempts.recent_tokens
 END`;
 
 /** The live tokens and this request's tokens as one set (UNION removes
- * duplicates, so retries of a known token never grow the set).
- * Params: now, window ms, new-tokens JSON. */
+ * duplicates, so retries of a known token never grow the set). */
 const UNION_TOKENS = `(
   SELECT value FROM json_each(${LIVE_TOKENS})
   UNION
-  SELECT value FROM json_each(?)
+  SELECT value FROM json_each(${NEW_TOKENS})
 ) AS hashedToken`;
 
 const MERGED_COUNT = `(SELECT count(*) FROM ${UNION_TOKENS})`;
 const MERGED_JSON = `(SELECT json_group_array(hashedToken.value) FROM ${UNION_TOKENS})`;
+
+const LOCK_IS_ACTIVE = `token_attempts.locked_until > ${NOW}`;
 
 /** One statement tumbles the window, merges the new tokens, and applies the
  * lockout — all inside the database, so two failures arriving at once can
@@ -66,28 +77,28 @@ const MERGED_JSON = `(SELECT json_group_array(hashedToken.value) FROM ${UNION_TO
 const RECORD_FAILURE_SQL = `
   INSERT INTO token_attempts (ip, recent_tokens, locked_until, window_start, last_attempt)
   VALUES (
-    ?,
-    CASE WHEN json_array_length(?) >= ? THEN '[]' ELSE ? END,
-    CASE WHEN json_array_length(?) >= ? THEN ? ELSE NULL END,
-    ?,
-    ?
+    ${IP},
+    CASE WHEN json_array_length(${NEW_TOKENS}) >= ${TOKEN_LIMIT} THEN '[]' ELSE ${NEW_TOKENS} END,
+    CASE WHEN json_array_length(${NEW_TOKENS}) >= ${TOKEN_LIMIT} THEN ${LOCK_DEADLINE} ELSE NULL END,
+    ${NOW},
+    ${NOW}
   )
   ON CONFLICT (ip) DO UPDATE SET
     recent_tokens = CASE
-      WHEN token_attempts.locked_until > ? THEN token_attempts.recent_tokens
-      WHEN ${MERGED_COUNT} >= ? THEN '[]'
+      WHEN ${LOCK_IS_ACTIVE} THEN token_attempts.recent_tokens
+      WHEN ${MERGED_COUNT} >= ${TOKEN_LIMIT} THEN '[]'
       ELSE ${MERGED_JSON}
     END,
     locked_until = CASE
-      WHEN token_attempts.locked_until > ? THEN token_attempts.locked_until
-      WHEN ${MERGED_COUNT} >= ? THEN ?
+      WHEN ${LOCK_IS_ACTIVE} THEN token_attempts.locked_until
+      WHEN ${MERGED_COUNT} >= ${TOKEN_LIMIT} THEN ${LOCK_DEADLINE}
       ELSE NULL
     END,
     window_start = CASE
-      WHEN ? - token_attempts.window_start > ? THEN ?
+      WHEN ${NOW} - token_attempts.window_start > ${WINDOW_MS} THEN ${NOW}
       ELSE token_attempts.window_start
     END,
-    last_attempt = ?
+    last_attempt = ${NOW}
   RETURNING locked_until`;
 
 const recordFailure = makeAttemptRecorder(RECORD_FAILURE_SQL);
@@ -113,45 +124,16 @@ export const recordTokenFailure = async (
 
   const hashedIp = await hmacHash(ip);
   const hashedTokens = await Promise.all(tokens.map((t) => hmacHash(t)));
-  const newTokensJson = JSON.stringify([...new Set(hashedTokens)]);
   const current = nowMs();
-  const lockedUntil = current + TOKEN_LOCKOUT_MS;
 
+  // One value per numbered parameter, in ?1..?6 order.
   return recordFailure([
     hashedIp,
-    // VALUES recent_tokens: a big enough first burst locks immediately
-    newTokensJson,
+    JSON.stringify([...new Set(hashedTokens)]),
     MAX_TOKEN_404S,
-    newTokensJson,
-    // VALUES locked_until
-    newTokensJson,
-    MAX_TOKEN_404S,
-    lockedUntil,
-    // VALUES window_start, last_attempt
-    current,
-    current,
-    // SET recent_tokens: active-lock guard, merged count, limit, merged set
-    current,
+    current + TOKEN_LOCKOUT_MS,
     current,
     TOKEN_WINDOW_MS,
-    newTokensJson,
-    MAX_TOKEN_404S,
-    current,
-    TOKEN_WINDOW_MS,
-    newTokensJson,
-    // SET locked_until: active-lock guard, merged count, limit, deadline
-    current,
-    current,
-    TOKEN_WINDOW_MS,
-    newTokensJson,
-    MAX_TOKEN_404S,
-    lockedUntil,
-    // SET window_start: tumble to now when the old window has passed
-    current,
-    TOKEN_WINDOW_MS,
-    current,
-    // SET last_attempt
-    current,
   ]);
 };
 

--- a/test/shared/db/client.test.ts
+++ b/test/shared/db/client.test.ts
@@ -7,6 +7,7 @@ import {
   andConditions,
   deleteByFieldStatement,
   execute,
+  executeReturningRow,
   executeUpdate,
   extractUpdateColumns,
   getDb,
@@ -430,6 +431,23 @@ describeWithEnv("db > client", { db: true }, () => {
         "missing_key",
       ]),
     ).toBe(false);
+  });
+
+  test("executeReturningRow reads back the written row", async () => {
+    const row = await executeReturningRow<{ value: string }>(
+      "INSERT INTO settings (key, value) VALUES ('returning_test', 'x') RETURNING value",
+      [],
+    );
+    expect(row).toEqual({ value: "x" });
+  });
+
+  test("executeReturningRow throws when the write returned no row", async () => {
+    await expect(
+      executeReturningRow(
+        "UPDATE settings SET value = 'y' WHERE key = ? RETURNING value",
+        ["missing_key"],
+      ),
+    ).rejects.toThrow("Write returned no row");
   });
 
   test("queryOne returns the single matching row", async () => {

--- a/test/shared/db/login-attempts.test.ts
+++ b/test/shared/db/login-attempts.test.ts
@@ -27,6 +27,42 @@ describeWithEnv("login attempt limiting", { db: true }, () => {
     expect(await limiter.isLimited("203.0.113.10")).toBe(false);
   });
 
+  test("concurrent attempts each count and lock at the threshold", async () => {
+    const limiter = makeIpRateLimiter("race:", 5, 1000);
+    const ip = "203.0.113.20";
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => limiter.record(ip)),
+    );
+
+    // Every attempt lands as its own increment; exactly one of them was the
+    // locking fifth. A read-then-write recorder loses concurrent increments
+    // (all five read zero attempts) and never locks.
+    expect(results.filter((locked) => locked)).toHaveLength(1);
+    expect(
+      await queryOne<{ attempts: number }>(
+        "SELECT attempts FROM login_attempts",
+      ),
+    ).toEqual({ attempts: 5 });
+    expect(await limiter.isLimited(ip)).toBe(true);
+  });
+
+  test("stamps last_attempt so stale counters can be pruned", async () => {
+    using time = new FakeTime(1_800_000_000_000);
+    const limiter = makeIpRateLimiter("stamp:", 5, 1000);
+    const ip = "203.0.113.21";
+
+    await limiter.record(ip);
+    time.tick(60_000);
+    await limiter.record(ip);
+
+    expect(
+      await queryOne<{ last_attempt: number }>(
+        "SELECT last_attempt FROM login_attempts",
+      ),
+    ).toEqual({ last_attempt: 1_800_000_060_000 });
+  });
+
   test("clears failed attempts after a successful login", async () => {
     const ip = "203.0.113.11";
     await loginLimiter.record(ip);

--- a/test/shared/db/migrations/2026-08-04_login_attempt_stamp.test.ts
+++ b/test/shared/db/migrations/2026-08-04_login_attempt_stamp.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+import { getDb } from "#shared/db/client.ts";
+import loginAttemptStampMigration from "#shared/db/migrations/2026-08-04_login_attempt_stamp.ts";
+import {
+  applySchemaChanges,
+  syncIndexes,
+} from "#shared/db/migrations/schema-sync.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { buildMigrationContext } from "#test-utils/migrations.ts";
+
+const context = buildMigrationContext({ applySchemaChanges, syncIndexes });
+const runMigration = (): Promise<void> =>
+  loginAttemptStampMigration(context).up();
+
+const insertRow = (ip: string, lastAttempt: number) =>
+  getDb().execute({
+    args: [ip, lastAttempt],
+    sql: "INSERT INTO login_attempts (ip, attempts, locked_until, last_attempt) VALUES (?, 2, NULL, ?)",
+  });
+
+const storedStamp = async (ip: string): Promise<number> => {
+  const result = await getDb().execute({
+    args: [ip],
+    sql: "SELECT last_attempt FROM login_attempts WHERE ip = ?",
+  });
+  return Number(result.rows[0]!.last_attempt);
+};
+
+describeWithEnv("db > migrations > login attempt stamp", { db: true }, () => {
+  test("declares its identity, column, and index", () => {
+    const migration = loginAttemptStampMigration(context);
+    expect({
+      description: migration.description,
+      id: migration.id,
+      requires: migration.requires,
+    }).toEqual({
+      description: "Track when each login-attempt row was last touched.",
+      id: "2026-08-04_login_attempt_stamp",
+      requires: {
+        columns: { login_attempts: ["last_attempt"] },
+        indexes: ["idx_login_attempts_last_attempt"],
+      },
+    });
+  });
+
+  test("starts the clock on rows that predate the stamp", async () => {
+    using _time = new FakeTime(1_800_000_000_000);
+    await insertRow("legacy-row", 0);
+
+    await runMigration();
+
+    // A legacy counter must age out one retention period from the
+    // migration, not be prunable immediately.
+    expect(await storedStamp("legacy-row")).toBe(1_800_000_000_000);
+  });
+
+  test("leaves already-stamped rows alone", async () => {
+    await insertRow("stamped-row", 1_700_000_000_000);
+
+    await runMigration();
+
+    expect(await storedStamp("stamped-row")).toBe(1_700_000_000_000);
+  });
+});

--- a/test/shared/db/migrations/schema/index.test.ts
+++ b/test/shared/db/migrations/schema/index.test.ts
@@ -47,6 +47,6 @@ describe("db > migrations > schema assembly", () => {
     // A site whose stored hash differs from this one gets migrated, so the
     // value is pinned. The schema change guard pins the same value beside the
     // migration list; this one keeps the stamp tied to the schema it is of.
-    expect(SCHEMA_HASH).toBe("1c2t2ah");
+    expect(SCHEMA_HASH).toBe("13v066p");
   });
 });

--- a/test/shared/db/migrations/schema/tables-core.test.ts
+++ b/test/shared/db/migrations/schema/tables-core.test.ts
@@ -5,7 +5,7 @@ import { jsonHash } from "#test-utils/hash.ts";
 
 test("keeps the complete core schema declaration exact", async () => {
   expect(await jsonHash(coreTables)).toBe(
-    "638fa5a199637c1f21c4b3a0fff7d4683e0e3edeb87af20252eda8802657f27f",
+    "79f5ba69fa918a2b2b9da55931c2891798064c30015c95575811e47177743c71",
   );
 });
 

--- a/test/shared/db/migrations/schema/version/guard.test.ts
+++ b/test/shared/db/migrations/schema/version/guard.test.ts
@@ -102,8 +102,9 @@ describe("db > migrations > schema change guard", () => {
         "2026-07-22_maintenance_completion",
         "2026-07-28_note_entities",
         "2026-07-26_payment_records",
+        "2026-08-04_login_attempt_stamp",
       ],
-      schemaHash: "1c2t2ah",
+      schemaHash: "13v066p",
     });
   });
 
@@ -117,7 +118,7 @@ describe("db > migrations > schema change guard", () => {
     }).toEqual({
       dbSchemaHash: "db_schema_hash",
       latestDbUpdate: "latest_db_update",
-      latestUpdate: "Add the tables one payment record lives in.",
+      latestUpdate: "Track when each login-attempt row was last touched.",
       migrationLock: "migration_lock",
       schemaMigrations: "schema_migrations",
     });

--- a/test/shared/db/prune/helpers.ts
+++ b/test/shared/db/prune/helpers.ts
@@ -137,11 +137,12 @@ export const insertLoginAttempt = async (
   ipPlain: string,
   attempts: number,
   lockedUntil: number | null,
+  lastAttempt: number,
 ): Promise<string> => {
   const ipHash = await hmacHash(ipPlain);
   await getDb().execute({
-    args: [ipHash, attempts, lockedUntil],
-    sql: "INSERT INTO login_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)",
+    args: [ipHash, attempts, lockedUntil, lastAttempt],
+    sql: "INSERT INTO login_attempts (ip, attempts, locked_until, last_attempt) VALUES (?, ?, ?, ?)",
   });
   return ipHash;
 };

--- a/test/shared/db/prune/tables.test.ts
+++ b/test/shared/db/prune/tables.test.ts
@@ -186,6 +186,7 @@ describeWithEnv("db > table pruning", { db: true }, () => {
         "1.2.3.4",
         5,
         nowMs() - PRUNE_LOGINS_RETENTION_MS - 60_000,
+        nowMs(),
       );
 
       await runDatabasePruning();
@@ -193,12 +194,25 @@ describeWithEnv("db > table pruning", { db: true }, () => {
       expect(await loginAttemptExists(ipHash)).toBe(false);
     });
 
-    test("keeps counter-only rows (locked_until IS NULL)", async () => {
-      const ipHash = await insertLoginAttempt("5.6.7.8", 2, null);
+    test("keeps counter-only rows attempted within retention", async () => {
+      const ipHash = await insertLoginAttempt("5.6.7.8", 2, null, nowMs());
 
       await runDatabasePruning();
 
       expect(await loginAttemptExists(ipHash)).toBe(true);
+    });
+
+    test("deletes counter-only rows untouched past retention", async () => {
+      const ipHash = await insertLoginAttempt(
+        "21.22.23.24",
+        2,
+        null,
+        nowMs() - PRUNE_LOGINS_RETENTION_MS - 60_000,
+      );
+
+      await runDatabasePruning();
+
+      expect(await loginAttemptExists(ipHash)).toBe(false);
     });
 
     test("keeps rows with currently-active lockouts", async () => {
@@ -206,6 +220,7 @@ describeWithEnv("db > table pruning", { db: true }, () => {
         "9.10.11.12",
         5,
         nowMs() + 60_000,
+        nowMs() - PRUNE_LOGINS_RETENTION_MS - 60_000,
       );
 
       await runDatabasePruning();

--- a/test/shared/db/token-attempts.test.ts
+++ b/test/shared/db/token-attempts.test.ts
@@ -125,6 +125,17 @@ describeWithEnv("db > token-attempts", { db: true }, () => {
       expect(await isTokenRateLimited(ip)).toBe(false);
     });
 
+    test("a failure recorded while locked keeps the lockout", async () => {
+      const ip = "10.0.0.13";
+      await recordTokenFailure(ip, makeTokens("lock", MAX_TOKEN_404S));
+      expect(await isTokenRateLimited(ip)).toBe(true);
+
+      // A straggler that queued behind the locking failure must not restart
+      // the count against the cleared token set and drop the lock.
+      expect(await recordTokenFailure(ip, ["straggler"])).toBe(true);
+      expect(await isTokenRateLimited(ip)).toBe(true);
+    });
+
     test("concurrent failures each count their distinct token", async () => {
       const ip = "10.0.0.12";
 

--- a/test/shared/db/token-attempts.test.ts
+++ b/test/shared/db/token-attempts.test.ts
@@ -10,7 +10,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
 import { hmacHash } from "#shared/crypto/hashing.ts";
-import { execute, queryOne } from "#shared/db/client.ts";
+import { queryOne } from "#shared/db/client.ts";
 import {
   clearTokenAttempts,
   isTokenRateLimited,
@@ -125,17 +125,21 @@ describeWithEnv("db > token-attempts", { db: true }, () => {
       expect(await isTokenRateLimited(ip)).toBe(false);
     });
 
-    test("rejects invalid stored token arrays", async () => {
+    test("concurrent failures each count their distinct token", async () => {
       const ip = "10.0.0.12";
-      const hashedIp = await hmacHash(ip);
-      await execute(
-        "INSERT INTO token_attempts (ip, recent_tokens, window_start, last_attempt) VALUES (?, ?, ?, ?)",
-        [hashedIp, '["valid",2]', Date.now(), Date.now()],
+
+      const results = await Promise.all(
+        makeTokens("race", MAX_TOKEN_404S).map((token) =>
+          recordTokenFailure(ip, [token]),
+        ),
       );
 
-      await expect(recordTokenFailure(ip, ["new"])).rejects.toThrow(
-        `Invalid stored JSON in token_attempts.recent_tokens for ${hashedIp}`,
-      );
+      // Each failure merges its token inside the database, so the last one to
+      // land sees all five distinct tokens and locks. A read-then-write
+      // recorder loses concurrent tokens (all five read an empty set) and
+      // never locks.
+      expect(results.filter((locked) => locked)).toHaveLength(1);
+      expect(await isTokenRateLimited(ip)).toBe(true);
     });
 
     test("locks when a single request supplies MAX_TOKEN_404S distinct tokens", async () => {

--- a/test/shared/maintenance/registry.test.ts
+++ b/test/shared/maintenance/registry.test.ts
@@ -91,7 +91,7 @@ describeWithEnv("maintenance registry", { db: true }, () => {
 
   test("the pruning task runs one bounded database batch", async () => {
     expect(await taskNamed("database_pruning").check.enabled()).toBe(true);
-    const ipHash = await insertLoginAttempt("192.0.2.10", 1, 0);
+    const ipHash = await insertLoginAttempt("192.0.2.10", 1, 0, 0);
     expect(await loginAttemptExists(ipHash)).toBe(true);
 
     expect(await runTask(taskNamed("database_pruning"))).toBeUndefined();


### PR DESCRIPTION
## What changed

All five per-IP rate limiters (login, API key, booking, address lookup, and token 404s) used to record an attempt in two steps: read the stored count, then write the count plus one. When two attempts from the same IP arrived at the same moment, both reads saw the same number, so one attempt was lost — an attacker hammering an endpoint in parallel could stay under the lockout threshold forever.

Each limiter now records through a single `INSERT … ON CONFLICT … RETURNING` statement. The database itself does the counting, the lockout decision, and (for token failures) the distinct-token merge and window tumble, so attempts arriving at once can never lose each other. The statement runner is one shared helper (`makeAttemptRecorder` in `attempt-lockout.ts`), and both tables' lockout checks now share `isIpLockedOut` too.

Also fixed in the same shape change: `login_attempts` rows below the lockout threshold used to stay in the table forever. They now carry a `last_attempt` stamp (a schema-declared column, added to existing sites automatically), and the nightly pruning removes counter-only rows that have gone stale, alongside the expired lockouts it already removed.

## Tests

- New regression tests fire five attempts at once and assert every one is counted and the lockout lands — they fail against the old read-then-write code (verified) and pass now.
- Same for concurrent distinct-token failures on the token limiter.
- Pruning tests cover stale counter rows being removed, fresh ones kept, and active lockouts surviving even with a stale `last_attempt`.
- `deno task precommit` (typecheck, lint, duplication, full suite) passes.

Closes the "Make rate-limit writes atomic and bounded" item from `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qGarzCRqwDNvoQhxUNxdg

---
_Generated by [Claude Code](https://claude.ai/code/session_018qGarzCRqwDNvoQhxUNxdg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login and token attempt tracking under concurrent requests, preventing missed attempts and inconsistent lockouts.
  * Enhanced cleanup of expired login-attempt records while retaining recent counters.
  * Improved reliability when recording and reading database updates.

* **Tests**
  * Added coverage for concurrent attempts, lockout thresholds, timestamp tracking, pruning behavior, and database write results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->