### PR TITLE
Bind repeated SQL values once with numbered parameters

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-m-z.txt
+++ b/scripts/mutation/equivalent-mutants/shared-m-z.txt
@@ -218,8 +218,8 @@ src/shared/merge/attendee-merge.ts:507:57  = → +=   # mergedPii is computed th
 # hash change can't surface via an idempotent-replay either; and no test or
 # production code queries the merged attendee's reversal legs by their
 # `event_group` value.
-src/shared/merge/attendee-merge.ts:725:18  merge-unbill → ""   # keyParts prefix feeds only the non-reversible event_group/reference hashes; never observed
-src/shared/merge/attendee-merge.ts:732:20  merge-credit → ""   # same as :725 — keyParts prefix feeds only the non-reversible hashes; never observed
+src/shared/merge/attendee-merge.ts:724:18  merge-unbill → ""   # keyParts prefix feeds only the non-reversible event_group/reference hashes; never observed
+src/shared/merge/attendee-merge.ts:731:20  merge-credit → ""   # same as :724 — keyParts prefix feeds only the non-reversible hashes; never observed
 
 # i18n copy handling (shared/rebrand.ts + shared/i18n.ts) — four provably-equivalent survivors.
 # needsIcu decides only whether a message takes the plain-string fast path or is

--- a/src/shared/db/listings/delete.ts
+++ b/src/shared/db/listings/delete.ts
@@ -24,8 +24,8 @@ export const deleteListing = async (listingId: number): Promise<void> => {
       sql: "DELETE FROM listing_attribute_options WHERE listing_id = ?",
     },
     {
-      args: [listingId, listingId],
-      sql: "DELETE FROM listing_parents WHERE parent_listing_id = ? OR child_listing_id = ?",
+      args: [listingId],
+      sql: "DELETE FROM listing_parents WHERE parent_listing_id = ?1 OR child_listing_id = ?1",
     },
     {
       args: [listingId],

--- a/src/shared/db/prune.ts
+++ b/src/shared/db/prune.ts
@@ -89,11 +89,13 @@ const pruneStatements = (): PruneStatement[] => [
   boundedDelete("sessions", "expires < ?", [
     nowMs() - PRUNE_SESSIONS_RETENTION_MS,
   ]),
+  // Both arms compare against the same cutoff, bound once as ?1; the builder's
+  // unnumbered LIMIT ? continues after the highest number, so it reads ?2.
   boundedDelete(
     "login_attempts",
-    `(locked_until IS NOT NULL AND locked_until < ?)
-        OR (locked_until IS NULL AND last_attempt < ?)`,
-    [nowMs() - PRUNE_LOGINS_RETENTION_MS, nowMs() - PRUNE_LOGINS_RETENTION_MS],
+    `(locked_until IS NOT NULL AND locked_until < ?1)
+        OR (locked_until IS NULL AND last_attempt < ?1)`,
+    [nowMs() - PRUNE_LOGINS_RETENTION_MS],
   ),
   boundedDelete("token_attempts", "last_attempt < ?", [
     nowMs() - PRUNE_TOKENS_RETENTION_MS,

--- a/src/shared/db/users.ts
+++ b/src/shared/db/users.ts
@@ -365,8 +365,8 @@ export const acceptInvite = async (
     passwordHash,
   );
   return executeChangedRow(
-    "UPDATE users SET password_hash = ?, wrapped_data_key = ?, kek_version = 2, invite_wrapped_data_key = NULL, invite_code_hash = ?, invite_expiry = ? WHERE id = ? AND invite_wrapped_data_key IS NOT NULL",
-    [encryptedHash, wrappedDataKey, encryptedEmpty, encryptedEmpty, userId],
+    "UPDATE users SET password_hash = ?1, wrapped_data_key = ?2, kek_version = 2, invite_wrapped_data_key = NULL, invite_code_hash = ?3, invite_expiry = ?3 WHERE id = ?4 AND invite_wrapped_data_key IS NOT NULL",
+    [encryptedHash, wrappedDataKey, encryptedEmpty, userId],
   );
 };
 
@@ -390,8 +390,8 @@ export const activateKeylessUser = async (
   const { encryptedHash, encryptedEmpty } =
     await buildActivationSecrets(password);
   return executeChangedRow(
-    "UPDATE users SET password_hash = ?, kek_version = 2, invite_code_hash = ?, invite_expiry = ? WHERE id = ? AND password_hash = ''",
-    [encryptedHash, encryptedEmpty, encryptedEmpty, userId],
+    "UPDATE users SET password_hash = ?1, kek_version = 2, invite_code_hash = ?2, invite_expiry = ?2 WHERE id = ?3 AND password_hash = ''",
+    [encryptedHash, encryptedEmpty, userId],
   );
 };
 

--- a/src/shared/merge/attendee-merge.ts
+++ b/src/shared/merge/attendee-merge.ts
@@ -656,15 +656,14 @@ const applyBookingDecisions = (
           targetId,
           item.listingId,
           item.startAt,
-          item.startAt,
           item.parentListingId,
           item.packageGroupId,
         ],
         sql: `DELETE FROM listing_attendees
-              WHERE attendee_id = ? AND listing_id = ?
-              AND (start_at IS ? OR start_at = ?)
-              AND parent_listing_id = ?
-              AND package_group_id = ?`,
+              WHERE attendee_id = ?1 AND listing_id = ?2
+              AND (start_at IS ?3 OR start_at = ?3)
+              AND parent_listing_id = ?4
+              AND package_group_id = ?5`,
       });
       insertStatements.push(
         bookingInsertStatement(targetId, item.sourceBooking),


### PR DESCRIPTION
## What changed

PR #2040 introduced numbered SQL parameters (`?1`, `?2`, …) so a statement that uses the same value in several places binds it once. This follow-up sweeps the rest of the codebase for whole statements that bound the same value twice and moves them onto the same pattern:

- The two invite-activation updates in `users.ts` bound the encrypted empty marker twice (`invite_code_hash` and `invite_expiry`); each now binds it once as `?2`/`?3`.
- The `listing_parents` delete bound the listing id twice (`parent_listing_id` and `child_listing_id`); now `?1` twice.
- The attendee-merge booking-replacement delete bound the booking's start time twice (`IS ?` and `= ?` for the null-safe match); now `?3` twice.
- The login-attempts prune bound the same retention cutoff for both its arms (expired lockouts and stale counters); now `?1` once — the prune builder's unnumbered `LIMIT ?` continues after the highest number, which a comment explains.

Composable SQL fragments (capacity checks, group counts, modifier stock conditions, ledger account matches) deliberately keep bare `?`: their arguments are concatenated into larger statements, where absolute numbering would collide. No behaviour changes — every statement binds the same values to the same columns as before.

## Tests

No new tests: the swept statements keep their exact behaviour, and the existing suites over users, listing deletion, attendee merge, and pruning all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qGarzCRqwDNvoQhxUNxdg

---
_Generated by [Claude Code](https://claude.ai/code/session_018qGarzCRqwDNvoQhxUNxdg)_