### PR TITLE
Fix four rule conflicts the guide review found after the merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,12 +126,12 @@ GitHub.
   the norm; a paragraph above a few lines of code is a smell, and usually a sign
   that the code needs to be clearer instead. Never re-narrate the lines below in
   prose, never restate a name (`/** Save the listing. */` above `saveListing`),
-  and never explain a language feature. If a comment is growing to explain a
-  tangle, fix the tangle: rename the thing, or pull the confusing part into a
-  named helper whose name carries the explanation. The bar to clear is "would a
-  competent reader be surprised or misled without this?" — if not, delete it.
-  This applies to prose in commit messages and PR descriptions too: say what
-  changed and why, then stop.
+  and never explain a language feature. If a comment grows to explain a tangle,
+  fix the tangle: rename the thing, or pull the confusing part into a named
+  helper whose name carries the explanation. The bar to clear is this question:
+  is a competent reader surprised or misled without the comment? If the answer
+  is no, delete the comment. This applies to prose in commit messages and PR
+  descriptions too: say what changed and why, then stop.
 
   `deno task check:comments` enforces the size half of this, since Biome never
   reflows comment text and so has never held a comment to any width. It caps the
@@ -1268,8 +1268,9 @@ rule:
   columns with `read.pick`, and specific tables narrow at the cache `fetchAll`
   layer instead.
 
-Even when a caller genuinely needs many columns, list them explicitly rather
-than `SELECT *`, so adding a column later does not silently widen every read.
+Outside these documented full-row exceptions, a caller that genuinely needs many
+columns must still list them explicitly rather than `SELECT *`. A column added
+later then does not silently widen every read.
 
 ### Transactions and Batches
 
@@ -1292,21 +1293,21 @@ query logging and table-scoped cache invalidation stay automatic.
   `deleteByFieldBatch` is a ready-made multi-table delete.
 
 - **Interactive transaction — logic between steps.** When a later statement
-  depends on the result of an earlier one — for example read a balance, validate
-  it, then conditionally update; or create → check capacity → finalize, where a
-  zero-row guard must abort and undo everything — use `withTransaction`. It
-  hands your callback a `TxScope` whose `execute` runs inside one interactive
-  write transaction, committing on success and rolling back (then rethrowing) on
-  any error. The write lock is acquired with a short retry so concurrent writers
-  serialize rather than failing; a database that stays locked surfaces as
-  `DatabaseBusyError`. Read-only statements and batches also retry fleeting
-  upstream HTTP errors (BunnyDB 421 and Turso 502/503/504). Interactive
-  transactions and write paths retry only `SQLITE_BUSY`; upstream HTTP errors
-  are never replayed because the operation can commit before the response
-  arrives. Note the trade-off: an interactive transaction locks the database for
-  writing until it commits or rolls back (with a timeout), so keep the work
-  inside it tight — do any expensive non-DB computation before opening it, and
-  prefer a plain batch whenever no inter-step logic is actually needed.
+  depends on the result of an earlier one, use `withTransaction`. One example is
+  read a balance, validate it, then conditionally update. Another is create →
+  check capacity → finalize, where a zero-row guard must abort and undo
+  everything. It hands your callback a `TxScope` whose `execute` runs inside one
+  interactive write transaction. The transaction commits on success. On any
+  error it rolls back, then rethrows. The write lock is acquired with a short
+  retry so concurrent writers serialize rather than fail. A database that stays
+  locked surfaces as `DatabaseBusyError`. Read-only statements and batches also
+  retry fleeting upstream HTTP errors (BunnyDB 421 and Turso 502/503/504).
+  Interactive transactions and write paths retry only `SQLITE_BUSY`. Upstream
+  HTTP errors are never replayed, because the operation can commit before the
+  response arrives. Note the trade-off: an interactive transaction locks the
+  database for writing until it commits or rolls back (with a timeout), so keep
+  the work inside it tight — do any expensive non-DB computation before opening
+  it, and prefer a plain batch whenever no inter-step logic is actually needed.
 
 ## Scripts
 
@@ -1844,10 +1845,10 @@ just guarantees the next person trips over the same survivor. This is the
 [Good citizen](#preferences) rule applied to mutation testing. It is a
 best-effort check with two documented blind spots (see the header of
 `scripts/precommit/mutation-step.ts`): it scopes to the _committed_ diff, so
-uncommitted work is not checked until committed; and it diffs against your
-_local_ `origin/main`, never re-fetching, so a stale local ref under a branch
+uncommitted work is not checked until committed. It also diffs against your
+_local_ `origin/main` and never re-fetches, so a stale local ref under a branch
 built on newer main commits can leak upstream src into the set (run
-`git fetch origin main` first; a branch's own author is unaffected). In each
+`git fetch origin main` first — a branch's own author is unaffected). In each
 case, reach for `deno task mutation` on the specific module.
 
 ### Coverage Requirements

--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -85,11 +85,11 @@ Write the smallest scenario that proves the rule:
   definitions; focused runs can leave unrelated shared definitions unused.
 - **Drive through the real rendered form.** A Cucumber `When`/`Then` that
   submits an admin edit must read the production HTML form, parse its fields and
-  CSRF token, and POST exactly what a browser would. Do not reconstruct the form
-  state from database rows — that bypasses the rendering layer the scenario
-  exists to prove and would silently keep passing if the editor stopped
-  rendering a field or emitted one the POST parser cannot consume. Exception:
-  pure data-in/data-out rules with no user-facing form action can read state
+  CSRF token, and POST exactly what a browser sends. Do not reconstruct the form
+  state from database rows — that bypasses the rendering layer that the scenario
+  exists to prove. The story then stays green when the editor drops a field, or
+  emits one that the POST parser cannot consume. Exception: pure
+  data-in/data-out rules with no user-facing form action can read state
   directly. When a form is involved, use `extractFormEntries`/`extractCsrfToken`
   against the real served page.
 

--- a/PR_WORKFLOW.md
+++ b/PR_WORKFLOW.md
@@ -53,8 +53,8 @@ than one case. Write `None` when a section truly does not apply; do not omit it.
 
 #### Trusted facts
 
-List every input and say why it can be trusted. Keep expected facts separate
-from observed facts.
+List every input and state whether it is trusted. Explain the basis for that
+decision. Keep expected facts separate from observed facts.
 
 Examples:
 


### PR DESCRIPTION
## Why this pull request exists

Pull request #2108 merged from the merge queue about 40 seconds before its
second CodeRabbit review landed. That review found four real conflicts in text
that #2108 edited. This pull request fixes all four. Each finding has a reply on
its #2108 thread that points here.

## The four fixes

| Finding | File | Fix |
|---|---|---|
| Edited paragraphs kept "would", "growing", and "stopped" | `AGENTS.md` (comments rule), `E2E_TESTS.md` (form rule) | Both paragraphs now use the simple present. The bar for a comment is now a direct question: "is a competent reader surprised or misled without the comment?" The form rule now says a story "stays green when the editor drops a field". |
| The column rule contradicted its own full-row exceptions | `AGENTS.md` | The closing sentence now opens with "Outside these documented full-row exceptions", so nobody narrows `getAllListings` or a table's whole-row read to satisfy the general rule. |
| Semicolons in edited sentences | `AGENTS.md` (interactive-transaction example, mutation blind-spots note) | Each is now two sentences. The formatter pulled three neighbouring sentences into the diff, so their semicolons and "-ing" forms came into line too. |
| "Say why it can be trusted" presumed every input is trusted | `PR_WORKFLOW.md` | The behavior contract now says: "List every input and state whether it is trusted. Explain the basis for that decision." Untrusted is now a first-class answer. |

## Scope

The change edits only the sentences the findings name, plus the neighbouring
sentences the formatter reflowed into the diff. The wider older prose stays as
it is, per the rule that a paragraph comes into line when somebody edits it.

## Checks

The change is markdown only. `deno fmt --check` passes on all 20 markdown
files, and the diff contains no contraction, semicolon, banned modal, or "-ing"
clause. `deno task precommit` is running and this description will be corrected
if it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7HSsRqQDhFwH6bcjt5Th7

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7HSsRqQDhFwH6bcjt5Th7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comment-writing and SQL query guidance.
  * Improved guidance for interactive transactions and mutation-testing caveats.
  * Updated end-to-end testing instructions to reflect real browser form submissions.
  * Clarified how to document whether inputs are trusted and the basis for that assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->