### PR TITLE
Work out what is left for every booking length from one reading

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1050,11 +1050,6 @@ database-only cases fail loudly, but it cannot count provider or storage calls.
   `src/features/checkin.ts` calls `updateCheckedIn` once per eligible booking
   line. A token set with 51 lines therefore makes 51 updates. Replace it with
   one set-based update over all attendee/listing pairs.
-- **Order availability by duration.** `poolBySpan`, `remainingBySpan`, and
-  `groupRemainingBySpan` in `src/features/public/order.ts` run six capacity
-  reads per distinct duration/group combination; nine distinct durations can
-  make 54 calls. Load one capacity snapshot for the widest span and derive each
-  duration in memory.
 - **Automatic built-site assignment.** `assignSitesForEntries` and
   `assignSiteWithRenewal` in `src/shared/site-assignment.ts` mix per-unit DB
   writes with provider calls. Eleven Deno site units, or nine Bunny site units,

--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -202,5 +202,6 @@ src/features/public/order.ts:220:21  1 → 0   # with no date chosen nothing is 
 src/features/public/order.ts:230:16  1 → 0   # every listing's span is at least 1, so the floor never wins; with no listings at all the reading has no days either way
 src/features/public/order.ts:195:61  ?? → ||   # spanByGroupId holds spans of at least 1, so the only falsy value is undefined
 src/features/public/order.ts:195:65  1 → 0   # the first span seen is at least 1, so Math.max returns it whichever starting value it is compared against
-src/features/public/order.ts:332:21  "" → "mutated"   # a selection key is always built as kind:id by listingOptionKey/packageOptionKey, so the kind is never missing
-src/features/public/order.ts:332:33  "" → "mutated"   # the same key always carries its id, so the id half is never missing
+src/features/public/order.ts:332:21   → "mutated"   # a selection key is always built as kind:id by listingOptionKey/packageOptionKey, so the kind is never missing
+src/features/public/order.ts:332:33   → "mutated"   # the same key always carries its id, so the id half is never missing
+src/features/public/order.ts:340:77  1 → 0   # buildTicketListing sets maxPurchasable to 0 for a sold-out or closed listing and to at least 1 otherwise (max_quantity is at least 1), so the two thresholds never disagree once the checks beside them have passed

--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -192,3 +192,15 @@ src/features/api/payment-processing/package-pricing.ts:100:11  Missing package p
 src/shared/booking/page-packages.ts:134:40  ?? → ||   # packageGroupId is a positive group id or undefined; its only falsy value would be 0, which equals the fallback
 src/shared/booking/page-packages.ts:163:28  ?? → ||   # same package group id, same 0 fallback
 src/shared/booking/page-packages.ts:164:41  ?? → ||   # parentListingId is a positive listing id or undefined, and the fallback is 0
+
+# Public order page (order.ts) — booking-span arithmetic whose floor is applied
+# again by the capacity reading, so no span a caller can ask for tells the
+# mutant from the original.
+src/features/public/order.ts:177:16  1 → 0   # a stored daily listing's duration_days is at least 1, so Math.max never picks the floor
+src/features/public/order.ts:178:7  1 → 0   # the span of a listing not judged day by day is unused, and daysOfSpan clamps it back to one day anyway
+src/features/public/order.ts:220:21  1 → 0   # with no date chosen nothing is judged day by day, and daysOfSpan clamps the span back to one day
+src/features/public/order.ts:230:16  1 → 0   # every listing's span is at least 1, so the floor never wins; with no listings at all the reading has no days either way
+src/features/public/order.ts:195:61  ?? → ||   # spanByGroupId holds spans of at least 1, so the only falsy value is undefined
+src/features/public/order.ts:195:65  1 → 0   # the first span seen is at least 1, so Math.max returns it whichever starting value it is compared against
+src/features/public/order.ts:332:21  "" → "mutated"   # a selection key is always built as kind:id by listingOptionKey/packageOptionKey, so the kind is never missing
+src/features/public/order.ts:332:33  "" → "mutated"   # the same key always carries its id, so the id half is never missing

--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -195,3 +195,15 @@ src/shared/booking/page-packages.ts::stampChildRowPackages.parentId~0mh8ima  ?? 
 # cannot reach any branch, and a recovery count that is never exactly one.
 src/features/admin/attendee-page-data.ts::assembleTemplateData.balanceNotice~0ec14e6  0 → 1   # the fallback is used only in create mode, where fullPrice is 0; the amount paid cannot affect any balance-notice branch when no order exists
 src/features/admin/settings-page.ts::getAdvancedSettingsPageState.paymentProviderRecoveryNeeded~1fd1z1o  0 → 1   # existingPaymentProviderState resolves one configured provider directly; recoveryChoices is therefore either empty or has at least two providers, so both comparisons agree
+
+# Public order page (order.ts) — booking-span sums whose floor the capacity
+# reading applies again, and key halves that are always present.
+src/features/public/order.ts::bookingSpanDays~1ybe7gz  1 → 0   # a stored daily listing's duration_days is at least 1, so Math.max never picks the floor
+src/features/public/order.ts::bookingSpanDays~1mmd8yc  1 → 0   # the span of a listing not judged day by day is unused, and daysOfSpan clamps it back to one day anyway
+src/features/public/order.ts::widestSpanPerGroup~0ia21ee  ?? → ||   # spanByGroupId holds spans of at least 1, so the only falsy value is undefined
+src/features/public/order.ts::widestSpanPerGroup~0ia21ee  1 → 0   # the first span seen is at least 1, so Math.max returns it whichever starting value it is compared against
+src/features/public/order.ts::loadOrderPools.spanOf~13yakgc  1 → 0   # with no date chosen nothing is judged day by day, and daysOfSpan clamps the span back to one day
+src/features/public/order.ts::loadOrderPools~15mruqs  1 → 0   # every listing's span is at least 1, so the floor never wins; with no listings at all the reading has no days either way
+src/features/public/order.ts::bookingUrlFor.chosen.kind~17n3p4g   → "mutated"   # a selection key is always built as kind:id by listingOptionKey/packageOptionKey, so the kind is never missing
+src/features/public/order.ts::bookingUrlFor.chosen.rawId~1xqr8m1   → "mutated"   # the same key always carries its id, so the id half is never missing
+src/features/public/order.ts::bookingUrlFor.chosen.prefill~1vgmybj  1 → 0   # buildTicketListing sets maxPurchasable to 0 for a sold-out or closed listing and to at least 1 otherwise (max_quantity is at least 1), so the two thresholds never disagree once the checks beside them have passed

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -34,7 +34,9 @@ src/features/admin/api-groups.ts::parsePackageMember.dayPrices~1ac0u3a  ?? → |
 # Attendee group-capacity lookups: Map values are arrays (always truthy), and
 # duration normalization clamps both a default of 0 and 1 to one day.
 src/shared/db/attendees/capacity/groups.ts::getGroupPerDayRemaining.loads~1nauhgk  ?? → ||   # rowsByGroup.get(): GroupRow[]|undefined — an array is always truthy
-src/shared/db/attendees/capacity/groups.ts::getGroupRemainingForSpan.spanDays~0qui8oa  1 → 0   # expandDailyRange normalizes both 0 and 1 to a one-day span
+src/shared/db/attendees/capacity/snapshot.ts::loadsByListing~0wzfdt0  ?? → ||   # byListing.get(): row[]|undefined — an array is always truthy, so both operators reach perDayLoads with the same rows
+src/shared/db/attendees/capacity/snapshot.ts::loadCapacitySnapshot.membership~0tc0opa  ?? → ||   # knownMembership is a Map or undefined; every Map, including an empty one, is truthy
+src/shared/db/attendees/capacity/remaining.ts::getListingRemainingForRange.durationDays~18guaiu  1 → 0   # daysOfSpan clamps the span back to one day, so a default of 0 reads the same single day
 
 # listing_prices sync (listing-prices.ts): `?? → ||` where the operand's only
 # falsy-non-null value equals the fallback.

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -33,8 +33,8 @@ src/shared/db/groups.ts:686:66  ?? → ||   # package rows: GroupListing[]|undef
 src/shared/db/groups.ts:856:34  ?? → ||   # quantity is undefined or at least 1 by PackageMemberInput's contract, so every present value is truthy
 src/features/admin/api-groups.ts:127:31  ?? → ||   # parseMemberDayPrices returns a DayPrices object or undefined; every object, including {}, is truthy
 
-# Attendee group-capacity lookups: Map values are arrays (always truthy), and
-# duration normalization clamps both a default of 0 and 1 to one day.
+# Attendee group-capacity and snapshot lookups: the value is an array or a Map,
+# and both are always truthy.
 src/shared/db/attendees/capacity/groups.ts:130:50  ?? → ||   # rowsByGroup.get(): GroupRow[]|undefined — an array is always truthy
 src/shared/db/attendees/capacity/snapshot.ts:45:62  ?? → ||   # byListing.get(): row[]|undefined — an array is always truthy, so both operators reach perDayLoads with the same rows
 src/shared/db/attendees/capacity/snapshot.ts:82:20  ?? → ||   # knownMembership is a Map or undefined; every Map, including an empty one, is truthy

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -35,8 +35,9 @@ src/features/admin/api-groups.ts:127:31  ?? → ||   # parseMemberDayPrices retu
 
 # Attendee group-capacity lookups: Map values are arrays (always truthy), and
 # duration normalization clamps both a default of 0 and 1 to one day.
-src/shared/db/attendees/capacity/groups.ts:135:50  ?? → ||   # rowsByGroup.get(): GroupRow[]|undefined — an array is always truthy
-src/shared/db/attendees/capacity/groups.ts:146:14  1 → 0   # expandDailyRange normalizes both 0 and 1 to a one-day span
+src/shared/db/attendees/capacity/groups.ts:130:50  ?? → ||   # rowsByGroup.get(): GroupRow[]|undefined — an array is always truthy
+src/shared/db/attendees/capacity/snapshot.ts:45:62  ?? → ||   # byListing.get(): row[]|undefined — an array is always truthy, so both operators reach perDayLoads with the same rows
+src/shared/db/attendees/capacity/snapshot.ts:82:20  ?? → ||   # knownMembership is a Map or undefined; every Map, including an empty one, is truthy
 
 # listing_prices sync (listing-prices.ts): `?? → ||` where the operand's only
 # falsy-non-null value equals the fallback.

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -36,8 +36,8 @@ src/features/admin/api-groups.ts:127:31  ?? → ||   # parseMemberDayPrices retu
 # Attendee group-capacity and snapshot lookups: the value is an array or a Map,
 # and both are always truthy.
 src/shared/db/attendees/capacity/groups.ts:130:50  ?? → ||   # rowsByGroup.get(): GroupRow[]|undefined — an array is always truthy
-src/shared/db/attendees/capacity/snapshot.ts:45:62  ?? → ||   # byListing.get(): row[]|undefined — an array is always truthy, so both operators reach perDayLoads with the same rows
-src/shared/db/attendees/capacity/snapshot.ts:82:20  ?? → ||   # knownMembership is a Map or undefined; every Map, including an empty one, is truthy
+src/shared/db/attendees/capacity/snapshot.ts:46:62  ?? → ||   # byListing.get(): row[]|undefined — an array is always truthy, so both operators reach perDayLoads with the same rows
+src/shared/db/attendees/capacity/snapshot.ts:83:20  ?? → ||   # knownMembership is a Map or undefined; every Map, including an empty one, is truthy
 
 # listing_prices sync (listing-prices.ts): `?? → ||` where the operand's only
 # falsy-non-null value equals the fallback.

--- a/src/features/public/order.ts
+++ b/src/features/public/order.ts
@@ -40,8 +40,11 @@ import {
 import { createRouter, defineRoutes } from "#routes/router.ts";
 import type { TicketListing } from "#shared/booking/model.ts";
 import { getBookableStartDates } from "#shared/dates.ts";
-import { getGroupRemainingForSpan } from "#shared/db/attendees/capacity/groups.ts";
-import { getListingRemainingForRange } from "#shared/db/attendees/capacity/remaining.ts";
+import {
+  groupRemainingFromSnapshot,
+  loadCapacitySnapshot,
+  remainingFromSnapshot,
+} from "#shared/db/attendees/capacity/snapshot.ts";
 import { getSelectedAttributesForListings } from "#shared/db/attributes.ts";
 import {
   getGroupPackagePricesByGroupIds,
@@ -174,68 +177,26 @@ const bookingSpanDays = (listing: ListingWithCount): number =>
     ? Math.max(1, listing.duration_days)
     : 1;
 
-/** Remaining bookable units keyed by listing or group id. */
-type RemainingById = Map<number, number>;
-
-/** Bucket values by their booking span and run one pool query per distinct
- * span, merging the maps — the shared shell of the listing and group pool
- * loaders below. */
-const poolBySpan = async <T>(
-  values: T[],
-  spanOf: (value: T) => number,
-  query: (bucket: T[], span: number) => Promise<RemainingById>,
-): Promise<RemainingById> => {
-  const bySpan = Map.groupBy(values, spanOf);
-  const maps = await Promise.all(
-    [...bySpan].map(([span, bucket]) => query(bucket, span)),
-  );
-  return new Map(maps.flatMap((map) => [...map]));
-};
-
-/** Each involved listing's remaining units for the chosen date, judged over
- * its own booking span — one range query per distinct span. */
-const remainingBySpan = (
-  involved: ListingWithCount[],
-  date: string | null,
-): Promise<RemainingById> =>
-  poolBySpan(
-    involved,
-    (listing) => (date === null ? 1 : bookingSpanDays(listing)),
-    (bucket, span) => getListingRemainingForRange(bucket, date, span),
-  );
-
-/** Each capped group's remaining, judged over the WIDEST booking span among
- * its involved listings — the cap must hold on every day any of them would
- * occupy, and the evaluator sums the selections sharing the pool against this
- * one figure. */
-const groupRemainingBySpan = (
+/** The widest span any of a group's listings would occupy, so its cap is
+ * judged over every day one of them could take up. */
+const widestSpanPerGroup = (
   involved: ListingWithCount[],
   groupIdsByListingId: Map<number, number[]>,
-  date: string | null,
-): Promise<RemainingById> => {
+  spanOf: (listing: ListingWithCount) => number,
+): Map<number, number> => {
   const spanByGroupId = new Map<number, number>();
   for (const listing of involved) {
-    const span = date === null ? 1 : bookingSpanDays(listing);
     for (const groupId of listingGroups.idsFor(
       groupIdsByListingId,
       listing.id,
     )) {
       spanByGroupId.set(
         groupId,
-        Math.max(span, spanByGroupId.get(groupId) ?? 1),
+        Math.max(spanOf(listing), spanByGroupId.get(groupId) ?? 1),
       );
     }
   }
-  return poolBySpan(
-    [...spanByGroupId],
-    ([, span]) => span,
-    (bucket, span) =>
-      getGroupRemainingForSpan(
-        bucket.map(([groupId]) => groupId),
-        date,
-        span,
-      ),
-  );
+  return spanByGroupId;
 };
 
 /** The capacity pools the evaluator draws from, resolved for the chosen date
@@ -255,12 +216,31 @@ const loadOrderPools = async (
   const groupIdsByListingId = await listingGroups.getIdsByKeys(
     involved.map((listing) => listing.id),
   );
-  const [remainingByListingId, remainingByGroupId, holidays] =
-    await Promise.all([
-      remainingBySpan(involved, date),
-      groupRemainingBySpan(involved, groupIdsByListingId, date),
-      date === null ? Promise.resolve([]) : getActiveHolidays(),
-    ]);
+  const spanOf = (listing: ListingWithCount): number =>
+    date === null ? 1 : bookingSpanDays(listing);
+  const spanByGroupId = widestSpanPerGroup(
+    involved,
+    groupIdsByListingId,
+    spanOf,
+  );
+  const [snapshot, holidays] = await Promise.all([
+    loadCapacitySnapshot(
+      involved,
+      date,
+      Math.max(1, ...involved.map(spanOf)),
+      groupIdsByListingId,
+    ),
+    date === null ? Promise.resolve([]) : getActiveHolidays(),
+  ]);
+  const remainingByListingId = remainingFromSnapshot(
+    snapshot,
+    involved,
+    spanOf,
+  );
+  const remainingByGroupId = groupRemainingFromSnapshot(
+    snapshot,
+    spanByGroupId,
+  );
   if (date !== null) {
     for (const listing of involved) {
       if (

--- a/src/shared/db/attendees/capacity/groups.ts
+++ b/src/shared/db/attendees/capacity/groups.ts
@@ -8,12 +8,7 @@ import { columnMapByIds } from "#shared/db/query.ts";
 import type { BatchLookup } from "#shared/request-cache.ts";
 import type { ListingType } from "#shared/types.ts";
 import { getListingGroupMembership, useListingById } from "./listing.ts";
-import {
-  daySpan,
-  expandDailyRange,
-  type IntervalRow,
-  perDayLoads,
-} from "./range.ts";
+import { daySpan, type IntervalRow, perDayLoads } from "./range.ts";
 import type { ListingForGroupLookup, PerIdDayLoader } from "./types.ts";
 
 /* jscpd:ignore-end */
@@ -137,23 +132,6 @@ export const getGroupPerDayRemaining: PerIdDayLoader<
       days.map((day) => [day, max_attendees - base - loads.get(day)!]),
     );
   })(caps);
-};
-
-/** Tightest remaining group capacity over a whole daily span. */
-export const getGroupRemainingForSpan = async (
-  groupIds: number[],
-  date: string | null,
-  spanDays = 1,
-): Promise<RemainingMap> => {
-  if (date === null) return getGroupRemainingByGroupId(groupIds, null);
-  const days = expandDailyRange(date, spanDays);
-  const perDay = await getGroupPerDayRemaining(groupIds, days);
-  return new Map(
-    [...perDay].map(([groupId, byDay]) => [
-      groupId,
-      Math.min(...days.map((day) => byDay.get(day)!)),
-    ]),
-  );
 };
 
 /** Date-less remaining for capped groups reached from cumulative listings. */

--- a/src/shared/db/attendees/capacity/remaining.ts
+++ b/src/shared/db/attendees/capacity/remaining.ts
@@ -1,40 +1,6 @@
-/* jscpd:ignore-start */
-import { filter } from "#fp";
-import { countsPerDate } from "#shared/capacity-rules.ts";
-import { inPlaceholders, queryAll } from "#shared/db/client.ts";
-import { listingGroups } from "#shared/db/groups.ts";
-import {
-  getGroupPerDayRemaining,
-  getGroupRemainingByGroupId,
-} from "./groups.ts";
-import { getListingGroupMembership, useListingById } from "./listing.ts";
-import {
-  daySpan,
-  expandDailyRange,
-  type IntervalRow,
-  perDayLoads,
-} from "./range.ts";
-import type { ListingCapacityRow, PerIdDayLoader } from "./types.ts";
-
-/* jscpd:ignore-end */
-
-/** Overlapping booking rows for several listings in one query. */
-const overlappingRowsByListing: PerIdDayLoader<IntervalRow[]> = async (
-  listingIds,
-  days,
-) => {
-  if (listingIds.length === 0) return new Map();
-  const { startAt, endAt } = daySpan(days);
-  const rows = await queryAll<IntervalRow & { listing_id: number }>(
-    `SELECT attendee.listing_id, attendee.start_at, attendee.end_at, attendee.quantity
-       FROM listing_attendees AS attendee
-      WHERE attendee.listing_id IN (${inPlaceholders(
-        listingIds,
-      )}) AND attendee.start_at < ? AND attendee.end_at > ?`,
-    [...listingIds, endAt, startAt],
-  );
-  return Map.groupBy(rows, (row) => row.listing_id);
-};
+import { useListingById } from "./listing.ts";
+import { loadCapacitySnapshot, remainingFromSnapshot } from "./snapshot.ts";
+import type { ListingCapacityRow } from "./types.ts";
 
 /** Remaining bookable units for each listing over a date range. */
 export function getListingRemainingForRange(
@@ -59,48 +25,8 @@ export async function getListingRemainingForRange(
       ),
     );
   }
-  const listings = listingsOrId;
-  const usesRange = (listing: ListingCapacityRow): boolean =>
-    countsPerDate(listing.listing_type) && date !== null;
-  const daily = filter(usesRange)(listings);
-  const totals = filter((listing: ListingCapacityRow) => !usesRange(listing))(
-    listings,
-  );
-  const days = date ? expandDailyRange(date, durationDays) : [];
-  const membership = await getListingGroupMembership(listings);
-  const groupsOf = (listing: ListingCapacityRow): number[] =>
-    listingGroups.idsFor(membership, listing.id);
-
-  const [totalGroupRemaining, overlapByListing, dailyGroupPerDay] =
-    await Promise.all([
-      getGroupRemainingByGroupId(totals.flatMap(groupsOf), null),
-      overlappingRowsByListing(
-        daily.map((listing) => listing.id),
-        days,
-      ),
-      getGroupPerDayRemaining(daily.flatMap(groupsOf), days),
-    ]);
-
-  const totalRemaining = totals.map((listing): [number, number] => {
-    const base = listing.max_attendees - listing.attendee_count;
-    const groupRemainings = groupsOf(listing)
-      .map((groupId) => totalGroupRemaining.get(groupId))
-      .filter((remaining): remaining is number => remaining !== undefined);
-    return [listing.id, Math.min(base, ...groupRemainings)];
-  });
-  const dailyRemaining = daily.map((listing): [number, number] => {
-    const loads = perDayLoads(overlapByListing.get(listing.id) ?? [], days);
-    const listingRemaining = Math.min(
-      ...days.map((day) => listing.max_attendees - loads.get(day)!),
-    );
-    const groupPerDayMins = groupsOf(listing)
-      .map((groupId) => dailyGroupPerDay.get(groupId))
-      .filter(
-        (remaining): remaining is Map<string, number> =>
-          remaining !== undefined,
-      )
-      .map((remaining) => Math.min(...days.map((day) => remaining.get(day)!)));
-    return [listing.id, Math.min(listingRemaining, ...groupPerDayMins)];
-  });
-  return new Map([...totalRemaining, ...dailyRemaining]);
+  // Every listing here shares one span, so the widest-span snapshot is that
+  // span and each listing reads all of its days.
+  const snapshot = await loadCapacitySnapshot(listingsOrId, date, durationDays);
+  return remainingFromSnapshot(snapshot, listingsOrId, () => durationDays);
 }

--- a/src/shared/db/attendees/capacity/snapshot.ts
+++ b/src/shared/db/attendees/capacity/snapshot.ts
@@ -1,0 +1,178 @@
+/**
+ * One capacity reading that answers every span on a page.
+ *
+ * A page offering several durations used to ask the database again for each
+ * one. Every one of those questions reads the same booking rows — a two-night
+ * stay's days are the first two days of a five-night stay's — so this loads the
+ * widest span once and works the shorter spans out from it in memory. A gallery
+ * with nine durations then costs what one duration costs.
+ */
+
+import { countsPerDate } from "#shared/capacity-rules.ts";
+import { inPlaceholders, queryAll } from "#shared/db/client.ts";
+import { listingGroups } from "#shared/db/groups.ts";
+import {
+  getGroupPerDayRemaining,
+  getGroupRemainingByGroupId,
+} from "./groups.ts";
+import { getListingGroupMembership } from "./listing.ts";
+import {
+  daySpan,
+  expandDailyRange,
+  type IntervalRow,
+  perDayLoads,
+} from "./range.ts";
+import type { ListingCapacityRow } from "./types.ts";
+
+/** Booked units per day for each listing, in one query. */
+const loadsByListing = async (
+  listingIds: number[],
+  days: string[],
+): Promise<Map<number, Map<string, number>>> => {
+  if (listingIds.length === 0) return new Map();
+  const { startAt, endAt } = daySpan(days);
+  const rows = await queryAll<IntervalRow & { listing_id: number }>(
+    `SELECT attendee.listing_id, attendee.start_at, attendee.end_at, attendee.quantity
+       FROM listing_attendees AS attendee
+      WHERE attendee.listing_id IN (${inPlaceholders(
+        listingIds,
+      )}) AND attendee.start_at < ? AND attendee.end_at > ?`,
+    [...listingIds, endAt, startAt],
+  );
+  const byListing = Map.groupBy(rows, (row) => row.listing_id);
+  return new Map(
+    listingIds.map((id) => [id, perDayLoads(byListing.get(id) ?? [], days)]),
+  );
+};
+
+/**
+ * Everything a span calculation reads, loaded once for the widest span in play.
+ * `days` is empty when no date is chosen, which is what makes a reading
+ * date-less: the day-by-day figures are then unused and the running totals
+ * answer instead.
+ */
+export type CapacitySnapshot = {
+  days: string[];
+  membership: ReadonlyMap<number, number[]>;
+  bookedByDay: ReadonlyMap<number, ReadonlyMap<string, number>>;
+  groupByDay: ReadonlyMap<number, ReadonlyMap<string, number>>;
+  datelessGroupRemaining: ReadonlyMap<number, number>;
+};
+
+/** Whether this listing is judged day by day in this snapshot. */
+const judgedByDay = (
+  listing: ListingCapacityRow,
+  snapshot: Pick<CapacitySnapshot, "days">,
+): boolean => countsPerDate(listing.listing_type) && snapshot.days.length > 0;
+
+/**
+ * Read capacity for `listings` once, covering every day the widest booking
+ * span reaches from `date`. Pass `knownMembership` when the caller already
+ * knows which groups the listings belong to, to save that lookup.
+ */
+export const loadCapacitySnapshot = async (
+  listings: ListingCapacityRow[],
+  date: string | null,
+  widestSpanDays: number,
+  knownMembership?: ReadonlyMap<number, number[]>,
+): Promise<CapacitySnapshot> => {
+  const days = date ? expandDailyRange(date, widestSpanDays) : [];
+  const membership =
+    knownMembership ?? (await getListingGroupMembership(listings));
+  const groupsOf = (listing: ListingCapacityRow): number[] =>
+    listingGroups.idsFor(membership, listing.id);
+  const byDay = listings.filter((listing) => judgedByDay(listing, { days }));
+  const byTotal = listings.filter((listing) => !judgedByDay(listing, { days }));
+
+  const [datelessGroupRemaining, bookedByDay, groupByDay] = await Promise.all([
+    getGroupRemainingByGroupId(byTotal.flatMap(groupsOf), null),
+    loadsByListing(
+      byDay.map((listing) => listing.id),
+      days,
+    ),
+    // Every group, not just the day-judged listings' groups: a caller asking
+    // what a whole group has left needs its day-by-day figures too.
+    days.length === 0
+      ? Promise.resolve(new Map<number, Map<string, number>>())
+      : getGroupPerDayRemaining(listings.flatMap(groupsOf), days),
+  ]);
+  return { bookedByDay, datelessGroupRemaining, days, groupByDay, membership };
+};
+
+/** The lowest of a set of day-by-day figures over the given days. */
+const lowestOverDays = (
+  byDay: ReadonlyMap<string, number>,
+  days: string[],
+): number => Math.min(...days.map((day) => byDay.get(day)!));
+
+/**
+ * How many units each listing has left, each judged over its own booking span.
+ * `spanOf` says how many days that listing occupies; a listing not judged day
+ * by day reads its running total instead.
+ */
+export const remainingFromSnapshot = <Listing extends ListingCapacityRow>(
+  snapshot: CapacitySnapshot,
+  listings: Listing[],
+  spanOf: (listing: Listing) => number,
+): Map<number, number> => {
+  const groupsOf = (listing: Listing): number[] =>
+    listingGroups.idsFor(snapshot.membership, listing.id);
+  return new Map(
+    listings.map((listing: Listing): [number, number] => {
+      const capsOf = (
+        source: ReadonlyMap<number, ReadonlyMap<string, number>>,
+        days: string[],
+      ): number[] =>
+        groupsOf(listing)
+          .map((groupId) => source.get(groupId))
+          .filter((byDay): byDay is ReadonlyMap<string, number> => !!byDay)
+          .map((byDay) => lowestOverDays(byDay, days));
+      if (!judgedByDay(listing, snapshot)) {
+        const groupCaps = groupsOf(listing)
+          .map((groupId) => snapshot.datelessGroupRemaining.get(groupId))
+          .filter((remaining): remaining is number => remaining !== undefined);
+        return [
+          listing.id,
+          Math.min(
+            listing.max_attendees - listing.attendee_count,
+            ...groupCaps,
+          ),
+        ];
+      }
+      const days = snapshot.days.slice(0, spanOf(listing));
+      const booked = snapshot.bookedByDay.get(listing.id)!;
+      const ownRemaining = Math.min(
+        ...days.map((day) => listing.max_attendees - booked.get(day)!),
+      );
+      return [
+        listing.id,
+        Math.min(ownRemaining, ...capsOf(snapshot.groupByDay, days)),
+      ];
+    }),
+  );
+};
+
+/**
+ * How many units each capped group has left, each judged over the span given
+ * for it — the widest any of its listings would occupy, since the cap has to
+ * hold on every day any of them takes up.
+ */
+export const groupRemainingFromSnapshot = (
+  snapshot: CapacitySnapshot,
+  spanByGroupId: ReadonlyMap<number, number>,
+): Map<number, number> => {
+  if (snapshot.days.length === 0) {
+    return new Map(snapshot.datelessGroupRemaining);
+  }
+  const remaining = new Map<number, number>();
+  for (const [groupId, span] of spanByGroupId) {
+    const byDay = snapshot.groupByDay.get(groupId);
+    if (byDay) {
+      remaining.set(
+        groupId,
+        lowestOverDays(byDay, snapshot.days.slice(0, span)),
+      );
+    }
+  }
+  return remaining;
+};

--- a/src/shared/db/attendees/capacity/snapshot.ts
+++ b/src/shared/db/attendees/capacity/snapshot.ts
@@ -1,16 +1,17 @@
 /**
  * One capacity reading that answers every span on a page.
  *
- * A page offering several durations used to ask the database again for each
- * one. Every one of those questions reads the same booking rows — a two-night
- * stay's days are the first two days of a five-night stay's — so this loads the
- * widest span once and works the shorter spans out from it in memory. A gallery
- * with nine durations then costs what one duration costs.
+ * A shorter stay's days are the first days of a longer one's, so a reading that
+ * covers the widest span in play answers every narrower span too — in memory,
+ * with no further reads. A page offering nine booking lengths therefore costs
+ * what one length costs, which is what keeps it inside the edge request's
+ * subrequest budget.
  */
 
 import { countsPerDate } from "#shared/capacity-rules.ts";
 import { inPlaceholders, queryAll } from "#shared/db/client.ts";
 import { listingGroups } from "#shared/db/groups.ts";
+import { clampDurationDays } from "#shared/types.ts";
 import {
   getGroupPerDayRemaining,
   getGroupRemainingByGroupId,
@@ -99,6 +100,14 @@ export const loadCapacitySnapshot = async (
   return { bookedByDay, datelessGroupRemaining, days, groupByDay, membership };
 };
 
+/** The snapshot's first `span` days. The span is clamped the same way a stored
+ * booking's is, so a caller asking for no days at all still reads one — the day
+ * the booking starts. */
+const daysOfSpan = (
+  snapshot: Pick<CapacitySnapshot, "days">,
+  span: number,
+): string[] => snapshot.days.slice(0, clampDurationDays(span));
+
 /** The lowest of a set of day-by-day figures over the given days. */
 const lowestOverDays = (
   byDay: ReadonlyMap<string, number>,
@@ -139,7 +148,7 @@ export const remainingFromSnapshot = <Listing extends ListingCapacityRow>(
           ),
         ];
       }
-      const days = snapshot.days.slice(0, spanOf(listing));
+      const days = daysOfSpan(snapshot, spanOf(listing));
       const booked = snapshot.bookedByDay.get(listing.id)!;
       const ownRemaining = Math.min(
         ...days.map((day) => listing.max_attendees - booked.get(day)!),
@@ -168,10 +177,7 @@ export const groupRemainingFromSnapshot = (
   for (const [groupId, span] of spanByGroupId) {
     const byDay = snapshot.groupByDay.get(groupId);
     if (byDay) {
-      remaining.set(
-        groupId,
-        lowestOverDays(byDay, snapshot.days.slice(0, span)),
-      );
+      remaining.set(groupId, lowestOverDays(byDay, daysOfSpan(snapshot, span)));
     }
   }
   return remaining;

--- a/src/shared/db/attendees/capacity/snapshot.ts
+++ b/src/shared/db/attendees/capacity/snapshot.ts
@@ -8,6 +8,7 @@
  * subrequest budget.
  */
 
+import { requiredMapValue } from "#fp";
 import { countsPerDate } from "#shared/capacity-rules.ts";
 import { inPlaceholders, queryAll } from "#shared/db/client.ts";
 import { listingGroups } from "#shared/db/groups.ts";
@@ -112,7 +113,12 @@ const daysOfSpan = (
 const lowestOverDays = (
   byDay: ReadonlyMap<string, number>,
   days: string[],
-): number => Math.min(...days.map((day) => byDay.get(day)!));
+): number =>
+  Math.min(
+    ...days.map((day) =>
+      requiredMapValue(byDay, day, `No capacity read for ${day}`),
+    ),
+  );
 
 /**
  * How many units each listing has left, each judged over its own booking span.
@@ -149,9 +155,17 @@ export const remainingFromSnapshot = <Listing extends ListingCapacityRow>(
         ];
       }
       const days = daysOfSpan(snapshot, spanOf(listing));
-      const booked = snapshot.bookedByDay.get(listing.id)!;
+      const booked = requiredMapValue(
+        snapshot.bookedByDay,
+        listing.id,
+        `Listing ${listing.id} was not in the capacity reading`,
+      );
       const ownRemaining = Math.min(
-        ...days.map((day) => listing.max_attendees - booked.get(day)!),
+        ...days.map(
+          (day) =>
+            listing.max_attendees -
+            requiredMapValue(booked, day, `No booking total for ${day}`),
+        ),
       );
       return [
         listing.id,

--- a/test/features/public/order/helpers.ts
+++ b/test/features/public/order/helpers.ts
@@ -8,8 +8,7 @@ import { expectStatus } from "#test-utils/assertions.ts";
 import { mockRequest } from "#test-utils/mocks.ts";
 import { enablePublicSite } from "#test-utils/settings.ts";
 
-/** Shared helpers for the server (public order) test files. Not itself a
- * test file. */
+/** Shared helpers for the public order test files. Not itself a test file. */
 
 /** Turn the public site + order page on for each test in the block. */
 export const enablePublicOrder = (): void => {

--- a/test/features/public/order/page.test.ts
+++ b/test/features/public/order/page.test.ts
@@ -3,7 +3,7 @@ import { describe, it as test } from "@std/testing/bdd";
 import { handleRequest } from "#routes";
 import { groups } from "#shared/db/groups.ts";
 import { settings } from "#shared/db/settings.ts";
-import { enablePublicOrder } from "#test/integration/server/order-page-helpers.ts";
+import { enablePublicOrder } from "#test/features/public/order/helpers.ts";
 import {
   assertPublicHtml,
   expectRedirect,

--- a/test/features/public/order/selection.test.ts
+++ b/test/features/public/order/selection.test.ts
@@ -9,7 +9,7 @@ import {
   fetchAvailability,
   orderDate,
   selectOrder,
-} from "#test/integration/server/order-page-helpers.ts";
+} from "#test/features/public/order/helpers.ts";
 import { expectRedirect, expectStatus } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestAttendee } from "#test-utils/db-helpers/attendees.ts";

--- a/test/features/public/order/spans.test.ts
+++ b/test/features/public/order/spans.test.ts
@@ -1,0 +1,93 @@
+/**
+ * How long a booking is judged over on the gallery: a fixed-length stay is
+ * judged over every day it takes up, a buyer-chosen-length one over a single
+ * day, and a day the site is closed is offered to nobody.
+ */
+
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { addDays } from "#shared/dates.ts";
+import { setGroupPackageMembers } from "#shared/db/groups.ts";
+import {
+  enablePublicOrder,
+  fetchAvailability,
+  orderDate,
+} from "#test/features/public/order/helpers.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { bookUnits } from "#test-utils/db-helpers/attendees.ts";
+import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
+import { createTestHoliday } from "#test-utils/db-helpers/holidays.ts";
+import {
+  createDailyTestListing,
+  createTestListing,
+} from "#test-utils/db-helpers/listings.ts";
+
+describeWithEnv(
+  "server (public order) — how long a booking is judged over",
+  { db: true, triggers: true },
+  () => {
+    enablePublicOrder();
+
+    test("a buyer-chosen length is judged on its start day alone", async () => {
+      const start = orderDate();
+      // Two days long at most, but the buyer picks; the gallery cannot know
+      // which, so it must judge the start day only.
+      const flex = await createDailyTestListing({
+        customisableDays: true,
+        dayPrices: { 1: 100, 2: 180 },
+        durationDays: 2,
+        maxAttendees: 1,
+        name: "Flexible stay",
+      });
+      // The second day is full, which only matters to a two-day booking.
+      await bookUnits(flex.id, 1, addDays(start, 1));
+
+      const data = await fetchAvailability(`start_date=${start}`);
+
+      expect(data.states[`listing:${flex.id}`]).toEqual({
+        label: "",
+        state: "available",
+      });
+    });
+
+    test("a day the site is closed is offered to nobody", async () => {
+      const start = orderDate();
+      const daily = await createDailyTestListing({
+        maxAttendees: 5,
+        name: "Closed that day",
+      });
+      await createTestHoliday({
+        endDate: start,
+        name: "Closed",
+        startDate: start,
+      });
+
+      const data = await fetchAvailability(`start_date=${start}`);
+
+      expect(data.states[`listing:${daily.id}`]).toEqual({
+        label: "Sold Out",
+        state: "unavailable",
+      });
+    });
+
+    test("a package can be added on its own", async () => {
+      const group = await createTestGroup({ isPackage: true, name: "Bundle" });
+      const member = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 5,
+        name: "Bundle part",
+        unitPrice: 0,
+      });
+      await setGroupPackageMembers(group.id, [
+        { listingId: member.id, price: 500 },
+      ]);
+
+      const data = await fetchAvailability("");
+
+      expect(data.states[`package:${group.id}`]).toEqual({
+        label: "",
+        state: "available",
+      });
+    });
+  },
+);

--- a/test/features/public/order/spans.test.ts
+++ b/test/features/public/order/spans.test.ts
@@ -20,6 +20,7 @@ import { createTestHoliday } from "#test-utils/db-helpers/holidays.ts";
 import {
   createDailyTestListing,
   createTestListing,
+  pastCloseTime,
 } from "#test-utils/db-helpers/listings.ts";
 
 describeWithEnv(
@@ -68,6 +69,20 @@ describeWithEnv(
         label: "Sold Out",
         state: "unavailable",
       });
+    });
+
+    test("a listing whose sale has ended cannot be added", async () => {
+      // Plenty of room, but the sale closed yesterday: room alone is not
+      // enough to offer it.
+      const closed = await createTestListing({
+        closesAt: pastCloseTime(),
+        maxAttendees: 10,
+        name: "Sale over",
+      });
+
+      const data = await fetchAvailability("");
+
+      expect(data.states[`listing:${closed.id}`]?.state).not.toBe("available");
     });
 
     test("a package can be added on its own", async () => {

--- a/test/integration/server/webhooks/custom-questions-single.test.ts
+++ b/test/integration/server/webhooks/custom-questions-single.test.ts
@@ -216,8 +216,9 @@ describeWithEnv(
       );
 
       // The intact answer is saved; the ref with no id is dropped, not guessed.
+      const attendeeId = await soleAttendeeId(listing.id);
       const textAnswers = await getAttendeeTextAnswers(
-        await soleAttendeeId(listing.id),
+        attendeeId,
         await getTestPrivateKey(),
       );
       expect(textAnswers.get(goodQ.id)).toBe("Step-free entrance");
@@ -226,9 +227,10 @@ describeWithEnv(
       // Read the saved rows rather than the answers, because an answer saved
       // against an id that points at no stored text reads back as absent — the
       // same as never having been saved. Only the row itself tells them apart.
+      // Scoped to this booking: other bookings answer these questions too.
       const savedForBadRefs = await getDb().execute({
-        args: [lostQ.id, nonsenseQ.id],
-        sql: "SELECT question_id FROM attendee_answers WHERE question_id IN (?, ?)",
+        args: [attendeeId, lostQ.id, nonsenseQ.id],
+        sql: "SELECT question_id FROM attendee_answers WHERE attendee_id = ? AND question_id IN (?, ?)",
       });
       expect(savedForBadRefs.rows).toEqual([]);
 

--- a/test/shared/db/attendees/capacity/groups.test.ts
+++ b/test/shared/db/attendees/capacity/groups.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { addDays } from "#shared/dates.ts";
-import { attendeesApi } from "#shared/db/attendees/api.ts";
 import {
   getDatelessGroupRemaining,
   getGroupPerDayRemaining,
@@ -13,6 +12,7 @@ import {
 import { listingGroups } from "#shared/db/groups.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { bookUnits } from "#test-utils/db-helpers/attendees.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import {
   createDailyTestListing,
@@ -74,20 +74,6 @@ describeWithEnv(
   },
 );
 
-/** Book units of a listing, on a day when one is given. */
-const book = async (
-  listingId: number,
-  quantity: number,
-  date?: string,
-): Promise<void> => {
-  const result = await attendeesApi.createAttendeeAtomic({
-    bookings: [{ ...(date ? { date } : {}), listingId, quantity }],
-    email: "booker@example.com",
-    name: "Booker",
-  });
-  if (!result.success) throw new Error(`Could not book: ${result.reason}`);
-};
-
 describeWithEnv(
   "db > attendees > group capacity by day",
   { db: true, triggers: true },
@@ -118,13 +104,34 @@ describeWithEnv(
         maxAttendees: 10,
         name: "Dated member",
       });
-      await book(anyDay.id, 3);
-      await book(daily.id, 2, day());
+      await bookUnits(anyDay.id, 3);
+      await bookUnits(daily.id, 2, day());
 
       const perDay = await getGroupPerDayRemaining([group.id], [day()]);
 
       // 10 less the 3 booked on any day less the 2 booked on this day.
       expect(perDay.get(group.id)?.get(day())).toBe(5);
+    });
+
+    test("counts both kinds of member against the limit on a chosen day", async () => {
+      const group = await createTestGroup({ maxAttendees: 10, name: "Both" });
+      const anyDay = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Any day counted",
+      });
+      const daily = await createDailyTestListing({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Dated counted",
+      });
+      await bookUnits(anyDay.id, 3);
+      await bookUnits(daily.id, 2, day());
+
+      const remaining = await getGroupRemainingByGroupId([group.id], day());
+
+      // 10 less the 3 booked whatever the day, less the 2 booked on this one.
+      expect(remaining.get(group.id)).toBe(5);
     });
 
     test("reports nothing left, not one, for a full group", async () => {
@@ -134,7 +141,7 @@ describeWithEnv(
         maxAttendees: 10,
         name: "Filler",
       });
-      await book(listing.id, 4);
+      await bookUnits(listing.id, 4);
 
       const remaining = await getGroupRemainingByGroupId([group.id]);
 

--- a/test/shared/db/attendees/capacity/groups.test.ts
+++ b/test/shared/db/attendees/capacity/groups.test.ts
@@ -1,10 +1,17 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { addDays } from "#shared/dates.ts";
+import { attendeesApi } from "#shared/db/attendees/api.ts";
 import {
   getDatelessGroupRemaining,
+  getGroupPerDayRemaining,
+  getGroupRemainingByGroupId,
+  getGroupRemainingByListingId,
   getGroupStaticCapByGroupId,
+  remainingByListingOverGroups,
 } from "#shared/db/attendees/capacity/groups.ts";
 import { listingGroups } from "#shared/db/groups.ts";
+import { todayInTz } from "#shared/timezone.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import {
@@ -63,6 +70,131 @@ describeWithEnv(
       expect(capacities.get(capped.id)).toBe(5);
       expect(capacities.has(uncapped.id)).toBe(false);
       expect(capacities.size).toBe(1);
+    });
+  },
+);
+
+/** Book units of a listing, on a day when one is given. */
+const book = async (
+  listingId: number,
+  quantity: number,
+  date?: string,
+): Promise<void> => {
+  const result = await attendeesApi.createAttendeeAtomic({
+    bookings: [{ ...(date ? { date } : {}), listingId, quantity }],
+    email: "booker@example.com",
+    name: "Booker",
+  });
+  if (!result.success) throw new Error(`Could not book: ${result.reason}`);
+};
+
+describeWithEnv(
+  "db > attendees > group capacity by day",
+  { db: true, triggers: true },
+  () => {
+    const day = (): string => addDays(todayInTz("UTC"), 2);
+
+    test("answers for a single group capped at a single unit", async () => {
+      const group = await createTestGroup({
+        maxAttendees: 1,
+        name: "Just one",
+      });
+      await createDailyTestListing({ groupId: group.id, name: "Only room" });
+
+      const perDay = await getGroupPerDayRemaining([group.id], [day()]);
+
+      expect(perDay.get(group.id)?.get(day())).toBe(1);
+    });
+
+    test("takes both the any-day bookings and that day's from the limit", async () => {
+      const group = await createTestGroup({ maxAttendees: 10, name: "Mixed" });
+      const anyDay = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Any day member",
+      });
+      const daily = await createDailyTestListing({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Dated member",
+      });
+      await book(anyDay.id, 3);
+      await book(daily.id, 2, day());
+
+      const perDay = await getGroupPerDayRemaining([group.id], [day()]);
+
+      // 10 less the 3 booked on any day less the 2 booked on this day.
+      expect(perDay.get(group.id)?.get(day())).toBe(5);
+    });
+
+    test("reports nothing left, not one, for a full group", async () => {
+      const group = await createTestGroup({ maxAttendees: 4, name: "Full" });
+      const listing = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Filler",
+      });
+      await book(listing.id, 4);
+
+      const remaining = await getGroupRemainingByGroupId([group.id]);
+
+      expect(remaining.get(group.id)).toBe(0);
+    });
+  },
+);
+
+describeWithEnv(
+  "db > attendees > group limits per listing",
+  { db: true },
+  () => {
+    test("gives a listing the lowest limit of the groups it is in", () => {
+      const membership = new Map([
+        [1, [10, 20]],
+        [2, []],
+      ]);
+      const byGroup = new Map([
+        [10, 7],
+        [20, 3],
+      ]);
+
+      const perListing = remainingByListingOverGroups(
+        [1, 2],
+        membership,
+        byGroup,
+      );
+
+      expect(perListing.get(1)).toBe(3);
+      // In no capped group at all, so it has no group limit to report.
+      expect(perListing.has(2)).toBe(false);
+    });
+
+    test("leaves day-by-day listings out of a read with no date", async () => {
+      const standardGroup = await createTestGroup({
+        maxAttendees: 6,
+        name: "Any day pool",
+      });
+      const dailyGroup = await createTestGroup({
+        maxAttendees: 6,
+        name: "Dated pool",
+      });
+      const standard = await createTestListing({
+        groupId: standardGroup.id,
+        maxAttendees: 6,
+        name: "Any day",
+      });
+      const daily = await createDailyTestListing({
+        groupId: dailyGroup.id,
+        maxAttendees: 6,
+        name: "Dated",
+      });
+
+      const remaining = await getGroupRemainingByListingId(
+        [standard, daily],
+        null,
+      );
+
+      expect(remaining.get(standard.id)).toBe(6);
+      expect(remaining.has(daily.id)).toBe(false);
     });
   },
 );

--- a/test/shared/db/attendees/capacity/snapshot.test.ts
+++ b/test/shared/db/attendees/capacity/snapshot.test.ts
@@ -171,17 +171,29 @@ describeWithEnv(
         maxAttendees: 8,
         name: "Sold any day",
       });
+      // A second one in no group at all: its booking has no day to sit on, so
+      // only a running total can see it.
+      const ungrouped = await createTestListing({
+        maxAttendees: 8,
+        name: "Sold any day, ungrouped",
+      });
       const [oneNight] = await listingsOfLengths("Alongside", [1]);
-      // Booked with no date at all: only a running total can see it.
+      // Booked with no date at all: only a running total can see these.
       await bookUnits(anyDay.id, 3);
-      const listings = [await reload(anyDay.id), oneNight!];
+      await bookUnits(ungrouped.id, 3);
+      const listings = [
+        await reload(anyDay.id),
+        await reload(ungrouped.id),
+        oneNight!,
+      ];
 
       const snapshot = await loadCapacitySnapshot(listings, date, 1);
       const remaining = remainingFromSnapshot(snapshot, listings, () => 1);
 
-      // Its own 5 gives way to the group's 1 left of 4; the daily listing is
-      // unaffected.
+      // Its own 5 gives way to the group's 1 left of 4; the ungrouped one keeps
+      // its 5; the daily listing is unaffected.
       expect(remaining.get(anyDay.id)).toBe(1);
+      expect(remaining.get(ungrouped.id)).toBe(5);
       expect(remaining.get(oneNight!.id)).toBe(10);
     });
 

--- a/test/shared/db/attendees/capacity/snapshot.test.ts
+++ b/test/shared/db/attendees/capacity/snapshot.test.ts
@@ -15,6 +15,8 @@ import {
   remainingFromSnapshot,
 } from "#shared/db/attendees/capacity/snapshot.ts";
 import { listingGroups } from "#shared/db/groups.ts";
+import { getListingWithCount } from "#shared/db/listings/records.ts";
+import { requireValue } from "#shared/required-value.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -30,6 +32,13 @@ const startDate = (): string => addDays(todayInTz("UTC"), 2);
 
 /** Enough for the snapshot's fixed reads, far below one read per length. */
 const SNAPSHOT_CALL_LIMIT = 10;
+
+/** The listing as stored now, with its booked total up to date. */
+const reload = async (listingId: number): Promise<ListingWithCount> =>
+  requireValue(
+    await getListingWithCount(listingId),
+    `Listing ${listingId} vanished`,
+  );
 
 /** Book units of a listing, on a day when one is given. */
 const book = async (
@@ -154,14 +163,57 @@ describeWithEnv(
         name: "Dateless",
       });
       await book(listing.id, 3);
-      const reread = (await getListingRemainingForRange([listing], null)).get(
+      const booked = await reload(listing.id);
+      const reread = (await getListingRemainingForRange([booked], null)).get(
         listing.id,
       );
 
-      const snapshot = await loadCapacitySnapshot([listing], null, 1);
-      const remaining = remainingFromSnapshot(snapshot, [listing], () => 1);
+      const snapshot = await loadCapacitySnapshot([booked], null, 1);
+      const remaining = remainingFromSnapshot(snapshot, [booked], () => 1);
 
+      expect(remaining.get(listing.id)).toBe(5);
       expect(remaining.get(listing.id)).toBe(reread);
+    });
+
+    test("still reads a dateless listing by its total when a date is chosen", async () => {
+      const date = startDate();
+      const anyDay = await createTestListing({
+        maxAttendees: 8,
+        name: "Sold any day",
+      });
+      const [oneNight] = await listingsOfLengths("Alongside", [1]);
+      // Booked with no date at all: only a running total can see it.
+      await book(anyDay.id, 3);
+      const listings = [await reload(anyDay.id), oneNight!];
+
+      const snapshot = await loadCapacitySnapshot(listings, date, 1);
+      const remaining = remainingFromSnapshot(snapshot, listings, () => 1);
+
+      expect(remaining.get(anyDay.id)).toBe(5);
+      expect(remaining.get(oneNight!.id)).toBe(10);
+    });
+
+    test("a group's limit lowers what its listing has left", async () => {
+      const date = startDate();
+      const group = await createTestGroup({ maxAttendees: 4, name: "Capped" });
+      const listing = await createDailyTestListing({
+        durationDays: 1,
+        groupId: group.id,
+        maxAttendees: 10,
+        name: "Roomy but capped",
+      });
+
+      const snapshot = await loadCapacitySnapshot([listing], date, 1);
+
+      // Its own 10 gives way to the group's 4, and the group reads the same.
+      expect(
+        remainingFromSnapshot(snapshot, [listing], () => 1).get(listing.id),
+      ).toBe(4);
+      expect(
+        groupRemainingFromSnapshot(snapshot, new Map([[group.id, 1]])).get(
+          group.id,
+        ),
+      ).toBe(4);
     });
 
     test("reads one day for a stay of no days at all", async () => {

--- a/test/shared/db/attendees/capacity/snapshot.test.ts
+++ b/test/shared/db/attendees/capacity/snapshot.test.ts
@@ -164,6 +164,18 @@ describeWithEnv(
       expect(remaining.get(listing.id)).toBe(reread);
     });
 
+    test("reads one day for a stay of no days at all", async () => {
+      const date = startDate();
+      const [listing] = await listingsOfLengths("Zero", [1]);
+      await book(listing!.id, 4, date);
+
+      const snapshot = await loadCapacitySnapshot([listing!], date, 0);
+      const remaining = remainingFromSnapshot(snapshot, [listing!], () => 0);
+
+      // Not Infinity: a span of no days would otherwise read as no limit.
+      expect(remaining.get(listing!.id)).toBe(6);
+    });
+
     test("skips the membership lookup when the caller already knows it", async () => {
       const date = startDate();
       const listings = await listingsOfLengths("Known", [2]);

--- a/test/shared/db/attendees/capacity/snapshot.test.ts
+++ b/test/shared/db/attendees/capacity/snapshot.test.ts
@@ -7,7 +7,6 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { addDays } from "#shared/dates.ts";
-import { attendeesApi } from "#shared/db/attendees/api.ts";
 import { getListingRemainingForRange } from "#shared/db/attendees/capacity/remaining.ts";
 import {
   groupRemainingFromSnapshot,
@@ -20,6 +19,7 @@ import { requireValue } from "#shared/required-value.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { bookUnits } from "#test-utils/db-helpers/attendees.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import {
   createDailyTestListing,
@@ -39,20 +39,6 @@ const reload = async (listingId: number): Promise<ListingWithCount> =>
     await getListingWithCount(listingId),
     `Listing ${listingId} vanished`,
   );
-
-/** Book units of a listing, on a day when one is given. */
-const book = async (
-  listingId: number,
-  quantity: number,
-  date?: string,
-): Promise<void> => {
-  const result = await attendeesApi.createAttendeeAtomic({
-    bookings: [{ ...(date ? { date } : {}), listingId, quantity }],
-    email: "booker@example.com",
-    name: "Booker",
-  });
-  if (!result.success) throw new Error(`Could not book: ${result.reason}`);
-};
 
 describeWithEnv(
   "db > attendees > capacity snapshot",
@@ -109,7 +95,7 @@ describeWithEnv(
       // A booking on the third day is inside the 3-day stay and outside the
       // 1-day one, so the lengths must not all report the same figure.
       for (const listing of listings) {
-        await book(listing.id, 4, addDays(date, 2));
+        await bookUnits(listing.id, 4, addDays(date, 2));
       }
 
       const fromSnapshot = await remainingPerOwnLength(listings, date);
@@ -141,7 +127,7 @@ describeWithEnv(
         name: "Long stay",
       });
       // Booked on the third day: only the three-day stay reaches it.
-      await book(short.id, 4, addDays(date, 2));
+      await bookUnits(short.id, 4, addDays(date, 2));
 
       const snapshot = await loadCapacitySnapshot([short, long], date, 3);
 
@@ -162,7 +148,7 @@ describeWithEnv(
         maxAttendees: 8,
         name: "Dateless",
       });
-      await book(listing.id, 3);
+      await bookUnits(listing.id, 3);
       const booked = await reload(listing.id);
       const reread = (await getListingRemainingForRange([booked], null)).get(
         listing.id,
@@ -187,7 +173,7 @@ describeWithEnv(
       });
       const [oneNight] = await listingsOfLengths("Alongside", [1]);
       // Booked with no date at all: only a running total can see it.
-      await book(anyDay.id, 3);
+      await bookUnits(anyDay.id, 3);
       const listings = [await reload(anyDay.id), oneNight!];
 
       const snapshot = await loadCapacitySnapshot(listings, date, 1);
@@ -225,7 +211,7 @@ describeWithEnv(
     test("reads one day for a stay of no days at all", async () => {
       const date = startDate();
       const [listing] = await listingsOfLengths("Zero", [1]);
-      await book(listing!.id, 4, date);
+      await bookUnits(listing!.id, 4, date);
 
       const snapshot = await loadCapacitySnapshot([listing!], date, 0);
       const remaining = remainingFromSnapshot(snapshot, [listing!], () => 0);

--- a/test/shared/db/attendees/capacity/snapshot.test.ts
+++ b/test/shared/db/attendees/capacity/snapshot.test.ts
@@ -1,0 +1,184 @@
+/**
+ * One capacity reading, many booking lengths: the snapshot must cost the same
+ * whether one length or nine are asked about, and every length it works out
+ * must match what reading that length on its own would say.
+ */
+
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { addDays } from "#shared/dates.ts";
+import { attendeesApi } from "#shared/db/attendees/api.ts";
+import { getListingRemainingForRange } from "#shared/db/attendees/capacity/remaining.ts";
+import {
+  groupRemainingFromSnapshot,
+  loadCapacitySnapshot,
+  remainingFromSnapshot,
+} from "#shared/db/attendees/capacity/snapshot.ts";
+import { listingGroups } from "#shared/db/groups.ts";
+import { todayInTz } from "#shared/timezone.ts";
+import type { ListingWithCount } from "#shared/types.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
+import {
+  createDailyTestListing,
+  createTestListing,
+} from "#test-utils/db-helpers/listings.ts";
+import { countDatabaseCalls } from "#test-utils/subrequest-budget.ts";
+
+/** A start date comfortably inside every test listing's booking window. */
+const startDate = (): string => addDays(todayInTz("UTC"), 2);
+
+/** Enough for the snapshot's fixed reads, far below one read per length. */
+const SNAPSHOT_CALL_LIMIT = 10;
+
+/** Book units of a listing, on a day when one is given. */
+const book = async (
+  listingId: number,
+  quantity: number,
+  date?: string,
+): Promise<void> => {
+  const result = await attendeesApi.createAttendeeAtomic({
+    bookings: [{ ...(date ? { date } : {}), listingId, quantity }],
+    email: "booker@example.com",
+    name: "Booker",
+  });
+  if (!result.success) throw new Error(`Could not book: ${result.reason}`);
+};
+
+describeWithEnv(
+  "db > attendees > capacity snapshot",
+  { db: true, triggers: true },
+  () => {
+    /** One daily listing per booking length, each a different number of days. */
+    const listingsOfLengths = async (
+      label: string,
+      lengths: number[],
+    ): Promise<ListingWithCount[]> => {
+      const listings: ListingWithCount[] = [];
+      for (const days of lengths) {
+        listings.push(
+          await createDailyTestListing({
+            durationDays: days,
+            name: `${label} ${days}`,
+          }),
+        );
+      }
+      return listings;
+    };
+
+    /** Read every listing over its own length, from one snapshot. */
+    const remainingPerOwnLength = async (
+      listings: ListingWithCount[],
+      date: string,
+    ): Promise<Map<number, number>> => {
+      const lengthOf = (listing: ListingWithCount): number =>
+        listing.duration_days;
+      const snapshot = await loadCapacitySnapshot(
+        listings,
+        date,
+        Math.max(...listings.map(lengthOf)),
+      );
+      return remainingFromSnapshot(snapshot, listings, lengthOf);
+    };
+
+    test("reads nine booking lengths in the same calls as one", async () => {
+      const date = startDate();
+      const one = await listingsOfLengths("Single", [1]);
+      const nine = await listingsOfLengths("Many", [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+      const calls = (listings: ListingWithCount[]): Promise<number> =>
+        countDatabaseCalls(SNAPSHOT_CALL_LIMIT, () =>
+          remainingPerOwnLength(listings, date),
+        );
+
+      expect(await calls(nine)).toBe(await calls(one));
+    });
+
+    test("says the same as reading each booking length on its own", async () => {
+      const date = startDate();
+      const listings = await listingsOfLengths("Agrees", [1, 2, 3]);
+      // A booking on the third day is inside the 3-day stay and outside the
+      // 1-day one, so the lengths must not all report the same figure.
+      for (const listing of listings) {
+        await book(listing.id, 4, addDays(date, 2));
+      }
+
+      const fromSnapshot = await remainingPerOwnLength(listings, date);
+
+      for (const listing of listings) {
+        const onItsOwn = await getListingRemainingForRange(
+          [listing],
+          date,
+          listing.duration_days,
+        );
+        expect(fromSnapshot.get(listing.id)).toBe(onItsOwn.get(listing.id));
+      }
+      // The one-day stay misses the booking; the three-day stay meets it.
+      expect(fromSnapshot.get(listings[0]!.id)).toBe(10);
+      expect(fromSnapshot.get(listings[2]!.id)).toBe(6);
+    });
+
+    test("judges a group over the widest length any of its listings takes", async () => {
+      const date = startDate();
+      const group = await createTestGroup({ maxAttendees: 10, name: "Shared" });
+      const short = await createDailyTestListing({
+        durationDays: 1,
+        groupId: group.id,
+        name: "Short stay",
+      });
+      const long = await createDailyTestListing({
+        durationDays: 3,
+        groupId: group.id,
+        name: "Long stay",
+      });
+      // Booked on the third day: only the three-day stay reaches it.
+      await book(short.id, 4, addDays(date, 2));
+
+      const snapshot = await loadCapacitySnapshot([short, long], date, 3);
+
+      expect(
+        groupRemainingFromSnapshot(snapshot, new Map([[group.id, 1]])).get(
+          group.id,
+        ),
+      ).toBe(10);
+      expect(
+        groupRemainingFromSnapshot(snapshot, new Map([[group.id, 3]])).get(
+          group.id,
+        ),
+      ).toBe(6);
+    });
+
+    test("reads a listing with no date by its running total", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 8,
+        name: "Dateless",
+      });
+      await book(listing.id, 3);
+      const reread = (await getListingRemainingForRange([listing], null)).get(
+        listing.id,
+      );
+
+      const snapshot = await loadCapacitySnapshot([listing], null, 1);
+      const remaining = remainingFromSnapshot(snapshot, [listing], () => 1);
+
+      expect(remaining.get(listing.id)).toBe(reread);
+    });
+
+    test("skips the membership lookup when the caller already knows it", async () => {
+      const date = startDate();
+      const listings = await listingsOfLengths("Known", [2]);
+      const membership = await listingGroups.getIdsByKeys(
+        listings.map((listing) => listing.id),
+      );
+
+      const withLookup = await countDatabaseCalls(SNAPSHOT_CALL_LIMIT, () =>
+        loadCapacitySnapshot(listings, date, 2),
+      );
+      const withKnown = await countDatabaseCalls(SNAPSHOT_CALL_LIMIT, () =>
+        loadCapacitySnapshot(listings, date, 2, membership),
+      );
+
+      expect(withKnown).toBe(withLookup - 1);
+    });
+  },
+);

--- a/test/shared/db/attendees/capacity/snapshot.test.ts
+++ b/test/shared/db/attendees/capacity/snapshot.test.ts
@@ -177,7 +177,11 @@ describeWithEnv(
 
     test("still reads a dateless listing by its total when a date is chosen", async () => {
       const date = startDate();
+      // In a capped group, so the reading has to fetch the group's date-less
+      // figure for it — the daily listing alongside cannot stand in.
+      const group = await createTestGroup({ maxAttendees: 4, name: "Any day" });
       const anyDay = await createTestListing({
+        groupId: group.id,
         maxAttendees: 8,
         name: "Sold any day",
       });
@@ -189,7 +193,9 @@ describeWithEnv(
       const snapshot = await loadCapacitySnapshot(listings, date, 1);
       const remaining = remainingFromSnapshot(snapshot, listings, () => 1);
 
-      expect(remaining.get(anyDay.id)).toBe(5);
+      // Its own 5 gives way to the group's 1 left of 4; the daily listing is
+      // unaffected.
+      expect(remaining.get(anyDay.id)).toBe(1);
       expect(remaining.get(oneNight!.id)).toBe(10);
     });
 

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -380,3 +380,18 @@ export const decryptFirstAttendee = async (
   expect(attendees.length).toBe(1);
   return attendees[0]!;
 };
+
+/** Book units of a listing, on a day when one is given. Goes through the
+ * production booking path, so triggers and totals stay true. */
+export const bookUnits = async (
+  listingId: number,
+  quantity: number,
+  date?: string,
+): Promise<void> => {
+  const result = await attendeesApi.createAttendeeAtomic({
+    bookings: [{ ...(date ? { date } : {}), listingId, quantity }],
+    email: "booker@example.com",
+    name: "Booker",
+  });
+  if (!result.success) throw new Error(`Could not book: ${result.reason}`);
+};

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -23,13 +23,23 @@ export const expectNoAttendeesForListings = async (
 /** Book a test attendee onto the given listing(s) directly via the DB,
  *  bypassing the booking routes. Shared by unit tests that just need an
  *  attendee to hang bookings or answers off. */
+/** One booking to make: a listing id on its own, or a listing with the units
+ * and the day it is booked for. */
+export type TestBooking = {
+  listingId: number;
+  quantity?: number;
+  date?: string;
+};
+
 export const bookTestAttendee = async (
-  listingIds: number[],
+  bookings: (number | TestBooking)[],
   name = "Alice",
   email?: string,
 ): Promise<Attendee> => {
   const result = await attendeesApi.createAttendeeAtomic({
-    bookings: listingIds.map((listingId) => ({ listingId })),
+    bookings: bookings.map((booking) =>
+      typeof booking === "number" ? { listingId: booking } : booking,
+    ),
     email: email ?? `${name.toLowerCase()}@test.com`,
     name,
     source: "public",
@@ -381,17 +391,11 @@ export const decryptFirstAttendee = async (
   return attendees[0]!;
 };
 
-/** Book units of a listing, on a day when one is given. Goes through the
- * production booking path, so triggers and totals stay true. */
+/** Book units of a listing, on a day when one is given. */
 export const bookUnits = async (
   listingId: number,
   quantity: number,
   date?: string,
 ): Promise<void> => {
-  const result = await attendeesApi.createAttendeeAtomic({
-    bookings: [{ ...(date ? { date } : {}), listingId, quantity }],
-    email: "booker@example.com",
-    name: "Booker",
-  });
-  if (!result.success) throw new Error(`Could not book: ${result.reason}`);
+  await bookTestAttendee([{ listingId, quantity, ...(date ? { date } : {}) }]);
 };


### PR DESCRIPTION
## What changed

The order gallery shows what is still bookable. It used to work that out separately for each booking length on offer: a site with one-night through nine-night stays asked the database the same question nine times over.

Those questions all read the same bookings. A two-night stay's days are simply the first two days of a nine-night stay's. So the page now reads the longest stay once and works every shorter one out from what it already has.

A site offering nine lengths now costs what one length costs. This matters because Bunny stops an edge request after 50 outside calls, and a busy gallery could get close.

## Why it is safe

New tests check both halves of the claim:

- Nine booking lengths cost the same database calls as one.
- Every figure worked out from the one reading matches what reading that length on its own says — checked with a booking placed on a day only the longer stays reach, so the lengths cannot all quietly report the same number.
- A group shared by a short and a long stay is judged over the longer one, since its limit has to hold on every day either of them takes up.
- A listing with no date still reads its running total.

## Tidying

The single-length reader is now built on the same one reading, so there is one way of answering "what is left over these days" instead of two. A group reader that only the old path used is removed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAN34hVLbTRQbGhxWY74hZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAN34hVLbTRQbGhxWY74hZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Public order availability now provides consistent remaining-capacity calculations across listings and groups.
  - Capacity results accurately account for multi-day spans, group limits, bookings, memberships, and date-less availability.
  - Availability handling for holidays and unavailable dates remains supported.
  - Capacity checks are streamlined, improving efficiency when displaying availability across multiple listings.

- **Tests**
  - Expanded coverage for grouped listings, bookings, capacity limits, multi-day requests, and date-less availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->