### PR TITLE
SumUp callbacks go behind the strict observation boundary (M3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -293,13 +293,19 @@ happen in production.
   this record for the whole payment — every listing line, every extra, and every
   price-modifier application as its own signed fact, discount or surcharge, even
   where today's pricing folds it into line prices — in one pass, each part with
-  a stable identity. The record is stored with the payment: reconciliation,
-  refund routing, and balance completion read the stored allocation and never
-  re-derive it, so no two consumers can disagree about a part. Today's
-  ticket-only `allocateReservationDeposit` does not survive the move. Store the
-  provider on each charge: M6's own reconciliation reads it to validate and
-  deduplicate charge identity, and the M7 engine routes refunds by it, closing
-  the multi-provider gap.
+  a stable identity. A reservation's deposit and balance payments share one
+  booking-level obligation identity: the line, extra, and modifier identities
+  are created once, under that obligation, when the deposit's allocation is
+  stored, and the balance payment's allocation references those same identities
+  — the full obligation is stored once and referenced, never duplicated, which
+  is what lets M7 cancel it exactly once and M8 lease every payment that shares
+  it. The record is stored with the payment: reconciliation, refund routing, and
+  balance completion read the stored allocation and never re-derive it, so no
+  two consumers can disagree about a part. Today's ticket-only
+  `allocateReservationDeposit` does not survive the move. Store the provider on
+  each charge: M6's own reconciliation reads it to validate and deduplicate
+  charge identity, and the M7 engine routes refunds by it, closing the
+  multi-provider gap.
 - Reads: every provider read goes behind one strict observation contract
   covering missing, invalid, unavailable, pending, paid, free, and failed.
   Square payment IDs are named by the order, not scanned from a short list.
@@ -800,6 +806,7 @@ mechanism and a regression test, or — if implementation proves the finding wro
 | F74 | A queued refund acting on stale evidence after the payment's outcome moved on          | M7              |
 | F75 | Cancelling a booking obligation that the failed completion never posted                | M8              |
 | F76 | A discount folded into line prices losing its signed modifier fact                     | M6              |
+| F77 | Deposit and balance allocations minting separate identities for one obligation         | M6              |
 
 ## Done means
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -25,13 +25,13 @@ ledger.
 
 ## Where we are
 
-| Milestone                               | Status                                                                                                                                            |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| M1 safety behavior (was PR 1)           | Merged as #2020. Also landed the M2 pure modules: `src/shared/payment/money.ts`, `resource-id.ts`, `refund-state.ts`, and `validated-session.ts`. |
-| M2 money/resource vocabulary (was PR 2) | Core modules merged inside #2020. Any provider parsing still off those schemas rides with M3 or M4.                                               |
-| M3 provider ownership (was PR 3)        | In flight. Merged slices so far: #2048 (payment processing core), #2050 (bounded registration delivery).                                          |
-| M11 verifier slice (was PR 13)          | Started early in #2056 — the verifier is read-only and parallelizable.                                                                            |
-| M4–M10 and M12–M13                      | Not started.                                                                                                                                      |
+| Milestone                               | Status                                                                                                                                                                        |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1 safety behavior (was PR 1)           | Merged as #2020. Also landed the M2 pure modules: `src/shared/payment/money.ts`, `resource-id.ts`, `refund-state.ts`, and `validated-session.ts`.                             |
+| M2 money/resource vocabulary (was PR 2) | Core modules merged inside #2020. Any provider parsing still off those schemas rides with M3 or M4.                                                                           |
+| M3 provider ownership (was PR 3)        | In flight. Merged slices so far: #2048 (payment processing core), #2050 (bounded registration delivery). The observation boundary + SumUp callback wiring slice is in review. |
+| M11 verifier slice (was PR 13)          | Started early in #2056 — the verifier is read-only and parallelizable.                                                                                                        |
+| M4–M10 and M12–M13                      | Not started.                                                                                                                                                                  |
 
 Budgets below count `src/` lines only. Observed totals run 4–15x the `src/`
 figure once tests, stories, and catalog copy are included (#2020: 714 src lines,
@@ -290,14 +290,16 @@ happen in production.
   modifier fact is never lost to the deposit fraction — today's pricing folds
   the deposit share into ticket lines while Money records the whole modifier,
   and both facts must survive as themselves. One canonical allocator produces
-  this record for the whole payment — every listing line and every extra in one
-  pass, each part with a stable identity — and the record is stored with the
-  payment: reconciliation, refund routing, and balance completion read the
-  stored allocation and never re-derive it, so no two consumers can disagree
-  about a part. Today's ticket-only `allocateReservationDeposit` does not
-  survive the move. Store the provider on each charge: M6's own reconciliation
-  reads it to validate and deduplicate charge identity, and the M7 engine routes
-  refunds by it, closing the multi-provider gap.
+  this record for the whole payment — every listing line, every extra, and every
+  price-modifier application as its own signed fact, discount or surcharge, even
+  where today's pricing folds it into line prices — in one pass, each part with
+  a stable identity. The record is stored with the payment: reconciliation,
+  refund routing, and balance completion read the stored allocation and never
+  re-derive it, so no two consumers can disagree about a part. Today's
+  ticket-only `allocateReservationDeposit` does not survive the move. Store the
+  provider on each charge: M6's own reconciliation reads it to validate and
+  deduplicate charge identity, and the M7 engine routes refunds by it, closing
+  the multi-provider gap.
 - Reads: every provider read goes behind one strict observation contract
   covering missing, invalid, unavailable, pending, paid, free, and failed.
   Square payment IDs are named by the order, not scanned from a short list.
@@ -401,12 +403,20 @@ over).
   claimed atomically with the refund result, so recovery retries it when the
   provider reversal succeeded but the local write failed — and can never run it
   twice. The buyer gets back what they paid, nothing is reversed twice, and a
-  cancelled booking leaves no debt behind. While an attendee has unfinished
-  refund pages, merging or deleting that attendee fails closed naming the
-  pending work — a merge posts its own Money adjustments, and replaying a
-  pre-merge allocation after them could reverse income twice; M8's general
-  repointing for queued work then replaces this fence. The migrated-payment
-  caller arrives in M11, when migrated payments first exist.
+  cancelled booking leaves no debt behind. Each queued item also stores the
+  payment-evidence revision it was built from, and the claiming transaction
+  re-runs the outcome and blocking-case checks before every provider call: a
+  payment whose evidence moved on — a second captured charge, an external
+  refund, a newly opened case — parks as owner-review work instead of being
+  refunded from a stale snapshot. While an attendee has unfinished refund pages,
+  merging or deleting that attendee fails closed naming the pending work — a
+  merge posts its own Money adjustments, and replaying a pre-merge allocation
+  after them could reverse income twice. This fence outlives M8 for refund
+  pages: repointing cannot make a frozen pre-merge allocation safe to replay
+  after the merge's own adjustments, so merges stay refused until the refund
+  work settles or the owner cancels it — M8's general repointing covers only
+  queued work whose facts a merge leaves unchanged. The migrated-payment caller
+  arrives in M11, when migrated payments first exist.
 - Persist provider refund identity before local completion; queue and schedule
   repair when provider success is followed by a local failure; keep callback and
   admin replay idempotent; keep refunds available while new sales are disabled.
@@ -452,28 +462,36 @@ one machine and merge together.
   allocation, but the commit is all lines or none in one transaction — as
   `createBookingAtomic` commits the shared order today — so one line selling out
   after payment sends the whole completion down the failure path (refund or
-  owner case) rather than half-booking the order. Before the effect runner
-  claims its first payment, an idempotent cutover pass adopts the M6-window
-  history: an aggregate payment the legacy path already completed has its folded
-  result marked done, never re-booked or re-posted to Money; a paid aggregate
-  payment with no completion result becomes due work; and a paid payment whose
-  folded result records a completion failure becomes the matching durable
-  failure effect — its chosen refund path or an owner case — never marked done
-  and never re-run as a fresh booking. So pre-M8 unfinished completions gain
-  durable recovery instead of being stranded. The pass runs only after the write
-  fence has risen and in-flight legacy commits have drained or failed, and the
-  runner revision-rechecks the folded state when claiming each payment, so a
-  legacy commit that landed between scan and claim is honoured, never redone.
-  Adoption also gates on a completion-safe `outcomeOf` state with no open
-  blocking case: a paid payment stopped for owner review — captured money on a
-  failed checkout, multiple captured charges — stays in its case workflow,
-  because due work must never bypass a required owner choice. Refund and
-  completion claims are mutually exclusive through one payment-wide claim: the
-  payment session row's shipped lease (`lease_token`, `lease_expires_at`).
-  Refund jobs, the adoption pass, and the effect runner each acquire that lease
-  atomically before acting and verify no unfinished refund job or effect owns
-  the payment, so two runners can never both read "nothing done yet" and act,
-  and a booking can never complete while its irreversible refund is in flight.
+  owner case) rather than half-booking the order. That refund is an
+  unhonoured-payment refund: it returns cash only and posts no booking-level
+  obligation cancellation, because the all-or-none commit never posted the
+  obligation — a cancellation runs only with proof the booking obligation effect
+  completed. Before the effect runner claims its first payment, an idempotent
+  cutover pass adopts the M6-window history: an aggregate payment the legacy
+  path already completed has its folded result marked done, never re-booked or
+  re-posted to Money; a paid aggregate payment with no completion result becomes
+  due work; and a paid payment whose folded result records a completion failure
+  becomes the matching durable failure effect — its chosen refund path or an
+  owner case — never marked done and never re-run as a fresh booking. So pre-M8
+  unfinished completions gain durable recovery instead of being stranded. The
+  pass runs only after the write fence has risen and in-flight legacy commits
+  have drained or failed, and the runner revision-rechecks the folded state when
+  claiming each payment, so a legacy commit that landed between scan and claim
+  is honoured, never redone. Adoption also gates on a completion-safe
+  `outcomeOf` state with no open blocking case: a paid payment stopped for owner
+  review — captured money on a failed checkout, multiple captured charges —
+  stays in its case workflow, because due work must never bypass a required
+  owner choice. Refund and completion claims are mutually exclusive through one
+  payment-wide claim: the payment session row's shipped lease (`lease_token`,
+  `lease_expires_at`). Refund jobs, the adoption pass, and the effect runner
+  each acquire that lease atomically before acting and verify no unfinished
+  refund job or effect owns the payment, so two runners can never both read
+  "nothing done yet" and act, and a booking can never complete while its
+  irreversible refund is in flight. For a reservation whose deposit and balance
+  are separate payments, the claim spans them: a runner acquires the lease of
+  every payment sharing the booking-level obligation, always in one fixed order,
+  before acting — so refund and completion can never split one booking between
+  two sessions.
 - From this cutover on, completion stops storing payment references in attendee
   PII — the aggregate owns the attendee-to-payment link — so the attendee-PII
   reference source M11 reads is closed at M8 and cannot grow while the copy
@@ -777,6 +795,11 @@ mechanism and a regression test, or — if implementation proves the finding wro
 | F69 | An obligation cancellation without a stable identity re-running or never retrying      | M7              |
 | F70 | Two runners both reading "nothing done yet" and acting on one payment                  | M8              |
 | F71 | A consumer re-deriving the allocation and disagreeing with the stored record           | M6              |
+| F72 | A booking split across two payment leases, refunding one while completing the other    | M8              |
+| F73 | Repointing replacing the merge fence and replaying a pre-merge allocation              | M7, M8          |
+| F74 | A queued refund acting on stale evidence after the payment's outcome moved on          | M7              |
+| F75 | Cancelling a booking obligation that the failed completion never posted                | M8              |
+| F76 | A discount folded into line prices losing its signed modifier fact                     | M6              |
 
 ## Done means
 

--- a/TODO.md
+++ b/TODO.md
@@ -2150,3 +2150,23 @@ promising shape is to give `mutation:audit-equivalents` a way to attempt a
 distinguishing input for each entry — or, failing that, an explicit re-audit
 stamp so an entry has to be re-confirmed after the file it lives in changes
 shape, instead of resting on a proof nobody has re-read since it was written.
+
+## Delete the sumupApi and squareApi alias wrapper exports (from PR #2060)
+
+`src/shared/sumup.ts` still exports `createCheckout`, `refundTransaction`,
+`getTransactionStatus`, and `testSumupConnection` as one-line wrappers over the
+same names on `sumupApi`, and `src/shared/square.ts` has the same pattern
+(`getSquareClient`, `resetSquareClient`, `testSquareConnection`,
+`createPaymentLink` and siblings around `square.ts:850`). AGENTS.md's "No alias
+exports" rule says to expose the shared mechanism itself: callers should import
+the api object and call `sumupApi.createCheckout(...)` directly, which
+late-binds through test stubs exactly like the wrappers do. PR #2060 deleted the
+one wrapper it had added (`readCheckoutById`) and migrated its callers to
+`sumupApi.readCheckoutById(...)`; the pre-existing wrappers were left alone
+because the sweep spans Square too and belongs in one dedicated pass. Starting
+point: `grep -n "^export const" src/shared/sumup.ts src/shared/square.ts`, then
+migrate `src/shared/sumup-provider.ts`, `src/shared/square-provider.ts`,
+`src/features/admin/settings-sumup.ts`, and the direct test importers
+(`test/shared/sumup/*.test.ts`). The only subtlety: a function handed away at
+module load (like `makeCreateCheckoutSession("SumUp", createCheckout, ...)`)
+must become a lambda over the api member so test stubbing keeps working.

--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -408,6 +408,14 @@ const handlePaymentWebhook = async (request: Request): Promise<Response> => {
   // resolve a session from its own webhook listing structure.
   const sessionResult = await provider.resolveWebhookSession(listing);
 
+  if (sessionResult === "retry") {
+    // Fixed, value-free refusal: a forged or unreadable callback must not
+    // learn why verification failed or spend alert subrequests, and the
+    // provider redelivers on a 503 where an acknowledgement is terminal.
+    logDebug("Webhook", "Refused a payment callback retryably");
+    return plainResponse("Payment verification failed", 503);
+  }
+
   if (sessionResult === "skip") {
     return webhookAckResponse({ status: "pending" });
   }

--- a/src/shared/db/sumup-checkouts.ts
+++ b/src/shared/db/sumup-checkouts.ts
@@ -54,6 +54,15 @@ export type SumupCheckoutEntry = {
   sumupId: string;
 };
 
+/** A staged row found by its SumUp id, still sealed: the booking metadata
+ *  stays encrypted until the reference that names the row arrives (from the
+ *  fetched checkout — the plaintext reference never rests in this database). */
+export type SealedSumupCheckout = {
+  metadata: KeyEncrypted;
+  referenceIndex: string;
+  wrappedKey: WrappedKey;
+};
+
 const metadataJson = defineStoredJson(v.record(v.string(), v.string()));
 
 /** Persist booking metadata for a checkout, encrypted under its reference. */
@@ -100,14 +109,57 @@ export const setSumupCheckoutId = async (
   }
 };
 
-/** Whether a webhook's checkout id belongs to a checkout we created.
- * Cheap local pre-filter so unsigned webhook spam never costs an API call. */
-export const hasSumupCheckoutId = async (sumupId: string): Promise<boolean> => {
-  const row = await queryOne<{ sumup_id: string }>(
-    "SELECT sumup_id FROM sumup_checkouts WHERE sumup_id = ?",
+/** Fetch the staged row for a webhook's checkout id, still sealed. One cheap
+ * indexed read serves as the pre-filter (unsigned webhook spam never costs an
+ * API call) and carries everything {@link openSumupCheckout} needs later. */
+export const getSealedSumupCheckout = async (
+  sumupId: string,
+): Promise<SealedSumupCheckout | null> => {
+  const row = await queryOne<{
+    metadata: KeyEncrypted;
+    reference_index: string;
+    wrapped_key: WrappedKey;
+  }>(
+    "SELECT metadata, reference_index, wrapped_key FROM sumup_checkouts WHERE sumup_id = ?",
     [sumupId],
   );
-  return row !== null;
+  if (!row) return null;
+  return {
+    metadata: row.metadata,
+    referenceIndex: row.reference_index,
+    wrappedKey: row.wrapped_key,
+  };
+};
+
+/** Open a sealed row with the reference the fetched checkout echoed back.
+ * Returns null when the reference does not name this row — the row's own
+ * index is the proof the reference must match before anything decrypts. */
+export const openSumupCheckout = async (
+  sealed: SealedSumupCheckout,
+  reference: string,
+): Promise<Record<string, string> | null> => {
+  if ((await hmacHash(reference)) !== sealed.referenceIndex) return null;
+  return decryptMetadata(
+    sealed.wrappedKey,
+    sealed.metadata,
+    reference,
+    sealed.referenceIndex,
+  );
+};
+
+/** Decrypt a row's metadata blob with the reference that keys its data key. */
+const decryptMetadata = async (
+  wrappedKey: WrappedKey,
+  ciphertext: KeyEncrypted,
+  reference: string,
+  referenceIndex: string,
+): Promise<Record<string, string>> => {
+  const dataKey = await unwrapKeyWithToken(wrappedKey, reference);
+  const json = await decryptWithKey(ciphertext, dataKey);
+  return metadataJson.read(
+    json,
+    `sumup_checkouts.metadata for reference_index ${referenceIndex}`,
+  );
 };
 
 /**
@@ -124,12 +176,12 @@ export const getSumupCheckout = async (
     [referenceIndex],
   );
   if (!row) return null;
-  const dataKey = await unwrapKeyWithToken(row.wrapped_key, reference);
-  const json = await decryptWithKey(row.metadata, dataKey);
   return {
-    metadata: metadataJson.read(
-      json,
-      `sumup_checkouts.metadata for reference_index ${referenceIndex}`,
+    metadata: await decryptMetadata(
+      row.wrapped_key,
+      row.metadata,
+      reference,
+      referenceIndex,
     ),
     sumupId: row.sumup_id,
   };

--- a/src/shared/db/sumup-checkouts.ts
+++ b/src/shared/db/sumup-checkouts.ts
@@ -85,11 +85,19 @@ export const setSumupCheckoutId = async (
   reference: string,
   sumupId: string,
 ): Promise<void> => {
-  await executeUpdate(
+  const result = await executeUpdate(
     "sumup_checkouts",
     { sumup_id: sumupId },
     { reference_index: await hmacHash(reference) },
   );
+  // The hosted URL must never reach a customer while this checkout's
+  // callbacks would still be refused as unknown, so creation fails here —
+  // before the URL is exposed — when the id did not land on exactly one row.
+  if (result.rowsAffected !== 1) {
+    throw new Error(
+      `Staging the SumUp checkout id updated ${result.rowsAffected} rows, expected exactly 1`,
+    );
+  }
 };
 
 /** Whether a webhook's checkout id belongs to a checkout we created.

--- a/src/shared/payment/provider-read.ts
+++ b/src/shared/payment/provider-read.ts
@@ -5,13 +5,12 @@
  * "the answer contradicts our own facts" — three situations that need three
  * different responses (give up, retry, refuse).
  *
- * Adapted from the observation boundary on `origin/claude/great-fermi-l2n29f`
- * (`payment-state/observation.ts`), cut down to the reads the current path
- * performs. M6 moves Stripe and Square behind the same vocabulary.
+ * SumUp's reads use this today; M6 moves Stripe and Square behind the same
+ * vocabulary.
  */
 
 /** Why the provider could not answer at all. Retrying can help. */
-export type ProviderUnavailableReason =
+type ProviderUnavailableReason =
   | "network_error"
   | "not_configured"
   | "provider_error";

--- a/src/shared/payment/provider-read.ts
+++ b/src/shared/payment/provider-read.ts
@@ -1,0 +1,38 @@
+/**
+ * What one read of a payment provider's records can come back as. Every read
+ * lands in exactly one of four states, so a caller can never confuse "the
+ * provider says this does not exist" with "the provider could not answer" or
+ * "the answer contradicts our own facts" — three situations that need three
+ * different responses (give up, retry, refuse).
+ *
+ * Adapted from the observation boundary on `origin/claude/great-fermi-l2n29f`
+ * (`payment-state/observation.ts`), cut down to the reads the current path
+ * performs. M6 moves Stripe and Square behind the same vocabulary.
+ */
+
+/** Why the provider could not answer at all. Retrying can help. */
+export type ProviderUnavailableReason =
+  | "network_error"
+  | "not_configured"
+  | "provider_error";
+
+/**
+ * Why an answer the provider did give was refused. The answer either broke
+ * its own documented shape, or it disagreed with facts we hold independently
+ * — the id we asked for, the account we are bound to, or the charges the
+ * record itself names.
+ */
+export type ProviderInvalidReason =
+  | "malformed_response"
+  | "mismatched_account"
+  | "mismatched_id"
+  | "missing_documented_resource"
+  | "unrecorded_child"
+  | "unsupported_status";
+
+/** One provider read: the resource, or exactly one reason there isn't one. */
+export type ProviderRead<Resource> =
+  | { status: "found"; resource: Resource }
+  | { status: "missing" }
+  | { status: "unavailable"; reason: ProviderUnavailableReason }
+  | { status: "invalid"; reason: ProviderInvalidReason };

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -223,6 +223,23 @@ export type WebhookVerifyResult =
   | { valid: true; listing: WebhookEvent }
   | { valid: false; error: string };
 
+/** Everything resolving a webhook's session can come back as: the session;
+ *  "skip" to acknowledge without processing; "retry" to answer with the fixed
+ *  retryable refusal; a rejection carrying a paid charge the boundary could
+ *  not read; or null for an event that is provably not ours. */
+export type WebhookSessionResult =
+  | ValidatedPaymentSession
+  | "skip"
+  | "retry"
+  | SessionRejection
+  | null;
+
+/** Everything retrieving a checkout session by id can come back as. */
+export type RetrieveSessionResult =
+  | ValidatedPaymentSession
+  | SessionRejection
+  | null;
+
 /** Provider-agnostic webhook event */
 export type WebhookEvent = {
   id: string;
@@ -300,11 +317,7 @@ export interface PaymentProvider {
    *          a paid charge the boundary could not read; or null for an event
    *          that is provably not ours.
    */
-  resolveWebhookSession(
-    listing: WebhookEvent,
-  ): Promise<
-    ValidatedPaymentSession | "skip" | "retry" | SessionRejection | null
-  >;
+  resolveWebhookSession(listing: WebhookEvent): Promise<WebhookSessionResult>;
 
   /**
    * Retrieve and validate a completed checkout session by ID.
@@ -318,7 +331,7 @@ export interface PaymentProvider {
   retrieveSession(
     sessionId: string,
     paidPaymentId?: string,
-  ): Promise<ValidatedPaymentSession | SessionRejection | null>;
+  ): Promise<RetrieveSessionResult>;
 
   /**
    * Set up a webhook endpoint for this provider.

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -292,14 +292,19 @@ export interface PaymentProvider {
    * Each provider knows how to extract/fetch session data from its own
    * event structure, so the webhook handler stays provider-agnostic.
    *
-   * @returns the session, "skip" if the event should be acknowledged
-   *          without processing (e.g. pending payment), a rejection when the
-   *          provider reported a paid charge the boundary could not read, or
-   *          null on error.
+   * @returns the session; "skip" if the event should be acknowledged
+   *          without processing (e.g. pending payment); "retry" when the
+   *          provider could not be read or its answer contradicted our facts,
+   *          so the route must refuse with the fixed retryable response and
+   *          let redelivery try again; a rejection when the provider reported
+   *          a paid charge the boundary could not read; or null for an event
+   *          that is provably not ours.
    */
   resolveWebhookSession(
     listing: WebhookEvent,
-  ): Promise<ValidatedPaymentSession | "skip" | SessionRejection | null>;
+  ): Promise<
+    ValidatedPaymentSession | "skip" | "retry" | SessionRejection | null
+  >;
 
   /**
    * Retrieve and validate a completed checkout session by ID.

--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -13,10 +13,7 @@
  */
 
 import { logDebug } from "#shared/logger.ts";
-import {
-  type SessionRejection,
-  validatedPaymentSession,
-} from "#shared/payment/validated-session.ts";
+import { validatedPaymentSession } from "#shared/payment/validated-session.ts";
 import {
   hasRequiredSessionMetadata,
   toCanonicalIso,
@@ -26,8 +23,9 @@ import {
 import type {
   CheckoutIntent,
   PaymentProvider,
-  ValidatedPaymentSession,
+  RetrieveSessionResult,
   WebhookEvent,
+  WebhookSessionResult,
   WebhookSetupResult,
 } from "#shared/payments.ts";
 import {
@@ -67,7 +65,7 @@ export const squarePaymentProvider: PaymentProvider = {
 
   async resolveWebhookSession(
     listing: WebhookEvent,
-  ): Promise<ValidatedPaymentSession | "skip" | SessionRejection | null> {
+  ): Promise<WebhookSessionResult> {
     const obj = listing.data.object;
 
     // Square nests payment fields under data.object.payment
@@ -111,7 +109,7 @@ export const squarePaymentProvider: PaymentProvider = {
   async retrieveSession(
     sessionId: string,
     paidPaymentId?: string,
-  ): Promise<ValidatedPaymentSession | SessionRejection | null> {
+  ): Promise<RetrieveSessionResult> {
     /* jscpd:ignore-end */
     // sessionId is the Square order ID
     const order = await retrieveOrder(sessionId);

--- a/src/shared/stripe-provider.ts
+++ b/src/shared/stripe-provider.ts
@@ -7,18 +7,16 @@
 
 import type Stripe from "stripe";
 import * as v from "valibot";
-import {
-  type SessionRejection,
-  validatedPaymentSession,
-} from "#shared/payment/validated-session.ts";
+import { validatedPaymentSession } from "#shared/payment/validated-session.ts";
 import {
   hasRequiredSessionMetadata,
   makeCreateCheckoutSession,
 } from "#shared/payment-helpers.ts";
 import type {
   PaymentProvider,
-  ValidatedPaymentSession,
+  RetrieveSessionResult,
   WebhookEvent,
+  WebhookSessionResult,
   WebhookVerifyResult,
 } from "#shared/payments.ts";
 import {
@@ -39,7 +37,7 @@ type StripeCheckoutCompletedEvent = Pick<
 
 const toValidatedSession = (
   session: StripeCheckoutSession,
-): ValidatedPaymentSession | SessionRejection | null => {
+): RetrieveSessionResult => {
   const {
     amount_total,
     currency,
@@ -86,9 +84,7 @@ export const stripePaymentProvider: PaymentProvider = {
 
   async resolveWebhookSession({
     data: { object: obj },
-  }: WebhookEvent): Promise<
-    ValidatedPaymentSession | "skip" | SessionRejection | null
-  > {
+  }: WebhookEvent): Promise<WebhookSessionResult> {
     const id = obj.id;
     if (typeof id !== "string" || id.length === 0) return null;
 
@@ -97,9 +93,7 @@ export const stripePaymentProvider: PaymentProvider = {
     return validated === null ? await this.retrieveSession(id) : validated;
   },
 
-  async retrieveSession(
-    sessionId: string,
-  ): Promise<ValidatedPaymentSession | SessionRejection | null> {
+  async retrieveSession(sessionId: string): Promise<RetrieveSessionResult> {
     const session = await stripeApi.retrieveCheckoutSession(sessionId);
     if (!session) return null;
     return toValidatedSession(session);

--- a/src/shared/sumup-observation.ts
+++ b/src/shared/sumup-observation.ts
@@ -128,8 +128,8 @@ type ChildRule = (
 ) => ChildVerdict;
 
 /** A still-open checkout may carry one charge of its own — alone, and under
- *  our merchant. Nothing here vouches for money: pending charges are never
- *  booked from. */
+ *  our merchant. The checkout's own amount stays readable; a pending session
+ *  is marked unpaid downstream, so nothing books from it. */
 const pendingChildVerdict: ChildRule = (c, charge, extras) => {
   if (extras.length > 0) return UNRECORDED_CHILD;
   if (charge !== undefined && charge.merchant_code !== c.merchant_code) {

--- a/src/shared/sumup-observation.ts
+++ b/src/shared/sumup-observation.ts
@@ -1,0 +1,206 @@
+/**
+ * Turns one fetched SumUp checkout into a typed provider read.
+ *
+ * This module is pure: the caller fetches and passes the raw body plus the
+ * independent facts it holds (the id it asked for, the merchant this site is
+ * bound to, the site currency for reading amounts). Everything here follows
+ * the sandbox evidence recorded in PR3_PLAN.md: pending checkouts carry an
+ * empty transactions array, paid checkouts name their transaction and carry
+ * exactly one matching successful entry, failed checkouts carry only failed
+ * entries.
+ *
+ * Ownership and money are deliberately separate refusals. A checkout whose
+ * id, merchant, or named charge disagrees with our facts is refused as an
+ * invalid read — nothing downstream may touch it. A checkout that proves
+ * ownership but carries unreadable money is still a found read: the session
+ * boundary refuses the money itself, and that refusal is what carries a
+ * captured charge to the refund path instead of stranding it.
+ */
+
+import * as v from "valibot";
+import { toMinorUnits } from "#shared/currency.ts";
+import { isCurrency } from "#shared/payment/money.ts";
+import type {
+  ProviderInvalidReason,
+  ProviderRead,
+} from "#shared/payment/provider-read.ts";
+import { isResourceId } from "#shared/payment/resource-id.ts";
+import { exceedsCurrencyPrecision } from "#shared/validation/money.ts";
+
+/** SumUp's documented checkout lifecycle (pinned @sumup/sdk 0.1.6). */
+const SumupCheckoutStatusSchema = v.picklist([
+  "PENDING",
+  "PAID",
+  "FAILED",
+  "EXPIRED",
+]);
+export type SumupCheckoutStatus = v.InferOutput<
+  typeof SumupCheckoutStatusSchema
+>;
+
+/** Normalized checkout shape consumed by the provider adapter. */
+export type SumupCheckout = {
+  /** Our generated checkout_reference — used as the session id throughout. */
+  reference: string;
+  /** SumUp checkout lifecycle status. */
+  status: SumupCheckoutStatus;
+  /** Total amount in the app's minor units, or null when the response carried
+   *  no amount, or one finer than the currency can hold — rounding that would
+   *  book an amount SumUp never took. The boundary refuses a null either way. */
+  amountMinor: number | null;
+  /** The currency the checkout was taken in, exactly as SumUp gave it (upper-
+   *  cased), or null when the response carried none. A code that is not three
+   *  letters is carried through unchanged so the boundary refuses it. */
+  currency: string | null;
+  /** Transaction id of the completing payment (refund/payment reference). */
+  transactionId: string;
+  /** Checkout creation time (ISO 8601), from SumUp's `date` field. */
+  createdAt?: string | undefined;
+};
+
+/** The independent facts a SumUp read is checked against. */
+export type SumupReadFacts = {
+  /** The merchant code this site is bound to. */
+  merchantCode: string;
+  /** The checkout id the read asked SumUp for. */
+  requestedId: string;
+  /** Currency used to read amounts when the response carries no usable code. */
+  siteCurrency: string;
+};
+
+/** The wire fields a checkout and each of its transactions both carry:
+ *  identity, money, merchant, and lifecycle status. */
+const wireSharedFields = {
+  amount: v.optional(v.number()),
+  currency: v.optional(v.string()),
+  id: v.optional(v.string()),
+  merchant_code: v.optional(v.string()),
+  status: v.optional(v.string()),
+};
+
+const WireTransactionSchema = v.object(wireSharedFields);
+type WireTransaction = v.InferOutput<typeof WireTransactionSchema>;
+
+/** The wire fields the read uses; unknown fields are dropped, and which
+ *  absences matter is decided by the rules below, not by the parse. */
+const WireCheckoutSchema = v.object({
+  ...wireSharedFields,
+  checkout_reference: v.optional(v.string()),
+  date: v.optional(v.string()),
+  transaction_id: v.optional(v.string()),
+  transactions: v.optional(v.array(WireTransactionSchema)),
+});
+type WireCheckout = v.InferOutput<typeof WireCheckoutSchema>;
+
+const invalidRead = (reason: ProviderInvalidReason): ProviderRead<never> => ({
+  reason,
+  status: "invalid",
+});
+
+/** Two wire money fields disagree only when both are present and differ —
+ *  an absent side has nothing to disagree with, and unreadable money must
+ *  reach the session boundary's refund path rather than refuse the read. */
+const moneyDisagrees = (
+  left: number | string | undefined,
+  right: number | string | undefined,
+): boolean => left !== undefined && right !== undefined && left !== right;
+
+/** The one unrecorded child the boundary accepts is a charge under its own
+ *  still-open checkout, so everything here applies to the other statuses:
+ *  a paid checkout must carry exactly the successful charge its own record
+ *  names, and a dead one must carry none. */
+const childFailure = (c: WireCheckout): ProviderInvalidReason | null => {
+  const successful = (c.transactions ?? []).filter(
+    (txn) => txn.status === "SUCCESSFUL",
+  );
+  if (c.status === "PENDING") return null;
+  if (c.status !== "PAID") {
+    return successful.length > 0 ? "unrecorded_child" : null;
+  }
+  if (!isResourceId(c.transaction_id ?? "")) {
+    return "missing_documented_resource";
+  }
+  const [charge, ...extras] = successful;
+  if (charge === undefined) return "missing_documented_resource";
+  if (extras.length > 0) return "unrecorded_child";
+  return namedChargeFailure(c, charge);
+};
+
+/** Whether the paid checkout's single successful charge is the one its own
+ *  record names, captured under our merchant, for the money it states. */
+const namedChargeFailure = (
+  c: WireCheckout,
+  charge: WireTransaction,
+): ProviderInvalidReason | null => {
+  if (charge.id !== c.transaction_id) return "unrecorded_child";
+  if (charge.merchant_code !== c.merchant_code) return "unrecorded_child";
+  if (moneyDisagrees(charge.amount, c.amount)) return "unrecorded_child";
+  if (
+    moneyDisagrees(charge.currency?.toUpperCase(), c.currency?.toUpperCase())
+  ) {
+    return "unrecorded_child";
+  }
+  return null;
+};
+
+/** Normalize the accepted wire checkout, reading its amount in the currency
+ *  SumUp returned with it and carrying unreadable money through as null. */
+const toSumupCheckout = (
+  c: WireCheckout,
+  status: SumupCheckoutStatus,
+  reference: string,
+  siteCurrency: string,
+): SumupCheckout => {
+  const amount = typeof c.amount === "number" ? c.amount : null;
+  const currency =
+    typeof c.currency === "string" && c.currency.trim() !== ""
+      ? c.currency.toUpperCase()
+      : null;
+  // Only a well-formed code may reach the currency helpers: Intl throws on
+  // anything else, and an unusable code falls back to the site's.
+  const conversionCurrency = isCurrency(currency) ? currency : siteCurrency;
+  // An amount finer than the currency can hold would round to something SumUp
+  // never charged, so it is as unreadable as an absent one.
+  const readable =
+    amount !== null && !exceedsCurrencyPrecision(amount, conversionCurrency);
+  return {
+    amountMinor: readable ? toMinorUnits(amount, conversionCurrency) : null,
+    createdAt: c.date,
+    currency,
+    reference,
+    status,
+    transactionId: c.transaction_id ?? "",
+  };
+};
+
+/**
+ * Check one fetched checkout body against the facts we hold independently,
+ * in the order the facts bind: shape, reference, id, merchant, lifecycle,
+ * then the charge the record names.
+ */
+export const classifySumupCheckout = (
+  body: unknown,
+  facts: SumupReadFacts,
+): ProviderRead<SumupCheckout> => {
+  const parsed = v.safeParse(WireCheckoutSchema, body);
+  if (!parsed.success) return invalidRead("malformed_response");
+  const c = parsed.output;
+  const reference = c.checkout_reference;
+  // A checkout we created always carries the reference we generated; the
+  // booking is encrypted under it, so without one the row cannot be opened.
+  if (reference === undefined || !isResourceId(reference)) {
+    return invalidRead("malformed_response");
+  }
+  if (c.id !== facts.requestedId) return invalidRead("mismatched_id");
+  if (c.merchant_code !== facts.merchantCode) {
+    return invalidRead("mismatched_account");
+  }
+  const status = v.safeParse(SumupCheckoutStatusSchema, c.status);
+  if (!status.success) return invalidRead("unsupported_status");
+  const failure = childFailure(c);
+  if (failure !== null) return invalidRead(failure);
+  return {
+    resource: toSumupCheckout(c, status.output, reference, facts.siteCurrency),
+    status: "found",
+  };
+};

--- a/src/shared/sumup-observation.ts
+++ b/src/shared/sumup-observation.ts
@@ -97,50 +97,70 @@ const invalidRead = (reason: ProviderInvalidReason): ProviderRead<never> => ({
   status: "invalid",
 });
 
-/** Two wire money fields disagree only when both are present and differ —
- *  an absent side has nothing to disagree with, and unreadable money must
- *  reach the session boundary's refund path rather than refuse the read. */
-const moneyDisagrees = (
-  left: number | string | undefined,
-  right: number | string | undefined,
-): boolean => left !== undefined && right !== undefined && left !== right;
+/** What checking a checkout's charges concluded: a refusal reason, or an
+ *  acceptance saying whether the named charge vouched for the money. Money a
+ *  charge did not vouch for is carried as unreadable — the session boundary's
+ *  refusal is what sends a captured charge to the refund path, while refusing
+ *  the whole read would strand it once SumUp's retries run out. */
+type ChildVerdict =
+  | { failure: ProviderInvalidReason }
+  | { failure: null; moneyVouchedFor: boolean };
 
-/** The one unrecorded child the boundary accepts is a charge under its own
- *  still-open checkout, so everything here applies to the other statuses:
- *  a paid checkout must carry exactly the successful charge its own record
- *  names, and a dead one must carry none. */
-const childFailure = (c: WireCheckout): ProviderInvalidReason | null => {
-  const successful = (c.transactions ?? []).filter(
-    (txn) => txn.status === "SUCCESSFUL",
-  );
-  if (c.status === "PENDING") return null;
-  if (c.status !== "PAID") {
-    return successful.length > 0 ? "unrecorded_child" : null;
-  }
-  if (!isResourceId(c.transaction_id ?? "")) {
-    return "missing_documented_resource";
-  }
-  const [charge, ...extras] = successful;
-  if (charge === undefined) return "missing_documented_resource";
-  if (extras.length > 0) return "unrecorded_child";
-  return namedChargeFailure(c, charge);
-};
-
-/** Whether the paid checkout's single successful charge is the one its own
- *  record names, captured under our merchant, for the money it states. */
-const namedChargeFailure = (
+/** The named charge vouches for the checkout's money only when it states
+ *  both fields itself and neither disputes the checkout's own record. */
+const chargeVouchesForMoney = (
   c: WireCheckout,
   charge: WireTransaction,
-): ProviderInvalidReason | null => {
-  if (charge.id !== c.transaction_id) return "unrecorded_child";
-  if (charge.merchant_code !== c.merchant_code) return "unrecorded_child";
-  if (moneyDisagrees(charge.amount, c.amount)) return "unrecorded_child";
-  if (
-    moneyDisagrees(charge.currency?.toUpperCase(), c.currency?.toUpperCase())
-  ) {
-    return "unrecorded_child";
+): boolean =>
+  charge.amount !== undefined &&
+  charge.currency !== undefined &&
+  (c.amount === undefined || charge.amount === c.amount) &&
+  (c.currency === undefined ||
+    charge.currency.toUpperCase() === c.currency.toUpperCase());
+
+const UNRECORDED_CHILD: ChildVerdict = { failure: "unrecorded_child" };
+
+/** One lifecycle status's rule for the charges a checkout may carry. */
+type ChildRule = (
+  c: WireCheckout,
+  charge: WireTransaction | undefined,
+  extras: readonly WireTransaction[],
+) => ChildVerdict;
+
+/** A still-open checkout may carry one charge of its own — alone, and under
+ *  our merchant. Nothing here vouches for money: pending charges are never
+ *  booked from. */
+const pendingChildVerdict: ChildRule = (c, charge, extras) => {
+  if (extras.length > 0) return UNRECORDED_CHILD;
+  if (charge !== undefined && charge.merchant_code !== c.merchant_code) {
+    return UNRECORDED_CHILD;
   }
-  return null;
+  return { failure: null, moneyVouchedFor: true };
+};
+
+/** A paid checkout must carry exactly the successful charge its own record
+ *  names, captured under our merchant. */
+const paidChildVerdict: ChildRule = (c, charge, extras) => {
+  if (!isResourceId(c.transaction_id ?? "") || charge === undefined) {
+    return { failure: "missing_documented_resource" };
+  }
+  if (extras.length > 0) return UNRECORDED_CHILD;
+  if (charge.id !== c.transaction_id) return UNRECORDED_CHILD;
+  if (charge.merchant_code !== c.merchant_code) return UNRECORDED_CHILD;
+  return { failure: null, moneyVouchedFor: chargeVouchesForMoney(c, charge) };
+};
+
+/** The one unrecorded child the boundary accepts is a charge under its own
+ *  still-open checkout; a dead checkout must carry none. */
+const checkChildren = (c: WireCheckout): ChildVerdict => {
+  const [charge, ...extras] = (c.transactions ?? []).filter(
+    (txn) => txn.status === "SUCCESSFUL",
+  );
+  if (c.status === "PENDING") return pendingChildVerdict(c, charge, extras);
+  if (c.status === "PAID") return paidChildVerdict(c, charge, extras);
+  return charge === undefined
+    ? { failure: null, moneyVouchedFor: true }
+    : UNRECORDED_CHILD;
 };
 
 /** Normalize the accepted wire checkout, reading its amount in the currency
@@ -149,7 +169,8 @@ const toSumupCheckout = (
   c: WireCheckout,
   status: SumupCheckoutStatus,
   reference: string,
-  siteCurrency: string,
+  facts: SumupReadFacts,
+  moneyVouchedFor: boolean,
 ): SumupCheckout => {
   const amount = typeof c.amount === "number" ? c.amount : null;
   const currency =
@@ -158,11 +179,17 @@ const toSumupCheckout = (
       : null;
   // Only a well-formed code may reach the currency helpers: Intl throws on
   // anything else, and an unusable code falls back to the site's.
-  const conversionCurrency = isCurrency(currency) ? currency : siteCurrency;
+  const conversionCurrency = isCurrency(currency)
+    ? currency
+    : facts.siteCurrency;
   // An amount finer than the currency can hold would round to something SumUp
-  // never charged, so it is as unreadable as an absent one.
+  // never charged — as unreadable as an absent one. Money the named charge
+  // did not vouch for is unreadable too: a booking must never be priced by a
+  // record the captured charge itself does not confirm.
   const readable =
-    amount !== null && !exceedsCurrencyPrecision(amount, conversionCurrency);
+    moneyVouchedFor &&
+    amount !== null &&
+    !exceedsCurrencyPrecision(amount, conversionCurrency);
   return {
     amountMinor: readable ? toMinorUnits(amount, conversionCurrency) : null,
     createdAt: c.date,
@@ -197,10 +224,16 @@ export const classifySumupCheckout = (
   }
   const status = v.safeParse(SumupCheckoutStatusSchema, c.status);
   if (!status.success) return invalidRead("unsupported_status");
-  const failure = childFailure(c);
-  if (failure !== null) return invalidRead(failure);
+  const verdict = checkChildren(c);
+  if (verdict.failure !== null) return invalidRead(verdict.failure);
   return {
-    resource: toSumupCheckout(c, status.output, reference, facts.siteCurrency),
+    resource: toSumupCheckout(
+      c,
+      status.output,
+      reference,
+      facts,
+      verdict.moneyVouchedFor,
+    ),
     status: "found",
   };
 };

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -29,17 +29,19 @@ import {
 import type {
   PaymentProvider,
   PaymentStatus,
+  RetrieveSessionResult,
   SessionMetadata,
   ValidatedPaymentSession,
   WebhookEvent,
+  WebhookSessionResult,
   WebhookSetupResult,
   WebhookVerifyResult,
 } from "#shared/payments.ts";
 import {
   createCheckout,
   getTransactionStatus,
-  readCheckoutById,
   refundTransaction,
+  sumupApi,
 } from "#shared/sumup.ts";
 import type {
   SumupCheckout,
@@ -109,9 +111,7 @@ export const sumupPaymentProvider: PaymentProvider = {
 
   async resolveWebhookSession(
     webhookEvent: WebhookEvent,
-  ): Promise<
-    ValidatedPaymentSession | "skip" | "retry" | SessionRejection | null
-  > {
+  ): Promise<WebhookSessionResult> {
     if (!isUsableSumupId(webhookEvent.id)) return null;
     // Unsigned webhooks: only fetch checkouts we created. Spam and other
     // integrations' listings never cost an API call — but they are refused
@@ -124,7 +124,7 @@ export const sumupPaymentProvider: PaymentProvider = {
     // The staging row already proved this checkout is ours, so anything but a
     // clean read is refused retryably: acknowledging is terminal, and a paid
     // checkout would be left with the money taken and no booking.
-    const read = await readCheckoutById(webhookEvent.id);
+    const read = await sumupApi.readCheckoutById(webhookEvent.id);
     if (read.status !== "found") {
       return refuseRetryably(
         "reason" in read
@@ -154,16 +154,22 @@ export const sumupPaymentProvider: PaymentProvider = {
      duplication: every provider must write this exact member signature, but
      the bodies share no logic (SumUp reads its locally staged checkout;
      Square fetches the order and its payment from the API). */
-  async retrieveSession(
-    sessionId: string,
-  ): Promise<ValidatedPaymentSession | SessionRejection | null> {
+  async retrieveSession(sessionId: string): Promise<RetrieveSessionResult> {
     /* jscpd:ignore-end */
     // sessionId is our checkout_reference (set on the redirect URL); the
     // staged row carries the SumUp id for a direct fetch. An empty sumupId
     // means checkout creation failed after staging — nothing to retrieve.
     const stored = await getSumupCheckout(sessionId);
     if (!stored?.sumupId) return null;
-    const read = await readCheckoutById(stored.sumupId);
+    const read = await sumupApi.readCheckoutById(stored.sumupId);
+    // SumUp being unreachable is temporary: throwing keeps the browser's
+    // answer honest — a "not found" page for a passing outage would read as
+    // a missing payment.
+    if (read.status === "unavailable") {
+      throw new Error(
+        `SumUp could not answer for a staged checkout (${read.reason})`,
+      );
+    }
     // The redirect's reference opened this staging row, so the checkout it
     // names must echo that same reference back; anything else is not this
     // booking.

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -16,7 +16,7 @@ import {
   getSumupCheckout,
   hasSumupCheckoutId,
 } from "#shared/db/sumup-checkouts.ts";
-import { isResourceId } from "#shared/payment/resource-id.ts";
+import { logDebug } from "#shared/logger.ts";
 import {
   isSessionRejection,
   type SessionRejection,
@@ -38,16 +38,34 @@ import type {
 import {
   createCheckout,
   getTransactionStatus,
+  readCheckoutById,
   refundTransaction,
-  retrieveCheckoutById,
-  type SumupCheckout,
 } from "#shared/sumup.ts";
+import type {
+  SumupCheckout,
+  SumupCheckoutStatus,
+} from "#shared/sumup-observation.ts";
 
 /** Map SumUp's checkout lifecycle to the provider-agnostic payment status.
  * FAILED (declined) and EXPIRED are terminal — the redirect handler shows the
  * cancel page for those instead of a "contact support" error. */
-const toPaymentStatus = (status: SumupCheckout["status"]): PaymentStatus =>
+const toPaymentStatus = (status: SumupCheckoutStatus): PaymentStatus =>
   status === "PAID" ? "paid" : status === "PENDING" ? "unpaid" : "failed";
+
+/** No real SumUp checkout id is anywhere near this long, so a longer one is
+ * provably not ours and is refused before it costs a database lookup. */
+const MAX_SUMUP_ID_BYTES = 255;
+
+const isUsableSumupId = (id: string): boolean =>
+  id !== "" && new TextEncoder().encode(id).byteLength <= MAX_SUMUP_ID_BYTES;
+
+/** Refuse a callback retryably with a value-free console line. Forged and
+ * unreadable callbacks must not spend alert subrequests, and the fixed words
+ * carry the outcome without carrying any value from the payload. */
+const refuseRetryably = (why: string): "retry" => {
+  logDebug("Webhook", `SumUp callback refused retryably: ${why}`);
+  return "retry";
+};
 
 /** Build a validated session from a fetched checkout and its staged metadata.
  * The metadata was written by our own buildItemsMetadata, so it always carries
@@ -91,32 +109,38 @@ export const sumupPaymentProvider: PaymentProvider = {
 
   async resolveWebhookSession(
     webhookEvent: WebhookEvent,
-  ): Promise<ValidatedPaymentSession | "skip" | SessionRejection | null> {
-    if (!webhookEvent.id) return null;
-    // Unsigned webhooks: only fetch checkouts we created. Spam or another
-    // integration's listings are acknowledged without an API call.
-    if (!(await hasSumupCheckoutId(webhookEvent.id))) return "skip";
-    // The staging row already proved this checkout is ours, so a failed fetch
-    // is SumUp being unreachable rather than a checkout we never made.
-    // Throwing answers retryably; acknowledging is terminal, and a paid
-    // checkout would be left with the money taken and no booking.
-    const checkout = await retrieveCheckoutById(webhookEvent.id);
-    if (!checkout) {
-      throw new Error(`SumUp checkout ${webhookEvent.id} could not be read`);
+  ): Promise<
+    ValidatedPaymentSession | "skip" | "retry" | SessionRejection | null
+  > {
+    if (!isUsableSumupId(webhookEvent.id)) return null;
+    // Unsigned webhooks: only fetch checkouts we created. Spam and other
+    // integrations' listings never cost an API call — but they are refused
+    // retryably rather than acknowledged, because the same answer covers a
+    // real callback racing our own staging write, and one fixed refusal
+    // tells a forger nothing about whether an id exists.
+    if (!(await hasSumupCheckoutId(webhookEvent.id))) {
+      return refuseRetryably("checkout is not one we staged");
     }
-    // The reference SumUp echoes back must be the one we generated for this
-    // checkout and staged under this webhook id. If it is blank, unknown, or
-    // another booking's, SumUp has contradicted itself about a checkout we
-    // created. Raise it: the booking is encrypted under that reference, so
-    // without a match we can neither read it nor prove the charge is ours to
-    // refund — and a paid charge is then sitting with SumUp unbooked.
-    const stored = isResourceId(checkout.reference)
-      ? await getSumupCheckout(checkout.reference)
-      : null;
-    if (!stored || stored.sumupId !== webhookEvent.id) {
-      throw new Error(
-        `SumUp checkout ${webhookEvent.id} came back under reference "${checkout.reference}", which is not the one staged for it (status=${checkout.status}, transaction=${checkout.transactionId})`,
+    // The staging row already proved this checkout is ours, so anything but a
+    // clean read is refused retryably: acknowledging is terminal, and a paid
+    // checkout would be left with the money taken and no booking.
+    const read = await readCheckoutById(webhookEvent.id);
+    if (read.status !== "found") {
+      return refuseRetryably(
+        "reason" in read
+          ? `read ${read.status} (${read.reason})`
+          : "read missing",
       );
+    }
+    const checkout = read.resource;
+    // The reference SumUp echoes back must be the one we generated for this
+    // checkout and staged under this webhook id. If it is unknown or another
+    // booking's, SumUp has contradicted itself about a checkout we created.
+    // The booking is encrypted under that reference, so without a match we
+    // can neither read it nor prove the charge is ours to refund.
+    const stored = await getSumupCheckout(checkout.reference);
+    if (!stored || stored.sumupId !== webhookEvent.id) {
+      return refuseRetryably("reference does not open the staged row");
     }
     const session = buildValidatedSession(checkout, stored.metadata);
     // A charge the boundary could not read: surface the rejection so a paid
@@ -139,8 +163,14 @@ export const sumupPaymentProvider: PaymentProvider = {
     // means checkout creation failed after staging — nothing to retrieve.
     const stored = await getSumupCheckout(sessionId);
     if (!stored?.sumupId) return null;
-    const checkout = await retrieveCheckoutById(stored.sumupId);
-    return checkout && buildValidatedSession(checkout, stored.metadata);
+    const read = await readCheckoutById(stored.sumupId);
+    // The redirect's reference opened this staging row, so the checkout it
+    // names must echo that same reference back; anything else is not this
+    // booking.
+    if (read.status !== "found" || read.resource.reference !== sessionId) {
+      return null;
+    }
+    return buildValidatedSession(read.resource, stored.metadata);
   },
 
   // SumUp sets return_url per checkout — there is no global endpoint to register.

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -13,8 +13,9 @@
  */
 
 import {
+  getSealedSumupCheckout,
   getSumupCheckout,
-  hasSumupCheckoutId,
+  openSumupCheckout,
 } from "#shared/db/sumup-checkouts.ts";
 import { logDebug } from "#shared/logger.ts";
 import {
@@ -54,8 +55,10 @@ import type {
 const toPaymentStatus = (status: SumupCheckoutStatus): PaymentStatus =>
   status === "PAID" ? "paid" : status === "PENDING" ? "unpaid" : "failed";
 
-/** No real SumUp checkout id is anywhere near this long, so a longer one is
- * provably not ours and is refused before it costs a database lookup. */
+/** No real SumUp checkout id is blank or anywhere near this long, so an id
+ * outside the bound is refused before it costs even a database lookup — and
+ * on the same fixed path as every other refusal, so the payload is never
+ * echoed into a log and a forger learns nothing from the answer's shape. */
 const MAX_SUMUP_ID_BYTES = 255;
 
 const isUsableSumupId = (id: string): boolean =>
@@ -112,16 +115,20 @@ export const sumupPaymentProvider: PaymentProvider = {
   async resolveWebhookSession(
     webhookEvent: WebhookEvent,
   ): Promise<WebhookSessionResult> {
-    if (!isUsableSumupId(webhookEvent.id)) return null;
+    if (!isUsableSumupId(webhookEvent.id)) {
+      return refuseRetryably("id is not one we could have staged");
+    }
     // Unsigned webhooks: only fetch checkouts we created. Spam and other
-    // integrations' listings never cost an API call — but they are refused
-    // retryably rather than acknowledged, because the same answer covers a
-    // real callback racing our own staging write, and one fixed refusal
-    // tells a forger nothing about whether an id exists.
-    if (!(await hasSumupCheckoutId(webhookEvent.id))) {
+    // integrations' listings never cost an API call — one indexed read
+    // answers the pre-filter and carries the sealed row for later. They are
+    // refused retryably rather than acknowledged, because the same answer
+    // covers a real callback racing our own staging write, and one fixed
+    // refusal tells a forger nothing about whether an id exists.
+    const sealed = await getSealedSumupCheckout(webhookEvent.id);
+    if (sealed === null) {
       return refuseRetryably("checkout is not one we staged");
     }
-    // The staging row already proved this checkout is ours, so anything but a
+    // The staged row already proved this checkout is ours, so anything but a
     // clean read is refused retryably: acknowledging is terminal, and a paid
     // checkout would be left with the money taken and no booking.
     const read = await sumupApi.readCheckoutById(webhookEvent.id);
@@ -134,15 +141,16 @@ export const sumupPaymentProvider: PaymentProvider = {
     }
     const checkout = read.resource;
     // The reference SumUp echoes back must be the one we generated for this
-    // checkout and staged under this webhook id. If it is unknown or another
-    // booking's, SumUp has contradicted itself about a checkout we created.
-    // The booking is encrypted under that reference, so without a match we
-    // can neither read it nor prove the charge is ours to refund.
-    const stored = await getSumupCheckout(checkout.reference);
-    if (!stored || stored.sumupId !== webhookEvent.id) {
+    // checkout and staged under this webhook id — the sealed row only opens
+    // with it. If it is unknown or another booking's, SumUp has contradicted
+    // itself about a checkout we created: the booking is encrypted under
+    // that reference, so without a match we can neither read it nor prove
+    // the charge is ours to refund.
+    const metadata = await openSumupCheckout(sealed, checkout.reference);
+    if (metadata === null) {
       return refuseRetryably("reference does not open the staged row");
     }
-    const session = buildValidatedSession(checkout, stored.metadata);
+    const session = buildValidatedSession(checkout, metadata);
     // A charge the boundary could not read: surface the rejection so a paid
     // one still reaches the refund path.
     if (isSessionRejection(session)) return session;

--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -10,17 +10,16 @@
  *   then authenticity comes from re-fetching the checkout
  * - Refunds operate on the transaction id (paymentReference), not the checkout
  *
- * Amounts: the app models money in minor units (e.g. pence); SumUp's API uses
- * major units. A retrieved checkout converts using the currency SumUp returned
- * with it, so a charge taken in another currency is read at its own decimal
- * places rather than the site's; an unusable code falls back to the site's.
+ * A fetched checkout is checked against our independent facts and normalized
+ * by the pure sumup-observation module; this module only owns the client and
+ * tells an authoritative not-found apart from SumUp being unreachable.
  */
 
 /* jscpd:ignore-start */
-import type { CheckoutSuccess, Currency } from "@sumup/sdk";
-import { SumUp } from "@sumup/sdk";
+import type { Currency } from "@sumup/sdk";
+import { APIError, SumUp } from "@sumup/sdk";
 import { priceCheckout } from "#shared/checkout-pricing.ts";
-import { toMajorUnits, toMinorUnits } from "#shared/currency.ts";
+import { toMajorUnits } from "#shared/currency.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
   setSumupCheckoutId,
@@ -28,7 +27,7 @@ import {
 } from "#shared/db/sumup-checkouts.ts";
 import { errorMessage } from "#shared/error-message.ts";
 import { ErrorCode, logDebug, logError } from "#shared/logger.ts";
-import { isCurrency } from "#shared/payment/money.ts";
+import type { ProviderRead } from "#shared/payment/provider-read.ts";
 import {
   assembleCheckoutMetadata,
   type CredentialCheck,
@@ -37,29 +36,12 @@ import {
 import { providerCurrencyBlock } from "#shared/payment-providers.ts";
 import { getPaymentWebhookUrl } from "#shared/payment-webhook-url.ts";
 import type { CheckoutIntent } from "#shared/payments.ts";
-import { exceedsCurrencyPrecision } from "#shared/validation/money.ts";
+import {
+  classifySumupCheckout,
+  type SumupCheckout,
+} from "#shared/sumup-observation.ts";
 
 /* jscpd:ignore-end */
-
-/** Normalized checkout shape consumed by the provider adapter. */
-export type SumupCheckout = {
-  /** Our generated checkout_reference — used as the session id throughout. */
-  reference: string;
-  /** SumUp checkout lifecycle status. */
-  status: CheckoutSuccess["status"];
-  /** Total amount in the app's minor units, or null when the response carried
-   *  no amount, or one finer than the currency can hold — rounding that would
-   *  book an amount SumUp never took. The boundary refuses a null either way. */
-  amountMinor: number | null;
-  /** The currency the checkout was taken in, exactly as SumUp gave it (upper-
-   *  cased), or null when the response carried none. A code that is not three
-   *  letters is carried through unchanged so the boundary refuses it. */
-  currency: string | null;
-  /** Transaction id of the completing payment (refund/payment reference). */
-  transactionId: string;
-  /** Checkout creation time (ISO 8601), from SumUp's `date` field. */
-  createdAt?: string | undefined;
-};
 
 /** Result of creating a hosted checkout. */
 export type SumupCheckoutResult = { reference: string; url: string } | null;
@@ -114,42 +96,18 @@ const sumupKeyError = (err: unknown): string => {
     : message;
 };
 
-/**
- * Normalize a SumUp checkout into our internal shape. Nothing here may throw:
- * it runs inside `withClient`, which turns any error into "no session", and the
- * webhook then acknowledges a paid charge as one it never heard of. So bad
- * money is carried through for the boundary to refuse, never asserted away.
- *
- * transaction_id only exists once a payment attempt succeeds; older attempts
- * in `transactions` may have FAILED, so the fallback picks the successful one.
- */
-const toSumupCheckout = (c: CheckoutSuccess): SumupCheckout => {
-  const amount = typeof c.amount === "number" ? c.amount : null;
-  const currency =
-    typeof c.currency === "string" && c.currency.trim() !== ""
-      ? c.currency.toUpperCase()
-      : null;
-  // Only a well-formed code may reach the currency helpers: Intl throws on
-  // anything else, and that throw would be swallowed here as "no session",
-  // stranding a paid charge the boundary would otherwise refuse and refund.
-  const conversionCurrency = isCurrency(currency)
-    ? currency
-    : settings.currency;
-  // An amount finer than the currency can hold would round to something SumUp
-  // never charged, so it is as unreadable as an absent one.
-  const readable =
-    amount !== null && !exceedsCurrencyPrecision(amount, conversionCurrency);
-  return {
-    amountMinor: readable ? toMinorUnits(amount, conversionCurrency) : null,
-    createdAt: c.date,
-    currency,
-    reference: c.checkout_reference!,
-    status: c.status,
-    transactionId:
-      c.transaction_id ??
-      c.transactions?.find((t) => t.status === "SUCCESSFUL")?.id ??
-      "",
-  };
+/** Turn a failed checkout fetch into the read it proves. The SDK's APIError
+ *  carries the HTTP status, so an authoritative not-found is told apart from
+ *  SumUp being unreachable; the status code is safe to log, the body is not. */
+const sumupReadFailure = (err: unknown): ProviderRead<SumupCheckout> => {
+  if (err instanceof APIError) {
+    logDebug("SumUp", `Checkout read answered ${err.status}`);
+    return err.status === 404
+      ? { status: "missing" }
+      : { reason: "provider_error", status: "unavailable" };
+  }
+  logDebug("SumUp", "Checkout read failed before SumUp answered");
+  return { reason: "network_error", status: "unavailable" };
 };
 
 /**
@@ -162,7 +120,7 @@ export const sumupApi: {
     intent: CheckoutIntent,
     baseUrl: string,
   ) => Promise<SumupCheckoutResult>;
-  retrieveCheckoutById: (id: string) => Promise<SumupCheckout | null>;
+  readCheckoutById: (id: string) => Promise<ProviderRead<SumupCheckout>>;
   refundTransaction: (transactionId: string) => Promise<boolean>;
   getTransactionStatus: (transactionId: string) => Promise<string | null>;
   testSumupConnection: () => Promise<SumupConnectionTestResult>;
@@ -232,6 +190,26 @@ export const sumupApi: {
     }, ErrorCode.PAYMENT_SESSION);
   },
 
+  /** Read a checkout by its SumUp id and check it against our facts. */
+  readCheckoutById: async (
+    id: string,
+  ): Promise<ProviderRead<SumupCheckout>> => {
+    const client = sumupApi.getSumupClient();
+    const merchantCode = getMerchantCode();
+    if (!client || !merchantCode) {
+      return { reason: "not_configured", status: "unavailable" };
+    }
+    try {
+      return classifySumupCheckout(await client.checkouts.get(id), {
+        merchantCode,
+        requestedId: id,
+        siteCurrency: settings.currency,
+      });
+    } catch (err) {
+      return sumupReadFailure(err);
+    }
+  },
+
   /** Refund a transaction in full. */
   refundTransaction: async (transactionId: string): Promise<boolean> => {
     const merchantCode = getMerchantCode();
@@ -242,13 +220,6 @@ export const sumupApi: {
     }, ErrorCode.PAYMENT_REFUND);
     return result ?? false;
   },
-
-  /** Retrieve a checkout by its SumUp id. */
-  retrieveCheckoutById: (id: string): Promise<SumupCheckout | null> =>
-    withClient(
-      async (client) => toSumupCheckout(await client.checkouts.get(id)),
-      ErrorCode.PAYMENT_SESSION,
-    ),
 
   /** Test connection: verify API key + merchant code + currency support. */
   testSumupConnection: async (): Promise<SumupConnectionTestResult> => {
@@ -294,8 +265,7 @@ export const sumupApi: {
 // Wrapper exports for production code (delegate to sumupApi for test mocking)
 export const createCheckout = (i: CheckoutIntent, b: string) =>
   sumupApi.createCheckout(i, b);
-export const retrieveCheckoutById = (id: string) =>
-  sumupApi.retrieveCheckoutById(id);
+export const readCheckoutById = (id: string) => sumupApi.readCheckoutById(id);
 export const refundTransaction = (id: string) => sumupApi.refundTransaction(id);
 export const getTransactionStatus = (id: string) =>
   sumupApi.getTransactionStatus(id);

--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -199,15 +199,20 @@ export const sumupApi: {
     if (!client || !merchantCode) {
       return { reason: "not_configured", status: "unavailable" };
     }
+    // Only the fetch is guarded: the classifier is pure, so anything it
+    // throws (Intl refusing a misconfigured site currency) is our own fault
+    // and must surface loudly, never dress up as SumUp being unreachable.
+    let body: unknown;
     try {
-      return classifySumupCheckout(await client.checkouts.get(id), {
-        merchantCode,
-        requestedId: id,
-        siteCurrency: settings.currency,
-      });
+      body = await client.checkouts.get(id);
     } catch (err) {
       return sumupReadFailure(err);
     }
+    return classifySumupCheckout(body, {
+      merchantCode,
+      requestedId: id,
+      siteCurrency: settings.currency,
+    });
   },
 
   /** Refund a transaction in full. */

--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -265,7 +265,6 @@ export const sumupApi: {
 // Wrapper exports for production code (delegate to sumupApi for test mocking)
 export const createCheckout = (i: CheckoutIntent, b: string) =>
   sumupApi.createCheckout(i, b);
-export const readCheckoutById = (id: string) => sumupApi.readCheckoutById(id);
 export const refundTransaction = (id: string) => sumupApi.refundTransaction(id);
 export const getTransactionStatus = (id: string) =>
   sumupApi.getTransactionStatus(id);

--- a/test/features/api/webhooks/provider.test.ts
+++ b/test/features/api/webhooks/provider.test.ts
@@ -59,6 +59,35 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
     expect(j.status).toBe("pending");
   });
 
+  test("retry session answers the fixed retryable refusal", async () => {
+    await setupStripe();
+    const { stripePaymentProvider } = await import(
+      "#shared/stripe-provider.ts"
+    );
+    using _rs = stub(stripePaymentProvider, "resolveWebhookSession", () =>
+      Promise.resolve("retry" as const),
+    );
+    using _v = await stubWebhookVerify(
+      webhookEvent({
+        amountTotal: 100,
+        eventId: "evt_retry1",
+        metadata: {},
+        paymentIntent: "pi_retry1",
+        sessionId: "cs_retry1",
+      }),
+    );
+    const res = await handleRequest(
+      mockWebhookRequest({}, { "stripe-signature": "sig" }),
+    );
+    // The exact contract: fixed status, header, and value-free body — and a
+    // console-only refusal, never an alert sink.
+    expect(res.status).toBe(503);
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await res.text()).toBe("Payment verification failed");
+    expect(E().calls.length).toBe(0);
+    expect(debugLogged(D, "Refused a payment callback retryably")).toBe(true);
+  });
+
   test("unpaid session acks as pending and logs", async () => {
     await setupStripe();
     await withWebhookVerify(

--- a/test/integration/server/webhooks/sumup.test.ts
+++ b/test/integration/server/webhooks/sumup.test.ts
@@ -107,9 +107,11 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
     }
   });
 
-  test("refuses unknown SumUp checkout ids retryably without fetching from the API", async () => {
-    // The fixed refusal covers a real callback racing our staging write, and
-    // its body never says why verification failed.
+  /** POST an unsigned callback for `id` and expect the fixed refusal with no
+   * SumUp fetch — the shared contract for every id refused locally. Its body
+   * never says why verification failed, and the payload is never echoed into
+   * a log or acknowledged. */
+  const expectRefusedLocally = async (id: string) => {
     const listing = await createTestListing({ unitPrice: 1000 });
     await stageSumupCheckout(listing);
     const fetchStub = stub(sumupApi, "readCheckoutById", () =>
@@ -117,10 +119,7 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
     );
     try {
       const response = await handleRequest(
-        mockWebhookRequest({
-          event_type: "CHECKOUT_STATUS_CHANGED",
-          id: "co_spam",
-        }),
+        mockWebhookRequest({ event_type: "CHECKOUT_STATUS_CHANGED", id }),
       );
       expect(response.status).toBe(503);
       expect(response.headers.get("content-type")).toBe(
@@ -131,7 +130,14 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
     } finally {
       fetchStub.restore();
     }
-  });
+  };
+
+  test("refuses an oversized SumUp checkout id with the fixed response", () =>
+    expectRefusedLocally("x".repeat(256)));
+
+  test("refuses unknown SumUp checkout ids retryably without fetching from the API", () =>
+    // The same refusal covers a real callback racing our staging write.
+    expectRefusedLocally("co_spam"));
 
   test("shows the cancel page when a SumUp payment fails", async () => {
     const listing = await createTestListing({ unitPrice: 1000 });

--- a/test/integration/server/webhooks/sumup.test.ts
+++ b/test/integration/server/webhooks/sumup.test.ts
@@ -75,13 +75,16 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
     status: "FAILED" | "PAID",
     transactionId: string,
   ) =>
-    stub(sumupApi, "retrieveCheckoutById", () =>
+    stub(sumupApi, "readCheckoutById", () =>
       Promise.resolve({
-        amountMinor: 1000,
-        currency: "GBP",
-        reference,
-        status,
-        transactionId,
+        resource: {
+          amountMinor: 1000,
+          currency: "GBP",
+          reference,
+          status,
+          transactionId,
+        },
+        status: "found" as const,
       }),
     );
 
@@ -104,11 +107,13 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
     }
   });
 
-  test("acknowledges unknown SumUp checkout ids without fetching from the API", async () => {
+  test("refuses unknown SumUp checkout ids retryably without fetching from the API", async () => {
+    // The fixed refusal covers a real callback racing our staging write, and
+    // its body never says why verification failed.
     const listing = await createTestListing({ unitPrice: 1000 });
     await stageSumupCheckout(listing);
-    const fetchStub = stub(sumupApi, "retrieveCheckoutById", () =>
-      Promise.resolve(null),
+    const fetchStub = stub(sumupApi, "readCheckoutById", () =>
+      Promise.resolve({ status: "missing" as const }),
     );
     try {
       const response = await handleRequest(
@@ -117,8 +122,11 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
           id: "co_spam",
         }),
       );
-      expect(response.status).toBe(200);
-      expect((await response.json()).received).toBe(true);
+      expect(response.status).toBe(503);
+      expect(response.headers.get("content-type")).toBe(
+        "text/plain; charset=utf-8",
+      );
+      expect(await response.text()).toBe("Payment verification failed");
       expect(fetchStub.calls.length).toBe(0);
     } finally {
       fetchStub.restore();

--- a/test/shared/db/sumup-checkouts.test.ts
+++ b/test/shared/db/sumup-checkouts.test.ts
@@ -132,6 +132,14 @@ describeWithEnv("db > sumup-checkouts", { db: true }, () => {
 
       expect(await hasSumupCheckoutId("co_spam")).toBe(false);
     });
+
+    test("setSumupCheckoutId throws when no staged row matches", async () => {
+      // Creation must fail before the hosted URL is exposed: with no staged
+      // id, every callback for this checkout would be refused as unknown.
+      await expect(setSumupCheckoutId(REFERENCE, "co_lost")).rejects.toThrow(
+        "expected exactly 1",
+      );
+    });
   });
 
   describe("at-rest properties", () => {

--- a/test/shared/db/sumup-checkouts.test.ts
+++ b/test/shared/db/sumup-checkouts.test.ts
@@ -14,8 +14,9 @@ import { unwrapKeyWithToken } from "#shared/crypto/keys.ts";
 import type { WrappedKey } from "#shared/crypto/sealed.ts";
 import { getDb } from "#shared/db/client.ts";
 import {
+  getSealedSumupCheckout,
   getSumupCheckout,
-  hasSumupCheckoutId,
+  openSumupCheckout,
   setSumupCheckoutId,
   storeSumupCheckout,
 } from "#shared/db/sumup-checkouts.ts";
@@ -108,7 +109,7 @@ describeWithEnv("db > sumup-checkouts", { db: true }, () => {
       await setSumupCheckoutId(REFERENCE, "co_abc123");
 
       expect((await getSumupCheckout(REFERENCE))!.sumupId).toBe("co_abc123");
-      expect(await hasSumupCheckoutId("co_abc123")).toBe(true);
+      expect(await getSealedSumupCheckout("co_abc123")).not.toBeNull();
     });
 
     test("setSumupCheckoutId updates only the matching reference", async () => {
@@ -126,11 +127,31 @@ describeWithEnv("db > sumup-checkouts", { db: true }, () => {
       expect((await getSumupCheckout(otherReference))!.sumupId).toBe("");
     });
 
-    test("hasSumupCheckoutId rejects ids we never created", async () => {
+    test("getSealedSumupCheckout rejects ids we never created", async () => {
       await storeSumupCheckout(REFERENCE, METADATA);
       await setSumupCheckoutId(REFERENCE, "co_abc123");
 
-      expect(await hasSumupCheckoutId("co_spam")).toBe(false);
+      expect(await getSealedSumupCheckout("co_spam")).toBeNull();
+    });
+
+    test("openSumupCheckout opens a sealed row with its own reference", async () => {
+      await storeSumupCheckout(REFERENCE, METADATA);
+      await setSumupCheckoutId(REFERENCE, "co_abc123");
+
+      const sealed = await getSealedSumupCheckout("co_abc123");
+      expect(await openSumupCheckout(sealed!, REFERENCE)).toEqual(METADATA);
+    });
+
+    test("openSumupCheckout refuses a reference that names another row", async () => {
+      // The row's own index is the proof: a different booking's reference
+      // must not decrypt this row's metadata.
+      await storeSumupCheckout(REFERENCE, METADATA);
+      await setSumupCheckoutId(REFERENCE, "co_abc123");
+
+      const sealed = await getSealedSumupCheckout("co_abc123");
+      expect(
+        await openSumupCheckout(sealed!, "some-other-reference"),
+      ).toBeNull();
     });
 
     test("setSumupCheckoutId throws when no staged row matches", async () => {

--- a/test/shared/sumup-observation.test.ts
+++ b/test/shared/sumup-observation.test.ts
@@ -142,25 +142,17 @@ describe("classifySumupCheckout", () => {
     });
   });
 
-  // A currency the conversion helpers cannot format — absent or blank — never
-  // reaches them: the amount converts with the site's currency instead and
-  // the boundary decides what to do with the carried null.
-  for (const [name, given] of [
-    ["no currency", undefined],
-    ["a blank currency", "   "],
-  ] as const) {
-    test(`reads amounts with the site currency given ${name}`, () => {
-      const txn = { ...WIRE_TXN, currency: given };
-      const read = classify(wirePaid({ currency: given, transactions: [txn] }));
-      expect(read).toEqual({
-        resource: expect.objectContaining({
-          amountMinor: 1000,
-          currency: null,
-        }),
-        status: "found",
-      });
+  test("reads amounts with the site currency given a blank currency", () => {
+    // A blank code never reaches the conversion helpers (Intl throws on
+    // one): the amount converts with the site's currency, and the carried
+    // null code is for the boundary to refuse.
+    const txn = { ...WIRE_TXN, currency: "   " };
+    const read = classify(wirePaid({ currency: "   ", transactions: [txn] }));
+    expect(read).toEqual({
+      resource: expect.objectContaining({ amountMinor: 1000, currency: null }),
+      status: "found",
     });
-  }
+  });
 
   test("reads a paid checkout that carries no amount", () => {
     // Nothing to convert or precision-check; the null reaches the session
@@ -239,15 +231,38 @@ describe("classifySumupCheckout", () => {
     );
   });
 
-  test("refuses a charge whose money disagrees with the checkout", () => {
-    const differentAmount = { ...WIRE_TXN, amount: 12 };
-    expect(classify(wirePaid({ transactions: [differentAmount] }))).toEqual(
-      invalid("unrecorded_child"),
-    );
-    const differentCurrency = { ...WIRE_TXN, currency: "EUR" };
-    expect(classify(wirePaid({ transactions: [differentCurrency] }))).toEqual(
-      invalid("unrecorded_child"),
-    );
+  // The named charge must vouch for the money a booking would be priced by:
+  // when it disputes the checkout's record, or omits the fields the paid
+  // shape documents, the money is carried as unreadable — ownership stands
+  // (id and merchant agree), so the refund path returns it rather than a
+  // refusal stranding it.
+  for (const [name, txnOverrides] of [
+    ["disputes the checkout's amount", { amount: 12 }],
+    ["disputes the checkout's currency", { currency: "EUR" }],
+    ["states no amount", { amount: undefined }],
+    ["states no currency", { currency: undefined }],
+  ] as const) {
+    test(`carries money to the refund path when the charge ${name}`, () => {
+      const txn = { ...WIRE_TXN, ...txnOverrides };
+      expect(classify(wirePaid({ transactions: [txn] }))).toEqual({
+        resource: expect.objectContaining({ amountMinor: null }),
+        status: "found",
+      });
+    });
+  }
+
+  test("refuses a second successful charge on a pending checkout", () => {
+    const second = { ...WIRE_TXN, id: "txn_2" };
+    const read = classify(wirePending({ transactions: [WIRE_TXN, second] }));
+    expect(read).toEqual(invalid("unrecorded_child"));
+  });
+
+  test("refuses a pending charge captured under another merchant", () => {
+    // The pending allowance covers a charge under this checkout — a charge
+    // under someone else's merchant is not that.
+    const foreign = { ...WIRE_TXN, merchant_code: "MC999" };
+    const read = classify(wirePending({ transactions: [foreign] }));
+    expect(read).toEqual(invalid("unrecorded_child"));
   });
 
   test("refuses captured money on a failed checkout", () => {

--- a/test/shared/sumup-observation.test.ts
+++ b/test/shared/sumup-observation.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import type { ProviderInvalidReason } from "#shared/payment/provider-read.ts";
 import {
   classifySumupCheckout,
   type SumupReadFacts,
@@ -165,7 +166,10 @@ describe("classifySumupCheckout", () => {
     });
   });
 
-  const invalid = (reason: string) => ({ reason, status: "invalid" });
+  const invalid = (reason: ProviderInvalidReason) => ({
+    reason,
+    status: "invalid",
+  });
 
   test("refuses a body that is not a checkout at all", () => {
     expect(classify("nonsense")).toEqual(invalid("malformed_response"));

--- a/test/shared/sumup-observation.test.ts
+++ b/test/shared/sumup-observation.test.ts
@@ -1,0 +1,268 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  classifySumupCheckout,
+  type SumupReadFacts,
+} from "#shared/sumup-observation.ts";
+
+/**
+ * Wire shapes follow the sandbox evidence recorded in PR3_PLAN.md ("SumUp
+ * sandbox evidence result", collected 2026-08-05): pending carries an empty
+ * transactions array and no transaction_id; paid names its transaction and
+ * carries exactly one matching successful entry; failed carries exactly one
+ * failed entry and no transaction_id.
+ */
+const FACTS: SumupReadFacts = {
+  merchantCode: "MC123",
+  requestedId: "co_1",
+  siteCurrency: "GBP",
+};
+
+const WIRE_TXN = {
+  amount: 10,
+  currency: "GBP",
+  id: "txn",
+  merchant_code: "MC123",
+  status: "SUCCESSFUL",
+};
+
+const wirePaid = (over: Record<string, unknown> = {}) => ({
+  amount: 10,
+  checkout_reference: "ref",
+  currency: "GBP",
+  date: "2026-08-05T12:00:00.000Z",
+  id: "co_1",
+  merchant_code: "MC123",
+  status: "PAID",
+  transaction_id: "txn",
+  transactions: [WIRE_TXN],
+  ...over,
+});
+
+const wirePending = (over: Record<string, unknown> = {}) => {
+  const { transaction_id: _, ...paidWithoutTxnId } = wirePaid({
+    status: "PENDING",
+    transactions: [],
+    ...over,
+  });
+  return paidWithoutTxnId;
+};
+
+const classify = (body: unknown) => classifySumupCheckout(body, FACTS);
+
+describe("classifySumupCheckout", () => {
+  test("reads a paid checkout into the normalized shape", () => {
+    expect(classify(wirePaid())).toEqual({
+      resource: {
+        amountMinor: 1000,
+        createdAt: "2026-08-05T12:00:00.000Z",
+        currency: "GBP",
+        reference: "ref",
+        status: "PAID",
+        transactionId: "txn",
+      },
+      status: "found",
+    });
+  });
+
+  test("reads a pending checkout with no attempts yet", () => {
+    const read = classify(wirePending());
+    expect(read).toEqual({
+      resource: expect.objectContaining({
+        status: "PENDING",
+        transactionId: "",
+      }),
+      status: "found",
+    });
+  });
+
+  test("allows failed attempts under a pending checkout", () => {
+    const failedAttempt = { ...WIRE_TXN, id: "txn_old", status: "FAILED" };
+    const read = classify(wirePending({ transactions: [failedAttempt] }));
+    expect(read).toEqual(expect.objectContaining({ status: "found" }));
+  });
+
+  test("allows a charge landing under its own still-open checkout", () => {
+    // The one unrecorded child the boundary accepts: a charge under the same
+    // pending checkout — the next fetch will read the checkout as paid.
+    const read = classify(wirePending({ transactions: [WIRE_TXN] }));
+    expect(read).toEqual(expect.objectContaining({ status: "found" }));
+  });
+
+  test("reads a failed checkout with its failed attempt", () => {
+    const failedTxn = { ...WIRE_TXN, status: "FAILED" };
+    const read = classify(
+      wirePending({ status: "FAILED", transactions: [failedTxn] }),
+    );
+    expect(read).toEqual({
+      resource: expect.objectContaining({ status: "FAILED" }),
+      status: "found",
+    });
+  });
+
+  test("reads an expired checkout like a failed one", () => {
+    const read = classify(wirePending({ status: "EXPIRED" }));
+    expect(read).toEqual({
+      resource: expect.objectContaining({ status: "EXPIRED" }),
+      status: "found",
+    });
+  });
+
+  test("carries unreadable money through for the boundary to refuse", () => {
+    // Ownership is proven (id, merchant, named child agree), so malformed
+    // money must not refuse the read: the session boundary turns it into a
+    // refundable rejection, which is what returns the buyer's captured money.
+    const txn = { ...WIRE_TXN, currency: "GB" };
+    const read = classify(wirePaid({ currency: "GB", transactions: [txn] }));
+    expect(read).toEqual({
+      resource: expect.objectContaining({ amountMinor: 1000, currency: "GB" }),
+      status: "found",
+    });
+  });
+
+  test("carries an amount finer than the currency through as unreadable", () => {
+    const txn = { ...WIRE_TXN, amount: 10.001 };
+    const read = classify(wirePaid({ amount: 10.001, transactions: [txn] }));
+    expect(read).toEqual({
+      resource: expect.objectContaining({ amountMinor: null }),
+      status: "found",
+    });
+  });
+
+  test("reads precision by the checkout's own currency", () => {
+    // 12.5 yen is finer than yen can hold, even though the site's GBP could
+    // hold it: the charge's own currency decides its decimal places.
+    const txn = { ...WIRE_TXN, amount: 12.5, currency: "JPY" };
+    const read = classify(
+      wirePaid({ amount: 12.5, currency: "JPY", transactions: [txn] }),
+    );
+    expect(read).toEqual({
+      resource: expect.objectContaining({ amountMinor: null, currency: "JPY" }),
+      status: "found",
+    });
+  });
+
+  // A currency the conversion helpers cannot format — absent or blank — never
+  // reaches them: the amount converts with the site's currency instead and
+  // the boundary decides what to do with the carried null.
+  for (const [name, given] of [
+    ["no currency", undefined],
+    ["a blank currency", "   "],
+  ] as const) {
+    test(`reads amounts with the site currency given ${name}`, () => {
+      const txn = { ...WIRE_TXN, currency: given };
+      const read = classify(wirePaid({ currency: given, transactions: [txn] }));
+      expect(read).toEqual({
+        resource: expect.objectContaining({
+          amountMinor: 1000,
+          currency: null,
+        }),
+        status: "found",
+      });
+    });
+  }
+
+  test("reads a paid checkout that carries no amount", () => {
+    // Nothing to convert or precision-check; the null reaches the session
+    // boundary, whose refusal is what sends the charge to the refund path.
+    const txn = { ...WIRE_TXN, amount: undefined };
+    const read = classify(wirePaid({ amount: undefined, transactions: [txn] }));
+    expect(read).toEqual({
+      resource: expect.objectContaining({ amountMinor: null }),
+      status: "found",
+    });
+  });
+
+  const invalid = (reason: string) => ({ reason, status: "invalid" });
+
+  test("refuses a body that is not a checkout at all", () => {
+    expect(classify("nonsense")).toEqual(invalid("malformed_response"));
+  });
+
+  test("refuses a checkout with no usable reference", () => {
+    expect(classify(wirePaid({ checkout_reference: " " }))).toEqual(
+      invalid("malformed_response"),
+    );
+    const { checkout_reference: _, ...withoutReference } = wirePaid();
+    expect(classify(withoutReference)).toEqual(invalid("malformed_response"));
+  });
+
+  test("refuses a checkout answering for a different id", () => {
+    expect(classify(wirePaid({ id: "co_other" }))).toEqual(
+      invalid("mismatched_id"),
+    );
+  });
+
+  test("refuses a checkout under another merchant", () => {
+    expect(classify(wirePaid({ merchant_code: "MC999" }))).toEqual(
+      invalid("mismatched_account"),
+    );
+  });
+
+  test("refuses a status outside the documented lifecycle", () => {
+    expect(classify(wirePaid({ status: "REFUNDED" }))).toEqual(
+      invalid("unsupported_status"),
+    );
+    const { status: _, ...withoutStatus } = wirePaid();
+    expect(classify(withoutStatus)).toEqual(invalid("unsupported_status"));
+  });
+
+  test("refuses a paid checkout that names no transaction", () => {
+    const { transaction_id: _, ...unnamed } = wirePaid();
+    expect(classify(unnamed)).toEqual(invalid("missing_documented_resource"));
+  });
+
+  test("refuses a paid checkout whose named transaction is absent", () => {
+    expect(classify(wirePaid({ transactions: [] }))).toEqual(
+      invalid("missing_documented_resource"),
+    );
+  });
+
+  test("refuses a second captured charge on a paid checkout", () => {
+    const second = { ...WIRE_TXN, id: "txn_2" };
+    expect(classify(wirePaid({ transactions: [WIRE_TXN, second] }))).toEqual(
+      invalid("unrecorded_child"),
+    );
+  });
+
+  test("refuses a successful charge that is not the named one", () => {
+    const other = { ...WIRE_TXN, id: "txn_other" };
+    expect(classify(wirePaid({ transactions: [other] }))).toEqual(
+      invalid("unrecorded_child"),
+    );
+  });
+
+  test("refuses a charge captured under another merchant", () => {
+    const foreign = { ...WIRE_TXN, merchant_code: "MC999" };
+    expect(classify(wirePaid({ transactions: [foreign] }))).toEqual(
+      invalid("unrecorded_child"),
+    );
+  });
+
+  test("refuses a charge whose money disagrees with the checkout", () => {
+    const differentAmount = { ...WIRE_TXN, amount: 12 };
+    expect(classify(wirePaid({ transactions: [differentAmount] }))).toEqual(
+      invalid("unrecorded_child"),
+    );
+    const differentCurrency = { ...WIRE_TXN, currency: "EUR" };
+    expect(classify(wirePaid({ transactions: [differentCurrency] }))).toEqual(
+      invalid("unrecorded_child"),
+    );
+  });
+
+  test("refuses captured money on a failed checkout", () => {
+    // Decided behavior: a dead checkout showing captured money stops
+    // automatic work — never booked, never silently acknowledged.
+    const read = classify(
+      wirePending({ status: "FAILED", transactions: [WIRE_TXN] }),
+    );
+    expect(read).toEqual(invalid("unrecorded_child"));
+  });
+
+  test("refuses captured money on an expired checkout", () => {
+    const read = classify(
+      wirePending({ status: "EXPIRED", transactions: [WIRE_TXN] }),
+    );
+    expect(read).toEqual(invalid("unrecorded_child"));
+  });
+});

--- a/test/shared/sumup-provider.test.ts
+++ b/test/shared/sumup-provider.test.ts
@@ -12,6 +12,7 @@ import {
   stageSumupCheckout,
   sumupCheckout,
   withFetchedSumupCheckout,
+  withSumupCheckoutRead,
 } from "#test-utils/sumup.ts";
 
 describe("sumup-provider", () => {
@@ -44,9 +45,21 @@ describe("sumup-provider", () => {
 
     test("returns null when the checkout cannot be fetched", async () => {
       await stageSumupCheckout();
-      await withFetchedSumupCheckout(null, async () => {
+      await withSumupCheckoutRead({ status: "missing" }, async () => {
         expect(await sumupPaymentProvider.retrieveSession("ref")).toBeNull();
       });
+    });
+
+    test("returns null when the checkout echoes another reference", async () => {
+      // The redirect's reference opened the staging row, so a checkout
+      // answering with a different reference is not this booking.
+      await stageSumupCheckout();
+      await withFetchedSumupCheckout(
+        sumupCheckout({ reference: "someone-elses" }),
+        async () => {
+          expect(await sumupPaymentProvider.retrieveSession("ref")).toBeNull();
+        },
+      );
     });
 
     test("asSession refuses a null or rejected result", () => {

--- a/test/shared/sumup-provider.test.ts
+++ b/test/shared/sumup-provider.test.ts
@@ -50,6 +50,20 @@ describe("sumup-provider", () => {
       });
     });
 
+    test("throws when SumUp cannot answer for a staged checkout", async () => {
+      // A passing outage must not read as a missing payment: throwing gives
+      // the browser the temporary failure page instead of "not found".
+      await stageSumupCheckout();
+      await withSumupCheckoutRead(
+        { reason: "network_error", status: "unavailable" },
+        async () => {
+          await expect(
+            sumupPaymentProvider.retrieveSession("ref"),
+          ).rejects.toThrow("could not answer");
+        },
+      );
+    });
+
     test("returns null when the checkout echoes another reference", async () => {
       // The redirect's reference opened the staging row, so a checkout
       // answering with a different reference is not this booking.

--- a/test/shared/sumup-provider/webhook.test.ts
+++ b/test/shared/sumup-provider/webhook.test.ts
@@ -54,21 +54,33 @@ describe("sumup-provider resolveWebhookSession", () => {
     refundable: true,
   };
 
-  test("returns null when the listing carries no id", async () => {
-    expect(await resolve("")).toBeNull();
-  });
-
-  test("returns null for an id too long to be a real checkout", async () => {
-    // 256 bytes is longer than any id SumUp mints, so the callback is
-    // provably not ours: acknowledged with zero reads of any kind.
-    await withSumupCheckoutRead({ status: "missing" }, async (calls) => {
-      expect(await resolve("x".repeat(256))).toBeNull();
-      expect(calls()).toEqual([]);
+  // Blank, or longer than any id SumUp mints: the same fixed refusal as
+  // every other unstaged callback, before even a database lookup — so the
+  // payload is never echoed into a log and the answer's shape leaks nothing.
+  for (const [name, id] of [
+    ["a blank id", ""],
+    ["an id too long to be real", "x".repeat(256)],
+  ] as const) {
+    test(`refuses ${name} without any lookup`, async () => {
+      await withSumupCheckoutRead({ status: "missing" }, async (calls) => {
+        expect(await resolve(id)).toBe("retry");
+        expect(calls()).toEqual([]);
+      });
     });
-  });
+  }
 
-  test("checks a 255-byte id against staging like any other", async () => {
-    expect(await resolve("x".repeat(255))).toBe("retry");
+  test("treats a 255-byte id like any other staged checkout", async () => {
+    const longId = "x".repeat(255);
+    await storeSumupCheckout("ref255", SUMUP_META);
+    await setSumupCheckoutId("ref255", longId);
+    await withFetchedSumupCheckout(
+      sumupCheckout({ reference: "ref255" }),
+      async () => {
+        expect(await resolve(longId)).toEqual(
+          expect.objectContaining({ id: "ref255" }),
+        );
+      },
+    );
   });
 
   test("asks ids we never created to be retried without calling SumUp", async () => {

--- a/test/shared/sumup-provider/webhook.test.ts
+++ b/test/shared/sumup-provider/webhook.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { settings } from "#shared/db/settings.ts";
 import {
   setSumupCheckoutId,
   storeSumupCheckout,
@@ -13,15 +14,21 @@ import {
   stageSumupCheckout,
   sumupCheckout,
   withFetchedSumupCheckout,
+  withSumupCheckoutRead,
   withSumupClient,
 } from "#test-utils/sumup.ts";
 
 describe("sumup-provider resolveWebhookSession", () => {
   beforeEach(async () => {
     await createTestDb();
+    settings.setForTest({
+      sumup_api_key: "sk_test_abc",
+      sumup_merchant_code: "MC123",
+    });
   });
 
   afterEach(() => {
+    settings.clearTestOverrides();
     resetDb();
   });
 
@@ -31,9 +38,11 @@ describe("sumup-provider resolveWebhookSession", () => {
     type: "CHECKOUT_STATUS_CHANGED",
   });
 
+  const resolve = (id: string) =>
+    sumupPaymentProvider.resolveWebhookSession(listing(id));
+
   /** Resolve the webhook the staging row maps to SumUp id "co_1". */
-  const resolveStaged = () =>
-    sumupPaymentProvider.resolveWebhookSession(listing("co_1"));
+  const resolveStaged = () => resolve("co_1");
 
   /** The refusal a paid charge earns when its money was captured but the
    *  boundary cannot read its amount or currency. The metadata comes back in
@@ -46,31 +55,53 @@ describe("sumup-provider resolveWebhookSession", () => {
   };
 
   test("returns null when the listing carries no id", async () => {
-    expect(
-      await sumupPaymentProvider.resolveWebhookSession(listing("")),
-    ).toBeNull();
+    expect(await resolve("")).toBeNull();
   });
 
-  test("skips ids we never created without calling SumUp", async () => {
-    await stageSumupCheckout();
-    await withFetchedSumupCheckout(sumupCheckout(), async (calls) => {
-      expect(
-        await sumupPaymentProvider.resolveWebhookSession(listing("co_spam")),
-      ).toBe("skip");
+  test("returns null for an id too long to be a real checkout", async () => {
+    // 256 bytes is longer than any id SumUp mints, so the callback is
+    // provably not ours: acknowledged with zero reads of any kind.
+    await withSumupCheckoutRead({ status: "missing" }, async (calls) => {
+      expect(await resolve("x".repeat(256))).toBeNull();
       expect(calls()).toEqual([]);
     });
   });
 
-  test("asks to be retried when a staged checkout cannot be fetched", async () => {
-    // The staging row already proved this checkout is ours, so a failed fetch
-    // is SumUp being unreachable, not a checkout we have never heard of.
-    // Acknowledging it would be terminal — SumUp never redelivers — and a paid
-    // checkout would sit with the money taken and no booking.
+  test("checks a 255-byte id against staging like any other", async () => {
+    expect(await resolve("x".repeat(255))).toBe("retry");
+  });
+
+  test("asks ids we never created to be retried without calling SumUp", async () => {
+    // Refusing retryably (not acknowledging) covers a real callback racing
+    // our own staging write, and costs a forger nothing but one indexed read.
     await stageSumupCheckout();
-    await withFetchedSumupCheckout(null, async () => {
-      await expect(resolveStaged()).rejects.toThrow("co_1");
+    await withFetchedSumupCheckout(sumupCheckout(), async (calls) => {
+      expect(await resolve("co_spam")).toBe("retry");
+      expect(calls()).toEqual([]);
     });
   });
+
+  // The staging row already proved the checkout is ours, so anything but a
+  // clean read answers retryably: acknowledging is terminal, and a paid
+  // checkout would sit with the money taken and no booking.
+  for (const [name, read] of [
+    ["SumUp says it does not exist", { status: "missing" }],
+    [
+      "SumUp cannot be reached",
+      { reason: "network_error", status: "unavailable" },
+    ],
+    [
+      "the answer contradicts our facts",
+      { reason: "mismatched_account", status: "invalid" },
+    ],
+  ] as const) {
+    test(`asks to be retried when ${name}`, async () => {
+      await stageSumupCheckout();
+      await withSumupCheckoutRead(read, async () => {
+        expect(await resolveStaged()).toBe("retry");
+      });
+    });
+  }
 
   for (const [name, checkoutOverrides] of [
     ["a malformed paid charge", { currency: "GB" }],
@@ -90,9 +121,10 @@ describe("sumup-provider resolveWebhookSession", () => {
 
   test("hands a paid charge SumUp priced in a malformed currency to the refund path", async () => {
     await stageSumupCheckout();
-    // The real adapter reads this response: a currency the currency helpers
-    // cannot format must not make the fetch fail, or the webhook would ack
-    // the charge as unrecognized and the captured money would be stranded.
+    // The real adapter reads this response through the real classifier: the
+    // ownership facts (id, merchant, named transaction) all agree, so the
+    // unreadable money must reach the refund path rather than refuse the
+    // read — otherwise the captured charge would be stranded.
     await withSumupClient(
       makeSumupClient({
         get: () =>
@@ -100,8 +132,19 @@ describe("sumup-provider resolveWebhookSession", () => {
             amount: 10,
             checkout_reference: "ref",
             currency: "GB",
+            id: "co_1",
+            merchant_code: "MC123",
             status: "PAID",
             transaction_id: "txn",
+            transactions: [
+              {
+                amount: 10,
+                currency: "GB",
+                id: "txn",
+                merchant_code: "MC123",
+                status: "SUCCESSFUL",
+              },
+            ],
           }),
       }),
       async () => {
@@ -113,10 +156,10 @@ describe("sumup-provider resolveWebhookSession", () => {
   // The webhook id proved a staged row exists, so the reference SumUp answers
   // with must name that same row. Anything else — blank, unheard-of, or
   // another booking's — is SumUp contradicting itself about a checkout we
-  // made. The booking is encrypted under that reference, so without a match we
-  // can neither read it nor prove the charge is ours to refund, and
-  // acknowledging would strand a paid one for good. "ref_other" is staged
-  // under its own SumUp id below.
+  // made. The booking is encrypted under that reference, so without a match
+  // we can neither read it nor prove the charge is ours to refund; refusing
+  // retryably keeps SumUp redelivering instead of stranding a paid charge.
+  // "ref_other" is staged under its own SumUp id below.
   for (const [name, reference] of [
     ["is blank", ""],
     ["matches no staged row", "unrelated"],
@@ -127,9 +170,7 @@ describe("sumup-provider resolveWebhookSession", () => {
       await storeSumupCheckout("ref_other", SUMUP_META);
       await setSumupCheckoutId("ref_other", "co_other");
       await withFetchedSumupCheckout(sumupCheckout({ reference }), async () => {
-        await expect(resolveStaged()).rejects.toThrow(
-          "is not the one staged for it",
-        );
+        expect(await resolveStaged()).toBe("retry");
       });
     });
   }

--- a/test/shared/sumup.test.ts
+++ b/test/shared/sumup.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { APIError } from "@sumup/sdk";
 import { settings } from "#shared/db/settings.ts";
-import { retrieveCheckoutById, sumupApi } from "#shared/sumup.ts";
+import { readCheckoutById, sumupApi } from "#shared/sumup.ts";
 import {
   makeSumupClient,
   setupSumupSuite,
@@ -25,159 +26,177 @@ describe("sumup", () => {
     });
   });
 
-  describe("retrieveCheckoutById", () => {
-    test("maps major-unit amount to minor units and reads transaction_id", async () => {
+  describe("readCheckoutById", () => {
+    /** A paid wire body whose ownership facts agree with the suite's
+     *  configured merchant (MC123) and the id the test asks for. */
+    const paidWire = (id: string, over: Record<string, unknown> = {}) => ({
+      amount: 12.5,
+      checkout_reference: "ref_a",
+      currency: "gbp",
+      id,
+      merchant_code: "MC123",
+      status: "PAID",
+      transaction_id: "txn_a",
+      transactions: [
+        {
+          amount: 12.5,
+          currency: "gbp",
+          id: "txn_a",
+          merchant_code: "MC123",
+          status: "SUCCESSFUL",
+        },
+      ],
+      ...over,
+    });
+
+    test("reads an owned paid checkout, converting to minor units", async () => {
       const client = makeSumupClient({
-        get: () =>
-          Promise.resolve({
-            amount: 12.5,
-            checkout_reference: "ref_a",
-            currency: "gbp",
-            status: "PAID",
-            transaction_id: "txn_a",
-          }),
+        get: () => Promise.resolve(paidWire("co_a")),
       });
       await withSumupClient(client, async () => {
-        const result = await retrieveCheckoutById("co_a");
-        expect(result).toEqual({
-          amountMinor: 1250,
-          currency: "GBP",
-          reference: "ref_a",
-          status: "PAID",
-          transactionId: "txn_a",
+        expect(await readCheckoutById("co_a")).toEqual({
+          resource: {
+            amountMinor: 1250,
+            currency: "GBP",
+            reference: "ref_a",
+            status: "PAID",
+            transactionId: "txn_a",
+          },
+          status: "found",
         });
       });
     });
 
-    test("falls back to the SUCCESSFUL transaction, skipping failed attempts", async () => {
+    test("converts with the site currency when the checkout carries none", async () => {
+      // Wiring proof: the classifier's site-currency fact comes from
+      // settings (the suite's site is GBP, two minor places).
       const client = makeSumupClient({
         get: () =>
-          Promise.resolve({
-            amount: 10,
-            checkout_reference: "ref_b",
-            currency: "gbp",
-            status: "PAID",
-            transactions: [
-              { id: "txn_declined", status: "FAILED" },
-              { id: "txn_ok", status: "SUCCESSFUL" },
-            ],
-          }),
+          Promise.resolve(
+            paidWire("co_cur", {
+              currency: undefined,
+              transactions: [
+                { id: "txn_a", merchant_code: "MC123", status: "SUCCESSFUL" },
+              ],
+            }),
+          ),
       });
       await withSumupClient(client, async () => {
-        const result = await retrieveCheckoutById("co_b");
-        expect(result!.transactionId).toBe("txn_ok");
+        expect(await readCheckoutById("co_cur")).toEqual({
+          resource: expect.objectContaining({
+            amountMinor: 1250,
+            currency: null,
+          }),
+          status: "found",
+        });
       });
     });
 
-    test("defaults the transaction id to empty when nothing succeeded", async () => {
+    test("refuses a checkout answering for a different id", async () => {
+      // Wiring proof: the id the caller asked for reaches the classifier.
+      const client = makeSumupClient({
+        get: () => Promise.resolve(paidWire("co_other")),
+      });
+      await withSumupClient(client, async () => {
+        expect(await readCheckoutById("co_b")).toEqual({
+          reason: "mismatched_id",
+          status: "invalid",
+        });
+      });
+    });
+
+    test("refuses a paid checkout that does not name its transaction", async () => {
+      const client = makeSumupClient({
+        get: () =>
+          Promise.resolve(paidWire("co_c", { transaction_id: undefined })),
+      });
+      await withSumupClient(client, async () => {
+        expect(await readCheckoutById("co_c")).toEqual({
+          reason: "missing_documented_resource",
+          status: "invalid",
+        });
+      });
+    });
+
+    test("reads an expired checkout with no transaction id", async () => {
       const client = makeSumupClient({
         get: () =>
           Promise.resolve({
             amount: 10,
             checkout_reference: "ref_c",
             currency: "GBP",
+            id: "co_exp",
+            merchant_code: "MC123",
             status: "EXPIRED",
           }),
       });
       await withSumupClient(client, async () => {
-        const result = await retrieveCheckoutById("co_c");
-        expect(result!.transactionId).toBe("");
-      });
-    });
-
-    test("uses the checkout currency for precision and minor-unit conversion", async () => {
-      const client = makeSumupClient({
-        get: () =>
-          Promise.resolve({
-            amount: 12.5, // one decimal place; JPY has none
-            checkout_reference: "ref_jpy",
-            currency: "JPY",
-            status: "PAID",
-          }),
-      });
-      await withSumupClient(client, async () => {
-        // Precision follows the checkout currency (JPY, no minor places), not
-        // the site (GBP, two): 12.5 yen is finer than yen can hold.
-        expect(await retrieveCheckoutById("co_jpy")).toEqual(
-          expect.objectContaining({ amountMinor: null }),
-        );
-      });
-    });
-
-    test("refuses a checkout amount more precise than the currency allows", async () => {
-      const client = makeSumupClient({
-        get: () =>
-          Promise.resolve({
-            amount: 12.505, // three decimal places in GBP
-            checkout_reference: "ref_overprecise",
-            currency: "GBP",
-            status: "PAID",
-          }),
-      });
-      await withSumupClient(client, async () => {
-        // Rounding would book an amount SumUp never took, so the amount is
-        // carried as unreadable and the boundary refuses the charge.
-        expect(await retrieveCheckoutById("co_overprecise")).toEqual(
-          expect.objectContaining({ amountMinor: null }),
-        );
-      });
-    });
-
-    test("reads a checkout that carries no amount", async () => {
-      const client = makeSumupClient({
-        get: () =>
-          Promise.resolve({
-            checkout_reference: "ref_noamount",
-            currency: "GBP",
-            status: "PAID",
-            transaction_id: "txn_noamount",
-          }),
-      });
-      await withSumupClient(client, async () => {
-        // Without an amount there is nothing to convert or precision-check —
-        // and doing either would throw, which is swallowed here as "no
-        // session" and would strand the charge. It is carried as null for the
-        // boundary to refuse, so the paid charge still reaches the refund path.
-        expect(await retrieveCheckoutById("co_noamount")).toEqual({
-          amountMinor: null,
-          currency: "GBP",
-          reference: "ref_noamount",
-          status: "PAID",
-          transactionId: "txn_noamount",
-        });
-      });
-    });
-
-    // A currency the conversion helpers cannot format — absent, blank, or not
-    // a real code — must never reach them: Intl throws on one, and the throw
-    // would be swallowed here as "no session", stranding a paid charge that
-    // should be refunded. The amount converts with the site's currency (GBP,
-    // two places) instead, and the raw code is carried for the boundary.
-    for (const [name, given, carried] of [
-      ["carries no currency", undefined, null],
-      ["carries a blank currency", "   ", null],
-      ["carries a malformed currency", "GB", "GB"],
-    ] as const) {
-      test(`reads a checkout that ${name}`, async () => {
-        const client = makeSumupClient({
-          get: () =>
-            Promise.resolve({
-              amount: 10,
-              checkout_reference: "ref_cur",
-              currency: given,
-              status: "PAID",
-            }),
-        });
-        await withSumupClient(client, async () => {
-          expect(await retrieveCheckoutById("co_cur")).toEqual({
-            amountMinor: 1000,
-            currency: carried,
-            reference: "ref_cur",
-            status: "PAID",
+        expect(await readCheckoutById("co_exp")).toEqual({
+          resource: expect.objectContaining({
+            status: "EXPIRED",
             transactionId: "",
-          });
+          }),
+          status: "found",
         });
       });
-    }
+    });
+
+    test("reads SumUp's 404 as an authoritative missing", async () => {
+      const client = makeSumupClient({
+        get: () =>
+          Promise.reject(new APIError(404, "not found", new Response())),
+      });
+      await withSumupClient(client, async () => {
+        expect(await readCheckoutById("co_gone")).toEqual({
+          status: "missing",
+        });
+        expect(loggedDebug("Checkout read answered 404")).toBe(true);
+      });
+    });
+
+    test("reads any other SumUp error as unavailable", async () => {
+      const client = makeSumupClient({
+        get: () =>
+          Promise.reject(new APIError(500, "server error", new Response())),
+      });
+      await withSumupClient(client, async () => {
+        expect(await readCheckoutById("co_down")).toEqual({
+          reason: "provider_error",
+          status: "unavailable",
+        });
+        expect(loggedDebug("Checkout read answered 500")).toBe(true);
+      });
+    });
+
+    test("reads a failure before SumUp answered as unavailable", async () => {
+      const client = makeSumupClient({
+        get: () => Promise.reject(new TypeError("connection reset")),
+      });
+      await withSumupClient(client, async () => {
+        expect(await readCheckoutById("co_net")).toEqual({
+          reason: "network_error",
+          status: "unavailable",
+        });
+        expect(loggedDebug("Checkout read failed before SumUp answered")).toBe(
+          true,
+        );
+      });
+    });
+
+    test("answers unavailable when no API key is configured", async () => {
+      settings.setForTest({ sumup_api_key: "" });
+      expect(await readCheckoutById("co_x")).toEqual({
+        reason: "not_configured",
+        status: "unavailable",
+      });
+    });
+
+    test("answers unavailable when no merchant code is configured", async () => {
+      settings.setForTest({ sumup_merchant_code: "" });
+      expect(await readCheckoutById("co_x")).toEqual({
+        reason: "not_configured",
+        status: "unavailable",
+      });
+    });
   });
 });

--- a/test/shared/sumup.test.ts
+++ b/test/shared/sumup.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { APIError } from "@sumup/sdk";
 import { settings } from "#shared/db/settings.ts";
-import { readCheckoutById, sumupApi } from "#shared/sumup.ts";
+import { sumupApi } from "#shared/sumup.ts";
 import {
   makeSumupClient,
   setupSumupSuite,
@@ -54,7 +54,7 @@ describe("sumup", () => {
         get: () => Promise.resolve(paidWire("co_a")),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_a")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_a")).toEqual({
           resource: {
             amountMinor: 1250,
             currency: "GBP",
@@ -76,13 +76,19 @@ describe("sumup", () => {
             paidWire("co_cur", {
               currency: undefined,
               transactions: [
-                { id: "txn_a", merchant_code: "MC123", status: "SUCCESSFUL" },
+                {
+                  amount: 12.5,
+                  currency: "GBP",
+                  id: "txn_a",
+                  merchant_code: "MC123",
+                  status: "SUCCESSFUL",
+                },
               ],
             }),
           ),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_cur")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_cur")).toEqual({
           resource: expect.objectContaining({
             amountMinor: 1250,
             currency: null,
@@ -98,7 +104,7 @@ describe("sumup", () => {
         get: () => Promise.resolve(paidWire("co_other")),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_b")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_b")).toEqual({
           reason: "mismatched_id",
           status: "invalid",
         });
@@ -111,7 +117,7 @@ describe("sumup", () => {
           Promise.resolve(paidWire("co_c", { transaction_id: undefined })),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_c")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_c")).toEqual({
           reason: "missing_documented_resource",
           status: "invalid",
         });
@@ -131,7 +137,7 @@ describe("sumup", () => {
           }),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_exp")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_exp")).toEqual({
           resource: expect.objectContaining({
             status: "EXPIRED",
             transactionId: "",
@@ -147,7 +153,7 @@ describe("sumup", () => {
           Promise.reject(new APIError(404, "not found", new Response())),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_gone")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_gone")).toEqual({
           status: "missing",
         });
         expect(loggedDebug("Checkout read answered 404")).toBe(true);
@@ -160,7 +166,7 @@ describe("sumup", () => {
           Promise.reject(new APIError(500, "server error", new Response())),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_down")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_down")).toEqual({
           reason: "provider_error",
           status: "unavailable",
         });
@@ -173,7 +179,7 @@ describe("sumup", () => {
         get: () => Promise.reject(new TypeError("connection reset")),
       });
       await withSumupClient(client, async () => {
-        expect(await readCheckoutById("co_net")).toEqual({
+        expect(await sumupApi.readCheckoutById("co_net")).toEqual({
           reason: "network_error",
           status: "unavailable",
         });
@@ -185,7 +191,7 @@ describe("sumup", () => {
 
     test("answers unavailable when no API key is configured", async () => {
       settings.setForTest({ sumup_api_key: "" });
-      expect(await readCheckoutById("co_x")).toEqual({
+      expect(await sumupApi.readCheckoutById("co_x")).toEqual({
         reason: "not_configured",
         status: "unavailable",
       });
@@ -193,7 +199,7 @@ describe("sumup", () => {
 
     test("answers unavailable when no merchant code is configured", async () => {
       settings.setForTest({ sumup_merchant_code: "" });
-      expect(await readCheckoutById("co_x")).toEqual({
+      expect(await sumupApi.readCheckoutById("co_x")).toEqual({
         reason: "not_configured",
         status: "unavailable",
       });

--- a/test/test-utils/payment-session.ts
+++ b/test/test-utils/payment-session.ts
@@ -1,8 +1,8 @@
-import {
-  isSessionRejection,
-  type SessionRejection,
-} from "#shared/payment/validated-session.ts";
-import type { ValidatedPaymentSession } from "#shared/payments.ts";
+import { isSessionRejection } from "#shared/payment/validated-session.ts";
+import type {
+  ValidatedPaymentSession,
+  WebhookSessionResult,
+} from "#shared/payments.ts";
 
 /**
  * Every metadata field the price signature covers, blank. The boundary hands
@@ -34,7 +34,7 @@ export const BLANK_SESSION_METADATA: ValidatedPaymentSession["metadata"] = {
 /** Narrow any provider session result to the session; fail the test on a
  *  rejection, a skip, a retry refusal, or null. */
 export const asSession = (
-  result: ValidatedPaymentSession | SessionRejection | "skip" | "retry" | null,
+  result: WebhookSessionResult,
 ): ValidatedPaymentSession => {
   if (
     result === null ||

--- a/test/test-utils/payment-session.ts
+++ b/test/test-utils/payment-session.ts
@@ -32,11 +32,16 @@ export const BLANK_SESSION_METADATA: ValidatedPaymentSession["metadata"] = {
 };
 
 /** Narrow any provider session result to the session; fail the test on a
- *  rejection, a skip, or null. */
+ *  rejection, a skip, a retry refusal, or null. */
 export const asSession = (
-  result: ValidatedPaymentSession | SessionRejection | "skip" | null,
+  result: ValidatedPaymentSession | SessionRejection | "skip" | "retry" | null,
 ): ValidatedPaymentSession => {
-  if (result === null || result === "skip" || isSessionRejection(result)) {
+  if (
+    result === null ||
+    result === "skip" ||
+    result === "retry" ||
+    isSessionRejection(result)
+  ) {
     throw new Error(`expected a session, got ${JSON.stringify(result)}`);
   }
   return result;

--- a/test/test-utils/sumup.ts
+++ b/test/test-utils/sumup.ts
@@ -7,7 +7,9 @@ import {
   setSumupCheckoutId,
   storeSumupCheckout,
 } from "#shared/db/sumup-checkouts.ts";
-import { type SumupCheckout, sumupApi } from "#shared/sumup.ts";
+import type { ProviderRead } from "#shared/payment/provider-read.ts";
+import { sumupApi } from "#shared/sumup.ts";
+import type { SumupCheckout } from "#shared/sumup-observation.ts";
 import { createTestDb, resetDb } from "#test-utils/db.ts";
 import { debugMessages, useDebugLogSpy } from "#test-utils/debug-log.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
@@ -63,16 +65,23 @@ export const stageSumupCheckout = async (): Promise<void> => {
   await setSumupCheckoutId("ref", "co_1");
 };
 
-/** Run `body` with retrieveCheckoutById stubbed to resolve `value`, handing it
+/** Run `body` with readCheckoutById stubbed to resolve `read`, handing it
  *  a reader for the arguments the adapter was called with. */
-export const withFetchedSumupCheckout = (
-  value: SumupCheckout | null,
+export const withSumupCheckoutRead = (
+  read: ProviderRead<SumupCheckout>,
   body: (calls: () => unknown[][]) => Promise<void>,
 ): Promise<void> =>
   withMocks(
-    () => stub(sumupApi, "retrieveCheckoutById", () => Promise.resolve(value)),
+    () => stub(sumupApi, "readCheckoutById", () => Promise.resolve(read)),
     (mock) => body(() => mock.calls.map((c) => c.args)),
   );
+
+/** {@link withSumupCheckoutRead} for the common case: the fetch found `value`. */
+export const withFetchedSumupCheckout = (
+  value: SumupCheckout,
+  body: (calls: () => unknown[][]) => Promise<void>,
+): Promise<void> =>
+  withSumupCheckoutRead({ resource: value, status: "found" }, body);
 
 /**
  * Give a SumUp suite a database, a site domain, and a configured SumUp account,


### PR DESCRIPTION
## What this does

SumUp's webhooks are unsigned, so today anyone can send our payment webhook a made-up checkout id. This PR finishes milestone M3's remainder: every SumUp checkout read now lands in exactly one of four states — **found**, **missing** (SumUp says it does not exist), **unavailable** (SumUp could not answer), or **invalid** (the answer contradicts our own facts) — and the callback path answers each one deliberately instead of collapsing them all into "null".

**Production paths that receive this:** `POST /payment/webhook` (SumUp callbacks) and `GET /payment/success` / `/payment/cancel` (SumUp browser reads via `retrieveSession`).

What changes for the system:

- **Unknown unsigned callbacks are bounded and oracle-free (fault F2).** An id we never staged costs one indexed database read, zero SumUp calls, and zero alert subrequests, and is refused with the fixed retryable response — `503`, `text/plain`, body exactly `Payment verification failed`. Blank or oversized ids (over 255 bytes) take the same fixed refusal before even a database lookup, so the payload is never echoed into a log and a forger learns nothing from the answer's shape. The same fixed answer covers a real callback racing our own staging write (SumUp redelivers four times over two hours).
- **A fetched checkout must agree with our independent facts.** The pure classifier (`src/shared/sumup-observation.ts`) checks the returned id against the one we asked for, the merchant against the one this site is bound to, the lifecycle status against SumUp's documented four, and the charges against the checkout's own record — following the sandbox evidence in PR3_PLAN.md. The one unrecorded child allowed is a single charge under its own still-pending checkout, under our merchant; a paid checkout must carry exactly the successful charge its record names, and a dead one must carry none.
- **Ownership and money are separate refusals.** The named charge must vouch for the money a booking would be priced by — it must state amount and currency itself and neither may dispute the checkout's record. Money the charge did not vouch for is carried as unreadable, so the session boundary's refusal sends the captured charge to the refund path instead of booking unverified money or stranding the buyer behind a permanent 503.
- **One sealed staging read per callback.** `getSealedSumupCheckout` fetches the staged row by SumUp id (the pre-filter), and `openSumupCheckout` opens it after the fetch with the reference the checkout echoed — refusing to decrypt when the reference does not name the row.
- **A transient SumUp outage is never "not found."** SumUp's 404 is told apart from SumUp being down (`APIError.status`, guarded around the fetch only, so a configuration fault surfaces loudly); the browser path throws on an unavailable read so buyers see the temporary failure page.
- **A checkout URL is never exposed unstaged**: `setSumupCheckoutId` now fails checkout creation unless exactly one staged row took the id.

## What was deleted

The null-swallowing `retrieveCheckoutById` (every failure looked identical), the old in-client normalisation, and `hasSumupCheckoutId` (subsumed by the sealed read). No new aliases; the provider result unions are named once in `payments.ts` (`WebhookSessionResult`, `RetrieveSessionResult`) and every provider, the interface, and the test helper share them. Stripe and Square move behind the same read vocabulary in M6; the pre-existing sumup/square wrapper-alias layer is recorded in TODO.md for one dedicated sweep.

## Also in this PR

`PLAN.md` fixes for the review rounds that landed after #2058 merged (faults F72–F77): booking-wide lease acquisition across deposit and balance payments, the merge fence permanently outliving M8 for refund pages, per-item evidence-revision rechecks before every provider refund call, cash-only refunds for bookings whose all-or-none completion never posted an obligation, signed modifier facts for folded discounts, and one shared booking-level obligation identity stored once and referenced by both a reservation's payments.

## Budgets

- 668 changed `src/` lines (insertions plus deletions, after formatting) — under the 800 cap.
- Subrequests per callback: unusable id = 0 reads; unstaged = 1 database read, 0 provider calls; staged = 1 database read + 1 provider read (was 2 + 1 before this PR's review round); browser = 1 database read + 1 provider read.

## Fault-ledger rows closed

F2 (unknown unsigned SumUp callbacks triggering outbound reads). Regression tests: zero-read assertions for blank/oversized/unstaged ids, the fixed-refusal contract test (status, header, exact body, no error-sink call), the endpoint-level 503 assertions, and the 255/256-byte boundary pair (a staged 255-byte id completes; a 256-byte id costs nothing).

## Tests and gates

- 132 tests green across the seven touched suites, including the 31-case pure classifier table built from the PR3_PLAN sandbox evidence.
- Mutation at 100% kill rate after the review rounds: `sumup-observation` 93/93, `sumup-provider` 69/69 (`--harness`), `sumup` 94/94 (`--harness`), `db/sumup-checkouts` 20/20 (`--harness`).
- `deno task precommit` passed in full on 9fb5ec7; the re-run on 86f778b is in flight and will be confirmed here.

## Review rounds

Codex and CodeRabbit reviewed both pushes. All accepted findings are fixed in 0a72fdf and 86f778b (tightened pending-checkout allowance, money-vouching, unavailable-read throw, unusable-id fixed refusal, sealed single read, narrowed try, typed test vocabulary, shared obligation identity); the declined ones are answered on their threads, and CodeRabbit withdrew them after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqLNrpvmNdGSSqUtSafiMd