### PR TITLE
Read a session and its user in one go

### DIFF
--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -17,7 +17,7 @@ import type { WrappedKey } from "#shared/crypto/sealed.ts";
 import { signCsrfToken, verifySignedCsrfToken } from "#shared/csrf.ts";
 import { apiKeyLimiter } from "#shared/db/api-key-attempts.ts";
 import { getApiKeyByToken, touchApiKeyLastUsed } from "#shared/db/api-keys.ts";
-import { deleteSession, getSession } from "#shared/db/sessions.ts";
+import { deleteSession, getSessionWithUser } from "#shared/db/sessions.ts";
 import {
   decryptAdminLevel,
   getUserAuthFieldsById,
@@ -55,18 +55,20 @@ export type AuthSession = {
   settingsNagItems?: readonly NagItem[];
 };
 
-/** Load the user's auth fields for a session or API key. When the id points at
- * no user, log an invalid-session error and give back null so the caller can
- * clear its own state and bail. */
-const loadAuthUserFields = async (
-  userId: number,
-  missingDetail: string,
-): Promise<UserAuthFields | null> => {
-  const user = await getUserAuthFieldsById(userId);
-  if (user) return user;
+/** Report a session or API key whose user has since been deleted. Always gives
+ * back null so a caller can `return reportMissingAuthUser(...)`. */
+const reportMissingAuthUser = (missingDetail: string): null => {
   logError({ code: ErrorCode.AUTH_INVALID_SESSION, detail: missingDetail });
   return null;
 };
+
+/** Load the user's auth fields for an API key. When the id points at no user,
+ * log an invalid-session error and give back null so the caller can bail. */
+const loadAuthUserFields = async (
+  userId: number,
+  missingDetail: string,
+): Promise<UserAuthFields | null> =>
+  (await getUserAuthFieldsById(userId)) ?? reportMissingAuthUser(missingDetail);
 
 /** Drop the cached session (and, when the caller has a token, the stored
  *  session row) — the one "this session is no longer valid" step every bail-out
@@ -96,17 +98,16 @@ export const getAuthenticatedSession = async (
   const token = cookies.get(getSessionCookieName());
   if (!token) return invalidateSession();
 
-  const session = await getSession(token);
-  if (!session) return invalidateSession();
+  const found = await getSessionWithUser(token);
+  if (!found) return invalidateSession();
+  const { session, user } = found;
 
   if (session.expires < nowMs()) return invalidateSession(token);
 
-  // Load user and decrypt admin level
-  const user = await loadAuthUserFields(
-    session.user_id,
-    "Session references non-existent user, invalidating",
-  );
-  if (!user) return invalidateSession(token);
+  if (!user) {
+    reportMissingAuthUser("Session references non-existent user, invalidating");
+    return invalidateSession(token);
+  }
 
   const adminLevel = await decryptAdminLevel(user);
   await signCsrfToken();

--- a/src/shared/db/sessions.ts
+++ b/src/shared/db/sessions.ts
@@ -18,6 +18,8 @@ import {
   queryOne,
 } from "#shared/db/client.ts";
 import { createPrimaryCacheRefill } from "#shared/db/primary-reads.ts";
+import type { UserAuthFields } from "#shared/db/users.ts";
+import { requireValue } from "#shared/required-value.ts";
 
 import type { Session } from "#shared/types.ts";
 
@@ -94,7 +96,19 @@ export const createSession = async (
 };
 
 /** The sessions columns selected by the by-token and list reads. */
-const SESSION_COLUMNS = "token, csrf_token, expires, wrapped_data_key, user_id";
+const SESSION_COLUMN_NAMES = [
+  "token",
+  "csrf_token",
+  "expires",
+  "wrapped_data_key",
+  "user_id",
+] as const;
+
+const SESSION_COLUMNS = SESSION_COLUMN_NAMES.join(", ");
+
+/** The same columns read through a join, where the table carries an alias. */
+const sessionColumnsOn = (alias: string): string =>
+  SESSION_COLUMN_NAMES.map((column) => `${alias}.${column}`).join(", ");
 
 /**
  * Get a session by token (with 10s TTL cache)
@@ -116,6 +130,66 @@ export const getSession = async (token: string): Promise<Session | null> => {
   );
   cacheSession(tokenHash, session);
   return session;
+};
+
+/** A session and the user it belongs to. `user` is null when the session
+ * outlived its user, which the caller reports and clears — never mistake it for
+ * a token nobody ever had. */
+export type SessionWithUser = {
+  readonly session: Session;
+  readonly user: UserAuthFields | null;
+};
+
+/** The joined row: session columns, plus the user's if one still exists. */
+type SessionUserRow = Session & {
+  user_row_id: number | null;
+  admin_level: UserAuthFields["admin_level"] | null;
+};
+
+const joinedUser = (row: SessionUserRow): UserAuthFields | null =>
+  row.user_row_id === null
+    ? null
+    : {
+        admin_level: requireValue(
+          row.admin_level,
+          `Session user ${row.user_row_id} has no admin level`,
+        ),
+        id: row.user_row_id,
+      };
+
+/**
+ * Read a session and the user it belongs to together.
+ *
+ * Authenticating needs both, and the user id is only known once the session has
+ * been read, so as two reads they can never overlap — on a cold edge server
+ * that is two waits before the page can start. A session whose user has since
+ * been deleted still comes back, so the caller can tell that apart from an
+ * unknown token and clear the stale row.
+ *
+ * The user's admin level decides what the viewer may do, so it is read afresh
+ * every time and never served from the session cache.
+ */
+export const getSessionWithUser = async (
+  token: string,
+): Promise<SessionWithUser | null> => {
+  const tokenHash = await hashSessionToken(token);
+  const row = await primaryRefill.fetch(() =>
+    queryOne<SessionUserRow>(
+      `SELECT ${sessionColumnsOn("session")},
+              adminUser.id AS user_row_id, adminUser.admin_level
+         FROM sessions AS session
+         LEFT JOIN users AS adminUser ON adminUser.id = session.user_id
+        WHERE session.token = ?`,
+      [tokenHash],
+    ),
+  );
+  if (row === null) {
+    cacheSession(tokenHash, null);
+    return null;
+  }
+  const { admin_level: _level, user_row_id: _userRowId, ...session } = row;
+  cacheSession(tokenHash, session);
+  return { session, user: joinedUser(row) };
 };
 
 /**

--- a/test/shared/db/sessions.test.ts
+++ b/test/shared/db/sessions.test.ts
@@ -7,7 +7,12 @@ import {
   invalidateCachesForTable,
   resetAllCaches,
 } from "#shared/cache-registry.ts";
-import { executeWithoutCacheInvalidation, getDb } from "#shared/db/client.ts";
+import { hashSessionToken } from "#shared/crypto/hashing.ts";
+import {
+  execute,
+  executeWithoutCacheInvalidation,
+  getDb,
+} from "#shared/db/client.ts";
 import {
   createSession,
   deleteAllSessions,
@@ -15,9 +20,12 @@ import {
   deleteSession,
   getAllSessions,
   getSession,
+  getSessionWithUser,
 } from "#shared/db/sessions.ts";
+import { createUser } from "#shared/db/users.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { withEnv } from "#test-utils/env.ts";
+import { countDatabaseCalls } from "#test-utils/subrequest-budget.ts";
 
 describeWithEnv("db > sessions", { db: true }, () => {
   test("createSession and getSession work together", async () => {
@@ -76,6 +84,54 @@ describeWithEnv("db > sessions", { db: true }, () => {
   test("getAllSessions returns empty array when no sessions", async () => {
     const sessions = await getAllSessions();
     expect(sessions).toEqual([]);
+  });
+
+  test("getSessionWithUser reads the session and its user in one call", async () => {
+    const user = await createUser("joined-user", "", null, "manager");
+    const expires = Date.now() + 1000;
+    await createSession("joined", "csrf-joined", expires, null, user.id);
+
+    let found: Awaited<ReturnType<typeof getSessionWithUser>> = null;
+    const calls = await countDatabaseCalls(1, async () => {
+      found = await getSessionWithUser("joined");
+    });
+
+    expect(calls).toBe(1);
+    expect(found).toEqual({
+      session: {
+        csrf_token: "csrf-joined",
+        expires,
+        token: await hashSessionToken("joined"),
+        user_id: user.id,
+        wrapped_data_key: null,
+      },
+      user: { admin_level: user.admin_level, id: user.id },
+    });
+  });
+
+  test("getSessionWithUser keeps a session whose user was deleted", async () => {
+    const user = await createUser("gone-user", "", null, "manager");
+    await createSession(
+      "orphan",
+      "csrf-orphan",
+      Date.now() + 1000,
+      null,
+      {
+        ...user,
+      }.id,
+    );
+    await execute("DELETE FROM users WHERE id = ?", [user.id]);
+
+    const found = await getSessionWithUser("orphan");
+
+    // The caller tells this apart from an unknown token: it reports the broken
+    // session and clears the row, rather than silently leaving it behind.
+    expect(found?.session.csrf_token).toBe("csrf-orphan");
+    expect(found?.user).toBeNull();
+  });
+
+  test("getSessionWithUser returns null for a token nobody has", async () => {
+    expect(await getSessionWithUser("never-issued")).toBeNull();
   });
 
   test("deleteOtherSessions removes all sessions except current", async () => {


### PR DESCRIPTION
# Read a session and its user in one go

Second of a short series of small changes that cut wasted database round trips, found by profiling real requests. Bunny allows 50 subrequests per request, and a cold edge server does the most work, so every trip saved is latency the visitor doesn't wait for.

## What was happening

Signing in gives you a session row. Working out what you're allowed to do needs the user that session belongs to. Those were two separate reads — and they can never overlap, because the user's id only exists once the session has been read. So every signed-in request waited for one, then waited for the other:

```
SELECT token, csrf_token, expires, wrapped_data_key, user_id FROM sessions WHERE token = ?
SELECT id, admin_level FROM users WHERE id = ? LIMIT 1
```

The session read has a ten-second in-memory cache; the user read has none. So a busy server often paid one read, but a **cold** server — the common case on the edge — paid both, on every admin page.

## The change

One join reads them together, so authenticating costs one trip instead of two.

Two details worth flagging, because both are easy to get wrong:

**It stays a LEFT join on purpose.** A session whose user has since been deleted is a real case the code already handles: it logs the broken session and deletes the row. An inner join would return nothing for it — identical to "no such session" — so the report would be skipped and the orphaned row would quietly stay in the table forever. The left join keeps the session visible with no user attached, so the existing handling still runs.

**The admin level is still read fresh every time.** It would have been easy to cache it next to the session and save another trip, but that level decides what someone is allowed to do, and the ten-second cache would delay a role change taking effect. Isolate caches are never authoritative for that, so the join reads it afresh on every request, exactly as before.

## What it saves

One round trip on every signed-in request on a cold server, and never more than before on a warm one. Admin pages drop from 11 reads to 10 cold.

## Tests

- The session and its user come back together, and it costs exactly **one** database call (asserted against the real call counter).
- A session whose user was deleted still comes back, with no user attached — the case that a plain join would have broken. This path had **no coverage at all** before.
- An unknown token still reads as nothing.
- Existing behaviour re-verified across the auth guards, admin routes, and integration server suites (5,900+ tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_