### PR TITLE
Capture evidence for editor, restore, and CSV stories

### DIFF
--- a/.github/workflows/spec-evidence.yml
+++ b/.github/workflows/spec-evidence.yml
@@ -76,4 +76,4 @@ jobs:
           name: tickets-evidence
           path: reports/evidence
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 35

--- a/.github/workflows/spec-evidence.yml
+++ b/.github/workflows/spec-evidence.yml
@@ -70,9 +70,10 @@ jobs:
         run: deno task specs:evidence
 
       - name: Upload specification evidence
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: tickets-evidence
           path: reports/evidence
           if-no-files-found: error
-          retention-days: 90
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ and capture IDs. It includes the app commit, image hash and dimensions, browser
 profile, viewport, and presentation type. Raw Cucumber messages and reports are
 not part of this evidence folder. The app workflow verifies the capture on pull
 requests. Main pushes and a monthly refresh upload this folder as the stable
-`tickets-evidence` artifact with GitHub's 90-day retention. The Tickets website
+`tickets-evidence` artifact with GitHub's 35-day retention. The Tickets website
 imports that artifact into a reviewed pull request
 and keeps its ordinary site build offline.
 

--- a/scripts/specs/evidence/capture-flow.ts
+++ b/scripts/specs/evidence/capture-flow.ts
@@ -115,7 +115,7 @@ const captureProfile = async (
     });
     // Download previews are self-contained documents, so they cannot read the
     // custom CSS stored for application pages.
-    if (path.startsWith("data:text/html,")) {
+    if (path.startsWith("data:text/html,") && theme !== "") {
       await page.addStyleTag({ content: theme });
     }
     await dependencies.waitForPage(page);

--- a/scripts/specs/evidence/capture-flow.ts
+++ b/scripts/specs/evidence/capture-flow.ts
@@ -91,11 +91,8 @@ const captureProfile = async (
   dependencies: EvidenceCaptureDependencies,
 ): Promise<void> => {
   const profile = SCREENSHOT_PROFILES[profileName];
-  await storeEvidenceCss(
-    declaration,
-    await dependencies.readTheme(declaration.id),
-    dependencies.writeCss,
-  );
+  const theme = await dependencies.readTheme(declaration.id);
+  await storeEvidenceCss(declaration, theme, dependencies.writeCss);
   const context = await browser.newContext({
     baseURL: baseUrl,
     ...screenshotContextOptions(profile),
@@ -112,9 +109,15 @@ const captureProfile = async (
     ]);
     const page = await context.newPage();
     page.setDefaultTimeout(CAPTURE_TIMEOUT_MS);
-    await page.goto(evidencePagePath(declaration, world.evidencePages), {
+    const path = evidencePagePath(declaration, world.evidencePages);
+    await page.goto(path, {
       waitUntil: "domcontentloaded",
     });
+    // Download previews are self-contained documents, so they cannot read the
+    // custom CSS stored for application pages.
+    if (path.startsWith("data:text/html,")) {
+      await page.addStyleTag({ content: theme });
+    }
     await dependencies.waitForPage(page);
     const { png } = await dependencies.capturePage(page, declaration.element);
     assertNoBlockedRequests(blocked);

--- a/scripts/specs/evidence/capture-flow.ts
+++ b/scripts/specs/evidence/capture-flow.ts
@@ -44,9 +44,9 @@ interface EvidenceCaptureDependencies {
 
 const browserCookie = async (
   baseUrl: string,
-  getCookie: () => Promise<string>,
+  cookie: string,
 ): Promise<{ name: string; url: string; value: string }> => {
-  const [pair] = (await getCookie()).split(";", 1);
+  const [pair] = cookie.split(";", 1);
   if (!pair) throw new Error("Test owner cookie is malformed");
   const splitAt = pair.indexOf("=");
   if (splitAt < 1 || splitAt === pair.length - 1) {
@@ -104,7 +104,11 @@ const captureProfile = async (
     const blocked = new Set<string>();
     await blockOutboundRequests(context, baseUrl, blocked);
     await context.addCookies([
-      await browserCookie(baseUrl, dependencies.getCookie),
+      await browserCookie(
+        baseUrl,
+        world.evidenceCookies.get(declaration.id) ??
+          (await dependencies.getCookie()),
+      ),
     ]);
     const page = await context.newPage();
     page.setDefaultTimeout(CAPTURE_TIMEOUT_MS);

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -116,6 +116,23 @@ export const EVIDENCE_CAPTURES = [
     "/admin/site/pages",
   ),
   brandedMobileCapture(
+    "editors.the-listings-show-no-money",
+    "editor-listings-without-takings",
+    ".page-regions.admin-page",
+    "/admin/listings",
+  ),
+  brandedMobileCapture(
+    "backup.restore-brings-back-bookings",
+    "backup-restore",
+    ".page-regions.admin-page",
+    "/admin/backup",
+  ),
+  brandedMobileCapture(
+    "download.the-chosen-length-not-the-maximum",
+    "attendee-csv-export",
+    ".page-regions.admin-page",
+  ),
+  brandedMobileCapture(
     "add-ons.it-appears-in-the-list-with-its-own-link",
     "add-on-in-the-list",
     "main",

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -130,7 +130,7 @@ export const EVIDENCE_CAPTURES = [
   brandedMobileCapture(
     "download.the-chosen-length-not-the-maximum",
     "attendee-csv-export",
-    ".page-regions.admin-page",
+    ".page-regions.entity-page",
   ),
   brandedMobileCapture(
     "add-ons.it-appears-in-the-list-with-its-own-link",

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -125,12 +125,11 @@ export const EVIDENCE_CAPTURES = [
     "backup.restore-brings-back-bookings",
     "backup-restore",
     ".page-regions.admin-page",
-    "/admin/backup",
   ),
   brandedMobileCapture(
     "download.the-chosen-length-not-the-maximum",
     "attendee-csv-export",
-    ".page-regions.entity-page",
+    "main",
   ),
   brandedMobileCapture(
     "add-ons.it-appears-in-the-list-with-its-own-link",

--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -124,7 +124,7 @@ export const EVIDENCE_CAPTURES = [
   brandedMobileCapture(
     "backup.restore-brings-back-bookings",
     "backup-restore",
-    ".page-regions.admin-page",
+    ".page-regions.entity-page",
   ),
   brandedMobileCapture(
     "download.the-chosen-length-not-the-maximum",

--- a/scripts/specs/evidence/hook.ts
+++ b/scripts/specs/evidence/hook.ts
@@ -10,6 +10,7 @@ export interface EvidenceWorld {
     data: Buffer,
     options: { fileName: string; mediaType: "image/png" },
   ): void | Promise<void>;
+  evidenceCookies: ReadonlyMap<string, string>;
   evidencePages: ReadonlyMap<string, string>;
 }
 

--- a/scripts/specs/evidence/pages.ts
+++ b/scripts/specs/evidence/pages.ts
@@ -14,6 +14,7 @@ import {
 /** The pages a running story has left behind, one for each screenshot it is
  * setting up. */
 export interface EvidencePages {
+  evidenceCookies: Map<EvidenceCaptureId, string>;
   evidencePages: Map<EvidenceCaptureId, string>;
 }
 
@@ -23,10 +24,13 @@ export const leaveEvidencePage = (
   world: EvidencePages,
   captureIds: readonly EvidenceCaptureId[],
   path: string,
+  cookie?: string,
 ): void => {
   const address = v.parse(EvidencePathSchema, path);
-  for (const captureId of captureIds)
+  for (const captureId of captureIds) {
     world.evidencePages.set(captureId, address);
+    if (cookie !== undefined) world.evidenceCookies.set(captureId, cookie);
+  }
 };
 
 /** The address to open for one screenshot: the one its declaration fixes, or

--- a/scripts/specs/evidence/schema.ts
+++ b/scripts/specs/evidence/schema.ts
@@ -45,10 +45,11 @@ const EvidenceProfilesSchema = v.pipe(
  * handing the finished address over with leaveEvidencePage. */
 export const EvidencePathSchema = v.pipe(
   TrimmedTextSchema,
-  v.startsWith("/", "Evidence path must start with /"),
   v.check(
-    (path) => !path.includes("{"),
-    "Evidence path must be a whole address, not a placeholder",
+    (path) =>
+      path.startsWith("data:text/html,") ||
+      (path.startsWith("/") && !path.includes("{")),
+    "Evidence path must be a whole address or HTML data page",
   ),
 );
 

--- a/test/scripts/specs/evidence-capture.test.ts
+++ b/test/scripts/specs/evidence-capture.test.ts
@@ -44,6 +44,7 @@ interface CaptureFixtureOptions {
   leftCookies?: ReadonlyArray<readonly [string, string]>;
   leftPages?: ReadonlyArray<readonly [string, string]>;
   serverCloseError?: Error;
+  theme?: string;
 }
 
 const twoCaseFeature = validFeature.replace(
@@ -164,7 +165,8 @@ const captureFixture = (
         ? Promise.reject(options.launchError)
         : Promise.resolve(browser as never),
     readCatalog: () => Promise.resolve(fixture.catalog),
-    readTheme: () => Promise.resolve(":root { --test-colour: blue; }"),
+    readTheme: () =>
+      Promise.resolve(options.theme ?? ":root { --test-colour: blue; }"),
     startServer: () => ({
       baseUrl: "http://127.0.0.1:4321",
       close: () => {
@@ -294,6 +296,19 @@ describe("Cucumber evidence capture", () => {
     await capture(world, hook);
 
     expect(calls.styles).toEqual([":root { --test-colour: blue; }"]);
+  });
+
+  test("does not inject an empty default theme into an HTML data page", async () => {
+    const { calls, capture, hook, world } = captureFixture({
+      leftPages: [
+        [declaration.id, "data:text/html,%3Cmain%3ECSV%3C%2Fmain%3E"],
+      ],
+      theme: "",
+    });
+
+    await capture(world, hook);
+
+    expect(calls.styles).toEqual([]);
   });
 
   test("uses the session the story left for a capture", async () => {

--- a/test/scripts/specs/evidence-capture.test.ts
+++ b/test/scripts/specs/evidence-capture.test.ts
@@ -40,6 +40,7 @@ interface CaptureFixtureOptions {
   feature?: string;
   hookPickle?: number;
   launchError?: Error;
+  leftCookies?: ReadonlyArray<readonly [string, string]>;
   leftPages?: ReadonlyArray<readonly [string, string]>;
   serverCloseError?: Error;
 }
@@ -193,6 +194,7 @@ const captureFixture = (
           options: attachmentOptions,
         });
       },
+      evidenceCookies: new Map(options.leftCookies),
       evidencePages: new Map(
         options.leftPages ?? [[declaration.id, PAYMENT_RESULT_PAGE]],
       ),
@@ -274,6 +276,22 @@ describe("Cucumber evidence capture", () => {
       },
     ]);
     expectCaptureClosed(calls);
+  });
+
+  test("uses the session the story left for a capture", async () => {
+    const { calls, capture, hook, world } = captureFixture({
+      leftCookies: [[declaration.id, "session=editor; Path=/"]],
+    });
+
+    await capture(world, hook);
+
+    expect(calls.cookies).toEqual([
+      {
+        name: "session",
+        url: "http://127.0.0.1:4321",
+        value: "editor",
+      },
+    ]);
   });
 
   test("rejects a request blocked while the screenshot is being prepared", async () => {

--- a/test/scripts/specs/evidence-capture.test.ts
+++ b/test/scripts/specs/evidence-capture.test.ts
@@ -26,6 +26,7 @@ interface CaptureCalls {
   goto: unknown[];
   page: unknown;
   serverClosed: number;
+  styles: string[];
   timeout: number[];
   waited: number;
 }
@@ -78,11 +79,16 @@ const captureFixture = (
     goto: [],
     page: null,
     serverClosed: 0,
+    styles: [],
     timeout: [],
     waited: 0,
   };
   let routeRequest: ((url: string) => Promise<void>) | undefined;
   const page = {
+    addStyleTag: ({ content }: { content: string }) => {
+      calls.styles.push(content);
+      return Promise.resolve(null);
+    },
     goto: (path: string, navigation: unknown) => {
       calls.goto.push({ navigation, path });
       return Promise.resolve(null);
@@ -276,6 +282,18 @@ describe("Cucumber evidence capture", () => {
       },
     ]);
     expectCaptureClosed(calls);
+  });
+
+  test("applies the selected theme to an HTML data page", async () => {
+    const { calls, capture, hook, world } = captureFixture({
+      leftPages: [
+        [declaration.id, "data:text/html,%3Cmain%3ECSV%3C%2Fmain%3E"],
+      ],
+    });
+
+    await capture(world, hook);
+
+    expect(calls.styles).toEqual([":root { --test-colour: blue; }"]);
   });
 
   test("uses the session the story left for a capture", async () => {

--- a/test/scripts/specs/evidence-hook.test.ts
+++ b/test/scripts/specs/evidence-hook.test.ts
@@ -14,6 +14,7 @@ import {
 
 const world = {
   attach: () => Promise.resolve(),
+  evidenceCookies: new Map<string, string>(),
   evidencePages: new Map<string, string>(),
 };
 

--- a/test/scripts/specs/evidence/pages.test.ts
+++ b/test/scripts/specs/evidence/pages.test.ts
@@ -9,6 +9,7 @@ import {
 import { PAYMENT_RESULT_CAPTURE as declaration } from "#test/scripts/specs/evidence-fixture.ts";
 
 const emptyWorld = (): EvidencePages => ({
+  evidenceCookies: new Map<EvidenceCaptureId, string>(),
   evidencePages: new Map<EvidenceCaptureId, string>(),
 });
 
@@ -37,6 +38,19 @@ describe("Evidence pages a story leaves", () => {
     expect(world.evidencePages.get("listing-ledger")).toBe(
       "/admin/ledger/revenue/2",
     );
+  });
+
+  test("keeps the session the story left for a capture", () => {
+    const world = emptyWorld();
+
+    leaveEvidencePage(
+      world,
+      ["listing-ledger"],
+      "/admin/ledger/revenue/1",
+      "session=editor",
+    );
+
+    expect(world.evidenceCookies.get("listing-ledger")).toBe("session=editor");
   });
 
   test("refuses a page that is not a whole address", () => {

--- a/test/scripts/specs/evidence/pages.test.ts
+++ b/test/scripts/specs/evidence/pages.test.ts
@@ -61,6 +61,15 @@ describe("Evidence pages a story leaves", () => {
     }
   });
 
+  test("accepts an HTML data page for a downloaded outcome", () => {
+    const world = emptyWorld();
+    const page = "data:text/html,%3Cmain%3ECSV%3C%2Fmain%3E";
+
+    leaveEvidencePage(world, ["listing-ledger"], page);
+
+    expect(world.evidencePages.get("listing-ledger")).toBe(page);
+  });
+
   test("opens the address the declaration fixes, ignoring what was left", () => {
     expect(
       evidencePagePath(

--- a/test/specs/steps/backup-restore.ts
+++ b/test/specs/steps/backup-restore.ts
@@ -8,8 +8,8 @@ import {
   adminBrowser,
   resetScenarioBrowser,
   scenarioBrowser,
-  sessionCookie,
 } from "#test/specs/support/browser.ts";
+import { sessionCookie } from "#test/specs/support/evidence.ts";
 import { rememberListing } from "#test/specs/support/listings.ts";
 import {
   requiredWorldValue,

--- a/test/specs/steps/backup-restore.ts
+++ b/test/specs/steps/backup-restore.ts
@@ -2,11 +2,13 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { restoreFromZip } from "#shared/db/backup.ts";
 import {
   adminBrowser,
   resetScenarioBrowser,
   scenarioBrowser,
+  sessionCookie,
 } from "#test/specs/support/browser.ts";
 import { rememberListing } from "#test/specs/support/listings.ts";
 import {
@@ -133,5 +135,11 @@ Then(
     );
     expect(browser.containsText(CUSTOMER)).toBe(true);
     expect(browser.containsText(CUSTOMER_EMAIL)).toBe(true);
+    leaveEvidencePage(
+      this,
+      ["backup-restore"],
+      browser.currentUrl,
+      sessionCookie(browser),
+    );
   },
 );

--- a/test/specs/steps/editors.ts
+++ b/test/specs/steps/editors.ts
@@ -5,6 +5,7 @@ import { expect } from "@std/expect";
 import { t } from "#i18n";
 import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { formatCurrency, toMinorUnits } from "#shared/currency.ts";
+import { sessionCookie } from "#test/specs/support/browser.ts";
 import {
   editorAddsListing,
   editorBrowser,
@@ -152,9 +153,7 @@ When(
       this,
       ["editor-listings-without-takings"],
       "/admin/listings",
-      [...browser.debugCookies()]
-        .map(([name, value]) => `${name}=${value}`)
-        .join("; "),
+      sessionCookie(browser),
     );
   },
 );

--- a/test/specs/steps/editors.ts
+++ b/test/specs/steps/editors.ts
@@ -5,7 +5,6 @@ import { expect } from "@std/expect";
 import { t } from "#i18n";
 import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { formatCurrency, toMinorUnits } from "#shared/currency.ts";
-import { sessionCookie } from "#test/specs/support/browser.ts";
 import {
   editorAddsListing,
   editorBrowser,
@@ -28,6 +27,7 @@ import {
   somethingSoldAndPaidFor,
   TAKINGS,
 } from "#test/specs/support/editors.ts";
+import { sessionCookie } from "#test/specs/support/evidence.ts";
 import {
   requiredWorldValue,
   type TicketsWorld,

--- a/test/specs/steps/editors.ts
+++ b/test/specs/steps/editors.ts
@@ -3,6 +3,7 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
 import { t } from "#i18n";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { formatCurrency, toMinorUnits } from "#shared/currency.ts";
 import {
   editorAddsListing,
@@ -145,7 +146,16 @@ Then(
 When(
   "{word} opens the listings",
   async function (this: TicketsWorld, _who: string): Promise<void> {
-    await editorBrowser(this).visit("/admin/listings");
+    const browser = editorBrowser(this);
+    await browser.visit("/admin/listings");
+    leaveEvidencePage(
+      this,
+      ["editor-listings-without-takings"],
+      "/admin/listings",
+      [...browser.debugCookies()]
+        .map(([name, value]) => `${name}=${value}`)
+        .join("; "),
+    );
   },
 );
 

--- a/test/specs/support/browser.test.ts
+++ b/test/specs/support/browser.test.ts
@@ -1,0 +1,34 @@
+// jscpd:ignore-start
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { getSessionCookieName } from "#shared/cookies.ts";
+import { sessionCookie } from "#test/specs/support/evidence.ts";
+
+// jscpd:ignore-end
+
+const browserWithCookies = (cookies: ReadonlyMap<string, string>) => ({
+  debugCookies: () => new Map(cookies),
+});
+
+describe("sessionCookie", () => {
+  test("returns only the configured admin session cookie", () => {
+    const name = getSessionCookieName();
+
+    expect(
+      sessionCookie(
+        browserWithCookies(
+          new Map([
+            ["theme", "dark"],
+            [name, "editor-session"],
+          ]),
+        ),
+      ),
+    ).toBe(`${name}=editor-session`);
+  });
+
+  test("refuses a browser without an admin session cookie", () => {
+    expect(() => sessionCookie(browserWithCookies(new Map()))).toThrow(
+      "The browser has no admin session cookie",
+    );
+  });
+});

--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -1,6 +1,5 @@
 // jscpd:ignore-start
 import { t } from "#i18n";
-import { getSessionCookieName } from "#shared/cookies.ts";
 import {
   type RowOnList,
   rowsOnList,
@@ -34,15 +33,6 @@ export const rememberBrowser = (
   who: string,
   browser: TestBrowser,
 ): TestBrowser => world.things.remember("browser", who, browser);
-
-/** The one cookie that authenticates a captured page. Other browser cookies do
- * not change which admin account sees it. */
-export const sessionCookie = (browser: TestBrowser): string => {
-  const name = getSessionCookieName();
-  const value = browser.debugCookies().get(name);
-  if (!value) throw new Error("The browser has no admin session cookie");
-  return `${name}=${value}`;
-};
 
 /** The window somebody is already looking at. A story that never gave them one
  * has nothing to read, so it says so rather than opening a fresh window and

--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -1,5 +1,6 @@
 // jscpd:ignore-start
 import { t } from "#i18n";
+import { getSessionCookieName } from "#shared/cookies.ts";
 import {
   type RowOnList,
   rowsOnList,
@@ -33,6 +34,15 @@ export const rememberBrowser = (
   who: string,
   browser: TestBrowser,
 ): TestBrowser => world.things.remember("browser", who, browser);
+
+/** The one cookie that authenticates a captured page. Other browser cookies do
+ * not change which admin account sees it. */
+export const sessionCookie = (browser: TestBrowser): string => {
+  const name = getSessionCookieName();
+  const value = browser.debugCookies().get(name);
+  if (!value) throw new Error("The browser has no admin session cookie");
+  return `${name}=${value}`;
+};
 
 /** The window somebody is already looking at. A story that never gave them one
  * has nothing to read, so it says so rather than opening a fresh window and

--- a/test/specs/support/by-hand.test.ts
+++ b/test/specs/support/by-hand.test.ts
@@ -20,6 +20,14 @@ describe("csvDateColumn", () => {
     ).toBe("Date\n2026-08-16 to 2026-08-17");
   });
 
+  test("keeps quoted attendee line breaks out of the date column", () => {
+    expect(
+      csvDateColumn(
+        'Date,Name,Email\n2026-08-16 to 2026-08-17,"Jane\nDoe",jane@example.com',
+      ),
+    ).toBe("Date\n2026-08-16 to 2026-08-17");
+  });
+
   test("renders escaped text in the data-page preview", () => {
     const path = csvEvidencePage("Retreat & <stay>", "Date & time");
 

--- a/test/specs/support/by-hand.test.ts
+++ b/test/specs/support/by-hand.test.ts
@@ -1,9 +1,15 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { csvDateColumn } from "#test/specs/support/evidence.ts";
+import {
+  csvDateColumn,
+  csvEvidencePage,
+} from "#test/specs/support/evidence.ts";
 
 // jscpd:ignore-end
+
+const previewHtml = (path: string): string =>
+  decodeURIComponent(path.slice("data:text/html,".length));
 
 describe("csvDateColumn", () => {
   test("keeps the exported dates without attendee personal data", () => {
@@ -12,5 +18,15 @@ describe("csvDateColumn", () => {
         "Date,Name,Email,Phone\n2026-08-16 to 2026-08-17,Jane Doe,jane@example.com,07123456789",
       ),
     ).toBe("Date\n2026-08-16 to 2026-08-17");
+  });
+
+  test("renders escaped text in the data-page preview", () => {
+    const path = csvEvidencePage("Retreat & <stay>", "Date & time");
+
+    expect(path.startsWith("data:text/html,")).toBe(true);
+    expect(previewHtml(path)).toContain(
+      "Retreat &amp; &lt;stay&gt; attendee CSV",
+    );
+    expect(previewHtml(path)).toContain("Date &amp; time");
   });
 });

--- a/test/specs/support/by-hand.test.ts
+++ b/test/specs/support/by-hand.test.ts
@@ -34,6 +34,18 @@ describe("csvDateColumn", () => {
     ).toThrow("Attendee CSV is missing the Date field");
   });
 
+  test("fails when the export has an empty date", () => {
+    expect(() => csvDateColumn("Date,Name\n,Jane Doe")).toThrow(
+      "Attendee CSV is missing the Date field",
+    );
+  });
+
+  test("fails when the export has a whitespace-only date", () => {
+    expect(() => csvDateColumn("Date,Name\n   ,Jane Doe")).toThrow(
+      "Attendee CSV is missing the Date field",
+    );
+  });
+
   test("renders escaped text in the data-page preview", () => {
     const path = csvEvidencePage("Retreat & <stay>", "Date & time");
 

--- a/test/specs/support/by-hand.test.ts
+++ b/test/specs/support/by-hand.test.ts
@@ -1,0 +1,16 @@
+// jscpd:ignore-start
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { csvDateColumn } from "#test/specs/support/evidence.ts";
+
+// jscpd:ignore-end
+
+describe("csvDateColumn", () => {
+  test("keeps the exported dates without attendee personal data", () => {
+    expect(
+      csvDateColumn(
+        "Date,Name,Email,Phone\n2026-08-16 to 2026-08-17,Jane Doe,jane@example.com,07123456789",
+      ),
+    ).toBe("Date\n2026-08-16 to 2026-08-17");
+  });
+});

--- a/test/specs/support/by-hand.test.ts
+++ b/test/specs/support/by-hand.test.ts
@@ -28,6 +28,12 @@ describe("csvDateColumn", () => {
     ).toBe("Date\n2026-08-16 to 2026-08-17");
   });
 
+  test("fails when the export has no date field", () => {
+    expect(() =>
+      csvDateColumn("Name,Email\nJane Doe,jane@example.com"),
+    ).toThrow("Attendee CSV is missing the Date field");
+  });
+
   test("renders escaped text in the data-page preview", () => {
     const path = csvEvidencePage("Retreat & <stay>", "Date & time");
 

--- a/test/specs/support/by-hand.ts
+++ b/test/specs/support/by-hand.ts
@@ -6,6 +6,7 @@
 
 // jscpd:ignore-start
 import { expect } from "@std/expect";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { openAdminPage } from "#test/specs/support/browser.ts";
 import { listingIdNamed } from "#test/specs/support/listings.ts";
 import type { BookingChoices } from "#test/specs/support/public-booking.ts";
@@ -51,7 +52,9 @@ export const organiserAddsBooking = async (
  * text of the file itself. Followed from the link on the page, so a story can
  * never read a file the organiser has no way to reach. */
 export const downloadAttendeeList: ReadAboutOneThing = async (world, name) => {
-  const browser = await openAdminPage(world, rosterPath(world, name));
+  const path = rosterPath(world, name);
+  leaveEvidencePage(world, ["attendee-csv-export"], path);
+  const browser = await openAdminPage(world, path);
   const download = browser.links.find(({ href }) => href.includes("/export"));
   if (!download) {
     throw new Error(`The ${name} roster offers no attendee list to download`);

--- a/test/specs/support/by-hand.ts
+++ b/test/specs/support/by-hand.ts
@@ -8,6 +8,7 @@
 import { expect } from "@std/expect";
 import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { openAdminPage } from "#test/specs/support/browser.ts";
+import { csvDateColumn } from "#test/specs/support/evidence.ts";
 import { listingIdNamed } from "#test/specs/support/listings.ts";
 import type { BookingChoices } from "#test/specs/support/public-booking.ts";
 import type {
@@ -27,10 +28,10 @@ const escapeHtml = (value: string): string =>
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
 
-/** The CSV is the outcome this story reads. Render that exact text in the
- * evidence browser so its screenshot proves the date range in the download. */
-const csvEvidencePage = (name: string, csv: string): string =>
-  `data:text/html,${encodeURIComponent(`<!doctype html><meta charset="utf-8"><style>body{background:#f3f4ef;color:#273320;font:16px Arial,sans-serif;margin:0;padding:32px}main{background:#fff;border:1px solid #d7e1cf;border-top:6px solid #568038;border-radius:8px;box-shadow:0 12px 28px #2f4a2024;margin:auto;max-width:720px;padding:24px}h1{font-size:24px;margin:0 0 20px}pre{background:#f1f5ed;border:1px solid #d7e1cf;overflow-wrap:anywhere;padding:16px;white-space:pre-wrap}</style><main><h1>${escapeHtml(name)} attendee CSV</h1><pre>${escapeHtml(csv)}</pre></main>`)}`;
+/** The CSV is the outcome this story reads. Render its date column in the
+ * evidence browser so its screenshot proves the exported date range. */
+const csvEvidencePage = (name: string, dates: string): string =>
+  `data:text/html,${encodeURIComponent(`<!doctype html><meta charset="utf-8"><style>:root{--border-radius:8px;--color-accent:#568038;--color-bg:#f1f5ed;--color-bg-secondary:#fff;--color-shadow:#2f4a2024;--color-text:#273320;--font-family:Arial,sans-serif}body{background:var(--color-bg);color:var(--color-text);font:16px var(--font-family);margin:0;padding:32px}main{background:var(--color-bg-secondary);border:1px solid #d7e1cf;border-top:6px solid var(--color-accent);border-radius:var(--border-radius);box-shadow:0 12px 28px var(--color-shadow);margin:auto;max-width:720px;padding:24px}h1{font-size:24px;margin:0 0 20px}pre{background:var(--color-bg);border:1px solid #d7e1cf;overflow-wrap:anywhere;padding:16px;white-space:pre-wrap}</style><main><h1>${escapeHtml(name)} attendee CSV</h1><pre>${escapeHtml(dates)}</pre></main>`)}`;
 
 /** The organiser adds a booking through the form on the listing's roster. Keeps
  * the page they land on, so a story can read what they were told. */
@@ -72,6 +73,10 @@ export const downloadAttendeeList: ReadAboutOneThing = async (world, name) => {
   const csv = new TextDecoder().decode(
     await browser.downloadBytes(download.href),
   );
-  leaveEvidencePage(world, ["attendee-csv-export"], csvEvidencePage(name, csv));
+  leaveEvidencePage(
+    world,
+    ["attendee-csv-export"],
+    csvEvidencePage(name, csvDateColumn(csv)),
+  );
   return csv;
 };

--- a/test/specs/support/by-hand.ts
+++ b/test/specs/support/by-hand.ts
@@ -8,7 +8,10 @@
 import { expect } from "@std/expect";
 import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { openAdminPage } from "#test/specs/support/browser.ts";
-import { csvDateColumn } from "#test/specs/support/evidence.ts";
+import {
+  csvDateColumn,
+  csvEvidencePage,
+} from "#test/specs/support/evidence.ts";
 import { listingIdNamed } from "#test/specs/support/listings.ts";
 import type { BookingChoices } from "#test/specs/support/public-booking.ts";
 import type {
@@ -21,17 +24,6 @@ import type {
 /** The listing's roster — where the add form and the download both live. */
 const rosterPath = (world: TicketsWorld, name: string): string =>
   `/admin/listing/${listingIdNamed(world, name)}/attendees`;
-
-const escapeHtml = (value: string): string =>
-  value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-
-/** The CSV is the outcome this story reads. Render its date column in the
- * evidence browser so its screenshot proves the exported date range. */
-const csvEvidencePage = (name: string, dates: string): string =>
-  `data:text/html,${encodeURIComponent(`<!doctype html><meta charset="utf-8"><style>:root{--border-radius:8px;--color-accent:#568038;--color-bg:#f1f5ed;--color-bg-secondary:#fff;--color-shadow:#2f4a2024;--color-text:#273320;--font-family:Arial,sans-serif}body{background:var(--color-bg);color:var(--color-text);font:16px var(--font-family);margin:0;padding:32px}main{background:var(--color-bg-secondary);border:1px solid #d7e1cf;border-top:6px solid var(--color-accent);border-radius:var(--border-radius);box-shadow:0 12px 28px var(--color-shadow);margin:auto;max-width:720px;padding:24px}h1{font-size:24px;margin:0 0 20px}pre{background:var(--color-bg);border:1px solid #d7e1cf;overflow-wrap:anywhere;padding:16px;white-space:pre-wrap}</style><main><h1>${escapeHtml(name)} attendee CSV</h1><pre>${escapeHtml(dates)}</pre></main>`)}`;
 
 /** The organiser adds a booking through the form on the listing's roster. Keeps
  * the page they land on, so a story can read what they were told. */

--- a/test/specs/support/by-hand.ts
+++ b/test/specs/support/by-hand.ts
@@ -21,6 +21,17 @@ import type {
 const rosterPath = (world: TicketsWorld, name: string): string =>
   `/admin/listing/${listingIdNamed(world, name)}/attendees`;
 
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+/** The CSV is the outcome this story reads. Render that exact text in the
+ * evidence browser so its screenshot proves the date range in the download. */
+const csvEvidencePage = (name: string, csv: string): string =>
+  `data:text/html,${encodeURIComponent(`<!doctype html><meta charset="utf-8"><style>body{background:#f3f4ef;color:#273320;font:16px Arial,sans-serif;margin:0;padding:32px}main{background:#fff;border:1px solid #d7e1cf;border-top:6px solid #568038;border-radius:8px;box-shadow:0 12px 28px #2f4a2024;margin:auto;max-width:720px;padding:24px}h1{font-size:24px;margin:0 0 20px}pre{background:#f1f5ed;border:1px solid #d7e1cf;overflow-wrap:anywhere;padding:16px;white-space:pre-wrap}</style><main><h1>${escapeHtml(name)} attendee CSV</h1><pre>${escapeHtml(csv)}</pre></main>`)}`;
+
 /** The organiser adds a booking through the form on the listing's roster. Keeps
  * the page they land on, so a story can read what they were told. */
 export const organiserAddsBooking = async (
@@ -53,11 +64,14 @@ export const organiserAddsBooking = async (
  * never read a file the organiser has no way to reach. */
 export const downloadAttendeeList: ReadAboutOneThing = async (world, name) => {
   const path = rosterPath(world, name);
-  leaveEvidencePage(world, ["attendee-csv-export"], path);
   const browser = await openAdminPage(world, path);
   const download = browser.links.find(({ href }) => href.includes("/export"));
   if (!download) {
     throw new Error(`The ${name} roster offers no attendee list to download`);
   }
-  return new TextDecoder().decode(await browser.downloadBytes(download.href));
+  const csv = new TextDecoder().decode(
+    await browser.downloadBytes(download.href),
+  );
+  leaveEvidencePage(world, ["attendee-csv-export"], csvEvidencePage(name, csv));
+  return csv;
 };

--- a/test/specs/support/evidence.ts
+++ b/test/specs/support/evidence.ts
@@ -20,7 +20,7 @@ export const csvDateColumn = (csv: string): string =>
     "Date",
     ...parse(csv, { skipFirstRow: true }).map((row) => {
       const date = row.Date;
-      if (typeof date !== "string") {
+      if (typeof date !== "string" || date.trim() === "") {
         throw new Error("Attendee CSV is missing the Date field");
       }
       return date;

--- a/test/specs/support/evidence.ts
+++ b/test/specs/support/evidence.ts
@@ -1,0 +1,22 @@
+import { getSessionCookieName } from "#shared/cookies.ts";
+import type { TestBrowser } from "#test-utils/test-browser.ts";
+
+/** The one cookie that authenticates a captured page. Other browser cookies do
+ * not change which admin account sees it. */
+export const sessionCookie = (
+  browser: Pick<TestBrowser, "debugCookies">,
+): string => {
+  const name = getSessionCookieName();
+  const value = browser.debugCookies().get(name);
+  if (!value) throw new Error("The browser has no admin session cookie");
+  return `${name}=${value}`;
+};
+
+/** The date column is what this story proves. Do not put attendee names or
+ * contact details into a screenshot artifact. */
+export const csvDateColumn = (csv: string): string =>
+  csv
+    .split(/\r?\n/)
+    .filter((line) => line !== "")
+    .map((line) => line.split(",", 1)[0])
+    .join("\n");

--- a/test/specs/support/evidence.ts
+++ b/test/specs/support/evidence.ts
@@ -1,3 +1,4 @@
+import { parse } from "@std/csv/parse";
 import { getSessionCookieName } from "#shared/cookies.ts";
 import type { TestBrowser } from "#test-utils/test-browser.ts";
 
@@ -15,11 +16,9 @@ export const sessionCookie = (
 /** The date column is what this story proves. Do not put attendee names or
  * contact details into a screenshot artifact. */
 export const csvDateColumn = (csv: string): string =>
-  csv
-    .split(/\r?\n/)
-    .filter((line) => line !== "")
-    .map((line) => line.split(",", 1)[0])
-    .join("\n");
+  ["Date", ...parse(csv, { skipFirstRow: true }).map((row) => row.Date)].join(
+    "\n",
+  );
 
 const escapeHtml = (value: string): string =>
   value

--- a/test/specs/support/evidence.ts
+++ b/test/specs/support/evidence.ts
@@ -16,9 +16,16 @@ export const sessionCookie = (
 /** The date column is what this story proves. Do not put attendee names or
  * contact details into a screenshot artifact. */
 export const csvDateColumn = (csv: string): string =>
-  ["Date", ...parse(csv, { skipFirstRow: true }).map((row) => row.Date)].join(
-    "\n",
-  );
+  [
+    "Date",
+    ...parse(csv, { skipFirstRow: true }).map((row) => {
+      const date = row.Date;
+      if (typeof date !== "string") {
+        throw new Error("Attendee CSV is missing the Date field");
+      }
+      return date;
+    }),
+  ].join("\n");
 
 const escapeHtml = (value: string): string =>
   value

--- a/test/specs/support/evidence.ts
+++ b/test/specs/support/evidence.ts
@@ -20,3 +20,14 @@ export const csvDateColumn = (csv: string): string =>
     .filter((line) => line !== "")
     .map((line) => line.split(",", 1)[0])
     .join("\n");
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+/** The CSV is the outcome this story reads. Render its date column in the
+ * evidence browser so its screenshot proves the exported date range. */
+export const csvEvidencePage = (name: string, dates: string): string =>
+  `data:text/html,${encodeURIComponent(`<!doctype html><meta charset="utf-8"><style>:root{--border-radius:8px;--color-accent:#568038;--color-bg:#f1f5ed;--color-bg-secondary:#fff;--color-shadow:#2f4a2024;--color-text:#273320;--font-family:Arial,sans-serif}body{background:var(--color-bg);color:var(--color-text);font:16px var(--font-family);margin:0;padding:32px}main{background:var(--color-bg-secondary);border:1px solid #d7e1cf;border-top:6px solid var(--color-accent);border-radius:var(--border-radius);box-shadow:0 12px 28px var(--color-shadow);margin:auto;max-width:720px;padding:24px}h1{font-size:24px;margin:0 0 20px}pre{background:var(--color-bg);border:1px solid #d7e1cf;overflow-wrap:anywhere;padding:16px;white-space:pre-wrap}</style><main><h1>${escapeHtml(name)} attendee CSV</h1><pre>${escapeHtml(dates)}</pre></main>`)}`;

--- a/test/specs/support/hooks.ts
+++ b/test/specs/support/hooks.ts
@@ -15,6 +15,7 @@ import { addDatabaseCleanup, type TicketsWorld } from "./world.ts";
 
 Before(async function (this: TicketsWorld): Promise<void> {
   this.cleanup = putsThingsBack();
+  this.evidenceCookies = new Map();
   this.evidencePages = new Map();
   this.things = namedThings();
   const cleanupDb = await setupTestDbEnvironment(true).catch((error) => {


### PR DESCRIPTION
## Summary
- capture editor listings, restored bookings, and attendee CSV export evidence
- preserve the exact admin session needed by each non-owner capture
- render only the parsed CSV date column, with the selected theme, so screenshot artifacts contain no attendee personal data
- keep non-PR evidence artifacts for 35 days so they remain available until the next monthly refresh; PR runs do not upload them

## Verification
- `nix develop -c deno task test:files test/specs/support/by-hand.test.ts`
- `nix develop -c deno task precommit`
- `nix develop -c deno task specs:evidence --themes /home/user/git/tickets-site/evidence-themes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added evidence capture coverage for editor listings, backup restoration, and attendee CSV exports.
  * Evidence captures now preserve session context and support themed HTML pages and downloaded content.
  * Attendee exports can display dates without exposing personal contact details.

* **Bug Fixes**
  * Improved cookie handling and validation for captured pages and downloads.
  * Added support for HTML data URLs in captured evidence.

* **Documentation**
  * Updated evidence artifact retention details.

* **Chores**
  * Reduced artifact retention from 90 to 35 days and limited uploads for pull-request builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->