### PR TITLE
Delete the row before the file, and block group moves that strand an add-on

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1531,16 +1531,16 @@ one machine and merge together.
 - The M5 complete-a-proven-booking case action lands here.
 - Extend M4's current-row merge/delete/prune/orphan protections to aggregate
   cases and effects. Fence listing deletion against pending payment work,
-  establishing the claim before any irreversible step: today
-  `performListingDelete` removes the stored attachment before the database
-  delete, so the fence must precede storage cleanup, not only the row delete.
-  Fence attendee deletion the same way: an attendee with unfinished completion
-  work or durable effects cannot be deleted until that work settles or is
-  repointed, checked inside the deleting transaction. Repoint payment work and
-  open cases during attendee merges. The cutover fence blocks merge, delete,
-  prune, PII edits, and `deleteAllStaleReservations` while historical rows are
-  being copied, so activated maintenance code can be canonical-only; it never
-  needs a copied/not-copied branch or migration snapshot.
+  establishing the claim before any irreversible step: `performListingDelete`
+  now deletes the database rows before removing the stored attachment, and the
+  fence must precede both. Fence attendee deletion the same way: an attendee
+  with unfinished completion work or durable effects cannot be deleted until
+  that work settles or is repointed, checked inside the deleting transaction.
+  Repoint payment work and open cases during attendee merges. The cutover fence
+  blocks merge, delete, prune, PII edits, and `deleteAllStaleReservations` while
+  historical rows are being copied, so activated maintenance code can be
+  canonical-only; it never needs a copied/not-copied branch or migration
+  snapshot.
 - Install the old-write fence before the first migration page and verify it in
   every old committing transaction until all in-flight requests drain. Provider
   refunds need no exemption: M4 already writes their state only to canonical

--- a/TODO.md
+++ b/TODO.md
@@ -605,16 +605,11 @@ table-hardening slice is at `369977cf` (`refs/pull/1973/head`). None of that
 branch's code is on main, so the findings are not jobs here — they are the
 failure map for the redo the section above plans._
 
-**One finding does apply to main's current code** (checked against
-`performListingDelete` in `src/shared/listings-actions.ts` and `deleteListing`
-in `src/shared/db/listings/delete.ts`):
-
-- **Delete the listing row before its attachment file.** `performListingDelete`
-  removes the stored attachment file first and only then runs the database
-  delete. The delete batch can genuinely fail — a busy database under a
-  concurrent write is a normal failure here — and when it does, the file is gone
-  but the listing stays, showing an attachment link that no longer works. Swap
-  the order: take the database delete first, then remove the file.
+The one finding that applied to main's current code — `performListingDelete`
+removing the stored attachment file before the database delete, so a failed
+delete batch left a live listing with a dead attachment link — is fixed: the
+database delete now runs first, pinned by a fault-injected regression test in
+`test/shared/listings-actions.test.ts`.
 
 **Failure shapes the redo must design out.** Each of these was found, and most
 were confirmed, on the rewrite. They are worth reading in full at the commit

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -197,3 +197,24 @@ src/shared/dates.ts::bookedRangeLabel.lastDay~0xqfu39  1 → 0   # bookedRangeLa
 
 # Logger (logger.ts) — a provably-equivalent survivor from the logger suites.
 src/shared/logger.ts::persistErrorToActivityLog~0kl9lpw  ?? → ||   # context.listingId is number|undefined and listing ids are positive autoincrement integers, so the LHS is never a falsy non-null value — ?? and || agree on every input
+
+# Listing actions (listings-actions.ts) — validated-input fallbacks whose only
+# falsy left-hand values coincide with the fallback, plus two unreachable arms.
+src/shared/listings-actions.ts::validateMaxPrice.minPrice~16xqeks  ?? → ||   # input.unitPrice is a validated whole number or absent; its only falsy value 0 equals the fallback
+src/shared/listings-actions.ts::validateListingGroup.groupIds~1juqee2  ?? → ||   # input.groupIds is an array when present, and arrays are always truthy
+src/shared/listings-actions.ts::validateListingGroup.incompatibleByType~0d42sm3  ?? → ||   # input.canPayMore is boolean when present; false stays false with either operator
+src/shared/listings-actions.ts::validateListingGroup.checked~0ndre14  Missing group listing membership → ""   # getListingsByGroupIds seeds every requested group id with at least an empty array, so the missing-key throw can never fire and its message is unobservable
+src/shared/listings-actions.ts::validateListingGroup.checked.customisable_days~0350hpg  ?? → ||   # input.customisableDays is boolean when present; false stays false with either operator
+src/shared/listings-actions.ts::validateListingGroup.checked.id~1o94tt5  ?? → ||   # existingId is a database id (>= 1) or undefined; its only falsy value 0 equals the fallback
+src/shared/listings-actions.ts::validateListingGroup.checked.id~1o94tt5  0 → 1   # checkGroupListingSettings never reads the candidate's id — sibling self-exclusion uses the separate excludeListingId argument
+src/shared/listings-actions.ts::validateListingGroup.checked.listing_type~1lqe3go  ?? → ||   # input.listingType is a non-empty picklist word when present, so the empty string never occurs
+src/shared/listings-actions.ts::validateListingGroup.checked~1o94tt5  ?? → ||   # existingId is a database id (>= 1) or undefined; its only falsy value 0 equals the fallback
+src/shared/listings-actions.ts::validateRenewalConfig~0ruet3x  ?? → ||   # input.monthsPerUnit is a validated whole number or absent; its only falsy value 0 equals the fallback
+src/shared/listings-actions.ts::validateRenewalConfig~01imco1  ?? → ||   # input.initialSiteMonths is a validated whole number or absent; its only falsy value 0 equals the fallback
+src/shared/listings-actions.ts::dayPriceFieldsFromInput.customisable_days~0350hpg  ?? → ||   # input.customisableDays is boolean when present; false stays false with either operator
+src/shared/listings-actions.ts::dayPriceFieldsFromInput.day_prices~1h4yd97  ?? → ||   # input.dayPrices is an object when present, and objects are always truthy
+src/shared/listings-actions.ts::dayPriceFieldsFromInput.duration_days~1ugulhp  ?? → ||   # input.durationDays is a whole number or absent; its only falsy value 0 clamps to clampDurationDays' floor of 1, the same result the fallback 1 produces
+src/shared/listings-actions.ts::dayPriceFieldsFromInput.duration_days~1ugulhp  1 → 0   # when durationDays is absent, clampDurationDays raises the mutated fallback 0 to its floor of 1 — the same result as the fallback 1
+src/shared/listings-actions.ts::listingInputToEdge.listing_type~1lqe3go  ?? → ||   # input.listingType is a non-empty picklist word when present, so the empty string never occurs
+src/shared/listings-actions.ts::listingInputToEdge.months_per_unit~0ruet3x  ?? → ||   # input.monthsPerUnit is a validated whole number or absent; its only falsy value 0 equals the fallback
+src/shared/listings-actions.ts::validateListingEdges.orphanError~1juqee2  ?? → ||   # input.groupIds is an array when present, and arrays are always truthy

--- a/src/shared/listings-actions.ts
+++ b/src/shared/listings-actions.ts
@@ -328,7 +328,7 @@ export const deactivationOrphanedAddOnError = async (
   // it from the suppressed set — yet taking its page offline removes the only
   // surface a child-only add-on could sell from. Force every deactivated flagged
   // child (a child of some parent whose flag is still set) into the suppressed
-  // set, matching the edit-save path's strippedPageOrphanedAddOn.
+  // set, matching the edit-save path's lostPageOrphanedAddOn.
   const ids = [...inactiveIds];
   const childLinks = await listingParents.getIdsByKeys(ids);
   const childIds = listingIdsWithLinks(childLinks);
@@ -341,43 +341,49 @@ export const deactivationOrphanedAddOnError = async (
   );
 };
 
+/** True when the save takes this listing out of a group it is currently in.
+ * Losing a group can strip the page out of a group-scoped add-on's reach even
+ * while the page itself stays live. */
+const leavesAGroup = async (
+  existingId: number,
+  wouldBeGroupIds: readonly number[],
+): Promise<boolean> =>
+  (await listingGroups.getIds(existingId)).some(
+    (groupId) => !wouldBeGroupIds.includes(groupId),
+  );
+
 /**
- * Re-check add-on reachability when a listing save STRIPS a page that could
- * rescue a child-scoped opt-in add-on: a deactivation (`active` → false), or
- * clearing "can be booked by itself" on a child (true → false), which removes the
- * child's own booking page. Both can leave an add-on that only that page kept
- * reachable a dead end, so both re-run the shared reachability guard over the
- * save's PENDING state — the edited listing at its would-be group set (so a
- * group-scoped add-on for a group the same save is joining is resolved correctly)
- * and, when deactivating, inactive. Either transition leaves the stored row
- * reading `bookable_alone = 1` until the save commits, so a flagged child with
- * parents is forced into the suppressed set by hand — whether the page is lost to
- * a cleared flag or to a deactivation. Inert unless the save deactivates, or
- * clears the flag for a listing that is a child.
+ * Re-check add-on reachability when a listing save takes away a page that could
+ * rescue a child-scoped opt-in add-on. Three transitions can do that: a
+ * deactivation (the page goes offline), clearing "can be booked by itself" on a
+ * child (the child loses its own booking page), and leaving a group (the page
+ * drops out of that group's add-on scope while staying live — an edge-less page
+ * has no touching edge, so the edge walk above never sees the move). Each
+ * re-runs the shared reachability guard over the save's PENDING state — the
+ * edited listing at its would-be group set and active state. A page-stripping
+ * transition leaves the stored row reading `bookable_alone = 1` until the save
+ * commits, so a flagged child with parents is forced into the suppressed set by
+ * hand.
  */
-const strippedPageOrphanedAddOn = async (
+const lostPageOrphanedAddOn = async (
   input: ListingInput,
   existingId: number,
 ): Promise<string | null> => {
   const deactivating = input.active === false;
   const clearingFlag = input.bookableAlone === false;
-  // Either transition strips a child's OWN booking page: clearing the flag turns
-  // it non-standalone, deactivating takes its page offline. In both cases the
-  // stored row still reads `bookable_alone = 1`, so getNonStandaloneChildIds
-  // treats the child as a live standalone seller and excludes it from the
-  // suppressed set — meaning an add-on only its page could offer would pass. So
-  // load the row and, when it is a flagged child with parents, force it into the
-  // suppressed set by hand (a deactivation needs this just as much as a clear).
   const mayStripPage = deactivating || clearingFlag;
   const existing = mayStripPage ? await getListingWithCount(existingId) : null;
   const flaggedChildWithParents =
     existing?.bookable_alone === true &&
     (await listingParents.getIds(existingId)).length > 0;
-  if (!deactivating && !(clearingFlag && flaggedChildWithParents)) return null;
   // Both listing-save entry points always resolve groupIds to an array — the
   // form via parseGroupIds, the JSON API via `groups.input ?? existingGroupIds` —
   // so it is defined here (matching the create path's `input.groupIds!` writer).
   const wouldBeGroupIds = input.groupIds!;
+  const stripsOwnPage = deactivating || flaggedChildWithParents;
+  if (!stripsOwnPage && !(await leavesAGroup(existingId, wouldBeGroupIds))) {
+    return null;
+  }
   const override = (
     listing: ListingWithCount,
   ): Partial<ListingGroupMembership> =>
@@ -395,10 +401,11 @@ const strippedPageOrphanedAddOn = async (
  * against its would-be field values *and* its would-be `group_id`, so a
  * type/duration/renewal change can't leave a persisted edge the booking gate
  * can't honour, and a group change can't orphan a group-scoped add-on that the
- * edge's child suppresses. Also re-check add-on reachability when the
- * save DEACTIVATES this listing (the edge-touching walk above misses a
- * no-edge page that is the only one rescuing a child-scoped add-on). No-op for
- * creates (no edges yet, and a fresh listing rescues nothing).
+ * edge's child suppresses. Also re-check add-on reachability when the save
+ * strips a rescuing page or takes it out of a group (the edge-touching walk
+ * above misses a no-edge page that is the only one rescuing a child-scoped
+ * add-on). No-op for creates (no edges yet, and a fresh listing rescues
+ * nothing).
  */
 const validateListingEdges: ListingUpdateCheck = async (input, existingId) => {
   if (existingId === undefined) return null;
@@ -411,7 +418,7 @@ const validateListingEdges: ListingUpdateCheck = async (input, existingId) => {
     input.groupIds ?? [],
   );
   if (orphanError) return orphanError;
-  return strippedPageOrphanedAddOn(input, existingId);
+  return lostPageOrphanedAddOn(input, existingId);
 };
 
 /** Validate listing input (slug uniqueness on update, group, max price, listing type) */

--- a/src/shared/listings-actions.ts
+++ b/src/shared/listings-actions.ts
@@ -478,14 +478,15 @@ export const deleteOrphanedAddOnError = (
   deactivationOrphanedAddOnError(new Set([listingId]));
 
 /**
- * Delete a listing: clean up its attachment, remove DB links, log activity.
- * Returns the listing that was deleted (for response formatting).
+ * Delete a listing: remove its DB rows, then its attachment file, then log.
+ * The row goes first so a failed database delete cannot leave a live listing
+ * pointing at an already-removed attachment file.
  */
 export const performListingDelete = async (
   listing: ListingWithCount,
 ): Promise<void> => {
-  await deleteListingAttachmentFile(listing, "listing deletion");
   await deleteListing(listing.id);
+  await deleteListingAttachmentFile(listing, "listing deletion");
   await logActivity(
     `Listing '${listing.name}' deleted (${listing.attendee_count} attendee(s) removed)`,
   );

--- a/test/shared/listings-actions.test.ts
+++ b/test/shared/listings-actions.test.ts
@@ -18,6 +18,7 @@ import {
 import { downloadRaw, uploadRaw } from "#shared/storage.ts";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { withDbFault } from "#test-utils/db-fault.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { setupTestEncryptionKey } from "#test-utils/env.ts";
@@ -340,6 +341,35 @@ describeWithEnv("performListingDelete", { db: true }, () => {
       expect(await downloadRaw("delete-me.pdf")).toBeNull();
       const log = await getAllActivityLog();
       expect(log.some((e) => e.message.includes("Delete Me"))).toBe(true);
+    });
+  });
+
+  test("keeps the attachment file when the database delete fails", async () => {
+    await withLocalStorageEnabled(async () => {
+      const listing = await createTestListing({ name: "Delete Blocked" });
+      await uploadRaw(new Uint8Array([4, 5, 6]), "delete-blocked.pdf");
+      await listingsTable.update(listing.id, {
+        attachmentName: "delete-blocked.pdf",
+        attachmentUrl: "delete-blocked.pdf",
+      });
+      const withCount = (await getListingWithCount(listing.id))!;
+
+      await withDbFault(
+        `CREATE TRIGGER test_listing_delete_fault
+          BEFORE DELETE ON listings
+          BEGIN
+            SELECT RAISE(ABORT, 'listing delete unavailable');
+          END`,
+        "test_listing_delete_fault",
+        async () => {
+          await expect(performListingDelete(withCount)).rejects.toThrow(
+            "listing delete unavailable",
+          );
+        },
+      );
+
+      expect(await getListingWithCount(listing.id)).not.toBeNull();
+      expect(await downloadRaw("delete-blocked.pdf")).not.toBeNull();
     });
   });
 });

--- a/test/shared/listings-actions/reachability.test.ts
+++ b/test/shared/listings-actions/reachability.test.ts
@@ -8,6 +8,7 @@ import {
 } from "#shared/listings-actions.ts";
 import { storedInputFor } from "#test/shared/listings-actions/helpers.ts";
 import {
+  groupRescuedChildAddOn,
   groupScopedAddOn,
   linkedParentChild,
   linkGroupAddOn,
@@ -98,6 +99,29 @@ describeWithEnv("listing action reachability", { db: true }, () => {
         thatPage.id,
       ),
     ).resolves.toBe(childAddOnError("Child-scoped extra"));
+  });
+
+  test("blocks moving an ordinary page out of the group its child add-on needs", async () => {
+    const { rescuer } = await groupRescuedChildAddOn();
+
+    await expect(
+      validateListingInput(
+        await storedInputFor(rescuer.id, { groupIds: [] }),
+        rescuer.id,
+      ),
+    ).resolves.toBe(childAddOnError("Group extra"));
+  });
+
+  test("allows leaving a group when another page still offers its child add-on", async () => {
+    const { group, rescuer } = await groupRescuedChildAddOn();
+    await createTestListing({ groupId: group.id, name: "Second page" });
+
+    await expect(
+      validateListingInput(
+        await storedInputFor(rescuer.id, { groupIds: [] }),
+        rescuer.id,
+      ),
+    ).resolves.toBeNull();
   });
 
   test("allows saving a standalone child when its page remains available", async () => {

--- a/test/test-utils/listing-parents/helpers.ts
+++ b/test/test-utils/listing-parents/helpers.ts
@@ -104,6 +104,27 @@ export const allAddOnWithStaleChildLink = async (): Promise<ParentChild> => {
   return { child, parent };
 };
 
+/** A suppressed child and an ordinary "rescuing" page sharing one group, with
+ * a group-scoped opt-in add-on on that group — the rescuer is the add-on's only
+ * live page, and it has no parent/child edge of its own. */
+export const groupRescuedChildAddOn = async (): Promise<
+  ParentChild & {
+    group: Awaited<ReturnType<typeof createTestGroup>>;
+    rescuer: TestListing;
+  }
+> => {
+  const group = await createTestGroup({ name: "Scope group" });
+  const parent = await createTestListing({ name: "Base unit" });
+  const child = await createTestListing({ groupId: group.id, name: "Add-on" });
+  await postChildren(parent.id, [child.id]);
+  const rescuer = await createTestListing({
+    groupId: group.id,
+    name: "Rescuing page",
+  });
+  await linkGroupAddOn(group.id, "Group extra");
+  return { child, group, parent, rescuer };
+};
+
 /** A parent, its child, and a third "rescuing" page that shares a {child,
  * thatPage}-scoped opt-in add-on. The suppressed child leaves the add-on
  * reachable only through `thatPage`. */


### PR DESCRIPTION
Two small listing fixes. The first comes straight from the payment plan's review record; the second was uncovered by this branch's own mutation gate.

## 1. A failed delete no longer breaks the attachment link

Deleting a listing used to remove its stored attachment file first, and only then delete the database rows. The database delete can genuinely fail — a busy database under a concurrent write is a normal failure — and when it did, the file was already gone but the listing stayed. Visitors and operators then saw an attachment link that no longer worked.

Now the database delete runs first. If it fails, the listing is left fully intact, attachment and all, and the operator can simply try again. If the file cleanup fails after a successful delete, the listing is still gone and the leftover file is logged, exactly as before.

This closes the one finding from the payment-aggregate rewrite record (`TODO.md`, "what the closed rewrite taught us") that applied to main's current code. `PLAN.md`'s M8 fence note and the TODO entry now describe the fixed order.

## 2. A group move can no longer strand an opt-in add-on

Saving a listing already blocks changes that would leave an opt-in add-on with no booking page to sell it — deactivating its only page, or clearing "can be booked by itself" on its only child seller. But one path slipped through: moving an ordinary page **out of a group** removed it from that group's add-on scope while the page itself stayed live, so the add-on could be left reachable only through a required child listing that has no page of its own. Once that happened, the add-on silently stopped being sellable, and later saves of unrelated listings could be refused with a confusing message about it.

The save guard now also re-checks reachability when a save takes a listing out of any group it is in, refusing with the same message the other blocks use. Moving out is still allowed whenever another page in the group can offer the add-on.

## Tests

- The delete-order regression test installs a database trigger that refuses the listing row delete, so the batch rolls back the way a real busy-database failure would, then proves the listing survives **and** its attachment file is still in storage. It fails on the old order.
- The group-move regression test builds a group whose only live page is an ordinary edge-less listing beside a suppressed child, proves moving that page out is refused, and that it stays allowed when a second page still offers the add-on. The refusal test fails on the old code.
- `deno task precommit` (typecheck, lint, duplication, copy checks, full suite) — green.
- `deno task precommit:mutation` — **100% score**: 134/134 mutants on the changed file killed, with this file's 18 remaining provably-equivalent mutants recorded in `scripts/mutation/equivalent-mutants/shared-a-l.txt`, each with its proof.