### PR TITLE
Show the site menu on booking pages, hiding it only in iframe mode

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,32 @@
 # TODO — remaining follow-ups
 
+## Anchor the booking-page site menu to its listing/group (from PR #2051)
+
+PR #2051 shows the public site menu on booking pages (dropped in iframe mode and
+when the public site is off). It builds the menu with `publicNavProps(null)`
+(`renderCtx` in `src/features/public/ticket-submit.ts`), which takes
+`publicNavModel`'s fixed-page fast path: two cached reads, root links only, no
+active-chain highlight or contextual submenu. Codex noted that when the booking
+target is a listing or group placed on an operator page, passing its
+`listing:<id>` / `group:<id>` key instead would let `buildNavModel` highlight
+the active chain and show the page's submenu.
+
+Left out here on purpose: a non-null current makes `publicNavModel` run
+`resolveTargets` (listing + group loads, `classifyForDiscovery`, hidden-member
+and bookable-group reads) on every booking-page GET — a real cold-start /
+subrequest cost on an explicitly hot path (see "Built for cold starts" in
+AGENTS.md), for a highlight that only changes anything when the item happens to
+sit on a nav page. The tradeoff is completeness vs the booking path's latency
+budget, and the budget wins for now.
+
+Starting point: derive the current key from `ctx.galleryTarget` (`{type, id}`,
+already set for single-listing/group pages, null for multi-item combos) via
+`sitePageItemTargets.of(...)`, and pass it to `publicNavProps` in `renderCtx`;
+keep `null` for multi-item pages. Measure the added reads against the cold-start
+benches before adopting.
+
+---
+
 ## Let --kill stop a run through its supervisor, not the child's pid (from PR #2042)
 
 `deno task mutation --kill` signals the child pid stored in the run record

--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -8,6 +8,7 @@ src/ui/templates/public/reservations/contact-fields.ts::pagePaid~07x8o1n  ?? →
 src/ui/templates/public/reservations/form.tsx::TicketPageForm.html~1470qil   → "mutated"   # TicketPageForm's only caller supplies YYYY-MM-DD options; the fallback affects HTML only if it equals an option, which "mutated" never can
 src/ui/templates/public/reservations/ticket-page.tsx::ticketPage~0nmjfxs  ?? → ||   # questions is QuestionWithAnswers[]|undefined, and every present array, including [], is truthy
 src/ui/templates/public/reservations/ticket-page.tsx::ticketPage~0pcr5er  ?? → ||   # childDatesById is a ReadonlyMap|undefined, and every present Map, including an empty one, is truthy
+src/ui/templates/public/reservations/ticket-page.tsx::cartConflicts.concealed.childrenByParentId~1gqpisn  ?? → ||   # childrenByParentId is Map<...>|undefined, and every present Map, including an empty one, is truthy — no falsy-non-null value exists, so ?? and || pick the same operand
 
 # attendee table values and columns
 src/ui/templates/attendee-table/values.ts::getAnswerDisplay.answerIds~1spki67  ?? → ||   # getAnswerDisplay attendeeAnswerMap.get(): number[]|undefined — an array is always truthy, so ?? and || coincide

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -33,6 +33,7 @@ import {
   applyDemoOverrides,
 } from "#shared/demo/overrides.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { getIframeMode } from "#shared/iframe.ts";
 /* jscpd:ignore-end */
 import type { CheckoutIntent } from "#shared/payments.ts";
 import type { Group, ListingWithCount } from "#shared/types.ts";
@@ -49,6 +50,7 @@ import {
   applyBookingPageParentSoldOut,
   childCapacityInfo,
 } from "./discovery.ts";
+import { publicNavProps } from "./site-nav.ts";
 /* jscpd:ignore-start */
 import {
   extractContact,
@@ -403,6 +405,7 @@ const renderCtx = async (ctx: TicketCtx): Promise<TicketCtx> => {
     membership,
     galleryImages,
     attributesByListing,
+    nav,
   ] = await Promise.all([
     getSharedGroupCapacities(children),
     getGroupRemainingByListingId(children),
@@ -420,6 +423,9 @@ const renderCtx = async (ctx: TicketCtx): Promise<TicketCtx> => {
       ...ctx.listings.map((entry) => entry.listing.id),
       ...children.map((child) => child.id),
     ]),
+    // The site menu shows above a normal booking page but is dropped in iframe
+    // mode, so an embedded page skips building it entirely.
+    getIframeMode() ? Promise.resolve(undefined) : publicNavProps(null),
   ]);
   const caps = childCapacityInfo(childCaps, childOwnRemaining, membership);
   return {
@@ -439,6 +445,7 @@ const renderCtx = async (ctx: TicketCtx): Promise<TicketCtx> => {
       caps,
       holidays,
     ),
+    ...(nav ? { nav } : {}),
   };
 };
 

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -27,6 +27,7 @@ import { getSelectedAttributesForListings } from "#shared/db/attributes.ts";
 import { listingGroups } from "#shared/db/groups.ts";
 import { getActiveHolidays } from "#shared/db/holidays.ts";
 import { getImagesForItem } from "#shared/db/images.ts";
+import { settings } from "#shared/db/settings.ts";
 /* jscpd:ignore-start */
 import {
   ATTENDEE_DEMO_FIELDS,
@@ -423,9 +424,13 @@ const renderCtx = async (ctx: TicketCtx): Promise<TicketCtx> => {
       ...ctx.listings.map((entry) => entry.listing.id),
       ...children.map((child) => child.id),
     ]),
-    // The site menu shows above a normal booking page but is dropped in iframe
-    // mode, so an embedded page skips building it entirely.
-    getIframeMode() ? Promise.resolve(undefined) : publicNavProps(null),
+    // The site menu shows above a normal booking page so a visitor can reach
+    // the rest of the site. It is dropped in an embedded iframe, and skipped
+    // when the public site is off (its Home/Listings links would only bounce a
+    // visitor to the admin login), so neither case builds a menu it won't show.
+    getIframeMode() || !settings.features.site
+      ? Promise.resolve(undefined)
+      : publicNavProps(null),
   ]);
   const caps = childCapacityInfo(childCaps, childOwnRemaining, membership);
   return {

--- a/src/features/public/types.ts
+++ b/src/features/public/types.ts
@@ -22,6 +22,7 @@ import type {
   BookingPrefill,
   GroupAvailability,
 } from "#templates/public/reservations/types.ts";
+import type { PublicNavProps } from "#templates/public/shared.tsx";
 
 /** Parent listing id → its bookable-child candidates, each hydrated to a
  * {@link TicketListing} so availability (isSoldOut/isClosed/maxPurchasable) is
@@ -93,6 +94,9 @@ export type TicketCtx = TicketSharedContext &
     attributesByListing?: ListingAttributesById;
     baseUrl?: string;
     prefill?: BookingPrefill | undefined;
+    /** The public site menu, built on the render path only (not on
+     * submit/quote/API) and dropped in iframe mode. */
+    nav?: PublicNavProps;
   };
 
 /** Shared context provider for ticket pages */

--- a/src/ui/templates/public/reservations/ticket-page.tsx
+++ b/src/ui/templates/public/reservations/ticket-page.tsx
@@ -34,6 +34,7 @@ import { ctxStandInNames } from "#shared/package-privacy.ts";
 import type { ItemImageColumns, ListingWithCount } from "#shared/types.ts";
 import { ErrorNote } from "#templates/components/error.tsx";
 import { Layout } from "#templates/layout.tsx";
+import { PublicNav } from "#templates/public/shared.tsx";
 import {
   buildPageTree,
   headerListing,
@@ -167,6 +168,7 @@ export const ticketPage = ({
   packageGroupRemainingByGroupId = new Map(),
   packageMemberGroupIds = new Map(),
   attributesByListing = new Map(),
+  nav,
 }: TicketPageOptions): string => {
   // The canonical booking tree drives node identity + the stable form field
   // names (via nodeQuantityFieldName/nodePriceFieldName): one node per
@@ -279,6 +281,7 @@ export const ticketPage = ({
 
   return String(
     <Layout
+      beforeContent={!inIframe && nav ? <PublicNav {...nav} /> : undefined}
       bodyClass={inIframe ? "iframe" : undefined}
       contentClassName="public-page"
       headExtra={headExtra}

--- a/src/ui/templates/public/reservations/types.ts
+++ b/src/ui/templates/public/reservations/types.ts
@@ -16,6 +16,7 @@ import type {
   Image,
   ItemImageColumns,
 } from "#shared/types.ts";
+import type { PublicNavProps } from "#templates/public/shared.tsx";
 /* jscpd:ignore-end */
 
 /** Quantity values parsed from ticket form */
@@ -122,4 +123,7 @@ export type TicketPageOptions = GroupAvailability & {
   /** Remaining spots for package member groups. */
   packageGroupRemainingByGroupId?: ReadonlyMap<number, number>;
   packageMemberGroupIds?: ReadonlyMap<number, number[]>;
+  /** The public site menu, shown above the form on a normal page and dropped
+   * in iframe mode. Set only on the render path; absent ⇒ no menu. */
+  nav?: PublicNavProps;
 };

--- a/test/integration/server/public/ticket-slug-get.test.ts
+++ b/test/integration/server/public/ticket-slug-get.test.ts
@@ -152,6 +152,8 @@ describeWithEnv(
         );
         expect(html).not.toContain("<h1>");
         expect(html).not.toContain("A <b>great</b> listing");
+        // The site menu is dropped inside an embedded iframe.
+        expect(html).not.toContain("admin-nav-group");
       });
 
       test("shows header and description without iframe param", async () => {
@@ -166,6 +168,9 @@ describeWithEnv(
           "A &lt;b&gt;great&lt;/b&gt; listing",
         );
         expect(html).not.toContain('class="iframe"');
+        // A normal booking page shows the site menu so visitors can navigate.
+        expect(html).toContain('<div class="admin-nav-group">');
+        expect(html).toContain('aria-label="Site menu"');
       });
 
       test("does not set CSRF cookies (uses signed tokens instead)", async () => {

--- a/test/integration/server/public/ticket-slug-get.test.ts
+++ b/test/integration/server/public/ticket-slug-get.test.ts
@@ -17,6 +17,7 @@ import {
   deactivateTestListing,
 } from "#test-utils/db-helpers/listings.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
+import { enablePublicSite } from "#test-utils/settings.ts";
 
 // jscpd:ignore-end
 
@@ -168,9 +169,27 @@ describeWithEnv(
           "A &lt;b&gt;great&lt;/b&gt; listing",
         );
         expect(html).not.toContain('class="iframe"');
-        // A normal booking page shows the site menu so visitors can navigate.
+        // With the public site off (the default), the menu's Home/Listings
+        // links would only bounce a visitor to the admin login, so no menu.
+        expect(html).not.toContain("admin-nav-group");
+      });
+
+      test("shows the site menu on a normal page when the public site is on", async () => {
+        await enablePublicSite();
+        const listing = await createTestListing({ maxAttendees: 50 });
+        const html = await assertPublicHtml(`/ticket/${listing.slug}`, "<h1>");
         expect(html).toContain('<div class="admin-nav-group">');
         expect(html).toContain('aria-label="Site menu"');
+      });
+
+      test("still drops the menu in iframe mode when the public site is on", async () => {
+        await enablePublicSite();
+        const listing = await createTestListing({ maxAttendees: 50 });
+        const html = await assertPublicHtml(
+          `/ticket/${listing.slug}?iframe=true`,
+          'class="iframe"',
+        );
+        expect(html).not.toContain("admin-nav-group");
       });
 
       test("does not set CSRF cookies (uses signed tokens instead)", async () => {

--- a/test/ui/templates/public/reservations/ticket-page.test.ts
+++ b/test/ui/templates/public/reservations/ticket-page.test.ts
@@ -8,7 +8,6 @@ import {
 } from "#shared/forms/saved-data.ts";
 import { detectIframeMode } from "#shared/iframe.ts";
 import { ticketPage } from "#templates/public/reservations/ticket-page.tsx";
-import type { PublicNavProps } from "#templates/public/shared.tsx";
 import {
   bigAndSmallListings,
   evenSplitPackages,
@@ -30,20 +29,6 @@ const attributeWithOptions = (
   name,
   options: [{ attribute_id: id, id: id * 10, sort_order: 0, text: optionText }],
   sort_order: 0,
-});
-
-/** A minimal public-nav prop set — the fixed root links only, no page tree. */
-const navProps = (): PublicNavProps => ({
-  hasContact: false,
-  hasNews: false,
-  hasOrder: false,
-  hasTerms: false,
-  pages: {
-    activeRootId: null,
-    currentChildren: [],
-    rootPageNodes: [],
-    submenuLevels: [],
-  },
 });
 
 describe("ticketPage — packages", () => {
@@ -119,83 +104,6 @@ describe("ticketPage — packages", () => {
     expect(html).toContain('<body class="iframe">');
     expect(html).toContain('class="page-regions public-page"');
     expect(html).not.toContain("<h1>Iframe-only heading</h1>");
-  });
-
-  test("shows the site menu above the form on a normal page", () => {
-    const html = ticketPage({
-      listings: [ticketListing({ name: "Listing" })],
-      nav: navProps(),
-      slugs: ["listing"],
-    });
-    expect(html).toContain('<div class="admin-nav-group">');
-    expect(html).toContain('aria-label="Site menu"');
-    expect(html).toContain('<a href="/listings">');
-  });
-
-  test("drops the site menu in iframe mode even when one is supplied", () => {
-    detectIframeMode(new URL("https://example.com/?iframe=true"));
-    const html = ticketPage({
-      listings: [ticketListing({ name: "Listing" })],
-      nav: navProps(),
-      slugs: ["listing"],
-    });
-    expect(html).toContain('<body class="iframe">');
-    expect(html).not.toContain("admin-nav-group");
-    expect(html).not.toContain('aria-label="Site menu"');
-  });
-
-  test("warns when the page's daily listings share no available date", () => {
-    const html = ticketPage({
-      cartDateItems: [
-        { dates: ["2026-01-01"], id: 1, name: "Near" },
-        { dates: ["2026-02-01"], id: 2, name: "Far" },
-      ],
-      listings: [
-        ticketListing({
-          id: 1,
-          listing_type: "daily",
-          name: "Near",
-          slug: "near1",
-        }),
-        ticketListing({
-          id: 2,
-          listing_type: "daily",
-          name: "Far",
-          slug: "far01",
-        }),
-      ],
-      slugs: ["near1", "far01"],
-    });
-    expect(html).toContain(
-      "'Near' and 'Far' do not share an available date. Book them separately.",
-    );
-  });
-
-  test("warns when the page's customisable listings share no booking length", () => {
-    const html = ticketPage({
-      listings: [
-        ticketListing({
-          customisable_days: true,
-          day_prices: { 1: 500 },
-          duration_days: 1,
-          id: 1,
-          name: "Short",
-          slug: "shrt1",
-        }),
-        ticketListing({
-          customisable_days: true,
-          day_prices: { 3: 900 },
-          duration_days: 3,
-          id: 2,
-          name: "Long",
-          slug: "long1",
-        }),
-      ],
-      slugs: ["shrt1", "long1"],
-    });
-    expect(html).toContain(
-      "'Short' and 'Long' do not share a booking length. Book them separately.",
-    );
   });
 
   test("hides quantity when exactly one open listing allows one ticket", () => {

--- a/test/ui/templates/public/reservations/ticket-page.test.ts
+++ b/test/ui/templates/public/reservations/ticket-page.test.ts
@@ -8,6 +8,7 @@ import {
 } from "#shared/forms/saved-data.ts";
 import { detectIframeMode } from "#shared/iframe.ts";
 import { ticketPage } from "#templates/public/reservations/ticket-page.tsx";
+import type { PublicNavProps } from "#templates/public/shared.tsx";
 import {
   bigAndSmallListings,
   evenSplitPackages,
@@ -29,6 +30,20 @@ const attributeWithOptions = (
   name,
   options: [{ attribute_id: id, id: id * 10, sort_order: 0, text: optionText }],
   sort_order: 0,
+});
+
+/** A minimal public-nav prop set — the fixed root links only, no page tree. */
+const navProps = (): PublicNavProps => ({
+  hasContact: false,
+  hasNews: false,
+  hasOrder: false,
+  hasTerms: false,
+  pages: {
+    activeRootId: null,
+    currentChildren: [],
+    rootPageNodes: [],
+    submenuLevels: [],
+  },
 });
 
 describe("ticketPage — packages", () => {
@@ -104,6 +119,83 @@ describe("ticketPage — packages", () => {
     expect(html).toContain('<body class="iframe">');
     expect(html).toContain('class="page-regions public-page"');
     expect(html).not.toContain("<h1>Iframe-only heading</h1>");
+  });
+
+  test("shows the site menu above the form on a normal page", () => {
+    const html = ticketPage({
+      listings: [ticketListing({ name: "Listing" })],
+      nav: navProps(),
+      slugs: ["listing"],
+    });
+    expect(html).toContain('<div class="admin-nav-group">');
+    expect(html).toContain('aria-label="Site menu"');
+    expect(html).toContain('<a href="/listings">');
+  });
+
+  test("drops the site menu in iframe mode even when one is supplied", () => {
+    detectIframeMode(new URL("https://example.com/?iframe=true"));
+    const html = ticketPage({
+      listings: [ticketListing({ name: "Listing" })],
+      nav: navProps(),
+      slugs: ["listing"],
+    });
+    expect(html).toContain('<body class="iframe">');
+    expect(html).not.toContain("admin-nav-group");
+    expect(html).not.toContain('aria-label="Site menu"');
+  });
+
+  test("warns when the page's daily listings share no available date", () => {
+    const html = ticketPage({
+      cartDateItems: [
+        { dates: ["2026-01-01"], id: 1, name: "Near" },
+        { dates: ["2026-02-01"], id: 2, name: "Far" },
+      ],
+      listings: [
+        ticketListing({
+          id: 1,
+          listing_type: "daily",
+          name: "Near",
+          slug: "near1",
+        }),
+        ticketListing({
+          id: 2,
+          listing_type: "daily",
+          name: "Far",
+          slug: "far01",
+        }),
+      ],
+      slugs: ["near1", "far01"],
+    });
+    expect(html).toContain(
+      "'Near' and 'Far' do not share an available date. Book them separately.",
+    );
+  });
+
+  test("warns when the page's customisable listings share no booking length", () => {
+    const html = ticketPage({
+      listings: [
+        ticketListing({
+          customisable_days: true,
+          day_prices: { 1: 500 },
+          duration_days: 1,
+          id: 1,
+          name: "Short",
+          slug: "shrt1",
+        }),
+        ticketListing({
+          customisable_days: true,
+          day_prices: { 3: 900 },
+          duration_days: 3,
+          id: 2,
+          name: "Long",
+          slug: "long1",
+        }),
+      ],
+      slugs: ["shrt1", "long1"],
+    });
+    expect(html).toContain(
+      "'Short' and 'Long' do not share a booking length. Book them separately.",
+    );
   });
 
   test("hides quantity when exactly one open listing allows one ticket", () => {

--- a/test/ui/templates/public/reservations/ticket-page/cart-conflicts.test.ts
+++ b/test/ui/templates/public/reservations/ticket-page/cart-conflicts.test.ts
@@ -1,0 +1,70 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { ticketPage } from "#templates/public/reservations/ticket-page.tsx";
+import {
+  registerPublicTemplateHooks,
+  ticketListing,
+} from "#test/ui/templates/helpers.ts";
+import { setupAdminPageTest } from "#test-utils/admin-page-test.ts";
+
+// The ticket page drops any concealed package member from the conflict facts
+// before naming a clash, so these cover the plain (nothing concealed) notes the
+// buyer sees when the page's items can't be booked together.
+describe("ticketPage (cart conflict notes)", () => {
+  beforeAll(setupAdminPageTest);
+  registerPublicTemplateHooks();
+
+  test("warns when the page's daily listings share no available date", () => {
+    const html = ticketPage({
+      cartDateItems: [
+        { dates: ["2026-01-01"], id: 1, name: "Near" },
+        { dates: ["2026-02-01"], id: 2, name: "Far" },
+      ],
+      listings: [
+        ticketListing({
+          id: 1,
+          listing_type: "daily",
+          name: "Near",
+          slug: "near1",
+        }),
+        ticketListing({
+          id: 2,
+          listing_type: "daily",
+          name: "Far",
+          slug: "far01",
+        }),
+      ],
+      slugs: ["near1", "far01"],
+    });
+    expect(html).toContain(
+      "'Near' and 'Far' do not share an available date. Book them separately.",
+    );
+  });
+
+  test("warns when the page's customisable listings share no booking length", () => {
+    const html = ticketPage({
+      listings: [
+        ticketListing({
+          customisable_days: true,
+          day_prices: { 1: 500 },
+          duration_days: 1,
+          id: 1,
+          name: "Short",
+          slug: "shrt1",
+        }),
+        ticketListing({
+          customisable_days: true,
+          day_prices: { 3: 900 },
+          duration_days: 3,
+          id: 2,
+          name: "Long",
+          slug: "long1",
+        }),
+      ],
+      slugs: ["shrt1", "long1"],
+    });
+    expect(html).toContain(
+      "'Short' and 'Long' do not share a booking length. Book them separately.",
+    );
+  });
+});

--- a/test/ui/templates/public/reservations/ticket-page/site-menu.test.ts
+++ b/test/ui/templates/public/reservations/ticket-page/site-menu.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { detectIframeMode } from "#shared/iframe.ts";
+import { ticketPage } from "#templates/public/reservations/ticket-page.tsx";
+import type { PublicNavProps } from "#templates/public/shared.tsx";
+import {
+  registerPublicTemplateHooks,
+  ticketListing,
+} from "#test/ui/templates/helpers.ts";
+import { setupAdminPageTest } from "#test-utils/admin-page-test.ts";
+
+/** A minimal public-nav prop set — the fixed root links only, no page tree. */
+const navProps = (): PublicNavProps => ({
+  hasContact: false,
+  hasNews: false,
+  hasOrder: false,
+  hasTerms: false,
+  pages: {
+    activeRootId: null,
+    currentChildren: [],
+    rootPageNodes: [],
+    submenuLevels: [],
+  },
+});
+
+describe("ticketPage (site menu)", () => {
+  beforeAll(setupAdminPageTest);
+  registerPublicTemplateHooks();
+
+  test("shows the site menu above the form on a normal page", () => {
+    const html = ticketPage({
+      listings: [ticketListing({ name: "Listing" })],
+      nav: navProps(),
+      slugs: ["listing"],
+    });
+    expect(html).toContain('<div class="admin-nav-group">');
+    expect(html).toContain('aria-label="Site menu"');
+    expect(html).toContain('<a href="/listings">');
+  });
+
+  test("drops the site menu in iframe mode even when one is supplied", () => {
+    detectIframeMode(new URL("https://example.com/?iframe=true"));
+    const html = ticketPage({
+      listings: [ticketListing({ name: "Listing" })],
+      nav: navProps(),
+      slugs: ["listing"],
+    });
+    expect(html).toContain('<body class="iframe">');
+    expect(html).not.toContain("admin-nav-group");
+    expect(html).not.toContain('aria-label="Site menu"');
+  });
+});


### PR DESCRIPTION
## What changed

Booking pages used to hide the site menu completely. That was only ever meant to happen when a booking page is embedded in an iframe on someone else's site. On a normal booking page it left a visitor with no way to get back to the rest of the site.

Now the site menu (Home, Listings, and the operator's pages) shows above the booking form, with two exceptions where it is correctly left off:

- **In an embedded (iframe) booking page** — it stays a clean, self-contained form.
- **When the public site is turned off** — in that mode the Home and Listings links only bounce a visitor to the admin login, so showing them would be dead links. The menu is skipped, matching every other public-site page.

The menu is built only when the page is actually being drawn, and only in the cases where it will be shown — so an embedded or site-off page does no work to build a menu it will never render.

## Why

A booking page is a real landing page: people arrive on it from a link, a QR code, or a search result. Hiding the menu on those pages stranded them. The menu should appear whenever the rest of the public site is reachable, and disappear only when it isn't (iframe embed, or the public site switched off).

## Tests

- Template tests prove the menu shows on a normal page and is gone in iframe mode (new `ticket-page/site-menu.test.ts`).
- The real request path (`GET /ticket/:slug`) is checked with the site off (no menu), with the site on (menu shows), and in iframe mode with the site on (still no menu).
- While here, filled a pre-existing coverage gap: added direct tests for the booking page's "these listings share no available date / booking length" notes (new `ticket-page/cart-conflicts.test.ts`), and recorded one provably-equivalent mutant, bringing the template back to a full mutation-test kill.

A follow-up to highlight the menu's active page when the booking target sits on an operator page is noted in `TODO.md` — left out here for its cold-start cost on the booking path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)