### PR TITLE
Stop a stolen port reading as a start that gave up too early

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,42 @@ GitHub.
   a flaky/fragile test while working — even in code you were not asked to touch
   and did not write — fix it in passing rather than stepping around it. A green
   build you helped produce is your responsibility too.
+- **A written-down diagnosis is a hypothesis, not a finding**: A `TODO.md`
+  entry, a review comment, a commit message, or a code comment explaining why
+  something breaks was written by someone reasoning about the code at a moment
+  that has passed. Re-derive it from the current source before you fix anything,
+  however confident and detailed it reads — a wrong diagnosis is more expensive
+  than none, because it aims your fix at the wrong place and takes the
+  regression test with it. The stripe-mock port-steal entry in `TODO.md` is the
+  worked example: it was a careful, plausible, thoroughly argued account of a
+  race in the wrong function, and following it would have "fixed" code that was
+  already correct while leaving the real hazard in place. When you find one
+  wrong, correct the note in the same change — leaving it sends the next person
+  down the same path.
+- **Stage what you changed, never `git add -A`**: Name the files you meant to
+  touch, and read `git status --short` before committing. A blanket add cannot
+  tell your work from a stray tool run, a build artefact, or a formatter that
+  rewrote a thousand files you never opened — and a commit is where that stops
+  being recoverable quietly. If the file list surprises you, that surprise is
+  the point: find out why before you commit, not after a reviewer counts the
+  diff.
+- **Judge nothing from a stale base ref**: `git fetch origin main` before you
+  read a `origin/main...HEAD` diff, count changed lines, or run the mutation
+  gate. A local `origin/main` left behind by a few merges makes an unrelated
+  branch look like it rewrote the tree, and every conclusion drawn from that —
+  what a PR contains, how big it is, what needs mutating — is wrong in the
+  alarming direction.
+- **A red check is not automatically yours**: Before treating a CI or status
+  failure as your breakage, ask what it could possibly have to do with your
+  diff, and look for a control. A sibling build of the identical commit that
+  succeeded, a failing test your files cannot reach, a provider outside the
+  repository — each is evidence that the cause is elsewhere, and none is proof.
+  A sibling passing shows the failure is nondeterministic or depends on its
+  environment, which a real bug in your own code can also be, so trace the
+  failing path far enough to name the cause before setting it aside. Say so,
+  once, with the evidence rather than the word "flaky", and keep going. This
+  never licenses ignoring a failure: not yours still means diagnosed, reported,
+  and re-run.
 - **Every bug fix ships with a regression test**: Never fix a bug without also
   adding a test that fails before the fix and passes after it. The test must
   exercise the real bug — reproduce the exact condition that was broken so it
@@ -1166,7 +1202,13 @@ query logging and table-scoped cache invalidation stay automatic.
 - `deno task specs:files <feature>... [--tags <expression>]` - Run selected
   Features through the shared harness
 - `deno task lint` - Format Markdown with Deno, then format and lint code with
-  Biome (`check --write`; auto-fixes in place).
+  Biome (`check --write`; auto-fixes in place). **Format through this task
+  rather than reaching for a formatter yourself.** The two own different file
+  types and neither refuses work outside its own, so `deno fmt` pointed at a
+  directory of TypeScript quietly reformats every file it finds to a style Biome
+  does not use — an enormous unrelated diff that buries the change you meant to
+  make. Naming one file directly is fine when you know whose it is: `deno fmt`
+  for Markdown, Biome for code. When in doubt, run the task.
 - `deno task lint:ci` - Strict, read-only formatting and lint. Runs
   `deno fmt --check` for Markdown and Biome `check --error-on-warnings` for
   code. Fails on lint warnings (e.g. cognitive complexity) and on any file that
@@ -1703,6 +1745,28 @@ import {
 | Duplicating test helpers        | Use `#test-utils`                |
 | Magic numbers/strings           | Import constants from production |
 | Testing private internals       | Test public API behavior         |
+
+### Tests That Share A Machine
+
+A test that reserves a real resource — a port, a lock file, a fixed path —
+shares it with every other suite running at that moment, and CI runs them loaded
+and in parallel. The failure this produces is the nastiest kind: rare,
+unreproducible locally, and landing on whichever pull request happens to be
+open, so it reads as that author's bug.
+
+`withUnusedPort` names the hazard exactly: it finds a free port and lets go of
+it before the code under test binds it, so anything else starting in that window
+can take it. **A test that takes a port and then asserts on what the start did
+must go through `retryWhilePortTaken`**
+(`test/test-utils/stripe-mock/ports.ts`), which asks again on a fresh port
+instead of reading a stolen one as the answer. Both known flakes in
+`lifecycle.test.ts` were a sibling case that had the guard sitting next to one
+that did not.
+
+The general rule: when a test can fail because of something outside itself,
+either remove the sharing or make the test able to tell the two apart. Never
+leave it to chance and a re-run — a test that is right nine times in ten is a
+test nobody trusts the tenth time, which is exactly when it matters.
 
 ### Fast Tests
 

--- a/TODO.md
+++ b/TODO.md
@@ -2440,34 +2440,33 @@ locally-recorded canonical charge. An attendee-wide `refund_cash` leg or a
 returned sibling charge is never deletion authority. Keep that exact-charge rule
 when the stable obligation model replaces the current booking projection.
 
-## The stripe-mock start-count test races its own subprocesses
+## The stripe-mock start-count test read a port somebody else had taken — fixed
 
 `test/scripts/stripe-mock/lifecycle.test.ts` — "stops trying once the mock has
-been started as many times as asked" — failed once on CI (PR #2065, run
-31501332067, 22,419 of 22,420 passing) on a commit that changed only Markdown
-and a test comment, and passes reliably locally.
+been started as many times as asked" — failed on CI twice on commits that
+changed only Markdown (PR #2065 run 31501332067, and PR #2104 run 32130150568 at
+24,020 of 24,021 passing), and passed reliably locally.
 
-The counting mock is a shell script whose whole body is `echo x >> <countPath>`
-(`writeCountingFailingMock` in `test/scripts/stripe-mock/fixtures.ts`).
-`triesBeforeGivingUp` spawns it three times, then reads the file ONCE with
-`startCount` and asserts exactly 3.
+**The first diagnosis recorded here was wrong**, and it is worth keeping the
+correction. It said the parent read the count file before the last `/bin/sh` had
+appended its line. It cannot: a failing attempt ends at
+`await stopProcess(spawned.process, ...)`, and `stopProcess` awaits the child's
+`status` on both of its branches — `beforeTimeout` resolves when the status
+does, and the timeout branch awaits it after the SIGKILL. Every spawned child
+has therefore exited, and written, before `startStripeMock` rejects.
 
-Nothing makes the children's writes happen-before that read. Each attempt gives
-up on `waitForOwnedStripeMock` returning false, which happens either when the
-child's `status` promise resolves OR when the per-attempt budget (50ms in this
-test) elapses — so the parent can move on, and finally reject and be read, while
-the last `/bin/sh` has been spawned but has not yet appended its line. On a
-loaded runner that gap is easily wide enough, and the count reads 2.
+The real cause is a stolen port. `attemptStartStripeMock` has exactly one early
+return before it spawns: the port is already listening, so an unpinned attempt
+gives up and asks for another. `withUnusedPort` picks a free port and lets go of
+it before the start binds it, so another suite can take it in between — and that
+attempt never spawns, so the count comes up one short. The sibling test at
+"gives a mock time to shut itself down" already guarded against exactly this
+with `retryWhilePortTaken`; `triesBeforeGivingUp` did not.
 
-Two ways to fix it. Wait for the count to REACH the expected number with a
-deadline instead of reading once — the property is "three starts happened", not
-"three starts had happened by the instant the promise rejected". Or make
-`startStripeMock` await each child's exit before the next attempt, which is
-tidier anyway: the CI run's cleanup reported an orphan process, and a start path
-that leaves children behind is worth a look on its own.
-
-The two sibling cases (`toBe(1)`) are not exposed, since one attempt gives the
-single child far longer to write before the read.
+`triesBeforeGivingUp` now takes the count it wants and retries on a fresh port
+while it comes up short, over the same shared helper. `retryWhilePortTaken`
+takes an optional description, read only once every try is spent, so a run that
+never gets a clean port reports what it actually saw.
 
 ## A schema migration between the two payment-record migrations can stop an upgrade
 

--- a/test/scripts/stripe-mock/lifecycle.test.ts
+++ b/test/scripts/stripe-mock/lifecycle.test.ts
@@ -40,30 +40,43 @@ const START_LOCK_NAME = "stripe-mock.start.lock";
 /**
  * Ask for three tries at a mock that always fails, with the port settled the
  * given way, and report how many times it was actually started.
+ *
+ * The port is picked and let go of before the start uses it, so another test
+ * can take it in between. A start that finds the port already listening
+ * returns without spawning — the only way an attempt skips its spawn — so a
+ * stolen port shows up as a count below `wanted`. Ask again on a fresh port
+ * rather than reading someone else's port as this test's answer.
  */
 const triesBeforeGivingUp = async (
   pinPort: (port: number) => StartOptions,
+  wanted: number,
 ): Promise<number> => {
   let tries = 0;
-  await withTempStripeMockPaths(async (paths) => {
-    const count = join(paths.binDir, "starts");
-    await writeCountingFailingMock(paths, count, "no good");
+  await retryWhilePortTaken(
+    async () => {
+      await withTempStripeMockPaths(async (paths) => {
+        const count = join(paths.binDir, "starts");
+        await writeCountingFailingMock(paths, count, "no good");
 
-    await withUnusedPort(async (port) => {
-      await expect(
-        startStripeMock({
-          budgetMs: 50,
-          choosePort: () => port,
-          delayMs: 1,
-          paths,
-          startAttempts: 3,
-          ...pinPort(port),
-        }),
-      ).rejects.toThrow(STRIPE_MOCK_FAILED_TO_START);
-    });
+        await withUnusedPort(async (port) => {
+          await expect(
+            startStripeMock({
+              budgetMs: 50,
+              choosePort: () => port,
+              delayMs: 1,
+              paths,
+              startAttempts: 3,
+              ...pinPort(port),
+            }),
+          ).rejects.toThrow(STRIPE_MOCK_FAILED_TO_START);
+        });
 
-    tries = await startCount(count);
-  });
+        tries = await startCount(count);
+      });
+      return tries < wanted;
+    },
+    () => `The mock started ${tries} times instead of ${wanted}`,
+  );
   return tries;
 };
 
@@ -153,18 +166,19 @@ describe("starting stripe-mock", () => {
 
   test("stops trying once the mock has been started as many times as asked", async () => {
     // Nobody pinned the port, so a fresh one is worth trying.
-    expect(await triesBeforeGivingUp(() => ({ env: testEnv({}) }))).toBe(3);
+    expect(await triesBeforeGivingUp(() => ({ env: testEnv({}) }), 3)).toBe(3);
   });
 
   test("tries a pinned port only once, however many tries were asked for", async () => {
-    expect(await triesBeforeGivingUp((port) => ({ port }))).toBe(1);
+    expect(await triesBeforeGivingUp((port) => ({ port }), 1)).toBe(1);
   });
 
   test("treats a port named in the environment as pinned too", async () => {
     expect(
-      await triesBeforeGivingUp((port) => ({
-        env: testEnv({ STRIPE_MOCK_PORT: String(port) }),
-      })),
+      await triesBeforeGivingUp(
+        (port) => ({ env: testEnv({ STRIPE_MOCK_PORT: String(port) }) }),
+        1,
+      ),
     ).toBe(1);
   });
 

--- a/test/test-utils/stripe-mock/ports.ts
+++ b/test/test-utils/stripe-mock/ports.ts
@@ -71,15 +71,18 @@ export const startFailedOrPortTaken = async (
   return true;
 };
 
-/** Ask again while something else keeps taking the port we were handed. */
+/** Ask again while something else keeps taking the port we were handed.
+ * `keptHappening` is read only once every try is spent, so a caller can
+ * describe what it actually saw rather than what it expected to see. */
 export const retryWhilePortTaken = async (
   attempt: () => Promise<boolean>,
+  keptHappening: () => string = () => "Starting stripe-mock kept succeeding",
 ): Promise<void> => {
   for (let tries = 0; tries < PORT_STEAL_TRIES; tries++) {
     if (!(await attempt())) return;
   }
   throw new Error(
-    `Starting stripe-mock kept succeeding: the port was taken ${PORT_STEAL_TRIES} times running.`,
+    `${keptHappening()}: the port was taken ${PORT_STEAL_TRIES} times running.`,
   );
 };
 


### PR DESCRIPTION
One test has now failed twice on CI for reasons nothing to do with the change
being tested — both times on commits that only touched Markdown. This fixes it,
and corrects the note that described the wrong cause.

## What was happening

The test starts a mock that always fails, three times, and checks it was started
three times. Every so often it counted two.

Ports are the reason. The test asks for a free port, lets go of it, and then
starts the mock on it — and in that gap another test running at the same moment
can take the port. When that happens the start finds something already listening
and moves on **without starting the mock at all**, so one of the three starts
never happened. On a busy machine that window is easily wide enough.

The test two cases above this one already knew about this and asked again on a
fresh port when it happened. This one did not. It does now.

## The note in TODO.md was wrong

It said the test read its counter before the last mock had finished writing to
it. That cannot happen: a failed start waits for the mock to exit before moving
on, and the mock writes its line before it exits. Following that note would have
meant changing code that was already correct and leaving the real problem in
place.

The entry has been rewritten with what actually happens, including why the first
explanation was wrong — it was careful and plausible, which is what made it
expensive.

## Three rules added to AGENTS.md

Each one is something this cost us today:

- **A written-down diagnosis is a hypothesis, not a finding.** Re-derive it from
  the current code before fixing anything, however confident it reads.
- **Judge nothing from a stale base ref.** `git fetch origin main` first — a
  local ref a few merges behind makes an unrelated branch look like it rewrote
  the tree.
- **A red check is not automatically yours.** Look for a control before assuming
  it is; say so with evidence rather than the word "flaky"; and still diagnose,
  report, and re-run.

There is also a new short section on tests that share a machine, saying that a
test taking a port and then asserting on the result must go through the
stolen-port retry. Both known flakes here were a guarded case sitting next to an
unguarded one.

## Checks

`deno task precommit` passes in full. The lifecycle suite passes all 16 cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9Sx6wdfDiFJEGK2FWSaEi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when temporary test services encounter port conflicts.
  * Added clearer failure messages when repeated startup attempts cannot proceed.

* **Tests**
  * Updated lifecycle coverage for both automatically assigned and explicitly configured ports.
  * Added retry handling for short-lived port collisions to reduce flaky test results.

* **Documentation**
  * Clarified development, formatting, testing, and troubleshooting guidance for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->