### PR TITLE
Ask Square again when a paid order is not readable yet

### DIFF
--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -129,9 +129,20 @@ const webhookPayment = (listing: WebhookEvent): SquareWebhookPayment => {
 
 const readSessionOrder = async (
   sessionId: string,
+  paidPaymentId: string | undefined,
 ): Promise<SquareOrder | null> => {
   const read = await squareApi.readOrder(sessionId);
   if (read.status === "missing") {
+    // A webhook naming a completed payment proves the order exists, so a
+    // missing read is Square lagging, not a stranger's order — the same
+    // window readOrderPayment refuses below. Acknowledging would end the
+    // redelivery and leave the buyer charged with no booking. Without a
+    // completed payment, missing really is "not one of ours".
+    if (paidPaymentId) {
+      throw new Error(
+        "Square order is not readable yet for a completed payment",
+      );
+    }
     logDebug("Square", "Square order not found");
     return null;
   }
@@ -293,7 +304,7 @@ export const squarePaymentProvider: PaymentProvider = {
     paidPaymentId?: string,
   ): Promise<RetrieveSessionResult> {
     /* jscpd:ignore-end */
-    const order = await readSessionOrder(sessionId);
+    const order = await readSessionOrder(sessionId, paidPaymentId);
     if (!order) return null;
     const metadata = sessionMetadata(order, paidPaymentId);
     if (!metadata) return null;

--- a/test/integration/server/webhooks/square.test.ts
+++ b/test/integration/server/webhooks/square.test.ts
@@ -68,6 +68,27 @@ describeWithEnv("Square payment webhooks", { db: true }, () => {
     await expectWebhookResponse(event, squareOrderRead(null), 0, 503);
   });
 
+  test("keeps a completed payment whose order is not readable yet retryable", async () => {
+    // Square named a payment it completed, so the order is ours and has not
+    // caught up. A 200 here would end the redelivery and leave the buyer
+    // charged with no booking.
+    const event: WebhookEvent = {
+      data: {
+        object: {
+          payment: {
+            id: "lagging-payment",
+            order_id: "lagging-order",
+            status: "COMPLETED",
+          },
+        },
+      },
+      id: "lagging-payment-event",
+      type: "payment.updated",
+    };
+
+    await expectWebhookResponse(event, squareOrderRead(null), 1, 503);
+  });
+
   test("acknowledges a completed payment for a foreign Square order", async () => {
     const event: WebhookEvent = {
       data: {

--- a/test/shared/square-provider/read-outcomes.test.ts
+++ b/test/shared/square-provider/read-outcomes.test.ts
@@ -163,15 +163,23 @@ describe("square-provider read outcomes", () => {
     );
   });
 
-  test("acknowledges a completed event only when Square proves the order is gone", async () => {
+  test("keeps an order Square cannot find retryable after a completed event", async () => {
     await withSquareClient(
       {
         ordersGet: () => Promise.reject(new SquareApiError(404)),
       },
       async () => {
-        expect(await completedSquareWebhook("pay_gone", "order_gone")).toBe(
-          "skip",
-        );
+        // A 404 used to be read as proof the order was gone, and the event was
+        // acknowledged. A completed payment names an order we created, so the
+        // likelier reading is that Square has not caught up — and an
+        // acknowledgement is final, leaving the buyer charged with no booking.
+        // Retry noise is the cheaper mistake, so this window stays retryable
+        // like every other unreadable order above.
+        expect(
+          await rejectionMessage(
+            completedSquareWebhook("pay_gone", "order_gone"),
+          ),
+        ).toBe("Square order is not readable yet for a completed payment");
       },
     );
   });

--- a/test/shared/square-provider/webhook.test.ts
+++ b/test/shared/square-provider/webhook.test.ts
@@ -383,6 +383,25 @@ describe("square-provider resolveWebhookSession", () => {
     );
   });
 
+  test("refuses a completed payment whose order is not readable yet", async () => {
+    await withMocks(
+      () =>
+        stub(squareApi, "readOrder", () =>
+          Promise.resolve(squareOrderRead(null)),
+        ),
+      async () => {
+        // Square named a COMPLETED payment, so the order exists and has not
+        // caught up. Acknowledging would stop the redelivery and leave the
+        // buyer charged with no booking.
+        expect(
+          await rejectionMessage(
+            completedSquareWebhook("pay_lagging", "order_lagging"),
+          ),
+        ).toBe("Square order is not readable yet for a completed payment");
+      },
+    );
+  });
+
   test("handles flat listing object without payment wrapper", async () => {
     await withMocks(
       () =>
@@ -390,19 +409,23 @@ describe("square-provider resolveWebhookSession", () => {
           Promise.resolve(squareOrderRead(null)),
         ),
       async (mockOrder) => {
-        const result = await squarePaymentProvider.resolveWebhookSession({
-          data: {
-            object: {
-              id: "pay_flat",
-              order_id: "order_flat",
-              status: "COMPLETED",
+        // The order id is read straight off the object rather than a nested
+        // payment key. It reaching readOrder is the whole point here; the
+        // refusal after that belongs to the missing-order case above.
+        await rejectionMessage(
+          squarePaymentProvider.resolveWebhookSession({
+            data: {
+              object: {
+                id: "pay_flat",
+                order_id: "order_flat",
+                status: "COMPLETED",
+              },
             },
-          },
-          id: "evt_flat",
-          type: "payment.updated",
-        });
+            id: "evt_flat",
+            type: "payment.updated",
+          }),
+        );
         expect(mockOrder.calls[0]!.args[0]).toBe("order_flat");
-        expect(result).toBe("skip");
       },
     );
   });


### PR DESCRIPTION
When Square tells us a payment completed, but we cannot read the order it
belongs to, we were replying "handled". Square then stops telling us. The
customer has paid, and there is no booking and no refund — and nothing left to
notice it.

## What changes

A completed payment names an order this site created, so an order we cannot
read is far more likely to be Square not having caught up than an order that
does not exist. We now say "not yet, try again", and Square sends it again a
short while later. The same file already does exactly this one function further
down, when the payment itself does not read back as completed.

The customer's own return from the payment page is untouched. It carries no
payment id, and there an order we cannot find really does mean the order is not
one of ours.

## This reverses an earlier decision, deliberately

The old behaviour was not an oversight. A test said so by name: a "not found"
answer from Square was treated as proof the order was gone, so the message was
accepted and closed. Everything else unreadable — timeouts, outages, damaged
responses — was already retried.

The owner chose to treat "not found" as lag as well. The reasoning is that the
two mistakes are not the same size: accepting the message is final and costs
somebody a booking they paid for, while retrying costs some noise in the logs.
The test now states the new rule and says why, so the next person reads a
decision rather than a puzzle.

One thing did not change: an order that reads back fine but is not ours — a
till sale, say — is still accepted and closed. Those are not retried forever.

## How it was checked

The new test was written first and watched fail for the right reason: the
message was being accepted instead of refused. Then the fix, then it passed.

- 81 tests across the Square suites pass.
- A webhook test proves the reply is now 503 rather than 200, and that the
  order was looked up exactly once.
- The existing test covering the customer's return path was left alone and
  still passes, which is what guards the other half of this.
- `deno task precommit` and the branch mutation gate are running; results to
  follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9Sx6wdfDiFJEGK2FWSaEi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed payment webhooks now retry when the associated order is temporarily unavailable.
  * Prevents completed payments from being incorrectly skipped when order details cannot yet be read.
  * Preserves existing not-found handling for orders without completed-payment evidence.

* **Tests**
  * Added regression coverage for retryable webhook responses when payment orders are unreadable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->