### PR TITLE
Answer canRefund from the lines the page already loaded

### DIFF
--- a/src/features/admin/attendee-page-data.ts
+++ b/src/features/admin/attendee-page-data.ts
@@ -27,7 +27,6 @@ import {
 } from "#shared/db/attendees/atomic-update.ts";
 import { getAttendeeOrderSummary } from "#shared/db/attendees/balance.ts";
 import { checkLinesCapacity } from "#shared/db/attendees/capacity/checks.ts";
-import { hasActiveBookingLine } from "#shared/db/attendees/queries.ts";
 import {
   getContactRecordOrRepair,
   hashEmail,
@@ -76,41 +75,54 @@ export type LoadedAttendee = {
   paymentReferences: RefundPaymentReferenceSet;
 };
 
-type AttendeePaymentFacts = Pick<
-  LoadedAttendee,
-  "canRefund" | "paymentReferences"
->;
-
 /** Load one bounded, typed payment set for both display and refund admission. */
-const attendeePaymentFacts = async (
+const attendeePaymentReferences = async (
   attendee: Attendee,
-): Promise<AttendeePaymentFacts> => {
-  const paymentReferences = await getRefundPaymentReferencesForAttendee(
+): Promise<RefundPaymentReferenceSet> =>
+  getRefundPaymentReferencesForAttendee(
     { currentPaymentId: attendee.payment_id, id: attendee.id },
     await requireRequestPrivateKey(),
   );
-  const hasAutomaticPayment =
-    paymentReferences.kind === "complete" &&
-    paymentReferences.references.length > 0;
-  return {
-    canRefund:
-      hasAutomaticPayment &&
-      refundWorkRemains(attendee, paymentReferences.references) &&
-      (await hasActiveBookingLine(attendee.id, attendee.listing_id)),
-    paymentReferences,
-  };
-};
+
+/** Whether the attendee still holds a real (quantity > 0) booking on this exact
+ * listing. Read from the lines the page has already loaded: asking the database
+ * again would answer the same question the same way. A no-quantity line does
+ * not count, so a line marked no-quantity stops offering the refund. */
+const holdsRealLineOn = (
+  existing: readonly ExistingLine[],
+  listingId: number,
+): boolean =>
+  existing.some(
+    ({ booking }) => booking.listing_id === listingId && booking.quantity > 0,
+  );
+
+/** Whether the page may offer a refund: automatic payment money that still has
+ * work left, against a booking the attendee really holds. */
+const refundIsOffered = (
+  attendee: Attendee,
+  paymentReferences: RefundPaymentReferenceSet,
+  existing: readonly ExistingLine[],
+): boolean =>
+  paymentReferences.kind === "complete" &&
+  paymentReferences.references.length > 0 &&
+  refundWorkRemains(attendee, paymentReferences.references) &&
+  holdsRealLineOn(existing, attendee.listing_id);
 
 /** Load an attendee + all its lines, or null (→ 404) when it doesn't exist. */
 export const loadAttendeeForEdit: (
   attendeeId: number,
 ) => Promise<LoadedAttendee | null> = withDecryptedAttendee(
   async (attendee) => {
-    const [payment, existing] = await Promise.all([
-      attendeePaymentFacts(attendee),
+    const [paymentReferences, existing] = await Promise.all([
+      attendeePaymentReferences(attendee),
       loadExistingLines(attendee.id),
     ]);
-    return { attendee, existing, ...payment };
+    return {
+      attendee,
+      canRefund: refundIsOffered(attendee, paymentReferences, existing),
+      existing,
+      paymentReferences,
+    };
   },
 );
 

--- a/test/features/admin/attendee-page-data/refund-actions.test.ts
+++ b/test/features/admin/attendee-page-data/refund-actions.test.ts
@@ -31,6 +31,7 @@ import {
   finalizeProcessedPayment,
   taggedPaymentReference,
 } from "#test-utils/processed-payments.ts";
+import { recordQueries } from "#test-utils/record-queries.ts";
 import { adminGet, withTestSession } from "#test-utils/session.ts";
 
 const getListingPageHtml = async (listingId: number): Promise<string> => {
@@ -118,6 +119,25 @@ describeWithEnv("server (admin refund actions)", { db: true }, () => {
     await setBookingLineQuantity(ctx.attendee.id, ctx.listing.id, 0);
 
     await expectCannotRefund(ctx.attendee.id, false);
+  });
+
+  test("decides canRefund without asking about the booking again", async () => {
+    const ctx = await setupRefundTest("pi_no_second_line_read");
+    const seen: string[] = [];
+    const restore = recordQueries(seen);
+    try {
+      await withTestSession(() => loadAttendeeForEdit(ctx.attendee.id));
+    } finally {
+      restore();
+    }
+
+    // The page loads every one of the attendee's lines; asking the database
+    // whether one of them is a real booking would be asking twice.
+    expect(
+      seen.filter((sql) =>
+        sql.includes("attendee_id = ? AND listing_id = ? AND quantity > 0"),
+      ),
+    ).toEqual([]);
   });
 
   test("loads canRefund as false once every charge is returned", async () => {


### PR DESCRIPTION
# Answer canRefund from the lines the page already loaded

Fourth of a short series of small changes that cut wasted database round trips, found by profiling real requests.

## What was happening

The attendee page loads **every one of that attendee's booking lines**. Then, to decide whether to offer the Refund button, it asked the database again:

```
SELECT 1 FROM listing_attendees
 WHERE attendee_id = ? AND listing_id = ? AND quantity > 0 LIMIT 1
```

That question was already answered by the rows in hand.

## The change

The decision reads the lines the page loaded rather than asking again. Both loads still run **together**, so this drops a round trip without making anything wait longer, and deciding whether a refund can be offered is now a small pure function over facts the page already holds.

The distinction the original query existed to protect is kept exactly. It checked the *exact* attendee-and-listing row rather than an arbitrary joined sibling, and excluded no-quantity placeholder lines, so a line marked no-quantity stops offering the refund. The in-memory check does the same: it looks for a line on that listing with a real quantity.

## What it saves

One round trip on every attendee page load — the actions tab, the edit form, and every other tab, since they share this loader.

## Tests

- A new test records the statements the page load makes and asserts that existence query is **not** among them. It fails without the change (the query shows up) and passes with it.
- The existing behaviour tests are unchanged and still pass, including the one that turns the refund off for a no-quantity line — the case the exact-row check exists for.
- Re-verified across the attendee page and page-data suites (52 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refund eligibility checks using existing attendee booking information.
  * Ensured payment references and booking details load efficiently when editing attendee records.
  * Prevented unnecessary duplicate booking-line queries during refund checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->