### PR TITLE
Close three gaps the Square webhook tests were not catching

### DIFF
--- a/test/shared/square-provider/metadata.test.ts
+++ b/test/shared/square-provider/metadata.test.ts
@@ -42,6 +42,28 @@ describe("square provider order ownership", () => {
     );
   });
 
+  test("says which reason it refused a half-filled order for", async () => {
+    // An order carrying our marker but not the fields it needs is a different
+    // fault from a till sale, and the operator reading the log has to be able
+    // to tell them apart.
+    await withMocks(
+      () =>
+        stub(squareApi, "readOrder", () =>
+          Promise.resolve(
+            completedOrder("order_partial_meta", { _origin: "localhost" }),
+          ),
+        ),
+      async () => {
+        expect(
+          await squarePaymentProvider.retrieveSession("order_partial_meta"),
+        ).toBeNull();
+        expect(debug().calls.at(-1)?.args).toEqual([
+          "[Square] Square order is missing required metadata fields",
+        ]);
+      },
+    );
+  });
+
   test("acknowledges a completed foreign order with a common metadata field", async () => {
     await withMocks(
       () =>

--- a/test/shared/square-provider/webhook-fields.test.ts
+++ b/test/shared/square-provider/webhook-fields.test.ts
@@ -42,6 +42,12 @@ describe("square-provider payment webhook fields", () => {
     ).rejects.toThrow("Square payment webhook is missing status");
   });
 
+  test("keeps a payment id that is a single character", async () => {
+    // A short id is still an id. Reading the field as blank would refuse a
+    // real callback as malformed, and Square never sends it again.
+    expect(await resolvePayment({ id: "x", status: "PENDING" })).toBe("skip");
+  });
+
   test("rejects an unknown payment status", async () => {
     await expect(
       resolvePayment({

--- a/test/shared/square-provider/webhook.test.ts
+++ b/test/shared/square-provider/webhook.test.ts
@@ -176,6 +176,31 @@ describe("square-provider resolveWebhookSession", () => {
     );
   });
 
+  test("reports a blank payment status as blank, not as unreadable", async () => {
+    // "unreadable" is reserved for a payment Square would not give us at all.
+    // A payment that came back carrying no status is a different fault, and
+    // saying so is what stops someone chasing an outage that never happened.
+    await withMocks(
+      () =>
+        withOrderAndPayment(
+          {
+            id: "order_blank_status",
+            metadata: SQUARE_ORDER_META,
+            state: "COMPLETED",
+            totalMoney: squareMoney(1000),
+          },
+          { id: "pay_blank_status", status: "" },
+        ),
+      async () => {
+        expect(
+          await rejectionMessage(
+            completedSquareWebhook("pay_blank_status", "order_blank_status"),
+          ),
+        ).toBe("Square payment did not read back as completed (status=)");
+      },
+    );
+  });
+
   test("books a completed payment whose order has no tender yet", async () => {
     // The completed event wins while Square's order tenders lag behind it.
     await withMocks(


### PR DESCRIPTION
Tests only. No behaviour changes.

The mutation gate on the Square fix (#2106) scored 98.1% against
`square-provider.ts`: three separate changes could be made to that file and
every single test still passed. Each one is a real fault that would have
reached customers, so each now has a test that catches it.

## What was not being caught

**A payment id one character long would have been thrown away.** The code
checks a field is text and is not empty. If that check had read "two or more
characters" instead of "not empty", a one-character payment id would have been
treated as a missing one, and the callback refused as malformed. Square does
not send a refused callback again, so that customer's payment would be lost.

**Two different faults would have looked identical in the log.** When Square
sends us an order we cannot use, there are two reasons: it is somebody else's
sale (a till sale, say), or it is ours but is missing fields we need. Those
need different responses from an operator. Nothing was checking that the second
one says so — the message could have been blanked out and no test would have
noticed.

**A payment that came back with no status would have been reported as an
outage.** "Unreadable" is the word for a payment Square would not give us at
all. A payment that arrives carrying no status is a different thing entirely.
Reporting the second as the first sends somebody looking for a Square outage
that never happened.

## How each test was checked

Writing a test that passes is not evidence it would catch anything. So for each
of the three, the fault was put into the code by hand, the new test was watched
failing because of it, and the fault was removed again:

| Fault put in                          | Test that failed                                       |
| ------------------------------------- | ------------------------------------------------------ |
| Text must be 2+ characters            | `keeps a payment id that is a single character`         |
| Blank the missing-fields log line     | `says which reason it refused a half-filled order for`  |
| Report a blank status as "unreadable" | `reports a blank payment status as blank, not as unreadable` |

In every case the failing test was the new one and no other test failed, which
is what shows the gap was real and is now closed.

`deno task precommit` and a targeted mutation run over `square-provider.ts`
were both run against this branch; results are in the thread below.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9Sx6wdfDiFJEGK2FWSaEi)_