### PR TITLE
Leave a costed hold's page as evidence

### DIFF
--- a/scripts/specs/evidence/declarations.ts
+++ b/scripts/specs/evidence/declarations.ts
@@ -47,6 +47,11 @@ export const EVIDENCE_CAPTURES = [
     ".page-regions.admin-page",
   ),
   brandedMobileCapture(
+    "servicing.record-cost",
+    "maintenance-cost-on-a-room",
+    "#servicing-costs",
+  ),
+  brandedMobileCapture(
     "servicing.hold-on-dashboard",
     "servicing-studio-floor-hold",
     "#servicing-form",

--- a/src/features/admin/servicing/page.tsx
+++ b/src/features/admin/servicing/page.tsx
@@ -33,6 +33,10 @@ import { buildServicingFieldSchema } from "./form-model.ts";
 
 const SERVICING_FORM_ID = "servicing-form";
 
+/** The costs already recorded against this hold. Named so a screenshot can be
+ * pointed at the costs alone, without the form that records them. */
+const SERVICING_COSTS_ID = "servicing-costs";
+
 export type ServicingPrefill = {
   quantities: Map<number, number>;
   startDate: string;
@@ -321,7 +325,7 @@ export const renderServicingPage = ({
             </CsrfForm>
           )}
           {costs.length > 0 && (
-            <>
+            <section id={SERVICING_COSTS_ID}>
               <h2>{t("servicing.recorded_costs")}</h2>
               {renderTable(servicingCostsTable, costs, {
                 context: {
@@ -330,7 +334,7 @@ export const renderServicingPage = ({
                   session,
                 },
               })}
-            </>
+            </section>
           )}
         </>
       )}

--- a/test/specs/steps/servicing-hold.ts
+++ b/test/specs/steps/servicing-hold.ts
@@ -202,7 +202,10 @@ Then(
   "the service event page shows the recorded cost",
   async function (this: TicketsWorld): Promise<void> {
     const id = requiredWorldValue(this.servicingEventId, "service event id");
-    const body = await renderAdminPage(`/admin/servicing/${id}`);
+    const path = `/admin/servicing/${id}`;
+    // The page carrying the cost this story just recorded, for a screenshot.
+    leaveEvidencePage(this, ["maintenance-cost-on-a-room"], path);
+    const body = await renderAdminPage(path);
     expect(body).toContain(">£90<");
     expect(body).toContain("Boiler part");
   },


### PR DESCRIPTION
## What this is

A screenshot capture for `servicing.record-cost`, the case that records £90 against a Boiler Service hold on Room A.

## The change

- `test/specs/steps/servicing-hold.ts` — the `Then` that reads the recorded cost back now leaves that page for a capture. Only that step: the story's other steps reach the same page before the cost exists.
- `src/features/admin/servicing/page.tsx` — the costs already recorded are wrapped in `<section id="servicing-costs">`, so a capture can be pointed at them without the form that records them. Same reason `#servicing-form` already has a name.
- `scripts/specs/evidence/declarations.ts` — declares `maintenance-cost-on-a-room` against that section.

## Companion change

[chobbledotcom/tickets-site#150](https://github.com/chobbledotcom/tickets-site/pull/150) carries the theme and the page it illustrates. (An earlier revision of this description linked #149, which is the unrelated Revel comparison page.)

That side has now merged, so this one should follow rather than wait: the site's evidence lock already names this branch's commit, and until this lands the site repository refers to a capture the app does not declare.

## Checks

- `deno task test` — 22,112 unit tests and 232 spec scenarios pass
- `deno task lint` — clean
- `deno task cpd` — 0 clones
- `deno task specs:evidence` — 26 scenarios, all captures taken