### PR TITLE
Close the ledger's mutation gaps, and stop the timeout hiding them

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -38,8 +38,13 @@ src/shared/ledger/reconcile.ts::reconcileLegs.got~15zy9vn  ?? → ||   # observe
 src/shared/ledger/reverse.ts::reverseOf.memo~0ibvp6e  ?? → ||   # reverseOf memo: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/mappers.ts::refundKind~1mw4vn3  ?? → ||   # REFUND_KIND[kind]: every value is non-empty and a miss is undefined — never "", so ?? and || coincide
 src/shared/accounting/mappers.ts::mapRefund.kind~0rfpt43  ?? → ||   # refundKind(leg.kind ?? ""): string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
+src/shared/accounting/store.ts::planGroup.existing~1qc9xlq  ?? → ||   # planGroup existingByGroup.get(): Transfer[]|undefined — an array is always truthy
+src/shared/accounting/rows.ts::legColumns~1u7xtcf  ?? → ||   # insertStatement kind: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
+src/shared/accounting/rows.ts::legColumns~12222gj  ?? → ||   # insertStatement memo: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
+src/shared/accounting/rows.ts::renderInsert.args~06yrdj4  ?? → ||   # renderInsert guard?.args: InValue[]|undefined — an array is always truthy
 src/shared/accounting/rows.ts::selectById~1v2xab7  ?? → ||   # selectById (await …)[0]: Transfer|undefined — a Transfer object is always truthy
 src/shared/accounting/rows.ts::selectTransfersMany~0htorzu  ?? → ||   # rowsByQuery.get(index): Transfer[]|undefined — an array is always truthy
+src/shared/accounting/rows.ts::selectTransfersMany.asked~16v286s  ?? → ||   # query.where: WhereClause[]|undefined — an array is always truthy
 src/shared/accounting/manual-entries.ts::assertManualLedgerTransfer.kind~1kt86ag  ?? → ||   # guard error message `transfer.kind ?? ""`: string|undefined, "" ?? "" === "" || ""
 src/shared/checkout-ledger.ts::bookingFactsFromOrder.bookingFee~0t6vqf5  ?? → ||   # find(...)?.amount: number|undefined; the only falsy-non-null amount is 0 and 0 ?? 0 === 0 || 0
 src/features/settings-bundles.ts::settingsForPath~1at4rp9  ?? → ||   # bundle is a readonly string[] or undefined; every present array, including [], is truthy

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -38,7 +38,6 @@ src/shared/ledger/reconcile.ts::reconcileLegs.got~15zy9vn  ?? → ||   # observe
 src/shared/ledger/reverse.ts::reverseOf.memo~0ibvp6e  ?? → ||   # reverseOf memo: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/mappers.ts::refundKind~1mw4vn3  ?? → ||   # REFUND_KIND[kind]: every value is non-empty and a miss is undefined — never "", so ?? and || coincide
 src/shared/accounting/mappers.ts::mapRefund.kind~0rfpt43  ?? → ||   # refundKind(leg.kind ?? ""): string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
-src/shared/accounting/store.ts::planGroup.existing~1qc9xlq  ?? → ||   # planGroup existingByGroup.get(): Transfer[]|undefined — an array is always truthy
 src/shared/accounting/rows.ts::selectById~1v2xab7  ?? → ||   # selectById (await …)[0]: Transfer|undefined — a Transfer object is always truthy
 src/shared/accounting/rows.ts::selectTransfersMany~0htorzu  ?? → ||   # rowsByQuery.get(index): Transfer[]|undefined — an array is always truthy
 src/shared/accounting/manual-entries.ts::assertManualLedgerTransfer.kind~1kt86ag  ?? → ||   # guard error message `transfer.kind ?? ""`: string|undefined, "" ?? "" === "" || ""

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -39,6 +39,9 @@ src/shared/ledger/reverse.ts::reverseOf.memo~0ibvp6e  ?? → ||   # reverseOf me
 src/shared/accounting/mappers.ts::refundKind~1mw4vn3  ?? → ||   # REFUND_KIND[kind]: every value is non-empty and a miss is undefined — never "", so ?? and || coincide
 src/shared/accounting/mappers.ts::mapRefund.kind~0rfpt43  ?? → ||   # refundKind(leg.kind ?? ""): string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/store.ts::planGroup.existing~1qc9xlq  ?? → ||   # planGroup existingByGroup.get(): Transfer[]|undefined — an array is always truthy
+src/shared/accounting/store.ts::newLegConflict~1dordwu  ?? → ||   # newLegConflict originalsById.get(id): Transfer|undefined — a Transfer object is always truthy
+src/shared/accounting/store.ts::eventGroupOf~004j2p7  Ledger event cannot be empty → ""   # every caller drops empty groups first (postTransfersTx returns early, assertUniqueGroups and loadBatchSnapshot take nonEmpty, planTransferBatch skips them), so requireValue never throws and no test can read its message
+src/shared/accounting/store.ts::postTransfers~0by69o5  Ledger post omitted its event → ""   # postTransferGroups returns one PostResult per group, so a one-group post always has a [0] and this message is unreachable
 src/shared/accounting/rows.ts::legColumns~1u7xtcf  ?? → ||   # insertStatement kind: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/rows.ts::legColumns~12222gj  ?? → ||   # insertStatement memo: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/rows.ts::renderInsert.args~06yrdj4  ?? → ||   # renderInsert guard?.args: InValue[]|undefined — an array is always truthy

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -39,10 +39,8 @@ src/shared/ledger/reverse.ts::reverseOf.memo~0ibvp6e  ?? → ||   # reverseOf me
 src/shared/accounting/mappers.ts::refundKind~1mw4vn3  ?? → ||   # REFUND_KIND[kind]: every value is non-empty and a miss is undefined — never "", so ?? and || coincide
 src/shared/accounting/mappers.ts::mapRefund.kind~0rfpt43  ?? → ||   # refundKind(leg.kind ?? ""): string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/store.ts::planGroup.existing~1qc9xlq  ?? → ||   # planGroup existingByGroup.get(): Transfer[]|undefined — an array is always truthy
-src/shared/accounting/rows.ts::legColumns~1u7xtcf  ?? → ||   # insertStatement kind: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
-src/shared/accounting/rows.ts::legColumns~12222gj  ?? → ||   # insertStatement memo: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/rows.ts::selectById~1v2xab7  ?? → ||   # selectById (await …)[0]: Transfer|undefined — a Transfer object is always truthy
-src/shared/accounting/rows.ts::renderInsert.args~06yrdj4  ?? → ||   # renderInsert guard?.args: InValue[]|undefined — an array is always truthy
+src/shared/accounting/rows.ts::selectTransfersMany~0htorzu  ?? → ||   # rowsByQuery.get(index): Transfer[]|undefined — an array is always truthy
 src/shared/accounting/manual-entries.ts::assertManualLedgerTransfer.kind~1kt86ag  ?? → ||   # guard error message `transfer.kind ?? ""`: string|undefined, "" ?? "" === "" || ""
 src/shared/checkout-ledger.ts::bookingFactsFromOrder.bookingFee~0t6vqf5  ?? → ||   # find(...)?.amount: number|undefined; the only falsy-non-null amount is 0 and 0 ?? 0 === 0 || 0
 src/features/settings-bundles.ts::settingsForPath~1at4rp9  ?? → ||   # bundle is a readonly string[] or undefined; every present array, including [], is truthy

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -340,6 +340,15 @@ type ResultPerBatch<Batches extends readonly TransferInput[][][]> = {
   [Index in keyof Batches]: PostTransferBatchResult;
 };
 
+/** The outcome for a set with no legs in it. Annotated rather than written
+ *  inline, so the shape is still checked despite the tuple cast at the return. */
+const nothingToPost = (
+  batch: readonly TransferInput[][],
+): PostTransferBatchResult => ({
+  kind: "posted",
+  results: batch.map(() => EMPTY_RESULT),
+});
+
 /**
  * Post several independent sets of event groups from one ledger snapshot and
  * one write. A stored-data conflict rejects only its own set; malformed input
@@ -354,10 +363,7 @@ export const postTransferGroupBatches = async <
   const nonEmpty = groups.filter((inputs) => inputs.length > 0);
   if (nonEmpty.length === 0) {
     // Mapped from the sets given, so it is one outcome per set by construction.
-    return batches.map((batch) => ({
-      kind: "posted",
-      results: batch.map(() => EMPTY_RESULT),
-    })) as ResultPerBatch<Batches>;
+    return batches.map(nothingToPost) as ResultPerBatch<Batches>;
   }
   assertUniqueGroups(groups);
   const snapshot = await loadBatchSnapshot(nonEmpty, fromDb);

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -334,21 +334,30 @@ const planTransferBatch = (
   return { inserts, kind: "posted", results };
 };
 
+/** One outcome for each set posted, in the order the sets were given, so a
+ *  caller passing a known number of sets can name them by destructuring. */
+type ResultPerBatch<Batches extends readonly TransferInput[][][]> = {
+  [Index in keyof Batches]: PostTransferBatchResult;
+};
+
 /**
  * Post several independent sets of event groups from one ledger snapshot and
  * one write. A stored-data conflict rejects only its own set; malformed input
  * and database failures still reject the whole call.
  */
-export const postTransferGroupBatches = async (
-  batches: TransferInput[][][],
-): Promise<PostTransferBatchResult[]> => {
+export const postTransferGroupBatches = async <
+  const Batches extends readonly TransferInput[][][],
+>(
+  batches: Batches,
+): Promise<ResultPerBatch<Batches>> => {
   const groups = batches.flat();
   const nonEmpty = groups.filter((inputs) => inputs.length > 0);
   if (nonEmpty.length === 0) {
+    // Mapped from the sets given, so it is one outcome per set by construction.
     return batches.map((batch) => ({
       kind: "posted",
       results: batch.map(() => EMPTY_RESULT),
-    }));
+    })) as ResultPerBatch<Batches>;
   }
   assertUniqueGroups(groups);
   const snapshot = await loadBatchSnapshot(nonEmpty, fromDb);
@@ -360,20 +369,18 @@ export const postTransferGroupBatches = async (
     batch.kind === "posted" ? batch.inserts : [],
   );
   if (inserts.length > 0) await executeBatch(inserts);
+  // Mapped from the sets given, so it is one outcome per set by construction.
   return planned.map((batch) =>
     batch.kind === "conflict"
       ? batch
       : { kind: batch.kind, results: batch.results },
-  );
+  ) as ResultPerBatch<Batches>;
 };
 
 export const postTransferGroups = async (
   groups: TransferInput[][],
 ): Promise<PostResult[]> => {
-  const result = requireValue(
-    (await postTransferGroupBatches([groups]))[0],
-    "Ledger post omitted its transfer batch",
-  );
+  const [result] = await postTransferGroupBatches([groups]);
   if (result.kind === "conflict") throw result.error;
   return result.results;
 };

--- a/test/shared/accounting/rows.test.ts
+++ b/test/shared/accounting/rows.test.ts
@@ -6,6 +6,8 @@ import {
   fromTx,
   insertStatement,
   type RowReader,
+  selectByEventGroup,
+  selectById,
   selectTransfers,
   selectTransfersMany,
 } from "#shared/accounting/rows.ts";
@@ -107,24 +109,27 @@ const recordingReader = (): {
   return { asked, reader };
 };
 
+const STORED_AT = "2026-06-21T12:00:00.000Z";
+
+const leg = (reference: string, eventGroup: string): TransferInput => ({
+  amount: 5000,
+  destination: account("revenue", 7),
+  eventGroup,
+  occurredAt: "2026-06-21T00:00:00.000Z",
+  reference,
+  source: account("attendee", 3),
+});
+
+/** Two legs under different events, so a reader that ignores its filter and
+ *  returns everything is visible. */
+const storeTwoLegs = (): Promise<void> =>
+  executeBatch([
+    insertStatement(leg("ref-a", "evt-a"), STORED_AT),
+    insertStatement(leg("ref-b", "evt-b"), STORED_AT),
+  ]);
+
 describe("accounting > rows > selectTransfersMany", () => {
   useTransactionalDb();
-  const recordedAt = "2026-06-21T12:00:00.000Z";
-
-  const leg = (reference: string, eventGroup: string): TransferInput => ({
-    amount: 5000,
-    destination: account("revenue", 7),
-    eventGroup,
-    occurredAt: "2026-06-21T00:00:00.000Z",
-    reference,
-    source: account("attendee", 3),
-  });
-
-  const storeTwoLegs = (): Promise<void> =>
-    executeBatch([
-      insertStatement(leg("ref-a", "evt-a"), recordedAt),
-      insertStatement(leg("ref-b", "evt-b"), recordedAt),
-    ]);
 
   test("gives each set of rows back to the query that asked for it", async () => {
     await storeTwoLegs();
@@ -135,8 +140,8 @@ describe("accounting > rows > selectTransfersMany", () => {
     ]);
 
     // Swapped answers would read as a stored collision that is not there.
-    expect(byGroup?.map((row) => row.reference)).toEqual(["ref-b"]);
-    expect(byReference?.map((row) => row.reference)).toEqual(["ref-a"]);
+    expect(byGroup.map((row) => row.reference)).toEqual(["ref-b"]);
+    expect(byReference.map((row) => row.reference)).toEqual(["ref-a"]);
   });
 
   test("answers a query nothing can match without asking for it", async () => {
@@ -193,6 +198,34 @@ describe("accounting > rows > selectTransfersMany", () => {
       ["ref-a"],
       ["ref-b"],
     ]);
+  });
+});
+
+describe("accounting > rows > readers for one event and one row", () => {
+  useTransactionalDb();
+
+  test("selectByEventGroup reads that event's legs and not its neighbour's", async () => {
+    await storeTwoLegs();
+
+    const legs = await selectByEventGroup(fromDb, "evt-a");
+
+    expect(legs.map((row) => row.reference)).toEqual(["ref-a"]);
+  });
+
+  test("selectById reads the transfer stored under that id", async () => {
+    await storeTwoLegs();
+    const [wanted] = await selectByEventGroup(fromDb, "evt-b");
+    if (wanted === undefined) throw new Error("The stored leg was not read");
+
+    const found = await selectById(fromDb, wanted.id);
+
+    expect(found).toEqual(wanted);
+  });
+
+  test("selectById answers null when no transfer has that id", async () => {
+    await storeTwoLegs();
+
+    expect(await selectById(fromDb, 999_999)).toBeNull();
   });
 });
 

--- a/test/shared/accounting/rows.test.ts
+++ b/test/shared/accounting/rows.test.ts
@@ -305,4 +305,22 @@ describe("accounting > rows > stored-row round-trip", () => {
     expect(stored!.kind).toBeUndefined();
     expect("kind" in stored!).toBe(false);
   });
+
+  test("a leg with no memo stores an empty one, not a stand-in", async () => {
+    const memoless: TransferInput = {
+      amount: 100,
+      destination: account("revenue", 7),
+      eventGroup: "evt-memoless",
+      occurredAt: "2026-06-21T00:00:00.000Z",
+      reference: "ref-memoless",
+      source: account("attendee", 3),
+    };
+    await executeBatch([insertStatement(memoless, recordedAt)]);
+
+    const [stored] = await selectTransfers(fromDb);
+
+    // Unlike kind, memo keeps its "" — so the absence must be stored as empty
+    // rather than as any filler a reader would later show to an operator.
+    expect(stored!.memo).toBe("");
+  });
 });

--- a/test/shared/accounting/rows.test.ts
+++ b/test/shared/accounting/rows.test.ts
@@ -13,6 +13,7 @@ import {
 } from "#shared/accounting/rows.ts";
 import {
   executeBatch,
+  queryOne,
   type SqlStatement,
   type TxScope,
   withTransaction,
@@ -128,6 +129,17 @@ const storeTwoLegs = (): Promise<void> =>
     insertStatement(leg("ref-b", "evt-b"), STORED_AT),
   ]);
 
+/** The id a reference was stored under, read straight from the table: a test of
+ *  one reader must not lean on another to set itself up. */
+const storedIdFor = async (reference: string): Promise<number> => {
+  const row = await queryOne<{ id: number | bigint }>(
+    "SELECT id FROM transfers WHERE reference = ?",
+    [reference],
+  );
+  if (row === null) throw new Error(`Nothing was stored for ${reference}`);
+  return Number(row.id);
+};
+
 describe("accounting > rows > selectTransfersMany", () => {
   useTransactionalDb();
 
@@ -214,12 +226,12 @@ describe("accounting > rows > readers for one event and one row", () => {
 
   test("selectById reads the transfer stored under that id", async () => {
     await storeTwoLegs();
-    const [wanted] = await selectByEventGroup(fromDb, "evt-b");
-    if (wanted === undefined) throw new Error("The stored leg was not read");
+    const id = await storedIdFor("ref-b");
 
-    const found = await selectById(fromDb, wanted.id);
+    const found = await selectById(fromDb, id);
 
-    expect(found).toEqual(wanted);
+    expect(found?.id).toBe(id);
+    expect(found?.reference).toBe("ref-b");
   });
 
   test("selectById answers null when no transfer has that id", async () => {


### PR DESCRIPTION
Follow-up to #2094. Mutation testing the two files that change touched found places where the code could be broken and no test would object — and, along the way, that the mutation runner had been reporting these files as perfect when it had never actually tested a third of the ways to break them.

## The measurement was wrong first

The runner gives each mutant ten seconds for everything: a lint, a type-check, waiting its turn, then the tests. Type-checking these files alone averages about four seconds, so most mutants ran out of time before a test ever saw them. A mutant that runs out of time is counted as caught — so the files read as **100%** when 35 of 52 and 40 of 99 had never reached a test at all.

Run with a budget that fits, the real scores were **90%** and **95.9%**.

This is worth knowing beyond this PR: the runner's "this entry is out of date, a test kills it now" warnings are produced the same way, so under a tight budget they can point at entries that are still perfectly valid. Three were removed on that advice earlier in this branch and are restored here.

## What was actually missing

**Two readers had no test of their own.** One reads a whole event's legs; the other reads a single stored transfer by its id. Both are used in the live system, but the column each filters on could have been changed to nonsense and the suite stayed quiet. They now have tests, and the by-id test sets itself up with a direct table read rather than leaning on the reader beside it.

**A missing memo could have been stored as anything.** Nothing checked that a leg with no memo stores an empty one, so the empty string could be swapped for any filler — and that filler would then be shown to an operator as if a person had typed it.

**A cast of mine had switched off a type check.** Casting a whole mapped array to a result tuple also stops TypeScript checking the object literals inside it, so the "posted" outcome could be replaced with an empty one and the build stayed green — a check that existed before this branch. The outcome is now built through an annotated helper, which restores it.

## Errors that can never happen

Three of these were code guarding against what the code itself makes impossible: a shortfall in results that cannot occur when the answers are built by going through the questions, an empty-group message whose every caller filters empty groups out first, and a missing-result message for a one-in-one-out call.

Where the guarantee could be stated in the types, it now is, and the unreachable error is gone. Where it rests on every caller filtering first, the mutant is recorded as unkillable with that reasoning — along with three more where swapping `??` for `||` cannot be told apart, because an array is always truthy.

## Result

Both files now score 100% with **nothing timed out** — every mutant reached the tests and a test failed for it:

| | mutants | killed by a test | timed out | suppressed with a proof |
|---|---|---|---|---|
| row readers | 52 | 46 | 0 | 6 |
| write path | 99 | 95 | 0 | 4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXUnTqyoPzb4VPSsyLwk69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved accounting transfer processing for more consistent results across batches.
  * Enhanced transfer lookup by event group and ID.
  * Improved handling of unknown transfer IDs.
  * Improved support for retrieving transfers with missing memos, which are now represented consistently as empty values.
  * Simplified single-batch transfer handling and clearer conflict reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->