### PR TITLE
Plan: a provider that took money is never acknowledged as nothing to do

### DIFF
--- a/PR_WORKFLOW.md
+++ b/PR_WORKFLOW.md
@@ -51,6 +51,25 @@ dormant foundation.
 Add the following sections to the feature plan. Use tables where there is more
 than one case. Write `None` when a section truly does not apply; do not omit it.
 
+**When the feature has a stateful lifecycle, declare the machine once and let
+these sections read off it.** Written as separate hand-maintained tables, the
+states, the commands, the failures, the retries and the races drift — and they
+drift silently, because nothing checks a plan's tables against each other or
+against the code. Fixing one disagreement then creates the next. Instead declare
+the nodes, the events, and an exhaustive moves table in the shape
+`src/shared/schema-atlas/machine-spec.ts` defines, put every fact the separate
+tables carried onto a node or an edge (may this node hold unresolved money? may
+it be deleted? what does this edge write, and what does it check before
+writing?), and write the sections below as projections that name no fact of
+their own. A cell left out of the table is a declared refusal, and the mirror
+sweep proves it refuses.
+
+Then write the plan's invariants as laws over that declaration rather than as
+prose promises, so a later node or event cannot break one quietly — "a node that
+may hold unresolved money is never deletable and is never a dead end" is a test,
+not a sentence. `SUMUP_RECOVERY_PLAN.md` is the worked example, and AGENTS.md's
+"Checked forwards and backwards" names the mechanisms.
+
 #### Trusted facts
 
 List every input and say why it may be trusted. Keep expected facts separate

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -146,21 +146,28 @@ one provider read per created checkout, once, at least 2.5 hours after creation
 
 ### Failure table
 
-| Work completed             | Failure                               | Required result                                                     | Retry owner |
-| -------------------------- | ------------------------------------- | ------------------------------------------------------------------- | ----------- |
-| Nothing                    | SumUp read unavailable                | Row stays `waiting`; no state written                               | Scheduler   |
-| Nothing                    | SumUp read `found` but not ours       | Row stays `waiting`; refusal logged (cannot happen — id is ours)    | Scheduler   |
-| Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created      | Owner       |
-| Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed` | Scheduler   |
-| Read says `PAID`           | Classify says `unverifiable`          | `owed` — a contradiction, not a foreign checkout (see below)        | Owner       |
-| Read says `PAID`           | Classify says `unreadable`            | Row stays `waiting`                                                 | Scheduler   |
-| Engine booked the attendee | State write fails                     | Booking stands; row stays `waiting`; next check is idempotent       | Scheduler   |
-| Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                  | Provider    |
+| Work completed             | Failure                               | Required result                                                     | Retry owner                                |
+| -------------------------- | ------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------ |
+| Nothing                    | SumUp read unavailable                | Row stays `waiting`; no state written                               | Scheduler                                  |
+| Nothing                    | SumUp read `found` but not ours       | Row stays `waiting`; refusal logged (cannot happen — id is ours)    | Scheduler                                  |
+| Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created      | Scheduler, and the owner can force a check |
+| Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed` | Scheduler                                  |
+| Read says `PAID`           | Classify says `unverifiable`          | `owed` — a contradiction, not a foreign checkout (see below)        | Scheduler, and the owner can force a check |
+| Read says `PAID`           | Classify says `unreadable`            | Row stays `waiting`                                                 | Scheduler                                  |
+| Engine booked the attendee | State write fails                     | Booking stands; row stays `waiting`; next check is idempotent       | Scheduler                                  |
+| Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                  | Provider                                   |
 
 The gap between provider success and local success is closed the way the rest of
-the payment engine closes it: `processed_payments` (PK = session id = the SumUp
-reference) is reserved before any work, so a replay returns the recorded outcome
-rather than repeating it.
+the payment engine closes it: `processed_payments` (PK = `payment_session_id` =
+the SumUp reference) is reserved before any work, so a replay returns the
+recorded outcome rather than repeating it.
+
+**`owed` has one retry owner: the scheduler.** Every `owed` row keeps its place
+in the scheduled queue and is checked again on its own `next_check_at` backoff,
+exactly like a `waiting` one — nothing that may hold unaccounted money is ever
+left waiting on a person to notice it. The owner's "Check again now" control
+does not own the retry; it only brings the next scheduled check forward for one
+row. So `owed` is never a manual-only state, and it is never abandoned.
 
 **Why a paid `unverifiable` is `owed`, not `unpaid`.** `unpaid` means SumUp told
 us the checkout was never paid; using it for "not ours" would give one word two
@@ -180,7 +187,7 @@ and takes the refund-or-`owed` row above.
 
 | Question                             | Answer                                                                                                                                                                                                        |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stable identity                      | `processed_payments.session_id` = the SumUp `checkout_reference`; the staging row's `reference_index`                                                                                                         |
+| Stable identity                      | `processed_payments.payment_session_id` = the SumUp `checkout_reference`; the staging row's `reference_index`                                                                                                 |
 | What an exact replay returns         | `alreadyProcessedResult` / the recorded terminal failure — no second booking, no second refund                                                                                                                |
 | Who retries after interruption       | The maintenance scheduler; the row keeps its state until a check writes a new one                                                                                                                             |
 | What stops two workers               | `claimNextMaintenanceTask`'s lease, plus `reserveSession`, plus a conditional state write (below)                                                                                                             |

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -27,7 +27,8 @@ with no booking, no refund, and — in one case — no record at all.
   down (`UNUSABLE_METADATA.retryCompletedWebhook`, and `readOrderPayment`
   throwing when the payment does not read `COMPLETED`).
 
-Value if nothing else ever ships:
+Value once the two pull requests in section 5 ship, whether or not any later one
+does — this plan itself changes no behaviour:
 
 > A SumUp checkout that was paid becomes a booking even when its only callback
 > was lost, and a Square webhook for a completed payment whose order is not
@@ -63,9 +64,17 @@ never read as "nothing happened".
 
 ### Valid states
 
-One new plaintext column, `sumup_checkouts.recovery_state`, is the authority for
-a staging row's own lifecycle. It holds a state word only — never a reference,
-an amount, or any buyer fact — so the row stays as unreadable as it is today.
+Two new plaintext columns. `sumup_checkouts.recovery_state` is the authority for
+a staging row's own lifecycle, and `next_check_at` is when that row is next due
+to be asked about. Both hold scheduling and state words only — never a
+reference, an amount, or any buyer fact — so the row stays as unreadable as it
+is today.
+
+`created_at` can only schedule the _first_ check. Without `next_check_at`, an
+oldest-first page under a fixed limit would keep re-selecting the same overdue
+rows and starve newer paid checkouts, so selection, claiming, and ordering all
+key on `next_check_at`, and every check that does not end the row pushes it
+forward by a backoff.
 
 | State      | Meaning                                                              | Facts required                     |
 | ---------- | -------------------------------------------------------------------- | ---------------------------------- |
@@ -82,6 +91,16 @@ routes on `sumup_id != ''` as a proxy for state (data law 4).
 `finished` covers both endings the payment engine can give a paid session: a
 booking, or a rejection whose money was sent back. Neither leaves anything owed.
 
+**Rows that already exist get their state derived, not defaulted.** A column
+added with one `DEFAULT` would label every live checkout `staged` and it would
+never be checked again. The migration therefore adds both columns and then, in
+the same migration's `after` hook (the fourth argument to `schemaMigration`),
+derives each existing row: `staged` where `sumup_id = ''`, `waiting` otherwise,
+with `next_check_at` set from `created_at` plus the first-check delay. The
+allowed-value check and `NOT NULL` are asserted after that derivation, and the
+maintenance task is registered in the same release, so it cannot run against
+un-derived rows.
+
 ### Commands and events
 
 | Starting state               | Command or event                               | Required result                                                       |
@@ -94,11 +113,28 @@ booking, or a rejection whose money was sent back. Neither leaves anything owed.
 | `waiting`                    | Recovery check, read says `PAID`, engine stuck | `owed`                                                                |
 | `waiting`                    | Recovery check, read says `PENDING`            | `waiting` (checked again later)                                       |
 | `waiting`                    | Recovery check, read unavailable               | `waiting` (checked again later)                                       |
-| `owed`                       | Recovery check succeeds later                  | `finished`                                                            |
-| `owed`                       | Owner presses "Check again now"                | Same three outcomes as a scheduled check                              |
+| `owed`                       | Recovery check reaches a final answer          | `finished` (only under the rule below)                                |
+| `owed`                       | Owner presses "Check again now"                | Same outcomes as a scheduled check                                    |
 | `staged`/`unpaid`/`finished` | Pruning past `PRUNE_SUMUP_RETENTION_HOURS`     | Row deleted                                                           |
-| `waiting`                    | Pruning past the new unchecked backstop        | Row deleted, after the live check has been showing it as overdue      |
-| `owed`                       | Pruning                                        | **Never** — it is the only record that money was taken                |
+| `waiting`/`owed`             | Pruning                                        | **Never** — both may hold money we have not accounted for             |
+
+**`owed` never clears on a replayed outcome.** `reserveSession` claims only
+missing and stale unresolved rows; a finalized or recorded-failure row comes
+back as `{reserved: false, existing}` and `handleReservationConflict` replays
+the stored outcome. So a later check on an `owed` row could be handed a
+previously recorded terminal failure and would call it done — marking money we
+know was taken as finished, with no booking. The rule that forbids this:
+
+> An `owed` row becomes `finished` only when the current attempt itself reaches
+> a final answer — a booking finalized now, a refund settled now, or a replay
+> whose existing row is finalized (`attendee_id` set). A replayed terminal
+> _failure_ under an `owed` row leaves it `owed`, because the row states that
+> the money was seen and this attempt did not account for it.
+
+This costs no change to `reserveSession`: today's webhook already calls
+`releaseReservation` when a rejected charge's refund fails, so an unsettled
+attempt leaves the row unresolved and re-reservable. The rule pins that
+behaviour and makes the contradictory case visible instead of silent.
 
 **Why the hot path does not stamp the row.** A completed webhook could mark its
 staging row `finished` and save the later read. It deliberately does not: the
@@ -116,7 +152,7 @@ one provider read per created checkout, once, at least 2.5 hours after creation
 | Nothing                    | SumUp read `found` but not ours       | Row stays `waiting`; refusal logged (cannot happen — id is ours)    | Scheduler   |
 | Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created      | Owner       |
 | Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed` | Scheduler   |
-| Read says `PAID`           | Classify says `unverifiable`          | `unpaid` — another site's checkout, nothing owed by us              | —           |
+| Read says `PAID`           | Classify says `unverifiable`          | `owed` — a contradiction, not a foreign checkout (see below)        | Owner       |
 | Read says `PAID`           | Classify says `unreadable`            | Row stays `waiting`                                                 | Scheduler   |
 | Engine booked the attendee | State write fails                     | Booking stands; row stays `waiting`; next check is idempotent       | Scheduler   |
 | Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                  | Provider    |
@@ -126,16 +162,30 @@ the payment engine closes it: `processed_payments` (PK = session id = the SumUp
 reference) is reserved before any work, so a replay returns the recorded outcome
 rather than repeating it.
 
+**Why a paid `unverifiable` is `owed`, not `unpaid`.** `unpaid` means SumUp told
+us the checkout was never paid; using it for "not ours" would give one word two
+meanings. And on this path `unverifiable` should be unreachable: the sealed row
+only opens when `hmacHash(reference) === reference_index`, so the metadata — and
+therefore the price proof `classifySessionIntent` checks — is one we wrote
+ourselves. A paid checkout that opened our row and _then_ fails its own proof is
+a contradiction, so it goes to the owner rather than into a normal ending. The
+mapping over the whole read is exhaustive by construction: ownership and money
+are already separate refusals in `sumup-observation.ts`, so a mismatched
+merchant, checkout id, or named charge never reaches classification at all (the
+read is refused as invalid), while a checkout that proves ownership and carries
+unreadable amount, currency, or transaction facts arrives as a session rejection
+and takes the refund-or-`owed` row above.
+
 ### Retry and replay table
 
-| Question                             | Answer                                                                                                                                                                      |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stable identity                      | `processed_payments.session_id` = the SumUp `checkout_reference`; the staging row's `reference_index`                                                                       |
-| What an exact replay returns         | `alreadyProcessedResult` / the recorded terminal failure — no second booking, no second refund                                                                              |
-| Who retries after interruption       | The maintenance scheduler; the row keeps its state until a check writes a new one                                                                                           |
-| What stops two workers               | `claimNextMaintenanceTask`'s lease, plus `reserveSession`, plus a conditional state write (below)                                                                           |
-| Permanent failures                   | `unpaid` (never paid) and `unverifiable` (not ours). Everything else stays retryable                                                                                        |
-| Can one failed item block later work | No — the page is selected oldest-first with a limit; a row that stays `waiting` or goes `owed` is skipped by the next page's ordering and retried on its own slower cadence |
+| Question                             | Answer                                                                                                                                                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stable identity                      | `processed_payments.session_id` = the SumUp `checkout_reference`; the staging row's `reference_index`                                                                                                         |
+| What an exact replay returns         | `alreadyProcessedResult` / the recorded terminal failure — no second booking, no second refund                                                                                                                |
+| Who retries after interruption       | The maintenance scheduler; the row keeps its state until a check writes a new one                                                                                                                             |
+| What stops two workers               | `claimNextMaintenanceTask`'s lease, plus `reserveSession`, plus a conditional state write (below)                                                                                                             |
+| Permanent failures                   | `unpaid` alone — SumUp said it was never paid. Everything else stays retryable, `owed` included                                                                                                               |
+| Can one failed item block later work | No — a row is selected only when `next_check_at` is due, and every non-ending check pushes its own `next_check_at` forward, so a stuck row falls behind newer ones rather than holding the front of the queue |
 
 ### Concurrency table
 
@@ -145,7 +195,7 @@ rather than repeating it.
 | Recovery check                 | Buyer's redirect             | One booking                                                                  | Same                                                                                                                |
 | Recovery check on two isolates | Same task                    | One runner                                                                   | Maintenance lease (`claimNextMaintenanceTask`)                                                                      |
 | Recovery state write           | `setSumupCheckoutId`         | No lost transition                                                           | `UPDATE … WHERE reference_index = ? AND recovery_state = ?` — the expected current value, checked by `rowsAffected` |
-| Recovery check                 | Pruning                      | An `owed` row survives; a checked row may go                                 | Prune's WHERE names the states it may delete                                                                        |
+| Recovery check                 | Pruning                      | The row under check always survives                                          | A row being checked is `waiting` or `owed`, and prune's WHERE names only `staged`/`unpaid`/`finished`               |
 | Owner "Check again now"        | Scheduled check              | One provider read wins; the other's conditional write finds 0 rows and stops | Expected current value                                                                                              |
 
 ### Owner choices
@@ -217,11 +267,19 @@ already performs on the webhook, under the same rules and the same durable
 | Does this refund money in the background?          | Only through the path the webhook already runs for a rejected paid charge. It is the same engine or it is a second one — the plan forbids a second one                   |
 | Square: does throwing break the browser redirect?  | No. `readSessionOrder` throws only when a `paidPaymentId` is present, which only the webhook supplies. The redirect keeps `null` — there, `missing` really is "not ours" |
 
-Open question for the human, and the only product choice left: **`owed` rows are
-never pruned.** They are small (one row, no PII) and they are the only record
-that money was taken, so growth is bounded by real incidents. The alternative —
-age them out after a long retention — loses the evidence. The contract assumes
-"never", resolved by the owner's action.
+Open question for the human, and the only product choice left: **a row that may
+hold money we have not accounted for is never deleted on age alone.** That
+covers `owed` (money seen, not accounted for) and `waiting` (never yet proved
+either way — a checkout paid while SumUp was unreachable for the whole retention
+window would otherwise be deleted, which is the exact harm this work exists to
+close). Both end on a definitive answer or an owner decision, never on a clock.
+
+The cost is that a site which disconnects SumUp keeps its unanswered `waiting`
+rows. They are small, and their metadata stays sealed under a reference this
+database does not hold, so the retained bytes are inert. Growth is bounded by
+real incidents, and the live check shows the operator exactly what is
+outstanding. The alternative — a long backstop that eventually deletes them —
+trades a rare lost payment for a tidier table, which is the wrong way round.
 
 ## 5. Vertical pull requests
 
@@ -234,23 +292,33 @@ age them out after a long retention — loses the evidence. The contract assumes
 - Old path deleted: the `missing → null → "skip" → 200` arm for paid webhooks.
 - Files: `src/shared/square-provider.ts`. **~20 src lines.**
 - Call budget: unchanged (no new reads).
+- Replay key: Square's stable identity is the **order id**. `createPaymentLink`
+  returns it, the webhook reads it from `payment.order_id`, `retrieveSession`
+  puts it on the session as `id: order.id`, and that becomes
+  `processed_payments.payment_session_id`. `payment.id` is only the payment
+  reference carried alongside, and Square's event id is not used at all — so a
+  redelivery of the same completed payment reserves the same row.
 - Tests: a direct test proving a `missing` order under a completed payment id
   throws and the same read without a payment id still returns `null`; a webhook
-  integration test proving 503 instead of 200. The regression test must fail on
-  today's code first.
-- Contract rows: the Square row of the failure table.
+  integration test proving 503 instead of 200; and a redelivery test that lets
+  the order become readable and then delivers the webhook twice, asserting one
+  attendee, one ledger group, and no second refund. The regression test must
+  fail on today's code first.
+- Contract rows: the Square row of the failure table, and the replay key above.
 
 ### PR 2 — A staged SumUp checkout must prove what happened to it
 
 - Value: the paid-but-lost checkout becomes a booking; the evidence stops being
   deleted at 24 hours; the owner can see anything still owed.
-- Change: `recovery_state` column and its migration; the state words as a
-  valibot picklist; the pure `sumupRecoveryOutcome`; `resolveSumupCheckoutById`
-  lifted out of the provider member; the `settlePaymentCallback` extraction with
+- Change: the `recovery_state` and `next_check_at` columns, with the migration's
+  `after` hook deriving both for existing rows; the state words as a valibot
+  picklist; the pure `sumupRecoveryOutcome`; `resolveSumupCheckoutById` lifted
+  out of the provider member; the `settlePaymentCallback` extraction with
   `webhooks.ts` reduced to mapping its outcome to a `Response`; the
-  `sumup_checkout_recovery` maintenance task; prune scoped to the states it may
-  delete plus the unchecked backstop limit; the machine spec and its atlas
-  entry; the bounded live check; the owner-only "Check again now" action.
+  `sumup_checkout_recovery` maintenance task, selecting and re-scheduling on
+  `next_check_at`; prune scoped to `staged`/`unpaid`/`finished`; the machine
+  spec and its atlas entry; the bounded live check; the owner-only "Check again
+  now" action.
 - Old path deleted: the blind
   `boundedDelete("sumup_checkouts", "created_at < ?")`, and the HTTP-shaped
   session handling inside `handlePaymentWebhook`.
@@ -274,14 +342,22 @@ age them out after a long retention — loses the evidence. The contract assumes
 
 Tests proving each row: direct unit tests for `sumupRecoveryOutcome` (table
 driven, one case per read × answer); the machine spec sweep executing every cell
-including the declared refusals; a fault-injected test crashing between the
-booking commit and the state write and proving the next check is idempotent; a
+including the declared refusals; fault-injected tests
+(`test/test-utils/db-fault.ts`) at each of the three windows — failing before
+the booking, during the refund of a rejected charge, and after the booking
+commits but before the state write — each proving the next check reaches the
+same single outcome; a test that puts a recorded terminal failure under an
+`owed` row and proves the replay leaves it `owed` rather than `finished`; a
+migration test starting from rows with and without a `sumup_id` and asserting
+the derived states and check times; a starvation test proving a permanently
+stuck row does not hold the front of the queue while newer rows wait; a
 concurrency test running webhook and recovery together and asserting exactly one
-attendee and one ledger group; a prune test proving an `owed` row survives and a
-`finished` row does not; a scan test reading the declared states back out; and a
-Cucumber story — `specs/payments/a-payment-with-no-callback.feature` — buying
-through the real public booking page, dropping the callback, running
-maintenance, and finding the ticket.
+attendee and one ledger group; a prune test proving `waiting` and `owed` rows
+survive and a `finished` row does not; a scan test reading the declared states
+back out; and a Cucumber story —
+`specs/payments/a-payment-with-no-callback.feature` — buying through the real
+public booking page, dropping the callback, running maintenance, and finding the
+ticket.
 
 ## 6. Where this sits against PLAN.md
 
@@ -309,7 +385,9 @@ rather than building it.
 This plan is not approved. Per PR_WORKFLOW.md step 6, please confirm or change:
 
 1. the two PR slices and their order;
-2. `owed` rows never being pruned (section 4's open question);
+2. never deleting a `waiting` or `owed` row on age alone (section 4's open
+   question) — this is the one that keeps unanswered rows on a disconnected
+   site;
 3. checking **every** created checkout once, rather than stamping the row from
    the completion path;
 4. pulling the task forward from M7 (section 6).

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -158,6 +158,14 @@ A replayed terminal failure is not its own event. It is classified by the same
 money fact as a fresh one, so it arrives as `read_paid_settled` or
 `read_paid_unsettled` and the table does the rest.
 
+**The callback path raises no event at all.** Only the recovery check moves a
+row, which is what lets `finished` refuse everything without a late callback
+ever hitting that refusal: a callback that arrives after a check has closed the
+row goes through the payment engine, replays the booking it already made,
+answers the provider, and leaves `recovery_state` alone. The same is true of the
+buyer returning to the success page days later. That is checked rather than
+assumed — see the callback-after-recovery tests.
+
 ### The moves table
 
 Every cell that is present is a required landing node. Every cell that is absent
@@ -265,8 +273,11 @@ beside it.
   whenever it has an outgoing system edge, which by the second law every
   money-holding node has. The owner's edge is additive — it brings the next
   check forward, it does not own the retry.
-- **Permanent failure** is not a list. It is exactly the terminal nodes:
-  `unpaid` and `finished`. `owed` is not terminal, so it is not permanent.
+- **Terminal** is not a list either — it is the two nodes no event can move,
+  `unpaid` and `finished`. Only one of them is a failure: `unpaid` means SumUp
+  says nobody ever paid, while `finished` means the money is accounted for, by a
+  booking or by returning it. `owed` is not terminal, so it is never permanent —
+  it is the one state that is still waiting for an answer.
 - **What a replay returns** stays the payment engine's answer, unchanged:
   `processed_payments.payment_session_id` (= the SumUp `checkout_reference`) is
   reserved before any work, so `alreadyProcessedResult` or the recorded terminal

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -1,0 +1,315 @@
+# Behavior contract: a provider that took money is never acknowledged as nothing to do
+
+Status: **awaiting human approval** (PR_WORKFLOW.md step 6). No tests or
+implementation code has been written.
+
+## 1. Current-system value
+
+Two live paths today let a provider take a customer's money and leave this site
+with no booking, no refund, and — in one case — no record at all.
+
+- **SumUp.** `sumupApi.createCheckout` stages the booking metadata, then hands
+  the buyer a hosted checkout whose `return_url` is our webhook. SumUp does not
+  sign that webhook, and there is no subscription to redeliver against: if the
+  single callback is lost and the buyer never comes back to
+  `/payment/success?session_id=…`, nothing ever asks SumUp what happened. The
+  staging row is the only trace, and `runDatabasePruning` deletes it 24 hours
+  later (`boundedDelete("sumup_checkouts", "created_at < ?")`,
+  `PRUNE_SUMUP_RETENTION_HOURS`). The buyer is charged, gets no ticket, and the
+  operator has nothing to find.
+- **Square.** `readSessionOrder` (`src/shared/square-provider.ts:130`) maps a
+  `missing` order read to `null`. Through `retrieveSession` →
+  `resolveWebhookSession` that `null` becomes `"skip"`, and
+  `handlePaymentWebhook` answers `webhookAckResponse({ status: "pending" })` —
+  HTTP 200. Square stops redelivering. But the webhook that arrived named a
+  **COMPLETED payment**, and an order that does not read back yet is the same
+  eventual-consistency window the file already treats as retryable two lines
+  down (`UNUSABLE_METADATA.retryCompletedWebhook`, and `readOrderPayment`
+  throwing when the payment does not read `COMPLETED`).
+
+Value if nothing else ever ships:
+
+> A SumUp checkout that was paid becomes a booking even when its only callback
+> was lost, and a Square webhook for a completed payment whose order is not
+> readable yet is redelivered instead of acknowledged.
+
+Production receivers: the `sumup_checkout_recovery` maintenance task (run by
+`features/scheduled.ts` and `maintenance.runOrganic` in
+`features/app/request.ts`), `runDatabasePruning`, the `/admin/schema` page, and
+`POST /payment/webhook` for Square.
+
+## 2. Behavior contract
+
+### Trusted facts
+
+| Fact                                              | Source                                                        | Why it may be trusted                                                        |
+| ------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `sumup_checkouts.sumup_id`                        | Written by `setSumupCheckoutId` before the buyer sees the URL | Ours by construction; not sensitive; the existing webhook pre-filter uses it |
+| `sumup_checkouts.reference_index`                 | `hmacHash(reference)` at staging                              | Signed by our key; proves a fetched reference names this row                 |
+| `sumup_checkouts.created_at`                      | Our clock at staging                                          | Ours; used only to schedule a check, never to decide a payment fact          |
+| The signed price proof inside the staged metadata | `assembleCheckoutMetadata`                                    | Cannot be forged without our key; already the ownership test                 |
+| Square webhook naming a `COMPLETED` payment       | Verified Square signature                                     | `requiresWebhookSignature: true`; the signature proves the sender            |
+
+Observed facts, kept separate and never substituted for the above:
+
+| Fact                                              | Source                                     | Trust                                                           |
+| ------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
+| SumUp checkout status/amount/currency/transaction | `sumupApi.readCheckoutById(sumup_id)`      | A read, refused by the existing observation boundary if it lies |
+| The `checkout_reference` SumUp echoes back        | Same read                                  | Only usable if it opens the sealed row (`openSumupCheckout`)    |
+| Square order + payment                            | `squareApi.readOrder` / `readOrderPayment` | Absent is **not** unpaid — that is the whole Square defect      |
+
+An unavailable read is never read as "not paid". A read we could not make is
+never read as "nothing happened".
+
+### Valid states
+
+One new plaintext column, `sumup_checkouts.recovery_state`, is the authority for
+a staging row's own lifecycle. It holds a state word only — never a reference,
+an amount, or any buyer fact — so the row stays as unreadable as it is today.
+
+| State      | Meaning                                                              | Facts required                     |
+| ---------- | -------------------------------------------------------------------- | ---------------------------------- |
+| `staged`   | Row written; SumUp has not given us a checkout id                    | `sumup_id = ''`                    |
+| `waiting`  | Checkout is live; the buyer may still pay                            | `sumup_id != ''`                   |
+| `unpaid`   | We asked SumUp and it said this checkout was never paid              | `sumup_id != ''`; a completed read |
+| `finished` | We asked, it was paid, and the payment engine reached a final answer | `sumup_id != ''`; a completed read |
+| `owed`     | It was paid and we could **not** reach a final answer                | `sumup_id != ''`; a completed read |
+
+`staged` and `waiting` are set in the same statement as the fact they mirror
+(`storeSumupCheckout`'s INSERT, `setSumupCheckoutId`'s UPDATE), so no consumer
+routes on `sumup_id != ''` as a proxy for state (data law 4).
+
+`finished` covers both endings the payment engine can give a paid session: a
+booking, or a rejection whose money was sent back. Neither leaves anything owed.
+
+### Commands and events
+
+| Starting state               | Command or event                               | Required result                                                       |
+| ---------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
+| —                            | `storeSumupCheckout`                           | `staged`                                                              |
+| `staged`                     | `setSumupCheckoutId`                           | `waiting` (same UPDATE; still exactly one row or throw)               |
+| `waiting`                    | Webhook or redirect completes the booking      | `waiting` (unchanged — see "Why the hot path does not stamp the row") |
+| `waiting`                    | Recovery check, read says `EXPIRED` / `FAILED` | `unpaid`                                                              |
+| `waiting`                    | Recovery check, read says `PAID`, engine final | `finished`                                                            |
+| `waiting`                    | Recovery check, read says `PAID`, engine stuck | `owed`                                                                |
+| `waiting`                    | Recovery check, read says `PENDING`            | `waiting` (checked again later)                                       |
+| `waiting`                    | Recovery check, read unavailable               | `waiting` (checked again later)                                       |
+| `owed`                       | Recovery check succeeds later                  | `finished`                                                            |
+| `owed`                       | Owner presses "Check again now"                | Same three outcomes as a scheduled check                              |
+| `staged`/`unpaid`/`finished` | Pruning past `PRUNE_SUMUP_RETENTION_HOURS`     | Row deleted                                                           |
+| `waiting`                    | Pruning past the new unchecked backstop        | Row deleted, after the live check has been showing it as overdue      |
+| `owed`                       | Pruning                                        | **Never** — it is the only record that money was taken                |
+
+**Why the hot path does not stamp the row.** A completed webhook could mark its
+staging row `finished` and save the later read. It deliberately does not: the
+recovery check asking SumUp about _every_ checkout we created is precisely the
+backwards check (AGENTS.md, "Check backwards from the data"). A site whose
+webhooks have been failing silently for a week is discovered by it. The cost is
+one provider read per created checkout, once, at least 2.5 hours after creation
+— bounded per run by the task's declared external-call budget.
+
+### Failure table
+
+| Work completed             | Failure                               | Required result                                                     | Retry owner |
+| -------------------------- | ------------------------------------- | ------------------------------------------------------------------- | ----------- |
+| Nothing                    | SumUp read unavailable                | Row stays `waiting`; no state written                               | Scheduler   |
+| Nothing                    | SumUp read `found` but not ours       | Row stays `waiting`; refusal logged (cannot happen — id is ours)    | Scheduler   |
+| Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created      | Owner       |
+| Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed` | Scheduler   |
+| Read says `PAID`           | Classify says `unverifiable`          | `unpaid` — another site's checkout, nothing owed by us              | —           |
+| Read says `PAID`           | Classify says `unreadable`            | Row stays `waiting`                                                 | Scheduler   |
+| Engine booked the attendee | State write fails                     | Booking stands; row stays `waiting`; next check is idempotent       | Scheduler   |
+| Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                  | Provider    |
+
+The gap between provider success and local success is closed the way the rest of
+the payment engine closes it: `processed_payments` (PK = session id = the SumUp
+reference) is reserved before any work, so a replay returns the recorded outcome
+rather than repeating it.
+
+### Retry and replay table
+
+| Question                             | Answer                                                                                                                                                                      |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stable identity                      | `processed_payments.session_id` = the SumUp `checkout_reference`; the staging row's `reference_index`                                                                       |
+| What an exact replay returns         | `alreadyProcessedResult` / the recorded terminal failure — no second booking, no second refund                                                                              |
+| Who retries after interruption       | The maintenance scheduler; the row keeps its state until a check writes a new one                                                                                           |
+| What stops two workers               | `claimNextMaintenanceTask`'s lease, plus `reserveSession`, plus a conditional state write (below)                                                                           |
+| Permanent failures                   | `unpaid` (never paid) and `unverifiable` (not ours). Everything else stays retryable                                                                                        |
+| Can one failed item block later work | No — the page is selected oldest-first with a limit; a row that stays `waiting` or goes `owed` is skipped by the next page's ordering and retried on its own slower cadence |
+
+### Concurrency table
+
+| Operation A                    | Operation B                  | Required result                                                              | Protection                                                                                                          |
+| ------------------------------ | ---------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Recovery check                 | Late webhook for the same id | One booking                                                                  | `reserveSession` on `processed_payments`                                                                            |
+| Recovery check                 | Buyer's redirect             | One booking                                                                  | Same                                                                                                                |
+| Recovery check on two isolates | Same task                    | One runner                                                                   | Maintenance lease (`claimNextMaintenanceTask`)                                                                      |
+| Recovery state write           | `setSumupCheckoutId`         | No lost transition                                                           | `UPDATE … WHERE reference_index = ? AND recovery_state = ?` — the expected current value, checked by `rowsAffected` |
+| Recovery check                 | Pruning                      | An `owed` row survives; a checked row may go                                 | Prune's WHERE names the states it may delete                                                                        |
+| Owner "Check again now"        | Scheduled check              | One provider read wins; the other's conditional write finds 0 rows and stops | Expected current value                                                                                              |
+
+### Owner choices
+
+None are added. This work never chooses a money outcome: the only genuine
+ambiguity it can produce is `owed`, and `owed` is not a decision the system
+takes — it is the honest statement that money was taken and the booking did not
+happen, shown to the owner with the SumUp checkout id and a control that tries
+again. Any refund on this path is the one the existing `settleRejectedCharge`
+already performs on the webhook, under the same rules and the same durable
+`payment_charges` authority.
+
+### Security and privacy
+
+- The staging row's protection is unchanged: metadata stays encrypted under a
+  key wrapped with the reference, the plaintext reference never rests in this
+  table, and `recovery_state` is a state word carrying no buyer or provider
+  fact. Data never moves to weaker protection (data law 6).
+- The recovery check re-obtains the reference the same way the webhook does —
+  from SumUp's own response — and it only decrypts when
+  `hmacHash(reference) === reference_index`.
+- Untrusted input that can cause provider work: none new. The task's inputs are
+  our own staged rows. Unlike the webhook, no external caller can trigger it.
+- `/admin/schema` and its live check are owner-only, matching the existing page.
+  The "Check again now" control is rendered only where the owner can use it and
+  only for a row that exists, so no dead or forbidden link is emitted.
+- The live check lists the SumUp checkout id (not sensitive, already the
+  pre-filter key) and the state word. No amount, no buyer fact.
+
+## 3. Shared contract
+
+- **One pure rule.** `sumupRecoveryOutcome(read, engineAnswer)` in
+  `src/shared/sumup/recovery.ts` — data in, next state out. No IO. Exhaustive
+  over `ProviderRead<SumupCheckout>` and the payment engine's answer, returning
+  a `SumupRecoveryState` from a valibot picklist that also derives the type, the
+  guard, and the state list (the `ContactFieldSchema` pattern).
+- **One engine, not a second one.** `handlePaymentWebhook` currently interleaves
+  the payment work with HTTP responses. Extract the work half — resolved session
+  → classify → `settlePaymentCallback` → an exhaustive `CallbackOutcome` union —
+  and have `webhooks.ts` map that union to a `Response`. The recovery task maps
+  the same union to a state word. One production implementation per command; the
+  HTTP layer becomes the thin shell.
+- **One way to ask SumUp about a checkout id.** `resolveWebhookSession` already
+  is that operation; lift its body to `resolveSumupCheckoutById(sumupId)` and
+  have both the webhook member and the recovery task call it. Not an alias — the
+  member keeps its interface job, the shared mechanism is exposed directly.
+- **The machine is declared, not described.** `sumup-recovery-machine-spec.ts`
+  with nodes, events, and an exhaustive moves table; a missing cell is a
+  declared refusal the sweep executes. It joins `SCHEMA_ATLAS_MACHINES` so
+  `/admin/schema` maps it with no other change.
+- **The backwards check reads the stored data.** A bounded scan (the
+  `joint-state-scan.ts` shape, `SCAN_LIMIT`-style cap) lists `owed` rows and
+  `waiting` rows past their check window, keyed by the declaration's own literal
+  states so a new state does not compile until the scan knows how to find it.
+
+## 4. Challenging the contract
+
+| Challenge                                          | Answer                                                                                                                                                                   |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Provider read succeeds, local write fails          | The booking commits atomically before the state write. A failed state write leaves `waiting`; the next check re-reads and `reserveSession` returns the recorded outcome  |
+| Callback replayed after recovery already booked it | `processed_payments` PK; `alreadyProcessedResult`                                                                                                                        |
+| Two paid checkouts, one buyer                      | Independent rows and independent session ids; nothing correlates them                                                                                                    |
+| Amount/currency/parent wrong                       | Untouched: the existing observation boundary and `classifySessionIntent` decide, and a rejected paid charge takes the existing refund path                               |
+| Buyer reloads mid-recovery                         | The redirect calls `retrieveSession`, which is already idempotent through the same reserve                                                                               |
+| The task runs on a site with no SumUp              | `check.enabled` reads `SUMUP_API_KEY`/`SUMUP_MERCHANT_CODE`; disabled tasks are removed by `syncMaintenanceTaskRows`                                                     |
+| SumUp is disconnected while rows are `waiting`     | They are never checked, the live check shows them as overdue, and the new unchecked backstop finally prunes them. They are not silently kept forever                     |
+| A busy site's checkouts flood the task             | Oldest-first page with a small limit and `requestFollowUp()`; at most **one** paid recovery per run, because a rejection can spend refund subrequests                    |
+| Budget: Bunny's 50 subrequests                     | Declared in the task's `maxDatabaseCalls`/`maxExternalCalls`, which `maintenanceStartupCalls` already sums and the runner already enforces via `budget.remaining()`      |
+| Does this refund money in the background?          | Only through the path the webhook already runs for a rejected paid charge. It is the same engine or it is a second one — the plan forbids a second one                   |
+| Square: does throwing break the browser redirect?  | No. `readSessionOrder` throws only when a `paidPaymentId` is present, which only the webhook supplies. The redirect keeps `null` — there, `missing` really is "not ours" |
+
+Open question for the human, and the only product choice left: **`owed` rows are
+never pruned.** They are small (one row, no PII) and they are the only record
+that money was taken, so growth is bounded by real incidents. The alternative —
+age them out after a long retention — loses the evidence. The contract assumes
+"never", resolved by the owner's action.
+
+## 5. Vertical pull requests
+
+### PR 1 — A Square webhook for a completed payment is never acknowledged as pending
+
+- Value: a paid Square booking whose order lags is redelivered, not dropped.
+- Change: `readSessionOrder` learns whether a `paidPaymentId` is in play and
+  throws on `missing` when it is, matching `readOrderPayment` two functions
+  down. The redirect keeps returning `null`.
+- Old path deleted: the `missing → null → "skip" → 200` arm for paid webhooks.
+- Files: `src/shared/square-provider.ts`. **~20 src lines.**
+- Call budget: unchanged (no new reads).
+- Tests: a direct test proving a `missing` order under a completed payment id
+  throws and the same read without a payment id still returns `null`; a webhook
+  integration test proving 503 instead of 200. The regression test must fail on
+  today's code first.
+- Contract rows: the Square row of the failure table.
+
+### PR 2 — A staged SumUp checkout must prove what happened to it
+
+- Value: the paid-but-lost checkout becomes a booking; the evidence stops being
+  deleted at 24 hours; the owner can see anything still owed.
+- Change: `recovery_state` column and its migration; the state words as a
+  valibot picklist; the pure `sumupRecoveryOutcome`; `resolveSumupCheckoutById`
+  lifted out of the provider member; the `settlePaymentCallback` extraction with
+  `webhooks.ts` reduced to mapping its outcome to a `Response`; the
+  `sumup_checkout_recovery` maintenance task; prune scoped to the states it may
+  delete plus the unchecked backstop limit; the machine spec and its atlas
+  entry; the bounded live check; the owner-only "Check again now" action.
+- Old path deleted: the blind
+  `boundedDelete("sumup_checkouts", "created_at < ?")`, and the HTTP-shaped
+  session handling inside `handlePaymentWebhook`.
+- Files: `src/shared/db/sumup-checkouts.ts`, `src/shared/db/prune.ts`,
+  `src/shared/db/migrations/` (+ schema), `src/shared/sumup/recovery.ts`,
+  `src/shared/sumup-provider.ts`, `src/features/api/webhooks.ts`,
+  `src/features/api/payment-callback.ts` (new),
+  `src/shared/maintenance/registry.ts`, `src/shared/limits.ts`,
+  `src/shared/payment/sumup-recovery-machine-spec.ts`,
+  `src/shared/schema-atlas/`, `src/shared/db/sumup-recovery-scan.ts`, the
+  `/admin/schema` action, and `src/locales/en/*.json` (not counted).
+- **~640 src lines**, under the 800 cap. If it overruns, the split is by
+  invariant: the task and its machine first, the live check and owner action
+  second — but only if the first still leaves `owed` reachable through the
+  scheduled retry.
+- Call budget: startup adds 1 settings read + 1 database call to the task check.
+  Per run: ≤3 database reads, ≤3 SumUp reads, ≤1 paid recovery (which may spend
+  the existing refund path's calls). Well inside `MAINTENANCE_TASK_CALL_LIMIT`.
+- Contract rows: every row of the state, failure, retry, and concurrency tables
+  except the Square one.
+
+Tests proving each row: direct unit tests for `sumupRecoveryOutcome` (table
+driven, one case per read × answer); the machine spec sweep executing every cell
+including the declared refusals; a fault-injected test crashing between the
+booking commit and the state write and proving the next check is idempotent; a
+concurrency test running webhook and recovery together and asserting exactly one
+attendee and one ledger group; a prune test proving an `owed` row survives and a
+`finished` row does not; a scan test reading the declared states back out; and a
+Cucumber story — `specs/payments/a-payment-with-no-callback.feature` — buying
+through the real public booking page, dropping the callback, running
+maintenance, and finding the ticket.
+
+## 6. Where this sits against PLAN.md
+
+`PLAN.md` currently lists the missed-SumUp-checkout task inside work package M7
+("M7 attaches scheduled retries, the missed-SumUp-checkout task, and the
+original checkout's handled marker to this same lifecycle"), and M6–M11 activate
+only as one atomic cutover. This contract proposes pulling it forward onto the
+current path instead, because:
+
+- it needs nothing from the aggregate reader — it uses the current
+  `processed_payments` engine, which M8 will displace along with every other
+  current completion writer;
+- it adds no parallel path and no dormant layer: one task, one engine, one
+  machine, all live the day it merges;
+- the harm it closes is live today on every SumUp site, and the evidence for it
+  is being deleted every 24 hours while the cutover is designed.
+
+If the plan is approved, `PLAN.md`'s M7 bullet and the "Where we are" table need
+the same-commit amendment PLAN.md's own rules require, recording that the
+missed-SumUp-checkout task shipped on the current path and that M7 inherits it
+rather than building it.
+
+## 7. Approval
+
+This plan is not approved. Per PR_WORKFLOW.md step 6, please confirm or change:
+
+1. the two PR slices and their order;
+2. `owed` rows never being pruned (section 4's open question);
+3. checking **every** created checkout once, rather than stamping the row from
+   the completion path;
+4. pulling the task forward from M7 (section 6).

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -146,16 +146,29 @@ one provider read per created checkout, once, at least 2.5 hours after creation
 
 ### Failure table
 
-| Work completed             | Failure                               | Required result                                                     | Retry owner                                |
-| -------------------------- | ------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------ |
-| Nothing                    | SumUp read unavailable                | Row stays `waiting`; no state written                               | Scheduler                                  |
-| Nothing                    | SumUp read `found` but not ours       | Row stays `waiting`; refusal logged (cannot happen — id is ours)    | Scheduler                                  |
-| Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created      | Scheduler, and the owner can force a check |
-| Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed` | Scheduler                                  |
-| Read says `PAID`           | Classify says `unverifiable`          | `owed` — a contradiction, not a foreign checkout (see below)        | Scheduler, and the owner can force a check |
-| Read says `PAID`           | Classify says `unreadable`            | Row stays `waiting`                                                 | Scheduler                                  |
-| Engine booked the attendee | State write fails                     | Booking stands; row stays `waiting`; next check is idempotent       | Scheduler                                  |
-| Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                  | Provider                                   |
+| Work completed             | Failure                               | Required result                                                                              | Retry owner                                |
+| -------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Nothing                    | SumUp read unavailable                | Stays `waiting`; `next_check_at` advanced by the backoff                                     | Scheduler                                  |
+| Nothing                    | SumUp read `found` but not ours       | Stays `waiting`, `next_check_at` advanced; refusal logged (cannot happen — id is ours)       | Scheduler                                  |
+| Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created                               | Scheduler, and the owner can force a check |
+| Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed`                          | Scheduler                                  |
+| Read says `PAID`           | Classify says `unverifiable`          | `owed` — a contradiction, not a foreign checkout (see below)                                 | Scheduler, and the owner can force a check |
+| Read says `PAID`           | Classify says `unreadable`            | Stays `waiting`; `next_check_at` advanced by the backoff                                     | Scheduler                                  |
+| Engine booked the attendee | State write fails                     | Booking stands; nothing written, so the task's own failure backoff carries the retry (below) | Scheduler                                  |
+| Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                                           | Provider                                   |
+
+**Every non-terminal outcome writes a new `next_check_at`.** Leaving a row
+untouched because its state did not change would leave it due, so the very next
+run would select it again — the starvation `next_check_at` exists to prevent.
+Staying `waiting` is therefore still a write: the state word is unchanged and
+the schedule moves.
+
+The one case that cannot write is a failed state write itself. Nothing durable
+can be recorded there by definition, so the retry falls to the maintenance
+framework: the task throws, and the runner holds it off for its declared
+`failureRetryIntervalMs` before running it again. The booking already committed
+and the next check is idempotent, so the cost of that re-selection is one wasted
+provider read, not a wrong answer.
 
 The gap between provider success and local success is closed the way the rest of
 the payment engine closes it: `processed_payments` (PK = `payment_session_id` =
@@ -196,14 +209,23 @@ and takes the refund-or-`owed` row above.
 
 ### Concurrency table
 
-| Operation A                    | Operation B                  | Required result                                                              | Protection                                                                                                          |
-| ------------------------------ | ---------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Recovery check                 | Late webhook for the same id | One booking                                                                  | `reserveSession` on `processed_payments`                                                                            |
-| Recovery check                 | Buyer's redirect             | One booking                                                                  | Same                                                                                                                |
-| Recovery check on two isolates | Same task                    | One runner                                                                   | Maintenance lease (`claimNextMaintenanceTask`)                                                                      |
-| Recovery state write           | `setSumupCheckoutId`         | No lost transition                                                           | `UPDATE … WHERE reference_index = ? AND recovery_state = ?` — the expected current value, checked by `rowsAffected` |
-| Recovery check                 | Pruning                      | The row under check always survives                                          | A row being checked is `waiting` or `owed`, and prune's WHERE names only `staged`/`unpaid`/`finished`               |
-| Owner "Check again now"        | Scheduled check              | One provider read wins; the other's conditional write finds 0 rows and stops | Expected current value                                                                                              |
+| Operation A                    | Operation B                  | Required result                                  | Protection                                                                                                                          |
+| ------------------------------ | ---------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Recovery check                 | Late webhook for the same id | One booking                                      | `reserveSession` on `processed_payments`                                                                                            |
+| Recovery check                 | Buyer's redirect             | One booking                                      | Same                                                                                                                                |
+| Recovery check on two isolates | Same task                    | One runner                                       | Maintenance lease (`claimNextMaintenanceTask`)                                                                                      |
+| Recovery state write           | `setSumupCheckoutId`         | No lost transition                               | `UPDATE … WHERE reference_index = ? AND recovery_state = ? AND next_check_at = ?` — both expected values, checked by `rowsAffected` |
+| Recovery check                 | Pruning                      | The row under check always survives              | A row being checked is `waiting` or `owed`, and prune's WHERE names only `staged`/`unpaid`/`finished`                               |
+| Owner "Check again now"        | Scheduled check              | One write wins; the loser finds 0 rows and stops | Same expected `recovery_state` **and** `next_check_at` — see "Why the fence needs both" below                                       |
+
+**Why the fence needs both.** Guarding only on `recovery_state` is enough for a
+transition that changes it, but not for the `waiting → waiting` writes above:
+two checks can both read `waiting`, both write `waiting`, and both report one
+affected row, so neither learns it raced. The loser would then overwrite the
+winner's `next_check_at` — including one an owner had just pulled forward.
+Naming the expected `next_check_at` in the same `WHERE` makes a stale write
+affect zero rows, which is how the loser finds out. The owner's control writes
+under the same fence, so it cannot clobber a scheduled check either.
 
 ### Owner choices
 
@@ -229,6 +251,14 @@ already performs on the webhook, under the same rules and the same durable
 - `/admin/schema` and its live check are owner-only, matching the existing page.
   The "Check again now" control is rendered only where the owner can use it and
   only for a row that exists, so no dead or forbidden link is emitted.
+- **"Check again now" is a POST built with `ownerFormHandler`**
+  (`src/shared/app-forms.ts`), which is `createAuthedHandler` under the
+  `OWNER_FORM` policy — CSRF plus owner auth from the one shared mechanism, not
+  new plumbing. The scheduled task has no external caller, but this control is a
+  state-changing HTTP entry point and gets the same guard every other admin form
+  has. All it may do is bring `next_check_at` forward under the fence above; it
+  never reads the provider itself, so a replayed submission costs nothing. Tests
+  cover a manager being refused and a missing or invalid token being refused.
 - The live check lists the SumUp checkout id (not sensitive, already the
   pre-filter key) and the state word. No amount, no buyer fact.
 
@@ -357,14 +387,17 @@ same single outcome; a test that puts a recorded terminal failure under an
 `owed` row and proves the replay leaves it `owed` rather than `finished`; a
 migration test starting from rows with and without a `sumup_id` and asserting
 the derived states and check times; a starvation test proving a permanently
-stuck row does not hold the front of the queue while newer rows wait; a
-concurrency test running webhook and recovery together and asserting exactly one
-attendee and one ledger group; a prune test proving `waiting` and `owed` rows
-survive and a `finished` row does not; a scan test reading the declared states
-back out; and a Cucumber story —
-`specs/payments/a-payment-with-no-callback.feature` — buying through the real
-public booking page, dropping the callback, running maintenance, and finding the
-ticket.
+stuck row does not hold the front of the queue while newer rows wait; a test
+that two concurrent checks on one `waiting` row leave exactly one new
+`next_check_at`, and that an owner-forced check is not overwritten by a
+scheduled one that raced it; route tests refusing a manager and refusing a
+missing or invalid CSRF token on "Check again now"; a concurrency test running
+webhook and recovery together and asserting exactly one attendee and one ledger
+group; a prune test proving `waiting` and `owed` rows survive and a `finished`
+row does not; a scan test reading the declared states back out; and a Cucumber
+story — `specs/payments/a-payment-with-no-callback.feature` — buying through the
+real public booking page, dropping the callback, running maintenance, and
+finding the ticket.
 
 ## 6. Where this sits against PLAN.md
 

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -62,170 +62,182 @@ Observed facts, kept separate and never substituted for the above:
 An unavailable read is never read as "not paid". A read we could not make is
 never read as "nothing happened".
 
-### Valid states
+### Square: one rule, no machine
 
-Two new plaintext columns. `sumup_checkouts.recovery_state` is the authority for
-a staging row's own lifecycle, and `next_check_at` is when that row is next due
-to be asked about. Both hold scheduling and state words only — never a
-reference, an amount, or any buyer fact — so the row stays as unreadable as it
-is today.
+Square needs no lifecycle of its own — it has a webhook subscription that
+redelivers, which is the whole thing SumUp lacks. It needs one rule, stated as a
+refusal:
 
-`created_at` can only schedule the _first_ check. Without `next_check_at`, an
-oldest-first page under a fixed limit would keep re-selecting the same overdue
-rows and starve newer paid checkouts, so selection, claiming, and ordering all
-key on `next_check_at`, and every check that does not end the row pushes it
-forward by a backoff.
+> A Square webhook naming a `COMPLETED` payment whose order is not readable is
+> refused, never acknowledged. `readSessionOrder` throws when a `paidPaymentId`
+> is present, matching `readOrderPayment` two functions down, and the boundary
+> answers 503 so Square sends it again.
 
-| State      | Meaning                                                              | Facts required                     |
-| ---------- | -------------------------------------------------------------------- | ---------------------------------- |
-| `staged`   | Row written; SumUp has not given us a checkout id                    | `sumup_id = ''`                    |
-| `waiting`  | Checkout is live; the buyer may still pay                            | `sumup_id != ''`                   |
-| `unpaid`   | We asked SumUp and it said this checkout was never paid              | `sumup_id != ''`; a completed read |
-| `finished` | We asked, it was paid, and the payment engine reached a final answer | `sumup_id != ''`; a completed read |
-| `owed`     | It was paid and we could **not** reach a final answer                | `sumup_id != ''`; a completed read |
+The browser redirect keeps today's behaviour: it supplies no `paidPaymentId`,
+and there a `missing` order really does mean "not one of ours". The replay
+identity is the **order id** — `retrieveSession` puts it on the session as
+`id: order.id`, and that becomes `processed_payments.payment_session_id`, so a
+redelivery reserves the same row. `payment.id` is only the payment reference;
+Square's event id is not read at all.
 
-`staged` and `waiting` are set in the same statement as the fact they mirror
-(`storeSumupCheckout`'s INSERT, `setSumupCheckoutId`'s UPDATE), so no consumer
-routes on `sumup_id != ''` as a proxy for state (data law 4).
+### One declared machine, not five prose tables
 
-`finished` covers both endings the payment engine can give a paid session: a
-booking, or a rejection whose money was sent back. Neither leaves anything owed.
+Earlier drafts of this contract carried the states, the commands, the failures,
+the retries, and the races as five hand-written tables. Every review finding so
+far has been one of those tables disagreeing with another or with the code: a
+column name nothing could look up, an outcome with two different retry owners, a
+failure row that wrote no schedule while the retry table promised one. Fixing
+each disagreement created the next, because nothing checked the tables against
+each other.
 
-**Rows that already exist get their state derived, not defaulted.** A column
-added with one `DEFAULT` would label every live checkout `staged` and it would
-never be checked again. The migration therefore adds both columns and then, in
-the same migration's `after` hook (the fourth argument to `schemaMigration`),
-derives each existing row: `staged` where `sumup_id = ''`, `waiting` otherwise,
-with `next_check_at` set from `created_at` plus the first-check delay. The
-allowed-value check and `NOT NULL` are asserted after that derivation, and the
-maintenance task is registered in the same release, so it cannot run against
-un-derived rows.
+So the machine is the contract. One declaration carries the nodes, the events,
+and an exhaustive moves table, in the shape
+`src/shared/schema-atlas/machine-spec.ts` already defines. Everything the five
+tables used to say is a property of a node or an edge, and the tables below are
+**projections of that one declaration, not separate sources**. It lands as
+`src/shared/payment/sumup-recovery-machine-spec.ts`, joins
+`SCHEMA_ATLAS_MACHINES`, and its mirror suite executes every (node × event ×
+shape) cell against the real transitions — a cell absent from the table is a
+declared refusal, and the sweep proves it refuses.
 
-### Commands and events
+### Nodes
 
-| Starting state               | Command or event                               | Required result                                                       |
-| ---------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
-| —                            | `storeSumupCheckout`                           | `staged`                                                              |
-| `staged`                     | `setSumupCheckoutId`                           | `waiting` (same UPDATE; still exactly one row or throw)               |
-| `waiting`                    | Webhook or redirect completes the booking      | `waiting` (unchanged — see "Why the hot path does not stamp the row") |
-| `waiting`                    | Recovery check, read says `EXPIRED` / `FAILED` | `unpaid`                                                              |
-| `waiting`                    | Recovery check, read says `PAID`, engine final | `finished`                                                            |
-| `waiting`                    | Recovery check, read says `PAID`, engine stuck | `owed`                                                                |
-| `waiting`                    | Recovery check, read says `PENDING`            | `waiting` (checked again later)                                       |
-| `waiting`                    | Recovery check, read unavailable               | `waiting` (checked again later)                                       |
-| `owed`                       | Recovery check reaches a final answer          | `finished` (only under the rule below)                                |
-| `owed`                       | Owner presses "Check again now"                | Same outcomes as a scheduled check                                    |
-| `staged`/`unpaid`/`finished` | Pruning past `PRUNE_SUMUP_RETENTION_HOURS`     | Row deleted                                                           |
-| `waiting`/`owed`             | Pruning                                        | **Never** — both may hold money we have not accounted for             |
+A node carries what the row is, plus the two facts the old tables kept
+restating: whether it may hold money nobody has accounted for, and whether
+pruning may delete it.
 
-**`owed` never clears on a replayed outcome.** `reserveSession` claims only
-missing and stale unresolved rows; a finalized or recorded-failure row comes
-back as `{reserved: false, existing}` and `handleReservationConflict` replays
-the stored outcome. So a later check on an `owed` row could be handed a
-previously recorded terminal failure and would call it done — marking money we
-know was taken as finished, with no booking. The rule that forbids this:
+| Node       | Meaning                                             | `owesMoney` | `prunable` |
+| ---------- | --------------------------------------------------- | ----------- | ---------- |
+| `staged`   | Row written; SumUp has not given us a checkout id   | no          | yes        |
+| `waiting`  | Checkout is live; the buyer may still pay           | **unknown** | **no**     |
+| `unpaid`   | SumUp said this checkout was never paid             | no          | yes        |
+| `finished` | Paid, and the payment engine reached a final answer | no          | yes        |
+| `owed`     | Paid, and we could **not** reach a final answer     | **yes**     | **no**     |
 
-> An `owed` row becomes `finished` only when the current attempt itself reaches
-> a final answer — a booking finalized now, a refund settled now, or a replay
-> whose existing row is finalized (`attendee_id` set). A replayed terminal
-> _failure_ under an `owed` row leaves it `owed`, because the row states that
-> the money was seen and this attempt did not account for it.
+`waiting` counts as unknown rather than no: until SumUp answers, we cannot say
+the buyer did not pay, and the whole point of this work is that a lost callback
+looks exactly like an unpaid checkout.
 
-This costs no change to `reserveSession`: today's webhook already calls
-`releaseReservation` when a rejected charge's refund fails, so an unsettled
-attempt leaves the row unresolved and re-reservable. The rule pins that
-behaviour and makes the contradictory case visible instead of silent.
+`nodeOf(row)` is total — it maps every stored row to exactly one node and throws
+on a combination no writer can produce, the way `rowNodeOf` does for the payment
+row. That is what makes the backwards scan possible: a row that does not map is
+a defect the operator sees, not a silent default.
 
-**Why the hot path does not stamp the row.** A completed webhook could mark its
-staging row `finished` and save the later read. It deliberately does not: the
-recovery check asking SumUp about _every_ checkout we created is precisely the
-backwards check (AGENTS.md, "Check backwards from the data"). A site whose
-webhooks have been failing silently for a week is discovered by it. The cost is
-one provider read per created checkout, once, at least 2.5 hours after creation
-— bounded per run by the task's declared external-call budget.
+### Events
 
-### Failure table
+An event carries what it runs, and the two things the old concurrency and
+failure tables kept separately: what it writes, and what its conditional
+`UPDATE` fences on.
 
-| Work completed             | Failure                               | Required result                                                                              | Retry owner                                |
-| -------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| Nothing                    | SumUp read unavailable                | Stays `waiting`; `next_check_at` advanced by the backoff                                     | Scheduler                                  |
-| Nothing                    | SumUp read `found` but not ours       | Stays `waiting`, `next_check_at` advanced; refusal logged (cannot happen — id is ours)       | Scheduler                                  |
-| Read says `PAID`           | Echoed reference does not open row    | `owed` — SumUp contradicted itself about a checkout we created                               | Scheduler, and the owner can force a check |
-| Read says `PAID`           | Boundary rejects the money            | Existing `settleRejectedCharge`: refunded ⇒ `finished`, else `owed`                          | Scheduler                                  |
-| Read says `PAID`           | Classify says `unverifiable`          | `owed` — a contradiction, not a foreign checkout (see below)                                 | Scheduler, and the owner can force a check |
-| Read says `PAID`           | Classify says `unreadable`            | Stays `waiting`; `next_check_at` advanced by the backoff                                     | Scheduler                                  |
-| Engine booked the attendee | State write fails                     | Booking stands; nothing written, so the task's own failure backoff carries the retry (below) | Scheduler                                  |
-| Square: webhook accepted   | Order reads `missing` under a paid id | **Throw** — 503, Square redelivers                                                           | Provider                                   |
+| Event                     | Actor     | Writes           | Fences on                   |
+| ------------------------- | --------- | ---------------- | --------------------------- |
+| `checkout_created`        | system    | state            | `reference_index` (one row) |
+| `read_unavailable`        | system    | schedule         | state + schedule            |
+| `read_pending`            | system    | schedule         | state + schedule            |
+| `read_expired_or_failed`  | system    | state + schedule | state + schedule            |
+| `read_paid_booked`        | system    | state + schedule | state + schedule            |
+| `read_paid_refunded`      | system    | state + schedule | state + schedule            |
+| `read_paid_unsettled`     | system    | state + schedule | state + schedule            |
+| `read_paid_unreadable`    | system    | schedule         | state + schedule            |
+| `read_paid_contradiction` | system    | state + schedule | state + schedule            |
+| `replayed_failure`        | system    | schedule         | state + schedule            |
+| `owner_forces_check`      | **owner** | schedule         | state + schedule            |
 
-**Every non-terminal outcome writes a new `next_check_at`.** Leaving a row
-untouched because its state did not change would leave it due, so the very next
-run would select it again — the starvation `next_check_at` exists to prevent.
-Staying `waiting` is therefore still a write: the state word is unchanged and
-the schedule moves.
+### The moves table
 
-The one case that cannot write is a failed state write itself. Nothing durable
-can be recorded there by definition, so the retry falls to the maintenance
-framework: the task throws, and the runner holds it off for its declared
-`failureRetryIntervalMs` before running it again. The booking already committed
-and the next check is idempotent, so the cost of that re-selection is one wasted
-provider read, not a wrong answer.
+Every cell that is present is a required landing node. Every cell that is absent
+is a declared refusal the sweep executes. This is the whole of what the old
+states, commands, and failure tables said:
 
-The gap between provider success and local success is closed the way the rest of
-the payment engine closes it: `processed_payments` (PK = `payment_session_id` =
-the SumUp reference) is reserved before any work, so a replay returns the
-recorded outcome rather than repeating it.
+```typescript
+export const EXPECTED_MOVES: MachineMoves<RecoveryNodeId, RecoveryEventId> = {
+  staged: { checkout_created: "waiting" },
+  waiting: {
+    read_unavailable: "waiting",
+    read_pending: "waiting",
+    read_paid_unreadable: "waiting",
+    read_expired_or_failed: "unpaid",
+    read_paid_booked: "finished",
+    read_paid_refunded: "finished",
+    read_paid_unsettled: "owed",
+    read_paid_contradiction: "owed",
+    owner_forces_check: "waiting",
+  },
+  owed: {
+    read_unavailable: "owed",
+    read_pending: "owed",
+    read_paid_unreadable: "owed",
+    read_paid_booked: "finished",
+    read_paid_refunded: "finished",
+    read_paid_unsettled: "owed",
+    read_paid_contradiction: "owed",
+    replayed_failure: "owed",
+    owner_forces_check: "owed",
+  },
+  unpaid: {},
+  finished: {},
+};
+```
 
-**`owed` has one retry owner: the scheduler.** Every `owed` row keeps its place
-in the scheduled queue and is checked again on its own `next_check_at` backoff,
-exactly like a `waiting` one — nothing that may hold unaccounted money is ever
-left waiting on a person to notice it. The owner's "Check again now" control
-does not own the retry; it only brings the next scheduled check forward for one
-row. So `owed` is never a manual-only state, and it is never abandoned.
+Read the refusals, because they are the contract too. `staged` takes no read
+event — a row with no checkout id has nothing to ask SumUp about. `unpaid` and
+`finished` take nothing at all: they are terminal, and a late event against them
+is a bug, not a transition. `owed` has no `checkout_created`. And
+`owed × replayed_failure` is a declared **self-move**, which is the round-one
+finding made executable: a replayed terminal failure may not finish a row that
+says money was seen.
 
-**Why a paid `unverifiable` is `owed`, not `unpaid`.** `unpaid` means SumUp told
-us the checkout was never paid; using it for "not ours" would give one word two
-meanings. And on this path `unverifiable` should be unreachable: the sealed row
-only opens when `hmacHash(reference) === reference_index`, so the metadata — and
-therefore the price proof `classifySessionIntent` checks — is one we wrote
-ourselves. A paid checkout that opened our row and _then_ fails its own proof is
-a contradiction, so it goes to the owner rather than into a normal ending. The
-mapping over the whole read is exhaustive by construction: ownership and money
-are already separate refusals in `sumup-observation.ts`, so a mismatched
-merchant, checkout id, or named charge never reaches classification at all (the
-read is refused as invalid), while a checkout that proves ownership and carries
-unreadable amount, currency, or transaction facts arrives as a session rejection
-and takes the refund-or-`owed` row above.
+### The laws over the declaration
 
-### Retry and replay table
+Prose can promise these; only a check enforces them. Each is a test over the
+declaration itself, so a future event or node cannot break it quietly. Every one
+of them is a finding this review already produced, turned into something that
+cannot recur:
 
-| Question                             | Answer                                                                                                                                                                                                        |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stable identity                      | `processed_payments.payment_session_id` = the SumUp `checkout_reference`; the staging row's `reference_index`                                                                                                 |
-| What an exact replay returns         | `alreadyProcessedResult` / the recorded terminal failure — no second booking, no second refund                                                                                                                |
-| Who retries after interruption       | The maintenance scheduler; the row keeps its state until a check writes a new one                                                                                                                             |
-| What stops two workers               | `claimNextMaintenanceTask`'s lease, plus `reserveSession`, plus a conditional state write (below)                                                                                                             |
-| Permanent failures                   | `unpaid` alone — SumUp said it was never paid. Everything else stays retryable, `owed` included                                                                                                               |
-| Can one failed item block later work | No — a row is selected only when `next_check_at` is due, and every non-ending check pushes its own `next_check_at` forward, so a stuck row falls behind newer ones rather than holding the front of the queue |
+| Law                                                                 | The finding it retires                        |
+| ------------------------------------------------------------------- | --------------------------------------------- |
+| A node with `owesMoney` other than `no` is never `prunable`         | Pruning deleting a paid-but-unchecked row     |
+| A node with `owesMoney` other than `no` has an outgoing system edge | `owed` becoming a manual-only dead end        |
+| Every edge landing on a non-terminal node writes the schedule       | A check that changed nothing left the row due |
+| Every self-move fences on the schedule, not just the state          | Two same-state writes both believing they won |
+| Every `actor: "owner"` edge names its route guard                   | The owner control with no stated CSRF policy  |
+| A terminal node has no outgoing edges                               | A late event silently reviving a closed row   |
+| `nodeOf` is total over stored rows, throwing on the impossible      | Existing rows with no derived state           |
 
-### Concurrency table
+The first two are the ones worth stating plainly: **a row that may hold money
+nobody has accounted for is never deleted, and always has something that will
+act on it.** Those two sentences are the safety property this whole feature
+exists to provide, and after this they are checked rather than promised.
 
-| Operation A                    | Operation B                  | Required result                                  | Protection                                                                                                                          |
-| ------------------------------ | ---------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Recovery check                 | Late webhook for the same id | One booking                                      | `reserveSession` on `processed_payments`                                                                                            |
-| Recovery check                 | Buyer's redirect             | One booking                                      | Same                                                                                                                                |
-| Recovery check on two isolates | Same task                    | One runner                                       | Maintenance lease (`claimNextMaintenanceTask`)                                                                                      |
-| Recovery state write           | `setSumupCheckoutId`         | No lost transition                               | `UPDATE … WHERE reference_index = ? AND recovery_state = ? AND next_check_at = ?` — both expected values, checked by `rowsAffected` |
-| Recovery check                 | Pruning                      | The row under check always survives              | A row being checked is `waiting` or `owed`, and prune's WHERE names only `staged`/`unpaid`/`finished`                               |
-| Owner "Check again now"        | Scheduled check              | One write wins; the loser finds 0 rows and stops | Same expected `recovery_state` **and** `next_check_at` — see "Why the fence needs both" below                                       |
+### What the projections say
 
-**Why the fence needs both.** Guarding only on `recovery_state` is enough for a
-transition that changes it, but not for the `waiting → waiting` writes above:
-two checks can both read `waiting`, both write `waiting`, and both report one
-affected row, so neither learns it raced. The loser would then overwrite the
-winner's `next_check_at` — including one an owner had just pulled forward.
-Naming the expected `next_check_at` in the same `WHERE` makes a stale write
-affect zero rows, which is how the loser finds out. The owner's control writes
-under the same fence, so it cannot clobber a scheduled check either.
+The remaining contract facts are read off the declaration rather than maintained
+beside it.
+
+- **Retry owner** is not a column. A node's retry owner is "the scheduler"
+  whenever it has an outgoing system edge, which by the second law every
+  money-holding node has. The owner's edge is additive — it brings the next
+  check forward, it does not own the retry.
+- **Permanent failure** is not a list. It is exactly the terminal nodes:
+  `unpaid` and `finished`. `owed` is not terminal, so it is not permanent.
+- **What a replay returns** stays the payment engine's answer, unchanged:
+  `processed_payments.payment_session_id` (= the SumUp `checkout_reference`) is
+  reserved before any work, so `alreadyProcessedResult` or the recorded terminal
+  failure comes back rather than a second booking or a second refund.
+- **Who wins a race** is the fence column. Two runners are already kept apart by
+  the maintenance lease (`claimNextMaintenanceTask`) and by `reserveSession`;
+  within one row, the loser of any pair finds zero affected rows because every
+  edge fences on the exact state and schedule it read.
+
+### The one gap the machine cannot close
+
+A failed state write can record nothing by definition, so no edge covers it: the
+booking has committed and the schedule did not move. The task throws, and the
+maintenance runner holds it off for its declared `failureRetryIntervalMs` before
+running it again. The next check is idempotent, so the cost is one wasted
+provider read. This is named here rather than modelled as an edge, because an
+edge that cannot write is not a transition — and the laws above would rightly
+reject it.
 
 ### Owner choices
 
@@ -264,11 +276,11 @@ already performs on the webhook, under the same rules and the same durable
 
 ## 3. Shared contract
 
-- **One pure rule.** `sumupRecoveryOutcome(read, engineAnswer)` in
-  `src/shared/sumup/recovery.ts` — data in, next state out. No IO. Exhaustive
-  over `ProviderRead<SumupCheckout>` and the payment engine's answer, returning
-  a `SumupRecoveryState` from a valibot picklist that also derives the type, the
-  guard, and the state list (the `ContactFieldSchema` pattern).
+- **The machine declaration is the contract**, not a description of it.
+  `src/shared/payment/sumup-recovery-machine-spec.ts` holds the nodes, the
+  events, and the moves table in section 2, and everything else derives from it:
+  the node union, the state words, the runtime guard, the `/admin/schema` map,
+  the live scan's queries, and the laws. Nothing restates it.
 - **One engine, not a second one.** `handlePaymentWebhook` currently interleaves
   the payment work with HTTP responses. Extract the work half — resolved session
   → classify → `settlePaymentCallback` → an exhaustive `CallbackOutcome` union —
@@ -279,10 +291,18 @@ already performs on the webhook, under the same rules and the same durable
   is that operation; lift its body to `resolveSumupCheckoutById(sumupId)` and
   have both the webhook member and the recovery task call it. Not an alias — the
   member keeps its interface job, the shared mechanism is exposed directly.
-- **The machine is declared, not described.** `sumup-recovery-machine-spec.ts`
-  with nodes, events, and an exhaustive moves table; a missing cell is a
-  declared refusal the sweep executes. It joins `SCHEMA_ATLAS_MACHINES` so
-  `/admin/schema` maps it with no other change.
+- **One pure rule, reading the declaration.**
+  `sumupRecoveryOutcome(read,
+  engineAnswer)` in `src/shared/sumup/recovery.ts`
+  — data in, event out. No IO. It names the event the observation amounts to;
+  the moves table, not this function, decides where that event lands. Exhaustive
+  over `ProviderRead<SumupCheckout>` and the payment engine's answer, so a
+  provider status the boundary cannot read becomes `read_unavailable` rather
+  than a guess.
+- **The sweep and the laws ship with it.** The mirror suite executes every (node
+  × event × shape) cell against the real transitions, and the law tests in
+  section 2 run over the declaration itself. It joins `SCHEMA_ATLAS_MACHINES`,
+  so `/admin/schema` maps it with no other change.
 - **The backwards check reads the stored data.** A bounded scan (the
   `joint-state-scan.ts` shape, `SCAN_LIMIT`-style cap) lists `owed` rows and
   `waiting` rows past their check window, keyed by the declaration's own literal
@@ -290,19 +310,21 @@ already performs on the webhook, under the same rules and the same durable
 
 ## 4. Challenging the contract
 
-| Challenge                                          | Answer                                                                                                                                                                   |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Provider read succeeds, local write fails          | The booking commits atomically before the state write. A failed state write leaves `waiting`; the next check re-reads and `reserveSession` returns the recorded outcome  |
-| Callback replayed after recovery already booked it | `processed_payments` PK; `alreadyProcessedResult`                                                                                                                        |
-| Two paid checkouts, one buyer                      | Independent rows and independent session ids; nothing correlates them                                                                                                    |
-| Amount/currency/parent wrong                       | Untouched: the existing observation boundary and `classifySessionIntent` decide, and a rejected paid charge takes the existing refund path                               |
-| Buyer reloads mid-recovery                         | The redirect calls `retrieveSession`, which is already idempotent through the same reserve                                                                               |
-| The task runs on a site with no SumUp              | `check.enabled` reads `SUMUP_API_KEY`/`SUMUP_MERCHANT_CODE`; disabled tasks are removed by `syncMaintenanceTaskRows`                                                     |
-| SumUp is disconnected while rows are `waiting`     | They are never checked, the live check shows them as overdue, and the new unchecked backstop finally prunes them. They are not silently kept forever                     |
-| A busy site's checkouts flood the task             | Oldest-first page with a small limit and `requestFollowUp()`; at most **one** paid recovery per run, because a rejection can spend refund subrequests                    |
-| Budget: Bunny's 50 subrequests                     | Declared in the task's `maxDatabaseCalls`/`maxExternalCalls`, which `maintenanceStartupCalls` already sums and the runner already enforces via `budget.remaining()`      |
-| Does this refund money in the background?          | Only through the path the webhook already runs for a rejected paid charge. It is the same engine or it is a second one — the plan forbids a second one                   |
-| Square: does throwing break the browser redirect?  | No. `readSessionOrder` throws only when a `paidPaymentId` is present, which only the webhook supplies. The redirect keeps `null` — there, `missing` really is "not ours" |
+| Challenge                                          | Answer                                                                                                                                                                                           |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Provider read succeeds, local write fails          | The booking commits atomically before the state write. A failed state write leaves `waiting`; the next check re-reads and `reserveSession` returns the recorded outcome                          |
+| Callback replayed after recovery already booked it | `processed_payments` PK; `alreadyProcessedResult`                                                                                                                                                |
+| Two paid checkouts, one buyer                      | Independent rows and independent session ids; nothing correlates them                                                                                                                            |
+| Amount/currency/parent wrong                       | Untouched: the existing observation boundary and `classifySessionIntent` decide, and a rejected paid charge takes the existing refund path                                                       |
+| Buyer reloads mid-recovery                         | The redirect calls `retrieveSession`, which is already idempotent through the same reserve                                                                                                       |
+| The task runs on a site with no SumUp              | `check.enabled` reads `SUMUP_API_KEY`/`SUMUP_MERCHANT_CODE`; disabled tasks are removed by `syncMaintenanceTaskRows`                                                                             |
+| SumUp is disconnected while rows are `waiting`     | They are never checked and never deleted — `waiting` is not `prunable`. The live check shows them as overdue, which is the honest answer; see the open question below                            |
+| A busy site's checkouts flood the task             | Oldest-first page with a small limit and `requestFollowUp()`; at most **one** paid recovery per run, because a rejection can spend refund subrequests                                            |
+| Budget: Bunny's 50 subrequests                     | Declared in the task's `maxDatabaseCalls`/`maxExternalCalls`, which `maintenanceStartupCalls` already sums and the runner already enforces via `budget.remaining()`                              |
+| Does this refund money in the background?          | Only through the path the webhook already runs for a rejected paid charge. It is the same engine or it is a second one — the plan forbids a second one                                           |
+| Square: does throwing break the browser redirect?  | No. `readSessionOrder` throws only when a `paidPaymentId` is present, which only the webhook supplies. The redirect keeps `null` — there, `missing` really is "not ours"                         |
+| A later change adds a node or an event             | It must satisfy the laws in section 2 or the suite fails: a money-holding node cannot be prunable or a dead end, a non-terminal edge cannot skip the schedule, a self-move cannot skip the fence |
+| SumUp returns a status we do not know              | `SumupCheckoutStatusSchema` is a closed picklist, so an unknown word fails the boundary and arrives as `read_unavailable` — the row stays put and is asked again                                 |
 
 Open question for the human, and the only product choice left: **a row that may
 hold money we have not accounted for is never deleted on age alone.** That
@@ -329,19 +351,14 @@ trades a rare lost payment for a tidier table, which is the wrong way round.
 - Old path deleted: the `missing → null → "skip" → 200` arm for paid webhooks.
 - Files: `src/shared/square-provider.ts`. **~20 src lines.**
 - Call budget: unchanged (no new reads).
-- Replay key: Square's stable identity is the **order id**. `createPaymentLink`
-  returns it, the webhook reads it from `payment.order_id`, `retrieveSession`
-  puts it on the session as `id: order.id`, and that becomes
-  `processed_payments.payment_session_id`. `payment.id` is only the payment
-  reference carried alongside, and Square's event id is not used at all — so a
-  redelivery of the same completed payment reserves the same row.
+- Replay key: the order id, as section 2 states it.
 - Tests: a direct test proving a `missing` order under a completed payment id
   throws and the same read without a payment id still returns `null`; a webhook
   integration test proving 503 instead of 200; and a redelivery test that lets
   the order become readable and then delivers the webhook twice, asserting one
   attendee, one ledger group, and no second refund. The regression test must
   fail on today's code first.
-- Contract rows: the Square row of the failure table, and the replay key above.
+- Contract rows: the whole of "Square: one rule, no machine" in section 2.
 
 ### PR 2 — A staged SumUp checkout must prove what happened to it
 
@@ -353,9 +370,11 @@ trades a rare lost payment for a tidier table, which is the wrong way round.
   out of the provider member; the `settlePaymentCallback` extraction with
   `webhooks.ts` reduced to mapping its outcome to a `Response`; the
   `sumup_checkout_recovery` maintenance task, selecting and re-scheduling on
-  `next_check_at`; prune scoped to `staged`/`unpaid`/`finished`; the machine
-  spec and its atlas entry; the bounded live check; the owner-only "Check again
-  now" action.
+  `next_check_at`; prune scoped to the `prunable` nodes; the machine spec, its
+  law suite, and its atlas entry; the bounded live check; the owner-only "Check
+  again now" action. The spec lands **first**: the task, the prune rule, the
+  scan, and the map all read it, so nothing in this PR restates a node or an
+  edge.
 - Old path deleted: the blind
   `boundedDelete("sumup_checkouts", "created_at < ?")`, and the HTTP-shaped
   session handling inside `handlePaymentWebhook`.
@@ -374,12 +393,19 @@ trades a rare lost payment for a tidier table, which is the wrong way round.
 - Call budget: startup adds 1 settings read + 1 database call to the task check.
   Per run: ≤3 database reads, ≤3 SumUp reads, ≤1 paid recovery (which may spend
   the existing refund path's calls). Well inside `MAINTENANCE_TASK_CALL_LIMIT`.
-- Contract rows: every row of the state, failure, retry, and concurrency tables
-  except the Square one.
+- Contract rows: every node, every event, every cell of the moves table, and
+  every law in section 2.
 
-Tests proving each row: direct unit tests for `sumupRecoveryOutcome` (table
-driven, one case per read × answer); the machine spec sweep executing every cell
-including the declared refusals; fault-injected tests
+Tests proving each row: the mirror sweep executing every (node × event × shape)
+cell against the real transitions, including every declared refusal, over the
+shared `registerConformanceSweep` / `registerTableChecks` harness with its size
+pinned; a law suite over the declaration itself — no money-holding node is
+prunable, no money-holding node lacks an outgoing system edge, no edge landing
+on a non-terminal node skips the schedule, no self-move skips the fence, no
+terminal node has an outgoing edge, and `nodeOf` is total; a graph suite proving
+every node is reachable from `staged` and every node can reach a terminal one;
+direct unit tests for `sumupRecoveryOutcome` (table driven, one case per read ×
+answer, naming the event rather than the landing node); fault-injected tests
 (`test/test-utils/db-fault.ts`) at each of the three windows — failing before
 the booking, during the refund of a rejected charge, and after the booking
 commits but before the state write — each proving the next check reaches the
@@ -425,9 +451,15 @@ rather than building it.
 This plan is not approved. Per PR_WORKFLOW.md step 6, please confirm or change:
 
 1. the two PR slices and their order;
-2. never deleting a `waiting` or `owed` row on age alone (section 4's open
-   question) — this is the one that keeps unanswered rows on a disconnected
-   site;
+2. never deleting a `waiting` or `owed` row on age alone — declared as
+   `prunable: no` on both nodes and enforced by the first law. This is the one
+   that keeps unanswered rows on a disconnected site;
 3. checking **every** created checkout once, rather than stamping the row from
    the completion path;
 4. pulling the task forward from M7 (section 6).
+
+The moves table and the laws in section 2 are the parts worth reading closely,
+because they are what the code will be held to. In particular the refusals: a
+cell left empty there is a promise that the transition throws, and the sweep
+will prove it. If a cell should exist that does not, or one exists that should
+not, that is a product decision, not an implementation detail.

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -131,17 +131,32 @@ failure tables kept separately: what it writes, and what its conditional
 
 | Event                     | Actor     | Writes           | Fences on                   |
 | ------------------------- | --------- | ---------------- | --------------------------- |
-| `checkout_created`        | system    | state            | `reference_index` (one row) |
+| `checkout_created`        | system    | state + schedule | `reference_index` (one row) |
 | `read_unavailable`        | system    | schedule         | state + schedule            |
 | `read_pending`            | system    | schedule         | state + schedule            |
 | `read_expired_or_failed`  | system    | state + schedule | state + schedule            |
 | `read_paid_booked`        | system    | state + schedule | state + schedule            |
-| `read_paid_refunded`      | system    | state + schedule | state + schedule            |
+| `read_paid_settled`       | system    | state + schedule | state + schedule            |
 | `read_paid_unsettled`     | system    | state + schedule | state + schedule            |
 | `read_paid_unreadable`    | system    | schedule         | state + schedule            |
 | `read_paid_contradiction` | system    | state + schedule | state + schedule            |
-| `replayed_failure`        | system    | schedule         | state + schedule            |
 | `owner_forces_check`      | **owner** | schedule         | state + schedule            |
+
+The five `read_paid_*` events are exhaustive over what the payment engine can
+answer for a paid checkout, and each is named for the **money fact** it
+establishes, because that is what decides whether the row may be deleted:
+
+| Engine answer                                     | Event                     | Money                       |
+| ------------------------------------------------- | ------------------------- | --------------------------- |
+| Booked (including a replay of an earlier booking) | `read_paid_booked`        | Accounted for by a booking  |
+| Handled failure, refunded or nothing to refund    | `read_paid_settled`       | Accounted for               |
+| Handled failure, a required refund did not go     | `read_paid_unsettled`     | **Not** accounted for       |
+| Reservation held elsewhere, or an unreadable one  | `read_paid_unreadable`    | Not yet known               |
+| The reference does not open the staged row        | `read_paid_contradiction` | Not knowable from this side |
+
+A replayed terminal failure is not its own event. It is classified by the same
+money fact as a fresh one, so it arrives as `read_paid_settled` or
+`read_paid_unsettled` and the table does the rest.
 
 ### The moves table
 
@@ -158,20 +173,18 @@ export const EXPECTED_MOVES: MachineMoves<RecoveryNodeId, RecoveryEventId> = {
     read_paid_unreadable: "waiting",
     read_expired_or_failed: "unpaid",
     read_paid_booked: "finished",
-    read_paid_refunded: "finished",
+    read_paid_settled: "finished",
     read_paid_unsettled: "owed",
     read_paid_contradiction: "owed",
     owner_forces_check: "waiting",
   },
   owed: {
     read_unavailable: "owed",
-    read_pending: "owed",
     read_paid_unreadable: "owed",
     read_paid_booked: "finished",
-    read_paid_refunded: "finished",
+    read_paid_settled: "finished",
     read_paid_unsettled: "owed",
     read_paid_contradiction: "owed",
-    replayed_failure: "owed",
     owner_forces_check: "owed",
   },
   unpaid: {},
@@ -182,10 +195,44 @@ export const EXPECTED_MOVES: MachineMoves<RecoveryNodeId, RecoveryEventId> = {
 Read the refusals, because they are the contract too. `staged` takes no read
 event — a row with no checkout id has nothing to ask SumUp about. `unpaid` and
 `finished` take nothing at all: they are terminal, and a late event against them
-is a bug, not a transition. `owed` has no `checkout_created`. And
-`owed × replayed_failure` is a declared **self-move**, which is the round-one
-finding made executable: a replayed terminal failure may not finish a row that
-says money was seen.
+is a bug, not a transition. `owed` has no `checkout_created`.
+
+`owed` also refuses `read_pending` and `read_expired_or_failed`. Every `owed`
+row got there from a read that said PAID, and SumUp never moves a checkout back
+off PAID, so a cell for either would be defending against the impossible. The
+round-one finding — a replayed terminal failure may not finish a row that says
+money was seen — is now carried by the table itself rather than by a special
+event: from `owed`, the only cells that reach `finished` are the two that
+establish the money is accounted for.
+
+### What drafting the code changed here
+
+Writing the first slice against this table found four places where it did not
+survive contact with the code. They are corrected above; they are listed here
+because each one is a decision, not a typo, and the reviewer is approving the
+corrected version:
+
+1. **`checkout_created` writes the schedule too**, not the state alone. The
+   Events table said state; the fourth law says every edge landing on a
+   non-terminal node writes the schedule. A newly created checkout with no check
+   time would never be asked about — the exact harm this work exists to close —
+   so the law was right and the row was wrong.
+2. **`replayed_failure` is gone.** It had no `waiting` cell, but the path is
+   reachable and common: a callback that arrives, fails terminally, and leaves
+   the row still `waiting` for its first check. Rather than add a cell, the
+   event was removed — a replayed terminal failure carries the same money fact
+   as a fresh one, so it classifies as `read_paid_settled` or
+   `read_paid_unsettled` like any other.
+3. **`read_paid_refunded` became `read_paid_settled`.** The engine has a
+   handled-failure answer with nothing to refund (no charge was captured). The
+   old name had no cell for it. The new name covers both, and says the thing
+   that actually decides the row's fate: the money is accounted for.
+4. **`owed` lost `read_pending`.** Every `owed` row got there from a PAID read,
+   and a checkout never moves back off PAID, so the cell was defending against
+   the impossible.
+
+The first three were found by the laws and the totality requirement rather than
+by reading — which is the argument for writing lifecycles this way.
 
 ### The laws over the declaration
 
@@ -389,7 +436,11 @@ trades a rare lost payment for a tidier table, which is the wrong way round.
 - **~640 src lines**, under the 800 cap. If it overruns, the split is by
   invariant: the task and its machine first, the live check and owner action
   second — but only if the first still leaves `owed` reachable through the
-  scheduled retry.
+  scheduled retry. `owner_forces_check` moves with the action that raises it,
+  not with the machine: an edge whose only caller is in a later slice is an
+  export with no production caller, which this repository deletes rather than
+  ships. The laws hold either way — the money-holding nodes keep their system
+  edges without it.
 - Call budget: startup adds 1 settings read + 1 database call to the task check.
   Per run: ≤3 database reads, ≤3 SumUp reads, ≤1 paid recovery (which may spend
   the existing refund path's calls). Well inside `MAINTENANCE_TASK_CALL_LIMIT`.
@@ -409,8 +460,9 @@ answer, naming the event rather than the landing node); fault-injected tests
 (`test/test-utils/db-fault.ts`) at each of the three windows — failing before
 the booking, during the refund of a rejected charge, and after the booking
 commits but before the state write — each proving the next check reaches the
-same single outcome; a test that puts a recorded terminal failure under an
-`owed` row and proves the replay leaves it `owed` rather than `finished`; a
+same single outcome; a test that puts a recorded terminal failure with an
+unreturned charge under an `owed` row and proves the replay leaves it `owed`
+rather than `finished`, and its pair that proves a refunded one does finish; a
 migration test starting from rows with and without a `sumup_id` and asserting
 the derived states and check times; a starvation test proving a permanently
 stuck row does not hold the front of the queue while newer rows wait; a test

--- a/SUMUP_RECOVERY_PLAN.md
+++ b/SUMUP_RECOVERY_PLAN.md
@@ -391,6 +391,26 @@ trades a rare lost payment for a tidier table, which is the wrong way round.
 
 ### PR 1 — A Square webhook for a completed payment is never acknowledged as pending
 
+**Shipped** in #2106. The code is now the authority: `readSessionOrder` in
+`src/shared/square-provider.ts` throws when a `paidPaymentId` is present and the
+order reads `missing`, and `retrieveSession` still answers `null` for the
+browser redirect. The tests are `test/shared/square-provider/webhook.test.ts`
+("refuses a completed payment whose order is not readable yet"),
+`test/shared/square-provider/read-outcomes.test.ts` ("keeps an order Square
+cannot find retryable after a completed event"), and
+`test/integration/server/webhooks/square.test.ts` ("keeps a completed payment
+whose order is not readable yet retryable").
+
+Two things differ from what is written below. The redelivery test named here was
+not written: the existing idempotency tests already deliver the same Square
+webhook twice and assert one attendee, so a third would have restated a pinned
+test rather than added one. And #2107 followed it, closing three gaps the
+mutation gate found in the same file — a one-character payment id being
+discarded, two different order faults logging identically, and a blank payment
+status reported as an outage.
+
+The original plan for this slice, kept for the record:
+
 - Value: a paid Square booking whose order lags is redelivered, not dropped.
 - Change: `readSessionOrder` learns whether a `paidPaymentId` is in play and
   throws on `missing` when it is, matching `readOrderPayment` two functions


### PR DESCRIPTION
This is a plan, not a fix. Nothing in the app changes yet — the only file
added is the behaviour contract, which is waiting for a person to approve it
(PR_WORKFLOW.md step 6).

## Why

Two live paths let a payment provider take a customer's money and leave this
site with no booking, no refund, and — in one case — no record at all.

**SumUp.** A SumUp checkout's only server-to-server message is a single
unsigned POST. There is no subscription to redeliver against. If that message
is lost and the customer never comes back to the success page, nothing ever
asks SumUp what happened. The staged row is the only trace, and database
pruning deletes it 24 hours later. The customer is charged, gets no ticket,
and the operator has nothing left to find.

**Square.** A webhook that names a completed payment, whose order is not
readable yet, is answered with a 200. Square takes that as "handled" and stops
sending it. But an order that has not caught up is exactly the same short
delay the same file already retries two functions further down.

## What the plan proposes

Two pull requests:

1. **Square** — a webhook naming a completed payment whose order reads as
   missing fails instead of being accepted, so Square sends it again. Roughly
   twenty lines. The customer's browser path is unchanged, because there
   "missing" really does mean "not ours".
2. **SumUp** — a background job that asks SumUp about every checkout this site
   created, once, a few hours after it was made. If it was paid, the payment
   goes through the same engine the webhook uses, so the booking is made
   exactly once. The staged row gains a state saying what happened to it,
   pruning stops deleting rows that still owe somebody a booking, and anything
   still owed is listed for the owner with a button to try again.

Asking about every checkout, rather than only the ones we think went wrong, is
deliberate: it is what would catch a site whose messages have been quietly
failing for a week.

## How the contract is written, and why that changed

The contract first described the behaviour as five hand-written tables — the
states, the commands, the failures, the retries, the races. Every review
finding on this PR was two of those tables disagreeing with each other, or one
disagreeing with the code. Fixing each disagreement created the next, because
nothing checked them against each other.

It is now **one declaration**: the nodes, the events, and a complete table of
which event moves which node where — in the shape this repository already uses
for its other payment machines. Everything the five tables used to say is a
property of a node or an edge: whether it may hold money nobody has accounted
for, whether pruning may delete it, what an edge writes, what it checks before
writing. A cell left out of the table is a promise that the move is refused,
and the test suite proves it refuses.

The findings then become rules over that declaration, checked rather than
promised:

- a row that may hold money nobody has accounted for is never deleted;
- and it always has something that will act on it, rather than waiting for a
  person to notice;
- a check that changes nothing still records when to look again;
- two checks racing on one row cannot both believe they won;
- a finished row has no way back out.

That is the part worth reading. It is also the part that should stop this
class of problem recurring on the next feature that needs a lifecycle.

## Four choices for the reviewer

The plan ends by asking a person to settle four things: the two pull requests
and their order; whether a row that owes somebody money should ever be
deleted; whether to check every checkout or have the success path mark its own
row; and whether this work should come forward from milestone M7 onto the
current path, which is what the plan recommends and gives its reasons for.

## Checks

`deno fmt --check` passes and the full `deno task precommit` was run against
this branch. The change is one Markdown file with no code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a recovery plan covering lost SumUp payments and delayed Square order updates, including retry behavior, recovery steps, security safeguards, and validation scenarios.
  * Documented proposed payment and order recovery workflows, including state tracking, scheduled checks, bounded scanning, and owner controls.
  * Updated contribution guidance to require explicit state definitions, events, transitions, and executable invariants for stateful features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->