### PR TITLE
Read a listing's children and parents in one go

### DIFF
--- a/src/shared/db/link-table.ts
+++ b/src/shared/db/link-table.ts
@@ -13,6 +13,10 @@
  * already have, `valueColumn` is the ids you want. Declare one side per
  * direction the module actually uses. Table and column names are internal
  * constants, never user input.
+ *
+ * When both columns name the same kind of record — a listing's children and
+ * its parents — declare the two sides together with {@link selfLinkTableSides},
+ * which answers both directions from one read.
  */
 
 import { reduce, requiredMapValue, unique } from "#fp";
@@ -65,11 +69,74 @@ export type LinkTableSide = {
   setIdsTx: TxIdsWrite;
 };
 
+/** Reads the linked ids for several keys at once. Every key asked for comes
+ * back, including keys with no links. */
+type ReadIdsByKeys = (
+  keyIds: readonly number[],
+) => Promise<Map<number, number[]>>;
+
+/** Rows of one link table, as the two id columns this module works in. */
+type LinkRow = { key_id: number; value_id: number };
+
+const linkRows = (
+  table: string,
+  keyColumn: string,
+  valueColumn: string,
+  where: string,
+  args: number[],
+): Promise<LinkRow[]> =>
+  queryAll<LinkRow>(
+    `SELECT ${keyColumn} AS key_id, ${valueColumn} AS value_id
+       FROM ${table}
+       WHERE ${where}
+       ORDER BY ${keyColumn}, ${valueColumn}`,
+    args,
+  );
+
+/** One direction's reader: its own query, remembered per request. */
+const oneDirectionReader = (
+  table: string,
+  keyColumn: string,
+  valueColumn: string,
+): ReadIdsByKeys => {
+  const fetchIdsByKeys = async (
+    keys: number[],
+  ): Promise<Map<number, number[]>> => {
+    const idsByKey = new Map(keys.map((id) => [id, [] as number[]]));
+    if (keys.length === 0) return idsByKey;
+    const rows = await linkRows(
+      table,
+      keyColumn,
+      valueColumn,
+      `${keyColumn} IN (${inPlaceholders(keys)})`,
+      keys,
+    );
+    return reduce((acc: Map<number, number[]>, row: LinkRow) => {
+      requiredMapValue(acc, row.key_id, "Unexpected link key").push(
+        row.value_id,
+      );
+      return acc;
+    }, idsByKey)(rows);
+  };
+
+  // Rendering a page asks the same side for overlapping key sets several
+  // times, so each key is read from the database once per request. Any write
+  // to the table clears what this request remembered.
+  const linksByKey = requestBatchCache(fetchIdsByKeys);
+  registerTableInvalidation([table], linksByKey.invalidate);
+  return (keyIds) => linksByKey.getMany(keyIds);
+};
+
 /** Build the helpers for one direction through a link table. */
 export const linkTableSide = (
   table: string,
   keyColumn: string,
   valueColumn: string,
+  readIdsByKeys: ReadIdsByKeys = oneDirectionReader(
+    table,
+    keyColumn,
+    valueColumn,
+  ),
 ): LinkTableSide => {
   // One multi-row INSERT regardless of id count, so a replace is always two
   // statements and a transactional caller stays clear of the round-trip guard.
@@ -108,40 +175,6 @@ export const linkTableSide = (
     ];
   };
 
-  /** Read the linked ids for several keys in one bounded query. Every key
-   * asked for is present in the result, including keys with no links. */
-  const fetchIdsByKeys = async (
-    keys: number[],
-  ): Promise<Map<number, number[]>> => {
-    const idsByKey = new Map(keys.map((id) => [id, [] as number[]]));
-    if (keys.length === 0) return idsByKey;
-    const rows = await queryAll<{ key_id: number; value_id: number }>(
-      `SELECT ${keyColumn} AS key_id, ${valueColumn} AS value_id
-         FROM ${table}
-         WHERE ${keyColumn} IN (${inPlaceholders(keys)})
-         ORDER BY ${keyColumn}, ${valueColumn}`,
-      keys,
-    );
-    return reduce(
-      (
-        acc: Map<number, number[]>,
-        row: { key_id: number; value_id: number },
-      ) => {
-        requiredMapValue(acc, row.key_id, "Unexpected link key").push(
-          row.value_id,
-        );
-        return acc;
-      },
-      idsByKey,
-    )(rows);
-  };
-
-  // Rendering a page asks the same side for overlapping key sets several
-  // times, so each key is read from the database once per request. Any write
-  // to the table clears what this request remembered.
-  const linksByKey = requestBatchCache(fetchIdsByKeys);
-  registerTableInvalidation([table], linksByKey.invalidate);
-
   const linkSide: LinkTableSide = {
     addIdsTx: async (tx, keyId, ids) => {
       const deduped = dedupe(ids);
@@ -162,7 +195,7 @@ export const linkTableSide = (
         keyId,
         `Missing link result for ${keyColumn} ${keyId}`,
       ),
-    getIdsByKeys: (keyIds) => linksByKey.getMany(keyIds),
+    getIdsByKeys: (keyIds) => readIdsByKeys(keyIds),
     getIdsTx: (tx, keyId) =>
       readIds(
         async (statement) =>
@@ -175,4 +208,86 @@ export const linkTableSide = (
     },
   };
   return linkSide;
+};
+
+/** What one record links to, both ways round, when a link table joins a kind of
+ * record to itself. */
+type BothDirections = { pointsAt: number[]; pointedAtBy: number[] };
+
+/** The two directions through a link table that joins a kind of record to
+ * itself. */
+export type SelfLinkTableSides = {
+  /** Keyed by the `keyColumn` record: the `valueColumn` ids it points at. */
+  pointsAt: LinkTableSide;
+  /** Keyed by the `valueColumn` record: the `keyColumn` ids pointing at it. */
+  pointedAtBy: LinkTableSide;
+};
+
+const emptyBothDirections = (
+  ids: readonly number[],
+): Map<number, BothDirections> =>
+  new Map(ids.map((id) => [id, { pointedAtBy: [], pointsAt: [] }]));
+
+/**
+ * Both directions through a link table whose two columns name the same kind of
+ * record — a listing's children and the parents it sits under.
+ *
+ * Both sides share one read and one memory of it, so asking each way round for
+ * the same records costs one round trip rather than two. Rows come back ordered
+ * by key then value, which leaves every list here ascending.
+ */
+export const selfLinkTableSides = (
+  table: string,
+  keyColumn: string,
+  valueColumn: string,
+): SelfLinkTableSides => {
+  const fetchBothDirections = async (
+    ids: number[],
+  ): Promise<Map<number, BothDirections>> => {
+    const linksById = emptyBothDirections(ids);
+    if (ids.length === 0) return linksById;
+    const slots = inPlaceholders(ids);
+    const rows = await linkRows(
+      table,
+      keyColumn,
+      valueColumn,
+      `${keyColumn} IN (${slots}) OR ${valueColumn} IN (${slots})`,
+      [...ids, ...ids],
+    );
+    for (const { key_id, value_id } of rows) {
+      // A row matched on either column, so only one of its two records has to
+      // be one the caller asked about.
+      linksById.get(key_id)?.pointsAt.push(value_id);
+      linksById.get(value_id)?.pointedAtBy.push(key_id);
+    }
+    return linksById;
+  };
+
+  const linksById = requestBatchCache(fetchBothDirections);
+  registerTableInvalidation([table], linksById.invalidate);
+
+  const directionReader =
+    (direction: keyof BothDirections): ReadIdsByKeys =>
+    async (keyIds) =>
+      new Map(
+        [...(await linksById.getMany(keyIds))].map(([id, links]) => [
+          id,
+          links[direction],
+        ]),
+      );
+
+  return {
+    pointedAtBy: linkTableSide(
+      table,
+      valueColumn,
+      keyColumn,
+      directionReader("pointedAtBy"),
+    ),
+    pointsAt: linkTableSide(
+      table,
+      keyColumn,
+      valueColumn,
+      directionReader("pointsAt"),
+    ),
+  };
 };

--- a/src/shared/db/listing-parents.ts
+++ b/src/shared/db/listing-parents.ts
@@ -19,7 +19,10 @@ import {
   resultRows,
   type TxScope,
 } from "#shared/db/client.ts";
-import { type LinkTableSide, linkTableSide } from "#shared/db/link-table.ts";
+import {
+  type LinkTableSide,
+  selfLinkTableSides,
+} from "#shared/db/link-table.ts";
 import { guardEdgeWriteTx } from "#shared/db/listing-edge-write.ts";
 import { relationshipErrorTx } from "#shared/db/listing-relationship-validation.ts";
 import { requireListingsWithCountsByIds } from "#shared/db/listings/records.ts";
@@ -34,26 +37,27 @@ import {
 } from "#shared/package-membership.ts";
 import type { ListingWithCount } from "#shared/types.ts";
 
-/** A parent's chooseable children, keyed by parent id (relationship only):
- * `getIds` reads them ascending; `setIds`/`setIdsTx` replace the set (the
- * admin edit-on-parent save — the Tx form runs on the caller's transaction so
- * the edges commit atomically with the listing row write). */
-export const listingChildren = linkTableSide(
+/** Both directions of the edge table. Parents and children are both listings,
+ * so one read answers "who are my children" and "whose child am I" together —
+ * the discovery, feed, and listing-save paths ask for both. */
+const listingEdges = selfLinkTableSides(
   "listing_parents",
   "parent_listing_id",
   "child_listing_id",
 );
+
+/** A parent's chooseable children, keyed by parent id (relationship only):
+ * `getIds` reads them ascending; `setIds`/`setIdsTx` replace the set (the
+ * admin edit-on-parent save — the Tx form runs on the caller's transaction so
+ * the edges commit atomically with the listing row write). */
+export const listingChildren = listingEdges.pointsAt;
 
 /** The parents a child is offered under, keyed by child id — the reverse
  * side. `addIdsTx` is the catalog-import writer for a freshly-created listing
  * that is a child of already-existing parents: additive (never a group-wide
  * delete), so it can't disturb a parent's other children the way a
  * `listingChildren.setIdsTx` replace would. */
-export const listingParents = linkTableSide(
-  "listing_parents",
-  "child_listing_id",
-  "parent_listing_id",
-);
+export const listingParents = listingEdges.pointedAtBy;
 
 const requireCurrentRelationshipRules = async (
   tx: TxScope,
@@ -259,8 +263,9 @@ export const hydrateListingLinks = async (
   };
 };
 
-/** Load both directions in three bounded queries and return named maps, so a
- * caller cannot swap parent and child results. */
+/** Load both directions and return named maps, so a caller cannot swap parent
+ * and child results. The two sides share one read (see `selfLinkTableSides`),
+ * so this costs one round trip for the edges plus one for the linked rows. */
 export const loadParentAndChildLinks = async (
   keyIds: readonly number[],
 ): Promise<ParentAndChildLinkMaps> => {

--- a/test/integration/server/public/listings-query-scaling.test.ts
+++ b/test/integration/server/public/listings-query-scaling.test.ts
@@ -83,10 +83,13 @@ describeWithEnv(
       const first = await recordListingsPage(firstNames);
       const seen = await recordGroupPageQueries("group", 1, 3);
 
-      const childLinkBatches = seen.filter((sql) =>
+      const edgeReads = seen.filter((sql) =>
         sql.startsWith(
-          "SELECT child_listing_id AS key_id, parent_listing_id AS value_id",
+          "SELECT parent_listing_id AS key_id, child_listing_id AS value_id",
         ),
+      );
+      const reverseEdgeReads = seen.filter((sql) =>
+        sql.startsWith("SELECT child_listing_id AS key_id"),
       );
       const batchedMembers = batchedMemberQueries(seen);
       const singleGroupMembers = seen.filter((sql) =>
@@ -97,9 +100,11 @@ describeWithEnv(
 
       // One classification decides regular-group liveness; the other decides
       // the individual listing cards. Adding groups must not add either query.
-      // Both classifications ask for the same child links, and a request reads
-      // each listing's links once, so the two share a single query.
-      expect(childLinkBatches.length).toBe(1);
+      // Both classifications ask about the same listings, and one read answers
+      // a listing's children and its parents together, so the whole page reads
+      // the edge table once and never separately for the other direction.
+      expect(edgeReads.length).toBe(1);
+      expect(reverseEdgeReads).toEqual([]);
       expect(batchedMembers.length).toBe(1);
       expect(singleGroupMembers.length).toBe(0);
       expect(seen.length).toBe(first.length);

--- a/test/shared/db/link-table.test.ts
+++ b/test/shared/db/link-table.test.ts
@@ -1,13 +1,31 @@
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { withTransaction } from "#shared/db/client.ts";
-import { linkTableSide } from "#shared/db/link-table.ts";
+import { linkTableSide, selfLinkTableSides } from "#shared/db/link-table.ts";
+import { runWithRequestCache } from "#shared/request-cache.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { countDatabaseCalls } from "#test-utils/subrequest-budget.ts";
 
 // Exercised through a real link table so the SQL runs against the schema's
 // unique (key, value) index — the constraint the factory's dedupe protects.
 const byUser = linkTableSide("user_logistics_agents", "user_id", "agent_id");
 const byAgent = linkTableSide("user_logistics_agents", "agent_id", "user_id");
+
+// A listing's children and its parents are both listings, so this table is
+// read from both ends of the same id.
+const edges = selfLinkTableSides(
+  "listing_parents",
+  "parent_listing_id",
+  "child_listing_id",
+);
+
+/** Count the database calls `work` makes with a request's memory switched on,
+ * the way a real request runs. */
+const callsInOneRequest = (
+  limit: number,
+  work: () => Promise<unknown>,
+): Promise<number> =>
+  runWithRequestCache(() => countDatabaseCalls(limit, work));
 
 describeWithEnv("db link-table", { db: true }, () => {
   test("getIds returns [] when the key has no links", async () => {
@@ -120,5 +138,84 @@ describeWithEnv("db link-table", { db: true }, () => {
     await byAgent.clear(4);
     expect(await byUser.getIds(1)).toEqual([5]);
     expect(await byUser.getIds(2)).toEqual([]);
+  });
+
+  describe("both directions of a self-linking table", () => {
+    test("each side reads its own direction, ascending", async () => {
+      await edges.pointsAt.setIds(1, [7, 3]);
+      await edges.pointsAt.setIds(2, [3]);
+
+      expect(await edges.pointsAt.getIds(1)).toEqual([3, 7]);
+      expect(await edges.pointedAtBy.getIds(3)).toEqual([1, 2]);
+    });
+
+    test("asking both ways round about one record costs a single read", async () => {
+      await edges.pointsAt.setIds(1, [3]);
+      await edges.pointedAtBy.setIds(1, [4]);
+
+      const both = await callsInOneRequest(1, async () => {
+        expect(await edges.pointsAt.getIds(1)).toEqual([3]);
+        expect(await edges.pointedAtBy.getIds(1)).toEqual([4]);
+      });
+
+      expect(both).toBe(1);
+    });
+
+    test("asking both ways round at once costs a single read", async () => {
+      await edges.pointsAt.setIds(1, [3]);
+      await edges.pointsAt.setIds(2, [3]);
+
+      const both = await callsInOneRequest(1, async () => {
+        const [children, parents] = await Promise.all([
+          edges.pointsAt.getIdsByKeys([1, 2, 3]),
+          edges.pointedAtBy.getIdsByKeys([1, 2, 3]),
+        ]);
+        expect(children).toEqual(
+          new Map([
+            [1, [3]],
+            [2, [3]],
+            [3, []],
+          ]),
+        );
+        expect(parents).toEqual(
+          new Map([
+            [1, []],
+            [2, []],
+            [3, [1, 2]],
+          ]),
+        );
+      });
+
+      expect(both).toBe(1);
+    });
+
+    test("a record nobody links to comes back empty both ways", async () => {
+      await edges.pointsAt.setIds(1, [3]);
+
+      expect(await edges.pointsAt.getIdsByKeys([9])).toEqual(
+        new Map([[9, []]]),
+      );
+      expect(await edges.pointedAtBy.getIdsByKeys([9])).toEqual(
+        new Map([[9, []]]),
+      );
+    });
+
+    test("an empty list of records reads nothing at all", async () => {
+      const calls = await callsInOneRequest(0, async () => {
+        expect(await edges.pointsAt.getIdsByKeys([])).toEqual(new Map());
+        expect(await edges.pointedAtBy.getIdsByKeys([])).toEqual(new Map());
+      });
+
+      expect(calls).toBe(0);
+    });
+
+    test("a write makes the next read fetch again", async () => {
+      await edges.pointsAt.setIds(1, [3]);
+      await runWithRequestCache(async () => {
+        expect(await edges.pointedAtBy.getIds(3)).toEqual([1]);
+        await edges.pointsAt.setIds(2, [3]);
+        expect(await edges.pointedAtBy.getIds(3)).toEqual([1, 2]);
+      });
+    });
   });
 });


### PR DESCRIPTION
# Read a listing's children and parents in one go

First of a short series of small changes that cut wasted database round trips, found by profiling real requests against the round-trip counter. Bunny allows 50 subrequests per request, and a cold edge server does the most work, so every trip saved is latency the visitor doesn't wait for.

## What was happening

The parent/child edge table is the one link table whose two columns both name **listings**. So a page that asks "which listings are my children?" almost always also asks "whose child am I?" — about the same listings, in the same breath. Those were two separate reads of one small table.

Measured on the public catalogue, both showed up on every render, warm or cold:

```
SELECT parent_listing_id AS key_id, child_listing_id AS value_id FROM listing_parents ...
SELECT child_listing_id AS key_id, parent_listing_id AS value_id FROM listing_parents ...
```

The same two-read pattern was paid by the ICS/RSS feeds and by every listing save, which re-checks the edges on both sides before writing.

## The change

`selfLinkTableSides` declares the two directions **together**. One read answers each way round, and both sides share one memory of it for the rest of the request — so whichever direction is asked for first, the second one is free. The list order is unchanged (ascending each way), and so is every result.

`linkTableSide` now takes its reader as an argument, which is how the pair hands both sides the shared one. That is the only change to it: the five tables that are read from a single direction keep their own reader and behave exactly as before.

## What it saves

One round trip on the public listings page, on both feeds, and on every listing save. Nothing else changes — this is the same data, read once instead of twice.

Being honest about scale: this is one trip, not a transformation. The public catalogue goes from 14 reads to 13 on a cold server. The larger remaining slices — the site navigation reads that repeat on every public page, and the group/attribute reads on the catalogue — are separate changes in this series.

## Tests

- Both directions still read correctly, ascending, including a record nobody links to.
- Asking each way round about one record costs **one** read (asserted against the real database-call counter, with a request's memory switched on, as production runs).
- Asking both ways round at once, concurrently, also costs one read.
- An empty list of records still reads nothing at all.
- A write still makes the next read fetch again.
- The existing listings-scaling test pinned the old two-query shape. It now holds a stronger line: the page reads the edge table exactly once and never separately for the reverse direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced database reads when loading both parent and child relationships.
  * Added request-level caching and batching for bidirectional relationship lookups.

* **Bug Fixes**
  * Ensured relationship results remain correctly ordered and caches are invalidated after writes.
  * Improved handling of empty-key queries.

* **Tests**
  * Expanded coverage for bidirectional links, caching, batching, invalidation, and query counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->