### PR TITLE
Re-bind two sentences that the earlier split left ambiguous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1302,9 +1302,9 @@ query logging and table-scoped cache invalidation stay automatic.
   retry so concurrent writers serialize rather than fail. A database that stays
   locked surfaces as `DatabaseBusyError`. Read-only statements and batches also
   retry fleeting upstream HTTP errors (BunnyDB 421 and Turso 502/503/504).
-  Interactive transactions and write paths retry only `SQLITE_BUSY`. Upstream
-  HTTP errors are never replayed, because the operation can commit before the
-  response arrives. Note the trade-off: an interactive transaction locks the
+  Interactive transactions and write paths retry only `SQLITE_BUSY`. A write
+  path never replays an upstream HTTP error, because the write can commit before
+  the response arrives. Note the trade-off: an interactive transaction locks the
   database for writing until it commits or rolls back (with a timeout), so keep
   the work inside it tight — do any expensive non-DB computation before opening
   it, and prefer a plain batch whenever no inter-step logic is actually needed.

--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -87,8 +87,8 @@ Write the smallest scenario that proves the rule:
   submits an admin edit must read the production HTML form, parse its fields and
   CSRF token, and POST exactly what a browser sends. Do not reconstruct the form
   state from database rows — that bypasses the rendering layer that the scenario
-  exists to prove. The story then stays green when the editor drops a field, or
-  emits one that the POST parser cannot consume. Exception: pure
+  exists to prove. A story built that way stays green when the editor drops a
+  field, or emits one that the POST parser cannot consume. Exception: pure
   data-in/data-out rules with no user-facing form action can read state
   directly. When a form is involved, use `extractFormEntries`/`extractCsrfToken`
   against the real served page.


### PR DESCRIPTION
## Why this pull request exists

Pull request #2111 merged from the queue while its review was in flight, the
same race as #2108. The review found two real ambiguities that the semicolon
splits in #2111 introduced. This pull request fixes both. Each finding has a
reply on its #2111 thread that points here.

## The two fixes

| File | Problem | Fix |
|---|---|---|
| `AGENTS.md` | The split decoupled "upstream HTTP errors are never replayed" from its write-path clause, so it contradicted the read-only retry sentence above it | The rule now names its scope: "A write path never replays an upstream HTTP error, because the write can commit before the response arrives." This matches `retryUpstream: isReadSql(...)` in `src/shared/db/client.ts`. |
| `E2E_TESTS.md` | "The story then stays green" read as a promise about the correct approach | The sentence describes the anti-pattern, so it now says "A story built that way stays green when the editor drops a field". |

## Checks

The change is markdown only, five lines. `deno fmt --check` passes on all 20
markdown files. The diff contains no contraction, semicolon, banned modal, or
"-ing" clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7HSsRqQDhFwH6bcjt5Th7

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7HSsRqQDhFwH6bcjt5Th7)_