### PR TITLE
Read the ledger's pre-write checks in one round trip

### DIFF
--- a/src/shared/accounting/rows.ts
+++ b/src/shared/accounting/rows.ts
@@ -7,23 +7,24 @@
  * here, so the column list and row mapping live in exactly one place.
  */
 
-import type { InValue } from "@libsql/client";
+import type { InValue, ResultSet } from "@libsql/client";
 import { ATTENDEE } from "#shared/accounting/accounts.ts";
 import {
   orIgnore,
-  queryAll,
+  queryBatch,
   resultRows,
   type SqlStatement,
   type TxScope,
 } from "#shared/db/client.ts";
 import { type Read, readStatement } from "#shared/db/read.ts";
-import { equals, rowsUnlessNoneMatch } from "#shared/db/where-clauses.ts";
+import { equals, matchesNoRows } from "#shared/db/where-clauses.ts";
 import { account } from "#shared/ledger/account.ts";
 import type {
   AccountRef,
   Transfer,
   TransferInput,
 } from "#shared/ledger/types.ts";
+import { requireValue } from "#shared/required-value.ts";
 import {
   epochMsToIso,
   instantToEpochMs,
@@ -197,43 +198,74 @@ export const bookingLegBatchInsert = (
   );
 
 /**
- * Reads rows either from the global client or from an open transaction. The
- * write path reads through its own transaction: the database write lock then
- * makes concurrent posters of the same event take turns, so the second one sees
- * the first one's rows and replays instead of double-posting.
+ * Answers a set of transfer queries together, in one round trip, and hands back
+ * one batch of rows per query in the order asked. Reading either from the global
+ * client or from an open transaction: the write path reads through its own
+ * transaction, so the database write lock makes concurrent posters of the same
+ * event take turns and the second one sees the first one's rows and replays
+ * instead of double-posting.
  */
 export type RowReader = (
-  sql: string,
-  args: InValue[],
-) => Promise<TransferRow[]>;
+  statements: readonly SqlStatement[],
+) => Promise<TransferRow[][]>;
 
-export const fromDb: RowReader = (sql, args) =>
-  queryAll<TransferRow>(sql, args);
+const rowsPerStatement = (results: readonly ResultSet[]): TransferRow[][] =>
+  results.map((result) => resultRows<TransferRow>(result));
+
+export const fromDb: RowReader = async (statements) =>
+  rowsPerStatement(await queryBatch([...statements]));
 
 export const fromTx =
   (tx: TxScope): RowReader =>
-  async (sql, args) =>
-    resultRows<TransferRow>(await tx.execute({ args, sql }));
+  async (statements) =>
+    rowsPerStatement(await tx.batch([...statements]));
 
 /** Which transfers to read, in what order, how many — everything but the
  * columns and the table, which a transfer read always knows. */
 export type TransferRead = Omit<Read, "columns" | "from">;
 
+const transferStatement = (query: TransferRead): SqlStatement =>
+  readStatement({ ...query, columns: COLUMNS, from: "transfers" });
+
+/** Select several sets of transfers at once, each saying which rows it wants
+ * and in what order rather than writing the query. `read` decides where the
+ * rows come from — the client, or an open transaction — and answers them all in
+ * one round trip. A query that can match no row is answered as empty without
+ * being asked, so wanting none of something still costs nothing. */
+export const selectTransfersMany = async (
+  read: RowReader,
+  queries: readonly TransferRead[],
+): Promise<Transfer[][]> => {
+  const asked = queries
+    .map((query, index) => ({ index, query }))
+    .filter(({ query }) => !matchesNoRows(query.where ?? []));
+  if (asked.length === 0) return queries.map(() => []);
+  const answers = await read(
+    asked.map(({ query }) => transferStatement(query)),
+  );
+  const rowsByQuery = new Map(
+    asked.map(({ index }, position) => [
+      index,
+      requireValue(
+        answers[position],
+        `Ledger read ${index} went unanswered`,
+      ).map(rowToTransfer),
+    ]),
+  );
+  // A query left out of the bundle was one nothing could match.
+  return queries.map((_, index) => rowsByQuery.get(index) ?? []);
+};
+
 /** Select transfers, saying which rows and in what order rather than writing
- * the query. `read` decides where the rows come from — the client, or an open
- * transaction. Pass nothing to read the whole table. */
-export const selectTransfers = (
+ * the query. Pass nothing to read the whole table. */
+export const selectTransfers = async (
   read: RowReader,
   query: TransferRead = {},
 ): Promise<Transfer[]> =>
-  rowsUnlessNoneMatch(query.where ?? [], async () => {
-    const { sql, args } = readStatement({
-      ...query,
-      columns: COLUMNS,
-      from: "transfers",
-    });
-    return (await read(sql, args)).map(rowToTransfer);
-  });
+  requireValue(
+    (await selectTransfersMany(read, [query]))[0],
+    "The ledger read went unanswered",
+  );
 
 /** Every leg of one business event (booking, refund, …). */
 export const selectByEventGroup = (

--- a/src/shared/accounting/rows.ts
+++ b/src/shared/accounting/rows.ts
@@ -227,22 +227,30 @@ export type TransferRead = Omit<Read, "columns" | "from">;
 const transferStatement = (query: TransferRead): SqlStatement =>
   readStatement({ ...query, columns: COLUMNS, from: "transfers" });
 
+/** One set of rows for each query, in the order the queries were given, so a
+ *  caller can name them by destructuring rather than counting positions. */
+type TransfersPerQuery<Queries extends readonly TransferRead[]> = {
+  [Index in keyof Queries]: Transfer[];
+};
+
 /** Select several sets of transfers at once, each saying which rows it wants
  * and in what order rather than writing the query. `read` decides where the
  * rows come from — the client, or an open transaction — and answers them all in
  * one round trip. A query that can match no row is answered as empty without
  * being asked, so wanting none of something still costs nothing. */
-export const selectTransfersMany = async (
+export const selectTransfersMany = async <
+  const Queries extends readonly TransferRead[],
+>(
   read: RowReader,
-  queries: readonly TransferRead[],
-): Promise<Transfer[][]> => {
+  queries: Queries,
+): Promise<TransfersPerQuery<Queries>> => {
   const asked = queries
     .map((query, index) => ({ index, query }))
     .filter(({ query }) => !matchesNoRows(query.where ?? []));
-  if (asked.length === 0) return queries.map(() => []);
-  const answers = await read(
-    asked.map(({ query }) => transferStatement(query)),
-  );
+  const answers =
+    asked.length === 0
+      ? []
+      : await read(asked.map(({ query }) => transferStatement(query)));
   const rowsByQuery = new Map(
     asked.map(({ index }, position) => [
       index,
@@ -252,8 +260,11 @@ export const selectTransfersMany = async (
       ).map(rowToTransfer),
     ]),
   );
-  // A query left out of the bundle was one nothing could match.
-  return queries.map((_, index) => rowsByQuery.get(index) ?? []);
+  // Built by mapping the queries, so it is one set per query by construction —
+  // and a query left out of the bundle was one nothing could match.
+  return queries.map(
+    (_, index) => rowsByQuery.get(index) ?? [],
+  ) as TransfersPerQuery<Queries>;
 };
 
 /** Select transfers, saying which rows and in what order rather than writing
@@ -261,11 +272,10 @@ export const selectTransfersMany = async (
 export const selectTransfers = async (
   read: RowReader,
   query: TransferRead = {},
-): Promise<Transfer[]> =>
-  requireValue(
-    (await selectTransfersMany(read, [query]))[0],
-    "The ledger read went unanswered",
-  );
+): Promise<Transfer[]> => {
+  const [rows] = await selectTransfersMany(read, [query]);
+  return rows;
+};
 
 /** Every leg of one business event (booking, refund, …). */
 export const selectByEventGroup = (

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -29,7 +29,8 @@ import {
   fromTx,
   insertStatement,
   type RowReader,
-  selectTransfers,
+  selectTransfersMany,
+  type TransferRead,
 } from "#shared/accounting/rows.ts";
 import {
   executeBatch,
@@ -159,20 +160,41 @@ type BatchSnapshot = {
   readonly originalsById: ReadonlyMap<number, Transfer>;
 };
 
-/** Read every transfer whose `column` is one of `values`; an empty set is
- *  answered without touching the database. `column` is a trusted constant. */
-const selectByColumnIn = (
-  read: RowReader,
+/** Wants every transfer whose `column` is one of `values`; an empty set asks for
+ *  nothing, and is answered without touching the database. `column` is a
+ *  trusted constant. */
+const byColumnIn = (
   column: string,
   values: readonly InValue[],
-): Promise<Transfer[]> =>
-  selectTransfers(read, { where: inList(column, values) });
+): TransferRead => ({
+  where: inList(column, values),
+});
+
+/** The three checks a snapshot is built from, named the moment they come back,
+ *  so no later code has to know which position meant what. */
+type SnapshotReads = {
+  readonly existing: Transfer[];
+  readonly originals: Transfer[];
+  readonly stored: Transfer[];
+};
+
+const namedSnapshotReads = (rows: readonly Transfer[][]): SnapshotReads => {
+  const [existing, stored, originals] = rows;
+  if (
+    existing === undefined ||
+    stored === undefined ||
+    originals === undefined
+  ) {
+    throw new Error(`Ledger snapshot answered ${rows.length} of 3 reads`);
+  }
+  return { existing, originals, stored };
+};
 
 /** Load everything {@link planGroup} needs to validate the batch, in three bulk
- *  selects — independent of the number of groups. `read` picks where the
- *  snapshot comes from: the global client for the batch path, or an open
- *  transaction for {@link postTransfersTx} (whose write lock makes the read
- *  authoritative). */
+ *  selects that travel as one round trip — independent of the number of groups.
+ *  `read` picks where the snapshot comes from: the global client for the batch
+ *  path, or an open transaction for {@link postTransfersTx} (whose write lock
+ *  makes the read authoritative). */
 const loadBatchSnapshot = async (
   groups: TransferInput[][],
   read: RowReader,
@@ -182,11 +204,13 @@ const loadBatchSnapshot = async (
   const reversesIds = unique(
     mapNotNullish((t: TransferInput) => t.reversesId)(groups.flat()),
   );
-  const [existing, stored, originals] = await Promise.all([
-    selectByColumnIn(read, "event_group", eventGroups),
-    selectByColumnIn(read, "reference", references),
-    selectByColumnIn(read, "id", reversesIds),
-  ]);
+  const { existing, stored, originals } = namedSnapshotReads(
+    await selectTransfersMany(read, [
+      byColumnIn("event_group", eventGroups),
+      byColumnIn("reference", references),
+      byColumnIn("id", reversesIds),
+    ]),
+  );
   return {
     existingByGroup: Map.groupBy(existing, (leg) => leg.eventGroup),
     originalsById: mapById(identity<Transfer>)(originals),

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -170,26 +170,6 @@ const byColumnIn = (
   where: inList(column, values),
 });
 
-/** The three checks a snapshot is built from, named the moment they come back,
- *  so no later code has to know which position meant what. */
-type SnapshotReads = {
-  readonly existing: Transfer[];
-  readonly originals: Transfer[];
-  readonly stored: Transfer[];
-};
-
-const namedSnapshotReads = (rows: readonly Transfer[][]): SnapshotReads => {
-  const [existing, stored, originals] = rows;
-  if (
-    existing === undefined ||
-    stored === undefined ||
-    originals === undefined
-  ) {
-    throw new Error(`Ledger snapshot answered ${rows.length} of 3 reads`);
-  }
-  return { existing, originals, stored };
-};
-
 /** Load everything {@link planGroup} needs to validate the batch, in three bulk
  *  selects that travel as one round trip — independent of the number of groups.
  *  `read` picks where the snapshot comes from: the global client for the batch
@@ -204,13 +184,11 @@ const loadBatchSnapshot = async (
   const reversesIds = unique(
     mapNotNullish((t: TransferInput) => t.reversesId)(groups.flat()),
   );
-  const { existing, stored, originals } = namedSnapshotReads(
-    await selectTransfersMany(read, [
-      byColumnIn("event_group", eventGroups),
-      byColumnIn("reference", references),
-      byColumnIn("id", reversesIds),
-    ]),
-  );
+  const [existing, stored, originals] = await selectTransfersMany(read, [
+    byColumnIn("event_group", eventGroups),
+    byColumnIn("reference", references),
+    byColumnIn("id", reversesIds),
+  ]);
   return {
     existingByGroup: Map.groupBy(existing, (leg) => leg.eventGroup),
     originalsById: mapById(identity<Transfer>)(originals),

--- a/src/shared/db/where-clauses.ts
+++ b/src/shared/db/where-clauses.ts
@@ -76,8 +76,9 @@ export const inSubquery: SubqueryFilter = bySubquery("IN");
 export const notInSubquery: SubqueryFilter = bySubquery("NOT IN");
 
 /** Whether these clauses can never match a row — the ordinary cause being a
- * filter asking for none of something. */
-const matchesNoRows = (parts: readonly WhereClause[]): boolean =>
+ * filter asking for none of something. A reader that bundles several queries
+ * asks this directly, to leave the already-answered ones out of the bundle. */
+export const matchesNoRows = (parts: readonly WhereClause[]): boolean =>
   parts.some((part) => part.matchesNothing);
 
 /** Run a read unless its clauses can match no row — asking for none of

--- a/src/shared/refund-ledger/record.ts
+++ b/src/shared/refund-ledger/record.ts
@@ -18,9 +18,8 @@ import {
   refundLedgerResult,
 } from "./result.ts";
 
-/** Account read + event-group read + reference read + write. Refund legs never
- * carry reversal ids, so the generic reversal-id query is skipped. */
-export const REFUND_LEDGER_BATCH_DATABASE_CALLS = 4;
+/** Account read + the post's own checks, which travel as one read + write. */
+export const REFUND_LEDGER_BATCH_DATABASE_CALLS = 3;
 
 const postComputedRefund = async (
   attendeeId: number,

--- a/test/features/admin/refunds/budget.test.ts
+++ b/test/features/admin/refunds/budget.test.ts
@@ -91,9 +91,9 @@ describe("admin refund subrequest budget", () => {
       total: 8,
     });
     expect(REFUND_LEDGER_SUBREQUEST_RESERVE).toEqual({
-      database: 4,
+      database: 3,
       external: 0,
-      total: 4,
+      total: 3,
     });
   });
 
@@ -112,9 +112,9 @@ describe("admin refund subrequest budget", () => {
           }),
       ),
     ).toEqual([
-      { database: 18, external: 3, total: 21 },
-      { database: 14, external: 1, total: 15 },
-      { database: 12, external: 1, total: 13 },
+      { database: 17, external: 3, total: 20 },
+      { database: 13, external: 1, total: 14 },
+      { database: 11, external: 1, total: 12 },
     ]);
     const prepared = {
       activeAuthorityCount: 1,
@@ -125,9 +125,9 @@ describe("admin refund subrequest budget", () => {
       ],
     };
     expect(refundPreparedSubrequestCost(prepared)).toEqual({
-      database: 12,
+      database: 11,
       external: 2,
-      total: 14,
+      total: 13,
     });
   });
 
@@ -144,7 +144,7 @@ describe("admin refund subrequest budget", () => {
         checkpoint: "before_claim",
         returned: new Set(),
       }),
-    ).toEqual({ database: 23, external: 6, total: 29 });
+    ).toEqual({ database: 22, external: 6, total: 28 });
   });
 
   test("reserves canonical lookup and ledger work for returned money", () => {
@@ -155,7 +155,7 @@ describe("admin refund subrequest budget", () => {
         returnedAuthorityCount: 1,
         sendReferences: [],
       }),
-    ).toEqual({ database: 8, external: 0, total: 8 });
+    ).toEqual({ database: 7, external: 0, total: 7 });
     expect(
       refundPreparedSubrequestCost({
         activeAuthorityCount: 0,
@@ -163,7 +163,7 @@ describe("admin refund subrequest budget", () => {
         returnedAuthorityCount: 2,
         sendReferences: [],
       }),
-    ).toEqual({ database: 9, external: 0, total: 9 });
+    ).toEqual({ database: 8, external: 0, total: 8 });
   });
 
   test("reserves completed-only refresh persistence with no provider reads", () => {
@@ -178,7 +178,7 @@ describe("admin refund subrequest budget", () => {
         checkpoint: "before_claim",
         returned: new Set(),
       }),
-    ).toEqual({ database: 14, external: 0, total: 14 });
+    ).toEqual({ database: 13, external: 0, total: 13 });
     expect(
       refundReadinessSubrequestCost({
         action: "refresh",
@@ -193,7 +193,7 @@ describe("admin refund subrequest budget", () => {
         checkpoint: "before_claim",
         returned: new Set(),
       }),
-    ).toEqual({ database: 15, external: 0, total: 15 });
+    ).toEqual({ database: 14, external: 0, total: 14 });
   });
 
   test("does not reserve returned-money recording twice before a refresh read", () => {
@@ -204,7 +204,7 @@ describe("admin refund subrequest budget", () => {
         checkpoint: "before_provider_read",
         returned: new Set(),
       }),
-    ).toEqual({ database: 11, external: 1, total: 12 });
+    ).toEqual({ database: 10, external: 1, total: 11 });
   });
 
   test("prices no late work when preparation can neither send nor return money", () => {
@@ -226,7 +226,7 @@ describe("admin refund subrequest budget", () => {
         returnedAuthorityCount: 0,
         sendReferences: [{ index: "index_live", provider: "stripe" }],
       }),
-    ).toEqual({ database: 12, external: 2, total: 14 });
+    ).toEqual({ database: 11, external: 2, total: 13 });
   });
 
   test("multiplies logical provider work by every physical attempt", () => {

--- a/test/shared/accounting/rows.test.ts
+++ b/test/shared/accounting/rows.test.ts
@@ -3,10 +3,19 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   bookingLegBatchInsert,
   fromDb,
+  fromTx,
   insertStatement,
+  type RowReader,
   selectTransfers,
+  selectTransfersMany,
 } from "#shared/accounting/rows.ts";
-import { executeBatch } from "#shared/db/client.ts";
+import {
+  executeBatch,
+  type SqlStatement,
+  type TxScope,
+  withTransaction,
+} from "#shared/db/client.ts";
+import { inList } from "#shared/db/where-clauses.ts";
 import { account } from "#shared/ledger/account.ts";
 import type { TransferInput } from "#shared/ledger/types.ts";
 import { useTransactionalDb } from "#test-utils/ledger.ts";
@@ -82,6 +91,108 @@ describe("accounting > rows > bookingLegBatchInsert", () => {
     expect(built.args.at(-1)).toBe("g"); // guard args come last
     expect(built.sql).toMatch(/^INSERT OR IGNORE INTO transfers /);
     expect(built.sql).toContain("WHERE ? = 'g'");
+  });
+});
+
+/** A reader that answers nothing but remembers what it was handed. */
+const recordingReader = (): {
+  asked: SqlStatement[][];
+  reader: RowReader;
+} => {
+  const asked: SqlStatement[][] = [];
+  const reader: RowReader = (statements) => {
+    asked.push([...statements]);
+    return Promise.resolve(statements.map(() => []));
+  };
+  return { asked, reader };
+};
+
+describe("accounting > rows > selectTransfersMany", () => {
+  useTransactionalDb();
+  const recordedAt = "2026-06-21T12:00:00.000Z";
+
+  const leg = (reference: string, eventGroup: string): TransferInput => ({
+    amount: 5000,
+    destination: account("revenue", 7),
+    eventGroup,
+    occurredAt: "2026-06-21T00:00:00.000Z",
+    reference,
+    source: account("attendee", 3),
+  });
+
+  const storeTwoLegs = (): Promise<void> =>
+    executeBatch([
+      insertStatement(leg("ref-a", "evt-a"), recordedAt),
+      insertStatement(leg("ref-b", "evt-b"), recordedAt),
+    ]);
+
+  test("gives each set of rows back to the query that asked for it", async () => {
+    await storeTwoLegs();
+
+    const [byGroup, byReference] = await selectTransfersMany(fromDb, [
+      { where: inList("event_group", ["evt-b"]) },
+      { where: inList("reference", ["ref-a"]) },
+    ]);
+
+    // Swapped answers would read as a stored collision that is not there.
+    expect(byGroup?.map((row) => row.reference)).toEqual(["ref-b"]);
+    expect(byReference?.map((row) => row.reference)).toEqual(["ref-a"]);
+  });
+
+  test("answers a query nothing can match without asking for it", async () => {
+    const { asked, reader } = recordingReader();
+
+    const [none, some] = await selectTransfersMany(reader, [
+      { where: inList("id", []) },
+      { where: inList("reference", ["ref-a"]) },
+    ]);
+
+    expect(none).toEqual([]);
+    expect(some).toEqual([]);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]?.map((statement) => statement.args)).toEqual([["ref-a"]]);
+  });
+
+  test("asks for nothing at all when no query can match", async () => {
+    const { asked, reader } = recordingReader();
+
+    const rows = await selectTransfersMany(reader, [
+      { where: inList("id", []) },
+      { where: inList("reference", []) },
+    ]);
+
+    expect(rows).toEqual([[], []]);
+    expect(asked).toEqual([]);
+  });
+
+  test("asks an open transaction once, not once per query", async () => {
+    await storeTwoLegs();
+    let batches = 0;
+    let singles = 0;
+
+    const rows = await withTransaction((scope) => {
+      const counted: TxScope = {
+        batch: (statements) => {
+          batches += 1;
+          return scope.batch(statements);
+        },
+        execute: (statement) => {
+          singles += 1;
+          return scope.execute(statement);
+        },
+      };
+      return selectTransfersMany(fromTx(counted), [
+        { where: inList("event_group", ["evt-a"]) },
+        { where: inList("reference", ["ref-b"]) },
+      ]);
+    });
+
+    expect(batches).toBe(1);
+    expect(singles).toBe(0);
+    expect(rows.map((set) => set.map((row) => row.reference))).toEqual([
+      ["ref-a"],
+      ["ref-b"],
+    ]);
   });
 });
 

--- a/test/shared/accounting/store/batching.test.ts
+++ b/test/shared/accounting/store/batching.test.ts
@@ -1,0 +1,86 @@
+/** The checks a post runs before writing are read in one go, not one by one. */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { transfersByEventGroup } from "#shared/accounting/queries.ts";
+import { postTransferGroups, postTransfers } from "#shared/accounting/store.ts";
+import { account } from "#shared/ledger/account.ts";
+import type { TransferInput } from "#shared/ledger/types.ts";
+import { saleAndPayment, tx, useTransactionalDb } from "#test-utils/ledger.ts";
+import { recordQueries } from "#test-utils/record-queries.ts";
+
+/** Every recorded statement that reads the ledger. `recordQueries` writes a
+ *  whole batch as one entry, so this counts round trips, not statements. */
+const ledgerReads = (seen: readonly string[]): string[] =>
+  seen.filter((sql) => sql.includes("FROM transfers"));
+
+/** The ledger round trips one piece of work takes. */
+const readsDuring = async (work: () => Promise<unknown>): Promise<string[]> => {
+  const seen: string[] = [];
+  const restore = recordQueries(seen);
+  try {
+    await work();
+  } finally {
+    restore();
+  }
+  return ledgerReads(seen);
+};
+
+/** A leg voiding `originalId`, which makes the post check the original too. */
+const reversalOf = (originalId: number): TransferInput[] => [
+  tx({
+    destination: account("attendee", 1),
+    eventGroup: "evt-void",
+    reference: "void",
+    reversesId: originalId,
+    source: account("revenue", 1),
+  }),
+];
+
+/** Store one sale on its own and hand back the id a reversal can point at. */
+const storedSaleId = async (): Promise<number> => {
+  await postTransfers([tx({ eventGroup: "evt-1", reference: "sale" })]);
+  const [sale] = await transfersByEventGroup("evt-1");
+  if (sale === undefined) throw new Error("The stored sale was not read back");
+  return sale.id;
+};
+
+describe("db > accounting > store > snapshot batching", () => {
+  useTransactionalDb();
+
+  test("checks a fresh event against the ledger in one round trip", async () => {
+    const reads = await readsDuring(() =>
+      postTransferGroups([saleAndPayment()]),
+    );
+
+    expect(reads).toHaveLength(1);
+  });
+
+  test("still takes one round trip when a reversal adds a third check", async () => {
+    const originalId = await storedSaleId();
+
+    const reads = await readsDuring(() =>
+      postTransferGroups([reversalOf(originalId)]),
+    );
+
+    expect(reads).toHaveLength(1);
+  });
+
+  test("asks all three checks within the one round trip it takes", async () => {
+    const originalId = await storedSaleId();
+
+    const [snapshot] = await readsDuring(() =>
+      postTransferGroups([reversalOf(originalId)]),
+    );
+
+    expect(snapshot).toContain("event_group IN");
+    expect(snapshot).toContain("reference IN");
+    expect(snapshot).toContain("id IN");
+  });
+
+  test("skips the round trip entirely when there is nothing to check", async () => {
+    const reads = await readsDuring(() => postTransferGroups([[], []]));
+
+    expect(reads).toEqual([]);
+  });
+});

--- a/test/shared/refund-ledger/helpers.ts
+++ b/test/shared/refund-ledger/helpers.ts
@@ -1,3 +1,4 @@
+import type { InStatement } from "@libsql/client";
 import { expect } from "@std/expect";
 import {
   attendeeAccount,
@@ -9,10 +10,13 @@ import {
   transfersByAccount,
 } from "#shared/accounting/queries.ts";
 import { postTransfers } from "#shared/accounting/store.ts";
+import { getDb, setDb } from "#shared/db/client.ts";
 import type { RefundPaymentReference } from "#shared/db/payment-references.ts";
 import type { Transfer } from "#shared/ledger/types.ts";
+import { proxyMembers } from "#shared/proxy-members.ts";
 import { recordAttendeeRefund } from "#shared/refund-ledger/record.ts";
 import { refundReference } from "#test-utils/payment-state.ts";
+import { statementSql } from "#test-utils/record-queries.ts";
 import { refundLedgerResult } from "#test-utils/refund-ledger.ts";
 
 export const ATTENDEE = 3;
@@ -85,6 +89,36 @@ export const refundCashAmounts = async (
     .filter((leg) => leg.kind === "refund_cash")
     .map((leg) => leg.amount)
     .sort((a, b) => a - b);
+
+export const readsTransfers = (sql: string): boolean =>
+  sql.includes("FROM transfers");
+
+/** Matches the plain and the `OR IGNORE` insert alike. */
+export const writesTransfers = (sql: string): boolean =>
+  sql.includes("INTO transfers");
+
+/** Run `work` with one kind of ledger statement broken. Reading and writing both
+ *  travel as batches, so which one breaks is decided by the statement itself. */
+export const withBrokenLedger = async <T>(
+  broken: (sql: string) => boolean,
+  message: string,
+  work: () => Promise<T>,
+): Promise<T> => {
+  const real = getDb();
+  setDb(
+    proxyMembers(real, {
+      batch: (statements: InStatement[], mode?: "write" | "read") =>
+        statements.map(statementSql).some(broken)
+          ? Promise.reject(new Error(message))
+          : real.batch(statements, mode),
+    }),
+  );
+  try {
+    return await work();
+  } finally {
+    setDb(real);
+  }
+};
 
 export const expectRecordedRefundClearsAttendeeAndRevenue = async (
   attendeeId = ATTENDEE,

--- a/test/shared/refund-ledger/record/batch.test.ts
+++ b/test/shared/refund-ledger/record/batch.test.ts
@@ -13,9 +13,7 @@ import {
 import { legReference } from "#shared/accounting/refs.ts";
 import { postTransfers } from "#shared/accounting/store.ts";
 import { balanceEventGroup } from "#shared/db/attendees/balance.ts";
-import { getDb, setDb } from "#shared/db/client.ts";
 import { runWithQueryLogContext } from "#shared/db/query-log.ts";
-import { proxyMembers } from "#shared/proxy-members.ts";
 import {
   REFUND_LEDGER_BATCH_DATABASE_CALLS,
   recordAttendeeRefund,
@@ -24,11 +22,14 @@ import {
 import {
   BOOKING_AT,
   postBooking,
+  readsTransfers,
   refundCashAmounts,
   refundLegsOf,
   refundTarget,
   returnedReference,
   sessionReference,
+  withBrokenLedger,
+  writesTransfers,
 } from "#test/shared/refund-ledger/helpers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
@@ -268,19 +269,12 @@ describeWithEnv(
 
     test("keeps every returned reference unrecorded when the shared read fails", async () => {
       const target = refundTarget(21, "sess-21");
-      const real = getDb();
-      setDb(
-        proxyMembers(real, {
-          execute: () => Promise.reject(new Error("ledger read failed")),
-        }),
-      );
-      try {
-        expect(await recordAttendeeRefundsBatch([target])).toEqual(
-          new Map([[21, refundLedgerResult([], target.references)]]),
-        );
-      } finally {
-        setDb(real);
-      }
+
+      expect(
+        await withBrokenLedger(readsTransfers, "ledger read failed", () =>
+          recordAttendeeRefundsBatch([target]),
+        ),
+      ).toEqual(new Map([[21, refundLedgerResult([], target.references)]]));
       expect(errors.lastMessage()).toContain(
         "Bulk refund ledger preparation failed for 1 attendee records",
       );
@@ -290,19 +284,12 @@ describeWithEnv(
     test("keeps every returned reference unrecorded when the shared write fails", async () => {
       await postBooking({ attendeeId: 22, eventId: "sess-22" });
       const target = refundTarget(22, "sess-22");
-      const real = getDb();
-      setDb(
-        proxyMembers(real, {
-          batch: () => Promise.reject(new Error("ledger write failed")),
-        }),
-      );
-      try {
-        expect(await recordAttendeeRefundsBatch([target])).toEqual(
-          new Map([[22, refundLedgerResult([], target.references)]]),
-        );
-      } finally {
-        setDb(real);
-      }
+
+      expect(
+        await withBrokenLedger(writesTransfers, "ledger write failed", () =>
+          recordAttendeeRefundsBatch([target]),
+        ),
+      ).toEqual(new Map([[22, refundLedgerResult([], target.references)]]));
       expect(errors.lastMessage()).toContain(
         "Bulk refund ledger post failed for 1 attendee records",
       );

--- a/test/shared/refund-ledger/record/single.test.ts
+++ b/test/shared/refund-ledger/record/single.test.ts
@@ -1,13 +1,13 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
-import { getDb, setDb } from "#shared/db/client.ts";
-import { proxyMembers } from "#shared/proxy-members.ts";
 import { recordAttendeeRefund } from "#shared/refund-ledger/record.ts";
 import {
   ATTENDEE,
   expectSingleRefundCash,
   postBooking,
+  readsTransfers,
   sessionReference,
+  withBrokenLedger,
 } from "#test/shared/refund-ledger/helpers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
@@ -30,19 +30,12 @@ describeWithEnv("refund ledger > record one attendee", { db: true }, () => {
 
   test("keeps every returned reference unrecorded when the ledger read fails", async () => {
     const reference = sessionReference("sess-read-failed");
-    const real = getDb();
-    setDb(
-      proxyMembers(real, {
-        execute: () => Promise.reject(new Error("ledger read failed")),
-      }),
-    );
-    try {
-      expect(await recordAttendeeRefund(ATTENDEE, [reference])).toEqual(
-        refundLedgerResult([], [reference]),
-      );
-    } finally {
-      setDb(real);
-    }
+
+    expect(
+      await withBrokenLedger(readsTransfers, "ledger read failed", () =>
+        recordAttendeeRefund(ATTENDEE, [reference]),
+      ),
+    ).toEqual(refundLedgerResult([], [reference]));
     expect(errors.lastMessage()).toContain("Refund ledger preparation failed");
     expect(errors.lastMessage()).toContain("attendee=3");
     expect(errors.lastMessage()).not.toContain("ledger read failed");


### PR DESCRIPTION
> Last of a short series of small changes that cut wasted database round trips, found by profiling real requests.

## What was happening

Every time money is written to the ledger — a booking, a payment, a refund — the system first checks three things:

1. the legs already stored for this event, so a repeat is a replay and not a double-post
2. anything already using the references it is about to write, so two events cannot claim the same one
3. the original a reversing leg points at, so a void cannot refer to nothing

Those went out as **three separate queries**. They were started at the same moment, so they were not slow, but on Bunny's edge servers each query is a separate request to the database — and one page load only gets fifty of those in total. Three were being spent where one would do.

## The change

The checks are now handed to the database **together** and answered in one trip.

The part that decides *where* the rows come from learned to take a whole set of questions at once rather than one. For an ordinary write that means the database client. For a write that is composed into a bigger one — a booking that must land with its money in a single all-or-nothing step — it means that open piece of work, so two people saving the same thing at the same moment still take turns and the second one sees the first one's rows.

A check that cannot possibly match anything is still answered as empty without being asked, so wanting none of something continues to cost nothing.

## What it saves

**A refund's ledger work drops from four database requests to three** — a quarter of the per-payment cost that the refund page budgets for, which is the same budget that produced the "too many payments to refund in one go" message this series started with.

Every other write to the ledger saves a request too, since they all share this one path.

## Tests

- New tests record what the database is actually asked and prove the whole check is **one** trip, including when a reversal makes it three questions instead of two. They fail before this change (three entries) and pass after it (one).
- New tests for the reader itself: each set of rows comes back to the question that asked for it, an unanswerable question is skipped, a set of only unanswerable questions asks nothing at all, and an open piece of work is asked once rather than once per question.
- Two existing tests told a broken read from a broken write by *which* method the database client was called with. Now that both travel the same way, they tell them apart by the statement instead — which is what they were really about. Both still fail for their own reason and pass for it.
- The number the refund page budgets for is measured by an existing test, so the drop from four to three is checked against the real count rather than asserted by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69)_