### PR TITLE
Read the public nav's three small tables in one go

### DIFF
--- a/src/features/public/site-nav.ts
+++ b/src/features/public/site-nav.ts
@@ -20,9 +20,12 @@
  */
 
 import { compact, filter, map, pipe, unique } from "#fp";
+import { fillTogether } from "#shared/db/fill-together.ts";
 import { getHiddenPackageMemberIds, groups } from "#shared/db/groups.ts";
 import { getListingsWithCountsByIds } from "#shared/db/listings/records.ts";
-import { hasNewsPosts } from "#shared/db/news-posts.ts";
+import { hasNewsPosts, newsExistenceRead } from "#shared/db/news-posts.ts";
+import { allPageItemsRead } from "#shared/db/site-page-items.ts";
+import { sitePagesNavRead } from "#shared/db/site-pages.ts";
 import { isQualifyingTierListing } from "#shared/site-assignment.ts";
 import { buildNavModel } from "#shared/site-pages/core.ts";
 import { loadPageForest } from "#shared/site-pages/load.ts";
@@ -130,14 +133,24 @@ export const publicNavModel = async (
   return buildNavModel(forest, targets, current);
 };
 
+/** The three small reads behind every public page's nav: is there any news, the
+ * pages, and what sits on them. None depends on the others, so one round trip
+ * answers all three — which on a cold edge server is one wait instead of
+ * three. Each read still fills its own request cache, so anything else on the
+ * page that wants the same rows reads them from there. */
+const fillNavReads = (): Promise<void> =>
+  fillTogether([newsExistenceRead, sitePagesNavRead, allPageItemsRead]);
+
 /** The full prop set {@link PublicNav} renders: the settings-driven page
- * flags, the news flag (one cached indexed existence read — see
- * {@link hasNewsPosts}), and the site-pages tree — built once per request by
- * each public handler. */
+ * flags, the news flag (see {@link hasNewsPosts}), and the site-pages tree —
+ * built once per request by each public handler. */
 export const publicNavProps = async (
   current: TargetKey | null,
-): Promise<PublicNavProps> => ({
-  ...navFlags(),
-  hasNews: await hasNewsPosts(),
-  pages: await publicNavModel(current),
-});
+): Promise<PublicNavProps> => {
+  await fillNavReads();
+  return {
+    ...navFlags(),
+    hasNews: await hasNewsPosts(),
+    pages: await publicNavModel(current),
+  };
+};

--- a/src/shared/db/fill-together.ts
+++ b/src/shared/db/fill-together.ts
@@ -1,0 +1,39 @@
+/**
+ * Several small cached reads, answered in one round trip.
+ *
+ * A page that needs three little tables — "is there any news?", the site pages,
+ * the items on them — would otherwise wait for three answers, one after
+ * another. Each read still owns its request cache, so every other caller in the
+ * request keeps reading from it exactly as before; this only changes where that
+ * cache's first answer comes from.
+ *
+ * Ask once, early, for the set a page is about to need: filling a cache that is
+ * already full just throws the batch's work away.
+ */
+
+import type { ResultSet } from "@libsql/client";
+import { queryBatch, type SqlStatement } from "#shared/db/client.ts";
+import { requireValue } from "#shared/required-value.ts";
+
+/** One cached read that can take its answer from a shared batch. */
+export type FillableRead = {
+  /** The statement this read would otherwise run on its own. */
+  readonly statement: SqlStatement;
+  /** Put this answer into the read's request cache. */
+  readonly fill: (result: ResultSet) => Promise<void> | void;
+};
+
+/** Answer every read in one round trip, then fill each one's cache. */
+export const fillTogether = async (
+  reads: readonly FillableRead[],
+): Promise<void> => {
+  if (reads.length === 0) return;
+  const results = await queryBatch(reads.map(({ statement }) => statement));
+  await Promise.all(
+    reads.map((read, index) =>
+      read.fill(
+        requireValue(results[index], `Batched read ${index} went unanswered`),
+      ),
+    ),
+  );
+};

--- a/src/shared/db/news-posts.ts
+++ b/src/shared/db/news-posts.ts
@@ -21,6 +21,7 @@ import {
   insertedRowId,
   queryAll,
   resultRows,
+  type SqlStatement,
   type TxScope,
   useTransaction,
 } from "#shared/db/client.ts";
@@ -32,6 +33,7 @@ import {
 import { encryptedNameAndSeoSchema } from "#shared/db/content-columns.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
 import { decryptTextOrEmpty } from "#shared/db/encrypted-text.ts";
+import type { FillableRead } from "#shared/db/fill-together.ts";
 import {
   clearImageUsesForItemStatement,
   imageFilenameSubqueries,
@@ -117,10 +119,20 @@ export const newsSlugBase = (created: string, name: string): string =>
 
 // The existence probe every public page's nav runs: one indexed LIMIT 1 read,
 // nothing decrypted. Request-scoped and auto-cleared on any news_posts write.
+const existenceStatement: SqlStatement = {
+  args: [],
+  sql: "SELECT id FROM news_posts LIMIT 1",
+};
 const existenceCache = requestCache(() =>
-  queryAll<{ id: number }>("SELECT id FROM news_posts LIMIT 1"),
+  queryAll<{ id: number }>(existenceStatement.sql),
 );
 registerTableInvalidation(["news_posts"], existenceCache.invalidate);
+
+/** The existence probe as a read the nav can batch with its other small ones. */
+export const newsExistenceRead: FillableRead = {
+  fill: (result) => existenceCache.prime(resultRows<{ id: number }>(result)),
+  statement: existenceStatement,
+};
 
 /** Does at least one news post exist? (Drives the public News nav link.) */
 export const hasNewsPosts = async (): Promise<boolean> =>

--- a/src/shared/db/site-page-items.ts
+++ b/src/shared/db/site-page-items.ts
@@ -19,6 +19,7 @@ import {
   type TxScope,
   useTransaction,
 } from "#shared/db/client.ts";
+import type { FillableRead } from "#shared/db/fill-together.ts";
 import {
   clearImageUsesForItemStatement,
   imageUseTargets,
@@ -68,10 +69,13 @@ export const sitePageItemOrder = defineOrderedCollection({
   table: "site_page_items",
 });
 
+const allItemsStatement: SqlStatement = {
+  args: [],
+  sql: `SELECT ${SELECT_COLS} FROM site_page_items ORDER BY page_id ASC, sort_order ASC, item_id ASC`,
+};
+
 const fetchAllItems = (): Promise<SitePageItem[]> =>
-  queryAll<SitePageItem>(
-    `SELECT ${SELECT_COLS} FROM site_page_items ORDER BY page_id ASC, sort_order ASC, item_id ASC`,
-  );
+  queryAll<SitePageItem>(allItemsStatement.sql);
 
 // Request-scoped: one query per request feeds the whole nav forest, fresh next
 // request, and cleared on any write to site_page_items.
@@ -81,6 +85,12 @@ registerTableInvalidation(["site_page_items"], itemsCache.invalidate);
 /** Every edge, ordered — the single read the public nav's forest is built from. */
 export const getAllPageItems = (): Promise<SitePageItem[]> =>
   itemsCache.getAll();
+
+/** The same read, as one the nav can batch with its other small ones. */
+export const allPageItemsRead: FillableRead = {
+  fill: (result) => itemsCache.prime(resultRows<SitePageItem>(result)),
+  statement: allItemsStatement,
+};
 
 /** Invalidate the edge cache (writes do this automatically). */
 export const invalidatePageItemsCache = (): void => itemsCache.invalidate();

--- a/src/shared/db/site-pages.ts
+++ b/src/shared/db/site-pages.ts
@@ -13,7 +13,9 @@
 import { decrypt, encrypt } from "#shared/crypto/encryption.ts";
 import { hmacHash } from "#shared/crypto/hashing.ts";
 import type { BlindIndex } from "#shared/crypto/sealed.ts";
+import type { StoredRowOf } from "#shared/db/chosen-columns.ts";
 import {
+  resultRows,
   type SqlStatement,
   type TxScope,
   useTransaction,
@@ -21,6 +23,7 @@ import {
 import { idAndEncryptedSlugSchema } from "#shared/db/common-schema.ts";
 import { encryptedNameAndSeoSchema } from "#shared/db/content-columns.ts";
 import { defineIdTable } from "#shared/db/define-id-table.ts";
+import type { FillableRead } from "#shared/db/fill-together.ts";
 import { defineOrderedCollection } from "#shared/db/ordered-collection.ts";
 import {
   unclaimedSiteSlugCondition,
@@ -58,8 +61,10 @@ const sitePageNavColumns = rawSitePagesTable.read.pick([
 /** Load the nav columns: only id/slug/name/sort_order, decrypting just slug
  * and name (never content/meta). Ordered by (sort_order, id). The raw row
  * carries name and slug still sealed; the map below opens them. */
+const NAV_ROW_ORDER = { order: "sort_order ASC, id ASC" } as const;
+
 const fetchNavRows = (): Promise<SitePageNavRow[]> =>
-  sitePageNavColumns.many({}, { order: "sort_order ASC, id ASC" });
+  sitePageNavColumns.many({}, NAV_ROW_ORDER);
 
 // Request-scoped cache over those columns: computed once per request, fresh on
 // the next request (no cross-isolate staleness), and auto-cleared on any write
@@ -69,6 +74,21 @@ export const sitePages = cachedTable({
   name: "site_pages_nav",
   table: rawSitePagesTable,
 });
+
+/** The nav rows as a read the nav can batch with its other small ones. The
+ * batch hands back stored rows, so slug and name are still sealed until the
+ * same column readers open them. */
+export const sitePagesNavRead: FillableRead = {
+  fill: async (result) =>
+    sitePages.prime(
+      await sitePageNavColumns.readAll(
+        resultRows<StoredRowOf<SitePage, typeof sitePageNavColumns.columns>>(
+          result,
+        ),
+      ),
+    ),
+  statement: sitePageNavColumns.statement({}, NAV_ROW_ORDER),
+};
 
 export const sitePageOrder = defineOrderedCollection({
   key: "id",

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -566,6 +566,7 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
 }): {
   getAll: () => Promise<Cached[]>;
   invalidate: () => void;
+  prime: (rows: Cached[]) => void;
   table: Table<Row, Input>;
 } => {
   const cache = requestCache(config.fetchAll);
@@ -578,6 +579,7 @@ export const cachedTable = <Row, Input, Cached = Row>(config: {
   return {
     getAll: () => cache.getAll(),
     invalidate: () => cache.invalidate(),
+    prime: (rows) => cache.prime(rows),
     table: config.table,
   };
 };

--- a/src/shared/request-cache.ts
+++ b/src/shared/request-cache.ts
@@ -28,6 +28,11 @@ type RequestStore = Map<symbol, unknown>;
 
 interface RequestCollectionCache<T> extends CollectionCache<T> {
   invalidate: (cause?: CacheInvalidation) => void;
+  /** Hand this request's cache an answer that has already been read — by a
+   * batch that asked several small reads at once — so `getAll` serves it
+   * instead of querying. Outside a request there is nowhere to keep it, so the
+   * next `getAll` reads for itself. */
+  prime: (items: T[]) => void;
 }
 
 const cacheScope = createScope<RequestStore>();
@@ -111,6 +116,8 @@ export const requestCache = <T>(
     },
 
     invalidate: slot.invalidate,
+
+    prime: (items: T[]): void => slot.write(items),
 
     size: (): number => {
       const cached = slot.read();

--- a/test/features/public/site-nav.test.ts
+++ b/test/features/public/site-nav.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { publicNavModel, publicNavProps } from "#routes/public/site-nav.ts";
+import { execute } from "#shared/db/client.ts";
+import { settings } from "#shared/db/settings.ts";
+import { addPageItem } from "#shared/db/site-page-items.ts";
+import { computeSitePageSlugIndex, sitePages } from "#shared/db/site-pages.ts";
+import { runWithRequestCache } from "#shared/request-cache.ts";
+import { sitePageItemTargets } from "#shared/site-pages/target.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { createTestNewsPost } from "#test-utils/db-helpers/misc.ts";
+import { countDatabaseCalls } from "#test-utils/subrequest-budget.ts";
+
+const addPage = async (name: string, slug: string, sortOrder: number) =>
+  sitePages.table.insert({
+    name,
+    slug,
+    slugIndex: await computeSitePageSlugIndex(slug),
+    sortOrder,
+  });
+
+describeWithEnv("public site nav", { db: true, triggers: true }, () => {
+  test("lists the site's pages in their chosen order", async () => {
+    await addPage("Second", "second", 2);
+    await addPage("First", "first", 1);
+
+    const model = await publicNavModel(null);
+
+    expect(model.rootPageNodes.map((node) => node.label)).toEqual([
+      "First",
+      "Second",
+    ]);
+  });
+
+  test("carries the settings flags and whether any news exists", async () => {
+    await settings.update.terms("Some terms");
+    await settings.update.orderEnabled(true);
+
+    const before = await publicNavProps(null);
+    expect(before).toMatchObject({ hasNews: false, hasTerms: true });
+    expect(before.hasOrder).toBe(true);
+
+    await createTestNewsPost("Launch day");
+
+    expect((await publicNavProps(null)).hasNews).toBe(true);
+  });
+
+  test("builds the whole nav from a single round trip", async () => {
+    await addPage("About", "about", 1);
+
+    const calls = await runWithRequestCache(() =>
+      // The three little tables the nav needs are read together, and nothing
+      // it does afterwards goes back for more.
+      countDatabaseCalls(1, () => publicNavProps(null)),
+    );
+
+    expect(calls).toBe(1);
+  });
+
+  test("resolves a page's listing item to a live link", async () => {
+    const page = await addPage("Things", "things", 1);
+    const listing = await createTestListing({ name: "Live listing" });
+    await addPageItem(page.id, "listing", listing.id);
+
+    const model = await publicNavModel(
+      sitePageItemTargets.key(sitePageItemTargets.of("page")(page.id)),
+    );
+
+    expect(model.currentChildren.map((node) => node.label)).toEqual([
+      "Live listing",
+    ]);
+    expect(model.currentChildren[0]?.href).toBe(`/ticket/${listing.slug}`);
+  });
+
+  test("keeps an inactive listing in the nav but not as a link", async () => {
+    const page = await addPage("Things", "things", 1);
+    const listing = await createTestListing({ name: "Off sale" });
+    await addPageItem(page.id, "listing", listing.id);
+    await execute("UPDATE listings SET active = 0 WHERE id = ?", [listing.id]);
+
+    const model = await publicNavModel(
+      sitePageItemTargets.key(sitePageItemTargets.of("page")(page.id)),
+    );
+
+    expect(model.currentChildren.map((node) => node.label)).toEqual([
+      "Off sale",
+    ]);
+    expect(model.currentChildren[0]?.live).toBe(false);
+  });
+});

--- a/test/features/public/site-nav.test.ts
+++ b/test/features/public/site-nav.test.ts
@@ -20,6 +20,24 @@ const addPage = async (name: string, slug: string, sortOrder: number) =>
     sortOrder,
   });
 
+/** Put one listing on a page and read the nav as that page. `change` runs
+ *  after the listing is placed, so a test can alter it first. */
+const navShowingListing = async (
+  listingName: string,
+  change: (listingId: number) => Promise<unknown> = () => Promise.resolve(),
+) => {
+  const page = await addPage("Things", "things", 1);
+  const listing = await createTestListing({ name: listingName });
+  await addPageItem(page.id, "listing", listing.id);
+  await change(listing.id);
+  return {
+    listing,
+    model: await publicNavModel(
+      sitePageItemTargets.key(sitePageItemTargets.of("page")(page.id)),
+    ),
+  };
+};
+
 describeWithEnv("public site nav", { db: true, triggers: true }, () => {
   test("lists the site's pages in their chosen order", async () => {
     await addPage("Second", "second", 2);
@@ -59,28 +77,18 @@ describeWithEnv("public site nav", { db: true, triggers: true }, () => {
   });
 
   test("resolves a page's listing item to a live link", async () => {
-    const page = await addPage("Things", "things", 1);
-    const listing = await createTestListing({ name: "Live listing" });
-    await addPageItem(page.id, "listing", listing.id);
-
-    const model = await publicNavModel(
-      sitePageItemTargets.key(sitePageItemTargets.of("page")(page.id)),
-    );
+    const { listing, model } = await navShowingListing("Live listing");
 
     expect(model.currentChildren.map((node) => node.label)).toEqual([
       "Live listing",
     ]);
     expect(model.currentChildren[0]?.href).toBe(`/ticket/${listing.slug}`);
+    expect(model.currentChildren[0]?.live).toBe(true);
   });
 
   test("keeps an inactive listing in the nav but not as a link", async () => {
-    const page = await addPage("Things", "things", 1);
-    const listing = await createTestListing({ name: "Off sale" });
-    await addPageItem(page.id, "listing", listing.id);
-    await execute("UPDATE listings SET active = 0 WHERE id = ?", [listing.id]);
-
-    const model = await publicNavModel(
-      sitePageItemTargets.key(sitePageItemTargets.of("page")(page.id)),
+    const { model } = await navShowingListing("Off sale", (listingId) =>
+      execute("UPDATE listings SET active = 0 WHERE id = ?", [listingId]),
     );
 
     expect(model.currentChildren.map((node) => node.label)).toEqual([

--- a/test/integration/server/public/nav-query-batching.test.ts
+++ b/test/integration/server/public/nav-query-batching.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { assertPublicHtml } from "#test-utils/assertions.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { recordQueries } from "#test-utils/record-queries.ts";
+import { enablePublicSite } from "#test-utils/settings.ts";
+
+/** The three small reads every public page's nav needs. */
+const NAV_READS = [
+  "SELECT id FROM news_posts LIMIT 1",
+  "FROM site_pages",
+  "FROM site_page_items",
+];
+
+const navReadsFor = (seen: readonly string[]): string[][] =>
+  NAV_READS.map((fragment) => seen.filter((sql) => sql.includes(fragment)));
+
+const recordPublicPage = async (path: string): Promise<string[]> => {
+  await enablePublicSite();
+  const seen: string[] = [];
+  const restore = recordQueries(seen);
+  try {
+    await assertPublicHtml(path);
+  } finally {
+    restore();
+  }
+  return seen;
+};
+
+describeWithEnv(
+  "server public > nav read batching",
+  { db: true, triggers: true },
+  () => {
+    test("reads news, pages, and page items once each for the home page", async () => {
+      const seen = await recordPublicPage("/");
+
+      // Each still runs exactly once — the batch replaces three round trips
+      // with one, it must not read anything twice or drop a read.
+      expect(navReadsFor(seen).map((reads) => reads.length)).toEqual([1, 1, 1]);
+    });
+
+    test("shares the batched reads with the rest of the listings page", async () => {
+      const seen = await recordPublicPage("/listings");
+
+      expect(navReadsFor(seen).map((reads) => reads.length)).toEqual([1, 1, 1]);
+    });
+  },
+);

--- a/test/shared/db/fill-together.test.ts
+++ b/test/shared/db/fill-together.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { fillTogether } from "#shared/db/fill-together.ts";
+import { hasNewsPosts, newsExistenceRead } from "#shared/db/news-posts.ts";
+import {
+  allPageItemsRead,
+  getAllPageItems,
+} from "#shared/db/site-page-items.ts";
+import {
+  computeSitePageSlugIndex,
+  sitePages,
+  sitePagesNavRead,
+} from "#shared/db/site-pages.ts";
+import { runWithRequestCache } from "#shared/request-cache.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { countDatabaseCalls } from "#test-utils/subrequest-budget.ts";
+
+const navReads = [newsExistenceRead, sitePagesNavRead, allPageItemsRead];
+
+describeWithEnv("db > fill-together", { db: true }, () => {
+  test("answers the nav's three reads in a single round trip", async () => {
+    await runWithRequestCache(async () => {
+      const calls = await countDatabaseCalls(1, () => fillTogether(navReads));
+
+      expect(calls).toBe(1);
+    });
+  });
+
+  test("leaves every read's own cache holding the answer", async () => {
+    await runWithRequestCache(async () => {
+      await fillTogether(navReads);
+
+      // Nothing reads again: the batch's answers are what these serve.
+      const calls = await countDatabaseCalls(0, async () => {
+        expect(await hasNewsPosts()).toBe(false);
+        expect(await sitePages.getAll()).toEqual([]);
+        expect(await getAllPageItems()).toEqual([]);
+      });
+
+      expect(calls).toBe(0);
+    });
+  });
+
+  test("serves the rows a later reader expects, with sealed columns opened", async () => {
+    const page = await sitePages.table.insert({
+      name: "About us",
+      slug: "about-us",
+      slugIndex: await computeSitePageSlugIndex("about-us"),
+      sortOrder: 3,
+    });
+
+    await runWithRequestCache(async () => {
+      await fillTogether(navReads);
+
+      expect(await sitePages.getAll()).toEqual([
+        { id: page.id, name: "About us", slug: "about-us", sort_order: 3 },
+      ]);
+      expect(await hasNewsPosts()).toBe(false);
+    });
+  });
+
+  test("asks nothing when there are no reads to fill", async () => {
+    const calls = await countDatabaseCalls(0, () => fillTogether([]));
+
+    expect(calls).toBe(0);
+  });
+});

--- a/test/shared/db/site-page-items.test.ts
+++ b/test/shared/db/site-page-items.test.ts
@@ -1,0 +1,190 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { executeBatch } from "#shared/db/client.ts";
+import {
+  appendImageToItem,
+  getImageById,
+  getImagesForItem,
+} from "#shared/db/images.ts";
+import {
+  addPageItem,
+  clearItemEdgesStatement,
+  deleteSitePageWithEdges,
+  getAllPageItems,
+  getItemsForPage,
+  invalidatePageItemsCache,
+  removePageItem,
+  sitePageItemOrder,
+} from "#shared/db/site-page-items.ts";
+import { getSitePageById } from "#shared/db/site-pages.ts";
+import { runWithRequestCache } from "#shared/request-cache.ts";
+import { sitePageItemTargets } from "#shared/site-pages/target.ts";
+import { makeImage } from "#test-utils/admin-images.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestSitePage } from "#test-utils/db-helpers/misc.ts";
+
+describeWithEnv("db > site-page-items", { db: true }, () => {
+  describe("page items", () => {
+    test("addPageItem appends with the next sort_order and includes page_id", async () => {
+      const p = await createTestSitePage("host");
+      await addPageItem(p.id, "listing", 100);
+      await addPageItem(p.id, "group", 200);
+      const items = await getItemsForPage(p.id);
+      expect(items).toEqual([
+        { item_id: 100, item_type: "listing", page_id: p.id, sort_order: 0 },
+        { item_id: 200, item_type: "group", page_id: p.id, sort_order: 1 },
+      ]);
+    });
+
+    test("the same item cannot be added to one page twice (unique key)", async () => {
+      const p = await createTestSitePage("dupe");
+      expect(await addPageItem(p.id, "listing", 7)).toBe(true);
+      // A repeat is reported as a conflict (false), not inserted a second time.
+      expect(await addPageItem(p.id, "listing", 7)).toBe(false);
+      expect((await getItemsForPage(p.id)).length).toBe(1);
+    });
+
+    test("a page cannot be nested under two parents (single-parent guard)", async () => {
+      const parentA = await createTestSitePage("pa");
+      const parentB = await createTestSitePage("pb");
+      const child = await createTestSitePage("child");
+      await addPageItem(parentA.id, "page", child.id);
+      expect(await addPageItem(parentB.id, "page", child.id)).toBe(false);
+      // Only the first parent's edge exists.
+      const edges = (await getAllPageItems()).filter(
+        (e) => e.item_type === "page" && e.item_id === child.id,
+      );
+      expect(edges).toEqual([
+        {
+          item_id: child.id,
+          item_type: "page",
+          page_id: parentA.id,
+          sort_order: 0,
+        },
+      ]);
+    });
+
+    test("an add is rejected when the host or child page is missing", async () => {
+      const p = await createTestSitePage("existing");
+      // Host page vanished (stale add racing a delete): no dangling edge.
+      expect(await addPageItem(9999, "listing", 1)).toBe(false);
+      // Child page vanished: the page edge would dangle, so it is rejected.
+      expect(await addPageItem(p.id, "page", 9999)).toBe(false);
+      expect(await getAllPageItems()).toEqual([]);
+    });
+
+    test("a page cannot be nested inside itself (N4 self-loop)", async () => {
+      const p = await createTestSitePage("self");
+      expect(await addPageItem(p.id, "page", p.id)).toBe(false);
+      expect(await getItemsForPage(p.id)).toEqual([]);
+    });
+
+    test("a page cannot be nested under its own descendant (N4 cycle)", async () => {
+      // A contains B; nesting A under B would close an A→B→A loop.
+      const a = await createTestSitePage("anc-a");
+      const b = await createTestSitePage("anc-b");
+      await addPageItem(a.id, "page", b.id);
+      expect(await addPageItem(b.id, "page", a.id)).toBe(false);
+      expect(await getItemsForPage(b.id)).toEqual([]);
+    });
+
+    test("removePageItem drops one edge by composite key", async () => {
+      const p = await createTestSitePage("rm");
+      await addPageItem(p.id, "listing", 1);
+      await addPageItem(p.id, "group", 1); // same numeric id, different type
+      await removePageItem(p.id, "listing", 1);
+      expect((await getItemsForPage(p.id)).map((i) => i.item_type)).toEqual([
+        "group",
+      ]);
+    });
+
+    test("sitePageItemOrder swaps by full composite key", async () => {
+      const p = await createTestSitePage("swap");
+      const q = await createTestSitePage("swap-other");
+      await addPageItem(p.id, "listing", 5);
+      await addPageItem(p.id, "group", 5);
+      await addPageItem(q.id, "listing", 5); // same type+id on ANOTHER page
+      await sitePageItemOrder.swap({
+        first: ["listing", 5],
+        scope: p.id,
+        second: ["group", 5],
+      });
+      const items = await getItemsForPage(p.id);
+      expect(items).toEqual([
+        { item_id: 5, item_type: "group", page_id: p.id, sort_order: 0 },
+        { item_id: 5, item_type: "listing", page_id: p.id, sort_order: 1 },
+      ]);
+      // page_id is part of the match: the other page's row is untouched.
+      expect((await getItemsForPage(q.id))[0]?.sort_order).toBe(0);
+    });
+
+    test("sitePageItemOrder is a no-op when an item is missing", async () => {
+      const p = await createTestSitePage("noop");
+      await addPageItem(p.id, "listing", 1);
+      await sitePageItemOrder.swap({
+        first: ["listing", 1],
+        scope: p.id,
+        second: ["group", 999],
+      });
+      expect((await getItemsForPage(p.id))[0]?.sort_order).toBe(0);
+    });
+  });
+
+  describe("cascade delete + edge cleanup", () => {
+    test("deleteSitePageWithEdges removes the row, its items, and edges naming it", async () => {
+      const parent = await createTestSitePage("parent");
+      const child = await createTestSitePage("kid");
+      await addPageItem(parent.id, "page", child.id);
+      await addPageItem(child.id, "listing", 42);
+
+      await deleteSitePageWithEdges(child.id);
+      invalidatePageItemsCache();
+
+      expect(await getSitePageById(child.id)).toBeNull();
+      const edges = await getAllPageItems();
+      // No edge references the deleted child (as parent OR as page item).
+      expect(edges.some((e) => e.page_id === child.id)).toBe(false);
+      expect(
+        edges.some((e) => e.item_type === "page" && e.item_id === child.id),
+      ).toBe(false);
+    });
+
+    test("deleteSitePageWithEdges prunes the page's image uses but keeps the images", async () => {
+      const page = await createTestSitePage("with-image");
+      const image = await makeImage("Page hero");
+      await appendImageToItem(image.id, { id: page.id, kind: "page" });
+      expect((await getImagesForItem("page", page.id)).length).toBe(1);
+
+      await deleteSitePageWithEdges(page.id);
+
+      // The link is gone, but the image itself stays in the library.
+      expect(await getImagesForItem("page", page.id)).toEqual([]);
+      expect(await getImageById(image.id)).not.toBeNull();
+    });
+
+    test("a page-item write clears the request-scoped edge cache", async () => {
+      const p = await createTestSitePage("cachebust");
+      await addPageItem(p.id, "listing", 1); // seed one edge (outside the scope)
+      await runWithRequestCache(async () => {
+        expect((await getAllPageItems()).length).toBe(1); // warm the cache
+        await removePageItem(p.id, "listing", 1); // write auto-invalidates it
+        expect(await getAllPageItems()).toEqual([]); // must re-fetch fresh
+      });
+    });
+
+    test("clearItemEdgesStatement removes every edge pointing at a listing/group", async () => {
+      const p1 = await createTestSitePage("h1");
+      const p2 = await createTestSitePage("h2");
+      await addPageItem(p1.id, "listing", 50);
+      await addPageItem(p2.id, "listing", 50);
+      await executeBatch([
+        clearItemEdgesStatement(sitePageItemTargets.of("listing")(50)),
+      ]);
+      invalidatePageItemsCache();
+      const edges = await getAllPageItems();
+      expect(
+        edges.some((e) => e.item_type === "listing" && e.item_id === 50),
+      ).toBe(false);
+    });
+  });
+});

--- a/test/shared/db/site-pages.test.ts
+++ b/test/shared/db/site-pages.test.ts
@@ -199,5 +199,4 @@ describeWithEnv("db > site-pages", { db: true }, () => {
       expect(row?.sort_order).toBe(0);
     });
   });
-
 });

--- a/test/shared/db/site-pages.test.ts
+++ b/test/shared/db/site-pages.test.ts
@@ -1,23 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { executeBatch, queryAll } from "#shared/db/client.ts";
+import { queryAll } from "#shared/db/client.ts";
 import { isGroupSlugTaken } from "#shared/db/groups.ts";
-import {
-  appendImageToItem,
-  getImageById,
-  getImagesForItem,
-} from "#shared/db/images.ts";
 import { isSlugTaken, listingNames } from "#shared/db/listings/records.ts";
-import {
-  addPageItem,
-  clearItemEdgesStatement,
-  deleteSitePageWithEdges,
-  getAllPageItems,
-  getItemsForPage,
-  invalidatePageItemsCache,
-  removePageItem,
-  sitePageItemOrder,
-} from "#shared/db/site-page-items.ts";
 import {
   computeSitePageSlugIndex,
   getSitePageById,
@@ -28,9 +13,7 @@ import {
   updateSitePage,
 } from "#shared/db/site-pages.ts";
 import { runWithRequestCache } from "#shared/request-cache.ts";
-import { sitePageItemTargets } from "#shared/site-pages/target.ts";
 import type { SitePage } from "#shared/types.ts";
-import { makeImage } from "#test-utils/admin-images.ts";
 import { expectEncryptedAtRest } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
@@ -217,167 +200,4 @@ describeWithEnv("db > site-pages", { db: true }, () => {
     });
   });
 
-  describe("page items", () => {
-    test("addPageItem appends with the next sort_order and includes page_id", async () => {
-      const p = await makePage("host");
-      await addPageItem(p.id, "listing", 100);
-      await addPageItem(p.id, "group", 200);
-      const items = await getItemsForPage(p.id);
-      expect(items).toEqual([
-        { item_id: 100, item_type: "listing", page_id: p.id, sort_order: 0 },
-        { item_id: 200, item_type: "group", page_id: p.id, sort_order: 1 },
-      ]);
-    });
-
-    test("the same item cannot be added to one page twice (unique key)", async () => {
-      const p = await makePage("dupe");
-      expect(await addPageItem(p.id, "listing", 7)).toBe(true);
-      // A repeat is reported as a conflict (false), not inserted a second time.
-      expect(await addPageItem(p.id, "listing", 7)).toBe(false);
-      expect((await getItemsForPage(p.id)).length).toBe(1);
-    });
-
-    test("a page cannot be nested under two parents (single-parent guard)", async () => {
-      const parentA = await makePage("pa");
-      const parentB = await makePage("pb");
-      const child = await makePage("child");
-      await addPageItem(parentA.id, "page", child.id);
-      expect(await addPageItem(parentB.id, "page", child.id)).toBe(false);
-      // Only the first parent's edge exists.
-      const edges = (await getAllPageItems()).filter(
-        (e) => e.item_type === "page" && e.item_id === child.id,
-      );
-      expect(edges).toEqual([
-        {
-          item_id: child.id,
-          item_type: "page",
-          page_id: parentA.id,
-          sort_order: 0,
-        },
-      ]);
-    });
-
-    test("an add is rejected when the host or child page is missing", async () => {
-      const p = await makePage("existing");
-      // Host page vanished (stale add racing a delete): no dangling edge.
-      expect(await addPageItem(9999, "listing", 1)).toBe(false);
-      // Child page vanished: the page edge would dangle, so it is rejected.
-      expect(await addPageItem(p.id, "page", 9999)).toBe(false);
-      expect(await getAllPageItems()).toEqual([]);
-    });
-
-    test("a page cannot be nested inside itself (N4 self-loop)", async () => {
-      const p = await makePage("self");
-      expect(await addPageItem(p.id, "page", p.id)).toBe(false);
-      expect(await getItemsForPage(p.id)).toEqual([]);
-    });
-
-    test("a page cannot be nested under its own descendant (N4 cycle)", async () => {
-      // A contains B; nesting A under B would close an A→B→A loop.
-      const a = await makePage("anc-a");
-      const b = await makePage("anc-b");
-      await addPageItem(a.id, "page", b.id);
-      expect(await addPageItem(b.id, "page", a.id)).toBe(false);
-      expect(await getItemsForPage(b.id)).toEqual([]);
-    });
-
-    test("removePageItem drops one edge by composite key", async () => {
-      const p = await makePage("rm");
-      await addPageItem(p.id, "listing", 1);
-      await addPageItem(p.id, "group", 1); // same numeric id, different type
-      await removePageItem(p.id, "listing", 1);
-      expect((await getItemsForPage(p.id)).map((i) => i.item_type)).toEqual([
-        "group",
-      ]);
-    });
-
-    test("sitePageItemOrder swaps by full composite key", async () => {
-      const p = await makePage("swap");
-      const q = await makePage("swap-other");
-      await addPageItem(p.id, "listing", 5);
-      await addPageItem(p.id, "group", 5);
-      await addPageItem(q.id, "listing", 5); // same type+id on ANOTHER page
-      await sitePageItemOrder.swap({
-        first: ["listing", 5],
-        scope: p.id,
-        second: ["group", 5],
-      });
-      const items = await getItemsForPage(p.id);
-      expect(items).toEqual([
-        { item_id: 5, item_type: "group", page_id: p.id, sort_order: 0 },
-        { item_id: 5, item_type: "listing", page_id: p.id, sort_order: 1 },
-      ]);
-      // page_id is part of the match: the other page's row is untouched.
-      expect((await getItemsForPage(q.id))[0]?.sort_order).toBe(0);
-    });
-
-    test("sitePageItemOrder is a no-op when an item is missing", async () => {
-      const p = await makePage("noop");
-      await addPageItem(p.id, "listing", 1);
-      await sitePageItemOrder.swap({
-        first: ["listing", 1],
-        scope: p.id,
-        second: ["group", 999],
-      });
-      expect((await getItemsForPage(p.id))[0]?.sort_order).toBe(0);
-    });
-  });
-
-  describe("cascade delete + edge cleanup", () => {
-    test("deleteSitePageWithEdges removes the row, its items, and edges naming it", async () => {
-      const parent = await makePage("parent");
-      const child = await makePage("kid");
-      await addPageItem(parent.id, "page", child.id);
-      await addPageItem(child.id, "listing", 42);
-
-      await deleteSitePageWithEdges(child.id);
-      invalidatePageItemsCache();
-
-      expect(await getSitePageById(child.id)).toBeNull();
-      const edges = await getAllPageItems();
-      // No edge references the deleted child (as parent OR as page item).
-      expect(edges.some((e) => e.page_id === child.id)).toBe(false);
-      expect(
-        edges.some((e) => e.item_type === "page" && e.item_id === child.id),
-      ).toBe(false);
-    });
-
-    test("deleteSitePageWithEdges prunes the page's image uses but keeps the images", async () => {
-      const page = await makePage("with-image");
-      const image = await makeImage("Page hero");
-      await appendImageToItem(image.id, { id: page.id, kind: "page" });
-      expect((await getImagesForItem("page", page.id)).length).toBe(1);
-
-      await deleteSitePageWithEdges(page.id);
-
-      // The link is gone, but the image itself stays in the library.
-      expect(await getImagesForItem("page", page.id)).toEqual([]);
-      expect(await getImageById(image.id)).not.toBeNull();
-    });
-
-    test("a page-item write clears the request-scoped edge cache", async () => {
-      const p = await makePage("cachebust");
-      await addPageItem(p.id, "listing", 1); // seed one edge (outside the scope)
-      await runWithRequestCache(async () => {
-        expect((await getAllPageItems()).length).toBe(1); // warm the cache
-        await removePageItem(p.id, "listing", 1); // write auto-invalidates it
-        expect(await getAllPageItems()).toEqual([]); // must re-fetch fresh
-      });
-    });
-
-    test("clearItemEdgesStatement removes every edge pointing at a listing/group", async () => {
-      const p1 = await makePage("h1");
-      const p2 = await makePage("h2");
-      await addPageItem(p1.id, "listing", 50);
-      await addPageItem(p2.id, "listing", 50);
-      await executeBatch([
-        clearItemEdgesStatement(sitePageItemTargets.of("listing")(50)),
-      ]);
-      invalidatePageItemsCache();
-      const edges = await getAllPageItems();
-      expect(
-        edges.some((e) => e.item_type === "listing" && e.item_id === 50),
-      ).toBe(false);
-    });
-  });
 });


### PR DESCRIPTION
# Read the public nav's three small tables in one go

Third of a short series of small changes that cut wasted database round trips, found by profiling real requests. This is the biggest saving of the series: it affects **every public page**, warm or cold.

## What was happening

Before a public page can draw its navigation it needs three little answers:

```
SELECT id FROM news_posts LIMIT 1
SELECT id, slug, name, sort_order FROM site_pages ORDER BY sort_order ASC, id ASC
SELECT page_id, item_type, item_id, sort_order FROM site_page_items ORDER BY ...
```

None of them depends on the others — but they were read one at a time, and the first two even ran in sequence rather than together. So a cold edge server waited three separate times before the page could start. These showed up on **every** public request measured: home, listings, order, terms, contact, ticket and news pages.

## The change

`fillTogether` asks for a set of small reads in one round trip, then hands each answer to the read that wanted it.

The important part is what it *doesn't* do: each read still owns its own request cache, and still fills it. The admin page builders and `/page/:slug` share those caches, so bypassing them would have traded two saved trips for a fresh one somewhere else in the same request. This only changes where a cache's first answer comes from.

One thing that looked like a blocker: the site-pages read couples its query to decrypting the sealed `slug` and `name` behind a single call, so it seemed un-batchable. The reader turns out to expose the statement and the row-opening separately, so the batch reads the sealed rows and the very same column readers open them — no duplicated decryption logic, no second code path.

## What it saves

Two round trips on every public page. The home page drops from 4 reads to 2 warm, and 14 to 12 cold.

## Tests

- The nav's three reads cost exactly **one** database call (asserted against the real call counter).
- After the batch, every read's own cache serves its rows with **zero** further calls — the property that keeps other callers on the page from re-reading.
- The site-pages rows come back with their sealed columns opened, exactly as the un-batched read returned them.
- No reads to fill asks nothing at all.
- Home and listings each still read news, pages, and page items exactly once — the batch must not read anything twice or drop a read.
- Re-verified across the public route, integration server, site-pages, and request-cache suites (612 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved public-site navigation loading by batching related data reads into fewer database queries.
  * Preloaded navigation data to reduce duplicate requests and improve page-rendering efficiency.
  * Preserved existing navigation results and caching behavior.

* **Bug Fixes**
  * Improved request-level cache population for news, pages, and page items.

* **Tests**
  * Added coverage verifying batched navigation queries and cache population.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->