### PR TITLE
Leave the day's compose page as evidence

### DIFF
--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -42,6 +42,11 @@ const brandedMobileCapture = <Id extends string>(
 
 export const EVIDENCE_CAPTURES = [
   brandedMobileCapture(
+    "writing.one-day-hears-and-the-others-do-not",
+    "one-days-audience",
+    ".page-regions.admin-page",
+  ),
+  brandedMobileCapture(
     "servicing.hold-on-dashboard",
     "servicing-studio-floor-hold",
     "#servicing-form",

--- a/test/specs/support/bulk-email.ts
+++ b/test/specs/support/bulk-email.ts
@@ -10,6 +10,7 @@
 
 // jscpd:ignore-start
 import { t } from "#i18n";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import { hashEmail, unsubscribeHash } from "#shared/db/contact-preferences.ts";
 import { settings } from "#shared/db/settings.ts";
 import {
@@ -180,6 +181,9 @@ export const opensEmailForListingDay = async (
     throw new Error(`${listingName} offers no way to write to ${date}`);
   }
   await browser.visit(wayIn);
+  // The compose page names the one day it is aimed at, which is the whole
+  // claim: a term booked date by date can be addressed a date at a time.
+  leaveEvidencePage(world, ["one-days-audience"], wayIn);
   return browser;
 };
 
@@ -250,6 +254,9 @@ export const opensEmailForListing = async (
     throw new Error(`"${listingName}" offers no way to write to its attendees`);
   }
   await browser.visit(wayIn);
+  // The compose page names the one day it is aimed at, which is the whole
+  // claim: a term booked date by date can be addressed a date at a time.
+  leaveEvidencePage(world, ["one-days-audience"], wayIn);
   return browser;
 };
 

--- a/test/specs/support/bulk-email.ts
+++ b/test/specs/support/bulk-email.ts
@@ -254,9 +254,6 @@ export const opensEmailForListing = async (
     throw new Error(`"${listingName}" offers no way to write to its attendees`);
   }
   await browser.visit(wayIn);
-  // The compose page names the one day it is aimed at, which is the whole
-  // claim: a term booked date by date can be addressed a date at a time.
-  leaveEvidencePage(world, ["one-days-audience"], wayIn);
   return browser;
 };
 


### PR DESCRIPTION
## Current-system value

The marketing site illustrates its pages with screenshots taken from these stories, so a page's picture is a real page a real case reached rather than a mock-up. The Perfect For pages have none of these yet; this adds the first one, for the online events page.

## What it does

One declaration and one line of spec support:

- `scripts/specs/evidence/declarations.ts` declares `one-days-audience`, taken from `writing.one-day-hears-and-the-others-do-not` (merged in #2067).
- `opensEmailForListingDay` calls `leaveEvidencePage` with the compose URL it already built, so the story hands over the address it reached rather than anything constructing one.

No production code changes. The capture is of `/admin/emails?listing=…&day=…`, which names the listing and the one day the message is aimed at, and counts who that day reaches — the claim the site's online events page makes.

## Why this case

The page tells organisers a term booked date by date can be addressed a date at a time. This case is that sentence: Rachel books day 1, Marco books day 8, the message goes to day 1, and only Rachel hears. The screenshot is the moment before sending, showing "Attendees of the Course on Tuesday 11 August 2026" and one recipient.

## What is not here

How it looks. `evidence-themes/one-days-audience.css` belongs to the site repository, per the split the evidence docs describe: the app decides what a capture is, the publisher decides what it looks like. The matching site change is in [tickets-site#146](https://github.com/chobbledotcom/tickets-site/pull/146).

## Checks

- `deno task specs` — 232 scenarios, 1525 steps, all pass
- `deno task specs:evidence --themes <site>/evidence-themes` — 25 scenarios, 171 steps, all pass; artifact validated and imported by the site
- `deno task lint` — clean
- `deno task typecheck` — the 5 pre-existing errors in `scripts/` and `uptime-kuma/socket.ts`, unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01UU8geYkKNGrFu5ArzfxSC6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded mobile evidence coverage for branded email composition screens.
  * Added verification points for day-based and attendee-based message workflows.
  * Improved consistency of captured evidence across related compose pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->