### PR TITLE
Leave the free listing's own page as evidence

### DIFF
--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -42,6 +42,11 @@ const brandedMobileCapture = <Id extends string>(
 
 export const EVIDENCE_CAPTURES = [
   brandedMobileCapture(
+    "payment.free-booking-records-no-money",
+    "free-headcount-no-money",
+    ".page-regions.entity-page",
+  ),
+  brandedMobileCapture(
     "writing.one-day-hears-and-the-others-do-not",
     "one-days-audience",
     ".page-regions.admin-page",

--- a/test/specs/steps/money-actions.ts
+++ b/test/specs/steps/money-actions.ts
@@ -2,6 +2,7 @@
 
 import { Given, Then, When } from "@cucumber/cucumber";
 import { expect } from "@std/expect";
+import { leaveEvidencePage } from "#scripts/specs/evidence/pages.ts";
 import {
   attendeeAccount,
   BOOKING_FEE_INCOME,
@@ -63,6 +64,13 @@ When(
   async function (this: TicketsWorld): Promise<void> {
     const listing = await sellPlacesAt(this, FREE_MEETUP, "0.00");
     await bookFreePlace(this, listing, "Free Guest", "free@example.com");
+    // The listing's own page, where the place taken and the money taken sit
+    // side by side: a headcount with nothing charged for it.
+    leaveEvidencePage(
+      this,
+      ["free-headcount-no-money"],
+      `/admin/listing/${listing.id}`,
+    );
   },
 );
 


### PR DESCRIPTION
## Current-system value

The marketing site illustrates its pages with screenshots taken from these stories, so a page's picture is a real page a real case reached. This adds the second one, for the free events page. (The first, `one-days-audience`, landed in #2068.)

## What it does

One declaration and one call, no production code:

- `scripts/specs/evidence/declarations.ts` declares `free-headcount-no-money`, taken from `payment.free-booking-records-no-money`.
- The `a customer books a free Free Meetup place` step leaves `/admin/listing/<id>` behind. The hook is in that step rather than in `bookFreePlace`, so it cannot leak into another scenario that books a free place for a different reason.

## Why this case

The site's free events page says a listing priced at zero needs no payment provider, charges nothing, and records no booking fee even when the site has one configured. That is this rule word for word — "a listing given away for free must never invent money, whatever fees the site charges on its paid listings" — with the `Given the site adds a 10 percent booking fee` premise making it worth proving.

The captured page shows the two halves together: **Ticket Price: Free**, **Listing Attendees 1 / 50 — 49 remain**, **Gross ticket sales £0**.

## Note on the selector

`.page-regions.admin-page` timed out here — the listing entity page uses `.page-regions.entity-page`, which is what the declaration targets.

## What is not here

How it looks. `evidence-themes/free-headcount-no-money.css` belongs to the site repository, per the split the evidence docs describe.

## Checks

- `deno task specs` — 232 scenarios, 1525 steps, all pass
- `deno task specs:evidence --themes <site>/evidence-themes` — 26 scenarios, 177 steps, all pass; artifact validated and imported by the site
- `deno task lint` — clean
- `deno task cpd` — 0 clones

---
_Generated by [Claude Code](https://claude.ai/code/session_01UU8geYkKNGrFu5ArzfxSC6)_