### PR TITLE
Write down what the closed payment rewrite taught us

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -594,6 +594,74 @@ The seven accepted safety rules are recorded as acceptance constraints in
   callback and webhook processing paths into focused modules. This predates PR 1
   and is deferred because the split would exceed its strict source-change limit.
 
+## Payment aggregate — what the closed rewrite taught us
+
+_Origin: the payment-aggregate rewrite (PRs #1962 and #1973, closed without
+merging). Before it closed, the branch went through repeated adversarial review
+and a coverage audit. The full record — around forty-five findings, each tied to
+a file and line on that branch — is in `TODO.md` at commit `3cf6929b` on
+`base/payment-aggregate` (also reachable as `refs/pull/1962/head`). The
+table-hardening slice is at `369977cf` (`refs/pull/1973/head`). None of that
+branch's code is on main, so the findings are not jobs here — they are the
+failure map for the redo the section above plans._
+
+**One finding does apply to main's current code** (checked against
+`performListingDelete` in `src/shared/listings-actions.ts` and `deleteListing`
+in `src/shared/db/listings/delete.ts`):
+
+- **Delete the listing row before its attachment file.** `performListingDelete`
+  removes the stored attachment file first and only then runs the database
+  delete. The delete batch can genuinely fail — a busy database under a
+  concurrent write is a normal failure here — and when it does, the file is gone
+  but the listing stays, showing an attachment link that no longer works. Swap
+  the order: take the database delete first, then remove the file.
+
+**Failure shapes the redo must design out.** Each of these was found, and most
+were confirmed, on the rewrite. They are worth reading in full at the commit
+above before re-attempting the aggregate; in one line each:
+
+- One stuck item must never block the queue behind it: a saved owner decision
+  the provider kept refusing halted every checkout, completion and refund; one
+  unredactable payment halted all payment-history redaction and the pruning
+  behind it.
+- "Cannot reach the provider" and "the provider said no" must be different
+  outcomes. Collapsing them turned permanent refusals into forever-retries — on
+  checkout creation, on refund reads, and on unmapped refund states.
+- Deferred work must run from facts saved when the money moved, not from live
+  rows an owner may have edited since — quantity, currency, recipient, and the
+  booking itself all drifted between capture and completion.
+- Every migration copy path needs an answer for imperfect history: a payment
+  whose listing was deleted, whose reference lives only on the attendee, or
+  whose two provider ids split across pages either failed the whole upgrade or
+  silently lost evidence.
+- Money-adjacent actions must be exact about their targets: a "refresh" that
+  could refund, a refund list that included charge-less payments, and a
+  confirmed refund that never reached the ledger all moved or lost money on
+  paper.
+
+**Checked against main and not applicable** — recorded so nobody re-raises them
+here: SumUp amounts convert once at checkout creation (no stored retry); emails
+send inline reading the config at send time (no queue to go stale); the attendee
+merge already fences live payment rows (`assertRowsFreeToMove`); Square's
+`order_id` is already optional in `src/shared/square/payment-outcomes.ts`; the
+success redirect already clears session tokens, and a revisit renders without
+them.
+
+**Process lessons for the redo:**
+
+- Build coverage with each slice, not after. The gate wants every line and
+  branch covered, guards usually sit in functions the module does not export,
+  and CI forbids exports that only tests use — so a guard is only reachable
+  through the public entry points, and retrofitting that across twenty-six files
+  at once is what kept the rewrite red.
+- Keep each PR under about three hundred changed files, or the automated
+  reviewer skips it entirely. The other reviewer re-reviews every push and opens
+  a fresh thread per finding each time, so answer the newest thread per finding
+  and batch pushes.
+- The two wording tables in the rewrite's `format.tsx` — every case reason and
+  every resource kind keyed to catalog words, so a new one cannot be added
+  silently — are the pattern to reuse for payment-case copy.
+
 ## Request performance: consolidate AsyncLocalStorage scopes
 
 `src/features/app/request.ts` enters eleven nested request scopes for locale,


### PR DESCRIPTION
The payment-aggregate rewrite (#1962 and #1973) was closed without merging. Its record of what review and testing found lived only in `TODO.md` on the closed branch, so main had none of it. This adds one section to main's `TODO.md` so that knowledge is not lost.

Every item was checked against main's current code before being added, so the section only carries what is relevant here:

- **One real job on main.** `performListingDelete` removes the stored attachment file before the database delete. That delete can genuinely fail — a busy database under a concurrent write is a normal failure — and then the file is gone while the listing stays, showing an attachment link that no longer works. The fix is to swap the order.
- **The failure shapes the planned redo must design out**, condensed to five one-line lessons — the "Payment aggregate — safety behaviour (PR 1)" section directly above already plans that redo, and these are the ways the first attempt went wrong.
- **The candidates checked against main and found not to apply**, written down so nobody re-raises them: SumUp converts money once at checkout creation, emails send inline, the attendee merge already fences live payment rows, Square's order id is already optional, and the success redirect already clears its tokens.
- **Where the full record lives**: `TODO.md` at commit `3cf6929b` on `base/payment-aggregate` (also `refs/pull/1962/head`), with the table-hardening slice at `369977cf` (`refs/pull/1973/head`).

No code changes — one markdown file. `deno fmt`, lint, typecheck, the copy checks and the duplication check all pass locally; the test suite does not read `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxEwtb9N1DGK1ks2VM3345

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxEwtb9N1DGK1ks2VM3345)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance from the completed payment-aggregate rewrite.
  * Documented a key data-handling lesson: remove database listings before attachment files.
  * Captured failure modes, non-applicable findings, and process guidance for future rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->