### PR TITLE
Style the embed cart so a strict host-page CSP can't block it

### DIFF
--- a/scripts/mutation/equivalent-mutants/ui-client.txt
+++ b/scripts/mutation/equivalent-mutants/ui-client.txt
@@ -38,7 +38,7 @@ src/ui/client/order.ts::buildStepper.dec%2etextContent~0e91dik  = → +=   # fre
 src/ui/client/order.ts::buildStepper.value%2etextContent~1wclfso  = → +=   # fresh quantity span textContent
 src/ui/client/order.ts::buildStepper.inc%2etextContent~0hr9vid  = → +=   # fresh increase button textContent
 src/ui/client/order.ts::buildStepper.remove%2etextContent~01m8w0s  = → +=   # fresh Remove button textContent
-src/ui/client/order.ts::buildStyles.style%2etextContent~1mep807  = → +=   # fresh style element textContent
+src/ui/client/order.ts::applyStyles.style%2etextContent~0eh5dyi  = → +=   # fresh style element textContent
 
 # buildButton's initial values are overwritten by the constructor's render
 # before the button is exposed.

--- a/src/ui/client/order.ts
+++ b/src/ui/client/order.ts
@@ -149,7 +149,7 @@ class CartController {
     host.setAttribute("data-chobble-order", "");
     document.body.appendChild(host);
     this.root = host.attachShadow({ mode: "open" });
-    this.root.appendChild(buildStyles());
+    applyStyles(this.root);
     this.button = buildButton(() => this.open());
     this.dialog = document.createElement("dialog");
     this.dialog.addEventListener("close", () => this.button.focus());
@@ -417,9 +417,9 @@ const buildStepper = (
   return wrap;
 };
 
-const buildStyles = (): HTMLStyleElement => {
-  const style = document.createElement("style");
-  style.textContent = `
+/** The cart widget's scoped CSS. Kept as one string so both delivery paths in
+ *  {@link applyStyles} use exactly the same rules. */
+const CART_STYLES = `
     .cart-button { position: fixed; right: 1rem; bottom: 1rem; padding: .75rem 1rem;
       border: 0; border-radius: 999px; background: #1a1a1a; color: #fff; cursor: pointer; }
     dialog { border: 0; border-radius: .5rem; box-sizing: border-box; padding: 1.25rem;
@@ -436,7 +436,32 @@ const buildStyles = (): HTMLStyleElement => {
       border: 0; border-radius: .35rem; background: #1a1a1a; color: #fff; cursor: pointer; }
     .close { display: block; width: 100%; margin-top: .5rem; padding: .5rem; }
   `;
-  return style;
+
+/** True when the browser can build a stylesheet in memory (Chrome 73+,
+ *  Firefox 101+, Safari 16.4+). An in-memory sheet is pure CSSOM, so a host
+ *  page's Content-Security-Policy never blocks it — but an injected `<style>`
+ *  element is subject to `style-src` and a strict policy without
+ *  `'unsafe-inline'` refuses it. `CSSStyleSheet` also exists as a plain
+ *  interface on older Safari where `new CSSStyleSheet()` throws, so we probe for
+ *  `replaceSync`, which only the constructable version carries. */
+const canBuildStyleSheet = (): boolean =>
+  typeof CSSStyleSheet === "function" &&
+  typeof CSSStyleSheet.prototype.replaceSync === "function";
+
+/** Attach the cart's scoped styles to its shadow root. Modern browsers adopt an
+ *  in-memory stylesheet so a strict host-page CSP can't block it; older ones
+ *  fall back to a `<style>` element, which works everywhere except a host page
+ *  that sets a strict `style-src`. */
+const applyStyles = (root: ShadowRoot): void => {
+  if (canBuildStyleSheet()) {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(CART_STYLES);
+    root.adoptedStyleSheets = [sheet];
+    return;
+  }
+  const style = document.createElement("style");
+  style.textContent = CART_STYLES;
+  root.appendChild(style);
 };
 
 const init = (): void => {

--- a/test/ui/client/order.test.ts
+++ b/test/ui/client/order.test.ts
@@ -24,6 +24,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   addLink,
+  adoptedCss,
   buttonType,
   cartButton,
   clickAnchor,
@@ -40,6 +41,7 @@ import {
   shadow,
   stepperButtons,
   storedCart,
+  styleEl,
   textOf,
   useOrderHarness,
 } from "./order/support.ts";
@@ -130,8 +132,10 @@ describe("order widget", {
   test("adding a listing reveals the cart button with a live count", () => {
     mountOpenListing(h, true);
 
-    // Scoped styles are mounted into the shadow root.
-    expect(shadow(h).querySelector("style")).not.toBeNull();
+    // Scoped styles are adopted as an in-memory stylesheet (the CSP-safe path),
+    // so no inline `<style>` element is added to the shadow root.
+    expect(adoptedCss(h)).toContain(".cart-button");
+    expect(styleEl(h)).toBeNull();
     expect(buttonType(shadow(h), ".cart-button")).toBe("button");
     expect(cartButton(h).hidden).toBe(true);
     const prevented = clickAnchor(h, "open");
@@ -186,11 +190,35 @@ describe("order widget", {
 
   test("gives mobile cart rows and actions their own space", () => {
     mountOpenListing(h, true);
-    const styles = shadow(h).querySelector("style")!.textContent;
+    const styles = adoptedCss(h);
 
     expect(styles).toContain("grid-template-columns: minmax(0, 1fr) auto");
     expect(styles).toContain(".stepper { grid-column: 1 / -1");
     expect(styles).toContain(".close { display: block; width: 100%");
+  });
+
+  test("falls back to a <style> element when the browser can't build a sheet", () => {
+    // Pre-16.4 Safari has no constructable CSSStyleSheet; the widget must still
+    // style itself, just without the CSP-safe adopted sheet.
+    h.setGlobal("CSSStyleSheet", undefined);
+    mountOpenListing(h, true);
+
+    const style = styleEl(h);
+    expect(style).not.toBeNull();
+    expect(style!.textContent).toContain(".stepper { grid-column: 1 / -1");
+    expect(adoptedCss(h)).toBe("");
+  });
+
+  test("falls back when CSSStyleSheet exists but isn't constructable", () => {
+    // The interface object exists on older Safari but lacks replaceSync, so
+    // `new CSSStyleSheet()` would throw — the widget must detect that and use
+    // the `<style>` fallback rather than crashing during init.
+    const bare = function CSSStyleSheet() {};
+    h.setGlobal("CSSStyleSheet", bare);
+    mountOpenListing(h, true);
+
+    expect(styleEl(h)).not.toBeNull();
+    expect(adoptedCss(h)).toBe("");
   });
 
   test("data-add-quantity adds the requested count, pluralising the label", () => {

--- a/test/ui/client/order/support.ts
+++ b/test/ui/client/order/support.ts
@@ -80,6 +80,7 @@ export const harness = (): Harness => {
   setGlobal("document", document);
   setGlobal("sessionStorage", window.sessionStorage);
   setGlobal("MutationObserver", window.MutationObserver);
+  setGlobal("CSSStyleSheet", window.CSSStyleSheet);
   setGlobal("location", { assign: (url: string) => navigations.push(url) });
 
   const origDebug = console.debug;
@@ -172,6 +173,25 @@ export const shadow = (h: Harness): Queryable =>
 
 export const cartButton = (h: Harness): QueryNode =>
   shadow(h).querySelector(".cart-button") as QueryNode;
+
+/** The scoped CSS the widget adopted as an in-memory stylesheet (the CSP-safe
+ *  path used when the browser supports constructable stylesheets). */
+export const adoptedCss = (h: Harness): string =>
+  Array.from(
+    (
+      shadow(h) as unknown as {
+        adoptedStyleSheets: { cssRules: ArrayLike<{ cssText: string }> }[];
+      }
+    ).adoptedStyleSheets,
+  )
+    .flatMap((sheet) => Array.from(sheet.cssRules))
+    .map((rule) => rule.cssText)
+    .join("\n");
+
+/** The `<style>` element the widget appends when the browser can't build an
+ *  in-memory stylesheet (the fallback path), or null when it adopted one. */
+export const styleEl = (h: Harness): QueryNode | null =>
+  shadow(h).querySelector("style") as QueryNode | null;
 
 export const dialogEl = (h: Harness): QueryNode =>
   shadow(h).querySelector("dialog") as QueryNode;


### PR DESCRIPTION
## What this changes

The add-to-cart widget we ship to other sites (`/order.js`) draws a small
floating cart. It styled itself by adding a `<style>` block to its own
shadow root at run time.

Some sites set a strict content security policy. When they do, the browser
refuses that injected `<style>` block, and the cart shows up unstyled on
those sites.

This change delivers the same styles a different way — as a stylesheet
built in memory and attached to the cart. Styles built this way are never
blocked by a site's security policy, so the cart looks right everywhere.

## Notes

- The rules themselves are unchanged; only how they reach the cart changed.
- Very old Safari (before 16.4) can't build a stylesheet in memory, so on
  those browsers the widget still falls back to the old `<style>` block —
  nothing that worked before stops working.
- This is separate from the console warning that first prompted the look:
  that one turned out to be uBlock Origin injecting its own script into the
  page, which the site's policy correctly blocks. No site code was involved
  there, so nothing needed changing for it.

## Tests

- Updated the widget tests to check the styles are adopted in memory (and
  that no `<style>` element is added on the modern path).
- Added two tests for the fallback path: when the browser can't build a
  stylesheet, and when the browser only pretends to support it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HduJJdPWa579TXSiX4tTqe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HduJJdPWa579TXSiX4tTqe)_