### PR TITLE
Cover the JSON API's role gate

### DIFF
--- a/test/features/auth/authorization.test.ts
+++ b/test/features/auth/authorization.test.ts
@@ -3,6 +3,7 @@ import { it as test } from "@std/testing/bdd";
 import type { AuthSession } from "#routes/auth.ts";
 import {
   anyUserPage,
+  requireAdminApiOr,
   requireContentOr,
   requireDeliveryOr,
   requireOwnerOr,
@@ -40,6 +41,16 @@ const roleCookies = async (): Promise<Record<string, string>> => ({
   manager: await createTestManagerSession(),
   owner: await testCookie(),
 });
+
+/** Run the JSON admin API gate. Its handler answers with the admitted role, so
+ *  a refusal and an admission can never be mistaken for each other. */
+const runAdminApi = (cookie?: string): Promise<Response | null> =>
+  requireAdminApiOr(
+    new Request("http://localhost/api/admin/x", {
+      headers: cookie ? { cookie } : {},
+    }),
+    (session) => new Response(session.adminLevel),
+  );
 
 /** Run a guard and return its response. The handler only fires when the guard
  *  admits the request, and returns 200 only when handed a real session (so a
@@ -128,6 +139,28 @@ describeWithEnv("auth authorization matrix", { db: true }, () => {
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("/admin");
     }
+  });
+
+  // The JSON API has its own role gate, separate from the page guards above.
+  // Without these, swapping that gate's two outcomes — letting the refused
+  // role in and turning the admitted one away — passed every test.
+  test("the admin API admits a staff role and runs the handler", async () => {
+    const response = await runAdminApi(await createTestManagerSession());
+
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("manager");
+  });
+
+  test("the admin API refuses a delivery agent, who is not staff", async () => {
+    const response = await runAdminApi((await createTestAgentSession()).cookie);
+
+    expect(response?.status).toBe(403);
+  });
+
+  test("the admin API refuses a request with no session at all", async () => {
+    const response = await runAdminApi();
+
+    expect(response?.status).toBe(401);
   });
 
   test("withSession runs the handler with the session, or the fallback when absent", async () => {


### PR DESCRIPTION
# Cover the JSON API's role gate

Found by the mutation gate while working on an unrelated change. Tests only — no behaviour changes.

## What was untested

The admin JSON API decides who may use it here:

```ts
return sessionRoleAllowed(auth.session.adminLevel, policy.role, policy.roles)
  ? auth
  : authFailure(channel, "forbidden");
```

Swap those two outcomes — turn away everyone who should be let in, and let in everyone who should be turned away — and **not one test failed**. That is the shape of a permission hole: a delivery agent reaching staff-only API endpoints, and a manager locked out of the ones they are entitled to.

It isn't that the area is untested. The page guards have a thorough role matrix, and individual endpoints do check their own rules (a manager gets 403 from the owner-only holidays API, for instance). But the page guards use a *different* role check, and the endpoint tests live where the mutation gate never runs them for this file. So this particular branch had nothing holding it directly.

## The tests

Three, added next to the existing role matrix:

- a manager is admitted and the handler runs with their role;
- a delivery agent is refused, because an agent is not staff;
- a request with no session at all is refused as unauthenticated, so "refused" isn't quietly standing in for "never got that far".

The test handler answers with the role it was handed, so an admission and a refusal can never be mistaken for one another — which is what makes the swap detectable rather than merely covered.

## Result

`src/features/auth.ts` scores **100% under mutation (190/190), up from 99.6%** — the repo's required bar. Verified with `deno task mutation src/features/auth.ts 'test/features/auth/*.test.ts'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_