### PR TITLE
Stop the two-charge refund test depending on which send lands first

### DIFF
--- a/test/features/admin/refunds/provider/batch/budget.test.ts
+++ b/test/features/admin/refunds/provider/batch/budget.test.ts
@@ -131,7 +131,9 @@ const expectCompletedCommand = async (
       kind: "finished",
     });
   });
-  expect(source.refunds).toEqual(references);
+  // A command sends its charges together, so they can come back either way
+  // round. What matters is that each one was sent exactly once.
+  expect([...source.refunds].sort()).toEqual([...references].sort());
   expect(granted.released).toEqual([sessionIds]);
 };
 


### PR DESCRIPTION
# Stop the two-charge refund test depending on which send lands first

**This is currently breaking CI on unrelated pull requests and in the merge queue.** One line of test change; no behaviour changes.

## What is happening

A refund command sends an attendee's charges **together**, so the two provider calls can come back in either order. The test asserted one exact order:

```ts
expect(source.refunds).toEqual(references);
```

So it fails whenever the second charge happens to land first. It has already failed on a pull request that had nothing to do with refunds, and taken another out of the merge queue.

## Evidence, measured before changing anything

I ran the exact scenario twelve times and recorded both the send order and the subrequest spend:

```
spends = 8 8 8 8 8 8 8 8 8 8 8 8
orders  = ..._0,..._1   (eleven times)
          ..._1,..._0   (once)
```

Two things follow. The order really does flip — about one run in twelve, which matches how it behaves in CI. And the command spends a steady **8** subrequests against a limit of 50, so the request budget was never involved; only the ordering assumption was wrong.

That mattered to check. If the cause had been the budget, the honest fix would have been a production change — a two-charge refund running close to the edge server's limit — not a test edit. It isn't: the spend is nowhere near it.

## The fix

Compare the charges sent as a set rather than a sequence. Each charge must still be sent exactly **once**; only the order it lands in is no longer part of the claim, because the code never promised one.

The sibling route-level test in the same original change already sorted for exactly this reason — this one was simply missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved refund batch validation to confirm each provider refund reference is sent exactly once, without relying on a specific processing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->