### PR TITLE
Stop capturing specification evidence on every pull request

### DIFF
--- a/.github/workflows/spec-evidence.yml
+++ b/.github/workflows/spec-evidence.yml
@@ -1,7 +1,6 @@
 name: Specification evidence
 
 on:
-  pull_request:
   push:
     branches: [main]
   schedule:
@@ -70,7 +69,6 @@ jobs:
         run: deno task specs:evidence
 
       - name: Upload specification evidence
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: tickets-evidence

--- a/README.md
+++ b/README.md
@@ -449,11 +449,12 @@ The task writes a versioned `reports/evidence/manifest.json` and PNG files under
 `reports/evidence/assets/`. The manifest uses the authored story, rule, case,
 and capture IDs. It includes the app commit, image hash and dimensions, browser
 profile, viewport, and presentation type. Raw Cucumber messages and reports are
-not part of this evidence folder. The app workflow verifies the capture on pull
-requests. Main pushes and a monthly refresh upload this folder as the stable
-`tickets-evidence` artifact with GitHub's 35-day retention. The Tickets website
-imports that artifact into a reviewed pull request and keeps its ordinary site
-build offline.
+not part of this evidence folder. Main pushes and a monthly refresh check the
+captures and upload this folder as the stable `tickets-evidence` artifact with
+GitHub's 35-day retention. Nothing checks the captures before a merge, so a
+broken capture shows up on `main` rather than on the branch that caused it. The
+Tickets website imports that artifact into a reviewed pull request and keeps its
+ordinary site build offline.
 
 ```bash
 # Install Deno, cache dependencies, run all checks


### PR DESCRIPTION
## What changed

The **Specification evidence** workflow no longer runs on pull requests. It still runs on pushes to `main`, on its monthly schedule, and when started by hand.

The upload step lost its `if: github.event_name != 'pull_request'` guard, which is now dead — the workflow can no longer be triggered by a pull request, so the condition was always true.

`README.md` said the workflow verifies captures on pull requests. It no longer does, so that sentence is replaced with what actually happens now.

## Why

Measured across 30 recent runs on 11 August, the evidence job was the slowest thing in the pull request loop:

| Workflow | Runs/day | Median wall time |
|---|---|---|
| **Specification evidence** | 52 | **5.2 min** |
| Test | 54 | 3.9 min |
| Merge Check | 52 | 0.35 min |

All three start within a couple of seconds of each other and run side by side, so the slowest one decides how long a push waits. That was the evidence job, at 52 pushes a day.

Its time went almost entirely on one step:

```
setup (checkout, Deno, Chromium deps)     33s
deno task test:screenshot-contract       236s   <- 75% of the job
deno task specs:evidence                  39s
                                total    310s
```

On a pull request the job also threw its own output away — the upload step already skipped pull request runs, so five minutes of work produced nothing that was kept.

## Measured result

This pull request is its own test case. Only **Merge Check** and **Test** ran on it; **Specification evidence** did not fire, which is the intended effect.

The two Test runs here finished in **4.2 and 4.5 minutes**, a little above the 3.9 min median the projection used. On that evidence the saving is roughly **50 to 70 minutes of elapsed time a day** at the current push rate, rather than the 70 a straight median-to-median comparison would suggest. Worth re-checking against a few days of real runs.

## What this gives up

The browser screenshot contracts (`test:screenshot-contract`) no longer run before a merge. They run after, on the push to `main`, plus monthly. A regression in screenshot timing or responsive layout will now be caught just after it lands rather than just before, and it will show up on `main` rather than on the branch that caused it. The README now says this outright.

This is a deliberate trade. If it bites, the middle option is to put the job back on pull requests but move it off the free 2-core `ubuntu-latest` runner onto `ubicloud-standard-8`, which should bring that 236-second step down to roughly a minute for about £8 a month.

## Checks

- The workflow YAML parses, and the triggers are now `push: [main]`, `schedule`, and `workflow_dispatch`.
- Both Test runs passed. Both Deno Deploy builds passed.
- This workflow has no `merge_group` trigger, unlike `test.yml`. It therefore cannot be a required status check today — a required check with no `merge_group` trigger would stall the merge queue, and the queue is merging normally. **Worth a glance at Settings → Branches to confirm before merging.**