### PR TITLE
Close the backup mutation gate's thirteen survivors

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -78,3 +78,9 @@ src/shared/sumup/transaction.ts::readSumupTransaction.events~0aphohd  ?? → || 
 # sessionId that is a key of that same map. requiredMapValue can never miss
 # there, and no input can observe the message on that unreachable throw.
 src/shared/db/payment-claim.ts::settleAttendeeRows~1iaqh2o Refund settlement lost a payment row→""   # unreachable: the IN-clause is built from the same map's keys
+
+# backup dump (shared/db/backup-snapshot.ts) — exportTable internals whose
+# intermediate values are overwritten or type-guaranteed before any read.
+src/shared/db/backup-snapshot.ts::exportTable.colList~1el369a   → "mutated"   # colList is only read when INSERT statements are built, which happens after the first non-empty page assigned it in the rowCount === 0 branch; the initializer is overwritten before every read (an empty table breaks out before any read)
+src/shared/db/backup-snapshot.ts::exportTable.rows~0k5qahc  ?? → ||   # suppliedPage is BackupRow[] | undefined: an array (even an empty one) is truthy and undefined is falsy, so ?? and || pick the same side for every possible value
+src/shared/db/backup-snapshot.ts::exportTable.colList~0ou5ceg  = → +=   # the rowCount === 0 branch runs at most once (rowCount grows past zero with the same page that enters it), so this appends to the initial empty string, and "" + x === x

--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -31,3 +31,10 @@ src/ui/templates/admin/questions.tsx::questionListingsFor.listingNames~1vj5u51  
 src/ui/templates/admin/questions.tsx::adminQuestionsPage.columns.key~0eka7sm  question → ""   # a column `key` is read only by renderTable's columnKeys/hiddenKeys lookups and saved-filter value rendering; reorderableListPage renders the questions table with only reorder options — no columnKeys, hiddenKeys, or filter — so this key is never read
 src/ui/templates/admin/questions.tsx::adminQuestionsPage.columns.key~1c98v7j  answers → ""   # same as questions.tsx:170:14 — the questions list table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
 src/ui/templates/admin/questions.tsx::adminQuestionsPage.columns.key~08wyblh  listings → ""   # same as questions.tsx:170:14 — the questions list table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
+
+# backups page (ui/templates/admin/backup.tsx) — column keys the page never
+# reads back, same class as the questions list table above.
+src/ui/templates/admin/backup.tsx::backupsTable.key~1353jpe  created → ""   # a column `key` is read only by renderTable's columnKeys/hiddenKeys lookups and saved-filter value rendering; adminBackupPage renders the backups table with none of those options, so this key is never read
+src/ui/templates/admin/backup.tsx::backupsTable.key~1o7pzgq  timestamp → ""   # same as backup.tsx's created key — the backups table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
+src/ui/templates/admin/backup.tsx::backupsTable.key~1tpb30l  size → ""   # same as backup.tsx's created key — the backups table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
+src/ui/templates/admin/backup.tsx::backupsTable.key~120g5gv  actions → ""   # same as backup.tsx's created key — the backups table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read

--- a/test/shared/db/backup-snapshot.test.ts
+++ b/test/shared/db/backup-snapshot.test.ts
@@ -10,6 +10,7 @@ import { getDb } from "#shared/db/client.ts";
 import { initDb, SCHEMA_TABLE_NAMES } from "#shared/db/migrations.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { withEnv } from "#test-utils/env.ts";
 
 describeWithEnv("backup snapshot", { db: true }, () => {
   describe("exportTable", () => {
@@ -46,6 +47,17 @@ describeWithEnv("backup snapshot", { db: true }, () => {
       expect(sql).toContain("NULL");
     });
 
+    test("escapes single quotes by doubling them", async () => {
+      // Seeded at the storage layer with bound args, so nothing escapes the
+      // quote on the way in — only the dump's own escaping can double it.
+      await getDb().execute({
+        args: ["quote-test", "O'Brien's Gala"],
+        sql: "INSERT INTO settings (key, value) VALUES (?, ?)",
+      });
+      const { sql } = await exportTable("settings");
+      expect(sql).toContain("'O''Brien''s Gala'");
+    });
+
     test("keyset-paginates across multiple pages without losing rows", async () => {
       const pageOne = await createTestListing({ name: "Page One" });
       const pageTwo = await createTestListing({ name: "Page Two" });
@@ -63,6 +75,20 @@ describeWithEnv("backup snapshot", { db: true }, () => {
       expect(sql.match(new RegExp(`\\(${pageOne.id},`, "g"))).toHaveLength(1);
       expect(sql.match(new RegExp(`\\(${pageTwo.id},`, "g"))).toHaveLength(1);
       expect(sql.match(new RegExp(`\\(${pageThree.id},`, "g"))).toHaveLength(1);
+      // Statements are newline-separated so a dump stays readable.
+      expect(sql).toContain(';\nINSERT INTO "listings"');
+    });
+
+    test("the keyset cursor tracks the last row id, not a running sum", async () => {
+      // Three pages: a summed cursor would agree on page two (0 + last id)
+      // and only overshoot from page three on, silently dropping rows.
+      const ids: number[] = [];
+      for (let n = 1; n <= 5; n++) {
+        ids.push((await createTestListing({ name: `Cursor ${n}` })).id);
+      }
+      const { sql, rowCount } = await exportTable("listings", 2);
+      expect(rowCount).toBe(5);
+      expect(sql).toContain(`(${ids[4]},`);
     });
   });
 
@@ -91,6 +117,12 @@ describeWithEnv("backup snapshot", { db: true }, () => {
     test("sums extra pages across tables", () => {
       expect(backupDumpDatabaseCalls([500, 1000, 499], 500)).toBe(5);
     });
+
+    test("reads the page size from BACKUP_PAGE_SIZE by default", () => {
+      using _env = withEnv({ BACKUP_PAGE_SIZE: "1" });
+      // Three one-row pages past the shared first-page batch: 2 + 3.
+      expect(backupDumpDatabaseCalls([3])).toBe(5);
+    });
   });
 
   describe("countSchemaTableRows", () => {
@@ -107,6 +139,16 @@ describeWithEnv("backup snapshot", { db: true }, () => {
     test("returns tables in SCHEMA order", async () => {
       const backups = await createBackup();
       expect(backups.map((b) => b.table)).toEqual(SCHEMA_TABLE_NAMES);
+    });
+
+    test("includes each table's first row", async () => {
+      // The batched first pages start their keyset cursor below every real
+      // rowid; a cursor of 1 would silently drop each table's first row.
+      const listing = await createTestListing({ name: "First Row" });
+      const backups = await createBackup();
+      const listings = backups.find((backup) => backup.table === "listings");
+      expect(listings?.rowCount).toBe(1);
+      expect(listings?.sql).toContain(`(${listing.id},`);
     });
 
     test("skips tables that do not exist", async () => {

--- a/test/shared/storage/config.test.ts
+++ b/test/shared/storage/config.test.ts
@@ -3,6 +3,7 @@ import { it as test } from "@std/testing/bdd";
 import {
   getStorageBackend,
   runWithStorageConfig,
+  storageZoneName,
   uploadRaw,
 } from "#shared/storage.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -80,6 +81,19 @@ describeWithEnv("storage environment config", STORAGE_TEST_ENV, () => {
     });
     await withStorageDisabled(() => {
       expect(getStorageBackend()).toBe("none");
+    });
+  });
+
+  test("names the zone when Bunny storage is active", () => {
+    runWithStorageConfig({ zoneKey: "mykey", zoneName: "myzone" }, () => {
+      expect(storageZoneName()).toBe("myzone");
+    });
+  });
+
+  test("has no zone name under local storage", async () => {
+    await withLocalStorageEnabled(async () => {
+      await Promise.resolve();
+      expect(storageZoneName()).toBe(null);
     });
   });
 });


### PR DESCRIPTION
## Why

The mutation gate for #2101 finished after that PR merged (the run was interrupted by a container restart and re-run), scoring 97.2% with **13 survivors** across the files it changed. Survivors on touched files are ours to close: each is either a real assertion gap or a proven equivalent. This PR does both — no production code changes, only tests and registry entries.

## Seven real gaps, now pinned

- **Quote escaping in dumps** (`escapeSql` `'' → ""`): nothing proved a dumped value's single quotes are doubled — broken escaping would corrupt every restore of real-world text. A settings row seeded with bound args (so nothing escapes the quote on the way in) now asserts `'O''Brien''s Gala'` appears in the dumped SQL.
- **Keyset cursor** (`cursor =` → `+=`): a running-sum cursor agrees with the real one for the first two pages and only starts dropping rows from page three. A five-row, page-size-two export (three pages) now pins `rowCount` 5 and the last row's presence.
- **First-page cursor** (`tablePageStatement(table, 0, …)` → `1`): a cursor starting at 1 silently drops every table's first row from every backup. The listings dump now proves row one is included.
- **`BACKUP_PAGE_SIZE` env key** (name → `""`): the default page size is now asserted to actually read that variable.
- **Statement separator** (`join("\n")` → `join("")`): the newline between dumped statements is pinned.
- **`storageZoneName` ternary arms swapped**: unit tests now hold both directions — the zone name under Bunny storage, null under local. (The whole-file mutation re-run for `storage.ts` was skipped as disproportionate for one two-line function; these two tests fail under any arm swap.)

## Six proven equivalents, recorded

- `exportTable`'s `colList` initializer and its `= → +=` assignment: the value is written in the `rowCount === 0` branch before any read, that branch runs at most once, and `"" + x === x`.
- `suppliedPage ?? …` → `||`: the operand is `BackupRow[] | undefined`; arrays (even empty) are truthy and `undefined` is falsy, so both operators agree on every possible value.
- The four backups-table column `key`s: the page renders the table without `columnKeys`, `hiddenKeys`, or filters, so the keys are never read — the same class as the questions table's recorded keys.

`deno task check:equivalents` confirms every new entry resolves to a real mutant. A targeted `deno task mutation src/shared/db/backup-snapshot.ts … --harness` re-run verifying all eight of that file's survivors is running; its score will be confirmed on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5kRwqm349kpsgkcQLeSpw

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5kRwqm349kpsgkcQLeSpw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for backup exports, including quote escaping, pagination, cursor handling, default page sizes, and first-row inclusion.
  * Added tests confirming storage zone detection for hosted and local storage configurations.

* **Mutation Testing**
  * Documented known-equivalent mutation cases for backup export logic and table rendering keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->