### PR TITLE
Report which site, which route, and the cause behind each error

### DIFF
--- a/.github/actions/sentry-sourcemaps/action.yml
+++ b/.github/actions/sentry-sourcemaps/action.yml
@@ -37,12 +37,32 @@ runs:
     # that actually runs in Bunny carries the IDs Sentry matches maps by. This
     # is filename-independent, which matters because we can't predict the path
     # the edge runtime reports in stack frames.
+    #
+    # The CLI injects only files it reads as JavaScript, and merely prints
+    # "Nothing to inject" for a `.ts` bundle, so the work happens on a `.js`
+    # copy. `prepare` writes that copy and `adopt` puts the injected code back
+    # on the deployed bundle. The copy stays on disk for the upload step, which
+    # must send the same pair the debug IDs were written into.
     - name: Inject debug IDs
       if: ${{ inputs.command == 'inject' && inputs.auth_token != '' }}
       shell: bash
-      run: npx @sentry/cli@^2 sourcemaps inject "${{ inputs.file }}" "${{ inputs.file }}.map"
+      run: |
+        js="$(deno run --allow-read --allow-write \
+          scripts/sentry-debug-ids.ts prepare "${{ inputs.file }}")"
+        npx @sentry/cli@^2 sourcemaps inject "$js" "$js.map"
+        grep -q "_sentryDebugIds" "$js" || {
+          echo "::error::sentry-cli injected no debug ID into $js"
+          exit 1
+        }
+        deno run --allow-read --allow-write \
+          scripts/sentry-debug-ids.ts adopt "${{ inputs.file }}"
+        grep -q "_sentryDebugIds" "${{ inputs.file }}" || {
+          echo "::error::the deployed bundle carries no debug ID"
+          exit 1
+        }
 
-    # Upload the bundle + map for this release *after* deploy.
+    # Upload the injected `.js` pair *after* deploy. It carries the same debug
+    # IDs as the deployed bundle, which is what Sentry matches a map by.
     - name: Upload source maps
       if: ${{ inputs.command == 'upload' && inputs.auth_token != '' }}
       shell: bash
@@ -52,6 +72,8 @@ runs:
         SENTRY_ORG: ${{ inputs.org }}
         SENTRY_PROJECT: ${{ inputs.project }}
       run: |
+        js="$(deno run --allow-read scripts/sentry-debug-ids.ts \
+          js-path "${{ inputs.file }}")"
         npx @sentry/cli@^2 sourcemaps upload \
           --release "${{ inputs.release }}" \
-          "${{ inputs.file }}" "${{ inputs.file }}.map"
+          "$js" "$js.map"

--- a/scripts/sentry-debug-ids.ts
+++ b/scripts/sentry-debug-ids.ts
@@ -1,0 +1,85 @@
+/**
+ * Give the deployed bundle a Sentry debug id.
+ *
+ * `sentry-cli sourcemaps inject` writes debug ids only into files it recognises
+ * as JavaScript. For anything else it prints "Nothing to inject" and exits 0.
+ * Our deployed bundle is `bunny-script.ts`, so it never received one: events
+ * arrived with no `debug_meta`, every uploaded source map went unmatched, and
+ * production stack traces stayed minified.
+ *
+ * These commands wrap the CLI. `prepare` writes a JavaScript copy for the CLI
+ * to inject. `adopt` copies the injected code back onto the deployed bundle, so
+ * the bundle we deploy and the map we upload carry the same debug id.
+ * `js-path` names that copy, for the upload step to send.
+ *
+ * Every command prints the JavaScript path, so a caller never has to rebuild
+ * the name itself.
+ */
+
+import { basename } from "@std/path";
+
+import { renameSourceMapLink } from "./edge-bundle-modules.ts";
+
+/** The JavaScript name the Sentry CLI accepts for a given bundle. */
+export const jsSiblingPath = (bundlePath: string): string =>
+  `${bundlePath.replace(/\.[jt]s$/, "")}.js`;
+
+/** A bundle and its map always travel together, under matching names. */
+const mapOf = (path: string): string => `${path}.map`;
+
+/**
+ * Copy `from` to `to`, re-pointing the map link at the destination's own map.
+ * The map is copied as it is; the Sentry CLI rewrites it in place.
+ *
+ * The link names a file beside the bundle, never a path, so the rename works
+ * on the file names alone. Pairing the bundle with its map is how the CLI
+ * finds the map to write a debug id into.
+ */
+const copyBundle = async (from: string, to: string): Promise<void> => {
+  const code = await Deno.readTextFile(from);
+  await Deno.writeTextFile(
+    to,
+    renameSourceMapLink(code, basename(mapOf(from)), basename(mapOf(to))),
+  );
+  await Deno.copyFile(mapOf(from), mapOf(to));
+};
+
+/** What each command does to the bundle before its path is printed. */
+const COMMANDS: Record<string, (bundlePath: string) => Promise<void>> = {
+  /** Copy the injected code and map back onto the bundle we deploy. */
+  adopt: (bundlePath) => copyBundle(jsSiblingPath(bundlePath), bundlePath),
+  /** Name the JavaScript copy without touching any file. */
+  "js-path": () => Promise.resolve(),
+  /** Write the JavaScript copy the Sentry CLI will inject debug ids into. */
+  prepare: (bundlePath) => copyBundle(bundlePath, jsSiblingPath(bundlePath)),
+};
+
+/** Run one named command, and return the JavaScript path it worked on. */
+export const runCommand = async (
+  command: string,
+  bundlePath: string,
+): Promise<string> => {
+  const run = COMMANDS[command];
+  if (!run) {
+    throw new Error(
+      `Unknown command "${command}". Use one of: ${Object.keys(COMMANDS).join(
+        ", ",
+      )}.`,
+    );
+  }
+  await run(bundlePath);
+  return jsSiblingPath(bundlePath);
+};
+
+if (import.meta.main) {
+  const [command, bundlePath] = Deno.args;
+  if (!command || !bundlePath) {
+    console.error(
+      `Usage: sentry-debug-ids.ts <${Object.keys(COMMANDS).join(
+        "|",
+      )}> <bundle-path>`,
+    );
+    Deno.exit(1);
+  }
+  console.log(await runCommand(command, bundlePath));
+}

--- a/scripts/sentry-debug-ids.ts
+++ b/scripts/sentry-debug-ids.ts
@@ -1,85 +1,17 @@
-/**
- * Give the deployed bundle a Sentry debug id.
- *
- * `sentry-cli sourcemaps inject` writes debug ids only into files it recognises
- * as JavaScript. For anything else it prints "Nothing to inject" and exits 0.
- * Our deployed bundle is `bunny-script.ts`, so it never received one: events
- * arrived with no `debug_meta`, every uploaded source map went unmatched, and
- * production stack traces stayed minified.
- *
- * These commands wrap the CLI. `prepare` writes a JavaScript copy for the CLI
- * to inject. `adopt` copies the injected code back onto the deployed bundle, so
- * the bundle we deploy and the map we upload carry the same debug id.
- * `js-path` names that copy, for the upload step to send.
- *
- * Every command prints the JavaScript path, so a caller never has to rebuild
- * the name itself.
- */
-
-import { basename } from "@std/path";
-
-import { renameSourceMapLink } from "./edge-bundle-modules.ts";
-
-/** The JavaScript name the Sentry CLI accepts for a given bundle. */
-export const jsSiblingPath = (bundlePath: string): string =>
-  `${bundlePath.replace(/\.[jt]s$/, "")}.js`;
-
-/** A bundle and its map always travel together, under matching names. */
-const mapOf = (path: string): string => `${path}.map`;
+#!/usr/bin/env -S deno run --allow-read --allow-write
 
 /**
- * Copy `from` to `to`, re-pointing the map link at the destination's own map.
- * The map is copied as it is; the Sentry CLI rewrites it in place.
- *
- * The link names a file beside the bundle, never a path, so the rename works
- * on the file names alone. Pairing the bundle with its map is how the CLI
- * finds the map to write a debug id into.
+ * Give the deployed bundle a Sentry debug id, so an uploaded source map can be
+ * matched to the stack traces it explains. See `sentry-debug-ids/run.ts`.
  */
-const copyBundle = async (from: string, to: string): Promise<void> => {
-  const code = await Deno.readTextFile(from);
-  await Deno.writeTextFile(
-    to,
-    renameSourceMapLink(code, basename(mapOf(from)), basename(mapOf(to))),
+
+import { COMMAND_NAMES, runCommand } from "./sentry-debug-ids/run.ts";
+
+const [command, bundlePath] = Deno.args;
+if (!command || !bundlePath) {
+  console.error(
+    `Usage: sentry-debug-ids.ts <${COMMAND_NAMES.join("|")}> <bundle-path>`,
   );
-  await Deno.copyFile(mapOf(from), mapOf(to));
-};
-
-/** What each command does to the bundle before its path is printed. */
-const COMMANDS: Record<string, (bundlePath: string) => Promise<void>> = {
-  /** Copy the injected code and map back onto the bundle we deploy. */
-  adopt: (bundlePath) => copyBundle(jsSiblingPath(bundlePath), bundlePath),
-  /** Name the JavaScript copy without touching any file. */
-  "js-path": () => Promise.resolve(),
-  /** Write the JavaScript copy the Sentry CLI will inject debug ids into. */
-  prepare: (bundlePath) => copyBundle(bundlePath, jsSiblingPath(bundlePath)),
-};
-
-/** Run one named command, and return the JavaScript path it worked on. */
-export const runCommand = async (
-  command: string,
-  bundlePath: string,
-): Promise<string> => {
-  const run = COMMANDS[command];
-  if (!run) {
-    throw new Error(
-      `Unknown command "${command}". Use one of: ${Object.keys(COMMANDS).join(
-        ", ",
-      )}.`,
-    );
-  }
-  await run(bundlePath);
-  return jsSiblingPath(bundlePath);
-};
-
-if (import.meta.main) {
-  const [command, bundlePath] = Deno.args;
-  if (!command || !bundlePath) {
-    console.error(
-      `Usage: sentry-debug-ids.ts <${Object.keys(COMMANDS).join(
-        "|",
-      )}> <bundle-path>`,
-    );
-    Deno.exit(1);
-  }
-  console.log(await runCommand(command, bundlePath));
+  Deno.exit(1);
 }
+console.log(await runCommand(command, bundlePath));

--- a/scripts/sentry-debug-ids/run.ts
+++ b/scripts/sentry-debug-ids/run.ts
@@ -1,0 +1,73 @@
+/**
+ * Give the deployed bundle a Sentry debug id.
+ *
+ * `sentry-cli sourcemaps inject` writes debug ids only into files it recognises
+ * as JavaScript. For anything else it prints "Nothing to inject" and exits 0.
+ * Our deployed bundle is `bunny-script.ts`, so it never received one: events
+ * arrived with no `debug_meta`, every uploaded source map went unmatched, and
+ * production stack traces stayed minified.
+ *
+ * These commands wrap the CLI. `prepare` writes a JavaScript copy for the CLI
+ * to inject. `adopt` copies the injected code back onto the deployed bundle, so
+ * the bundle we deploy and the map we upload carry the same debug id.
+ * `js-path` names that copy, for the upload step to send.
+ *
+ * Every command returns the JavaScript path, so a caller never has to rebuild
+ * the name itself.
+ */
+
+import { basename } from "@std/path";
+
+import { renameSourceMapLink } from "#scripts/edge-bundle-modules.ts";
+
+/** The JavaScript name the Sentry CLI accepts for a given bundle. */
+export const jsSiblingPath = (bundlePath: string): string =>
+  `${bundlePath.replace(/\.[jt]s$/, "")}.js`;
+
+/** A bundle and its map always travel together, under matching names. */
+const mapOf = (path: string): string => `${path}.map`;
+
+/**
+ * Copy `from` to `to`, re-pointing the map link at the destination's own map.
+ * The map is copied as it is; the Sentry CLI rewrites it in place.
+ *
+ * The link names a file beside the bundle, never a path, so the rename works
+ * on the file names alone. Pairing the bundle with its map is how the CLI
+ * finds the map to write a debug id into.
+ */
+const copyBundle = async (from: string, to: string): Promise<void> => {
+  const code = await Deno.readTextFile(from);
+  await Deno.writeTextFile(
+    to,
+    renameSourceMapLink(code, basename(mapOf(from)), basename(mapOf(to))),
+  );
+  await Deno.copyFile(mapOf(from), mapOf(to));
+};
+
+/** What each command does to the bundle before its path is printed. */
+const COMMANDS: Record<string, (bundlePath: string) => Promise<void>> = {
+  /** Copy the injected code and map back onto the bundle we deploy. */
+  adopt: (bundlePath) => copyBundle(jsSiblingPath(bundlePath), bundlePath),
+  /** Name the JavaScript copy without touching any file. */
+  "js-path": () => Promise.resolve(),
+  /** Write the JavaScript copy the Sentry CLI will inject debug ids into. */
+  prepare: (bundlePath) => copyBundle(bundlePath, jsSiblingPath(bundlePath)),
+};
+
+/** The commands this script accepts, for a caller to name in its usage line. */
+export const COMMAND_NAMES: string[] = Object.keys(COMMANDS);
+
+/** Run one named command, and return the JavaScript path it worked on. */
+export const runCommand = async (
+  command: string,
+  bundlePath: string,
+): Promise<string> => {
+  const run = COMMANDS[command];
+  if (!run) {
+    throw new Error(
+      `Unknown command "${command}". Use one of: ${COMMAND_NAMES.join(", ")}.`,
+    );
+  }
+  await run(bundlePath);
+  return jsSiblingPath(bundlePath);
+};

--- a/src/features/request-scopes.ts
+++ b/src/features/request-scopes.ts
@@ -10,6 +10,7 @@ import { runWithSavedFormContext } from "#shared/forms/saved-data.ts";
 import { runWithIframeContext } from "#shared/iframe.ts";
 import { runWithRequestId } from "#shared/logger.ts";
 import { runWithRequestCache } from "#shared/request-cache.ts";
+import { runWithRequestTrace } from "#shared/request-trace.ts";
 import { runWithSessionContext } from "#shared/session-context.ts";
 import { runWithSubrequestBudget } from "#shared/subrequest-budget.ts";
 import { runWithAdminFooterContext } from "#templates/admin/footer.tsx";
@@ -26,6 +27,7 @@ export const runWithRequestScopes = (
     (next) => runWithClientIp(getClientIp(request, server), next),
     runWithSubrequestBudget,
     runWithRequestId,
+    (next) => runWithRequestTrace(request, next),
     runWithRequestCache,
     runWithQueryLogContext,
     runWithFlashContext,

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -12,13 +12,13 @@ import {
   makeSuppressibleLogFlag,
   shouldSuppressDebugLogs,
 } from "#shared/log-settings.ts";
-import { redactPath } from "#shared/redact-path.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
 import {
   addPendingWork,
   hasPendingWorkScope,
   runWithPendingWork,
 } from "#shared/pending-work.ts";
+import { redactPath } from "#shared/redact-path.ts";
 import {
   createScope,
   createScopedValue,

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -12,6 +12,7 @@ import {
   makeSuppressibleLogFlag,
   shouldSuppressDebugLogs,
 } from "#shared/log-settings.ts";
+import { redactPath } from "#shared/redact-path.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
 import {
   addPendingWork,
@@ -190,45 +191,6 @@ export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
 export const errorCodeLabel: Record<ErrorCodeType, string> = Object.fromEntries(
   Object.values(ERROR_DEFS).map(([code, label]) => [code, label]),
 ) as Record<ErrorCodeType, string>;
-
-/**
- * Redact dynamic segments from paths for privacy-safe logging
- * Replaces:
- * - /ticket/:slug -> /ticket/[redacted]
- * - /admin/listings/:id -> /admin/listings/[id]
- * - /admin/listings/:id/attendees/:aid -> /admin/listings/[id]/attendees/[id]
- */
-export const redactPath = (path: string): string => {
-  // Redact ticket slugs: /ticket/anything -> /ticket/[redacted]
-  let redacted = path.replace(/^\/ticket\/[^/]+/, "/ticket/[redacted]");
-
-  // Redact numeric IDs in admin paths: /admin/listings/123 -> /admin/listings/[id]
-  redacted = redacted.replace(/\/(\d+)(\/|$)/g, "/[id]$2");
-
-  // Redact tokens in wallet webservice paths:
-  // /v1/devices/:device/registrations/:passType/:token → redact device + token
-  // /v1/passes/:passType/:token → redact token
-  redacted = redacted.replace(
-    /^\/v1\/devices\/[^/]+/,
-    "/v1/devices/[redacted]",
-  );
-  redacted = redacted.replace(
-    /^\/v1\/passes\/([^/]+)\/[^/]+/,
-    "/v1/passes/$1/[redacted]",
-  );
-  redacted = redacted.replace(
-    /^\/v1\/devices\/\[redacted\]\/registrations\/([^/]+)\/[^/]+/,
-    "/v1/devices/[redacted]/registrations/$1/[redacted]",
-  );
-
-  // Redact tokens in wallet download paths: /wallet/:token → redact token
-  redacted = redacted.replace(/^\/wallet\/[^/]+/, "/wallet/[redacted]");
-
-  // Redact tokens in checkin paths: /checkin/:token → redact token
-  redacted = redacted.replace(/^\/checkin\/[^/]+/, "/checkin/[redacted]");
-
-  return redacted;
-};
 
 /**
  * Request log entry (privacy-safe)

--- a/src/shared/redact-path.ts
+++ b/src/shared/redact-path.ts
@@ -1,0 +1,40 @@
+/**
+ * Strip the secret parts out of a request path, so a log line or an error
+ * report can name the route without naming the person on it.
+ *
+ * A ticket token is the whole credential for that ticket: anybody holding one
+ * can open the page. Every path segment that carries one is a secret.
+ */
+
+/** Routes that put a secret in the segment straight after the route name. */
+const SECRET_AFTER_ROUTE = ["t", "ticket", "wallet", "checkin"];
+
+/**
+ * Each rule replaces one dynamic part of a path. Order matters: the numeric-id
+ * rule runs before the Wallet webservice rules, which match whatever sits in
+ * the device segment, redacted id included.
+ */
+const RULES: readonly (readonly [RegExp, string])[] = [
+  ...SECRET_AFTER_ROUTE.map(
+    (route) =>
+      [new RegExp(`^/${route}/[^/]+`), `/${route}/[redacted]`] as const,
+  ),
+  [/\/(\d+)(\/|$)/g, "/[id]$2"],
+  [/^\/v1\/devices\/[^/]+/, "/v1/devices/[redacted]"],
+  [/^\/v1\/passes\/([^/]+)\/[^/]+/, "/v1/passes/$1/[redacted]"],
+  [
+    /^\/v1\/devices\/\[redacted\]\/registrations\/([^/]+)\/[^/]+/,
+    "/v1/devices/[redacted]/registrations/$1/[redacted]",
+  ],
+];
+
+/**
+ * Redact the dynamic segments of a path. The result is safe to log, to send to
+ * an error reporter, and to group error reports by.
+ */
+export const redactPath = (path: string): string =>
+  RULES.reduce(
+    (redacted, [pattern, replacement]) =>
+      redacted.replace(pattern, replacement),
+    path,
+  );

--- a/src/shared/request-trace.ts
+++ b/src/shared/request-trace.ts
@@ -33,19 +33,22 @@ export const runWithRequestTrace = <T>(request: Request, fn: () => T): T => {
 /** The request being served, or null when nothing is being served. */
 export const getRequestTrace = (): RequestTrace | null => requestTrace.read();
 
-/** Read one fact off the request being served, or null when none is. */
+/**
+ * Read one fact off the request being served. Undefined when none is, which is
+ * what the reporter wants for a field it should leave off the report.
+ */
 const fromTrace =
   <T>(read: (trace: RequestTrace) => T) =>
-  (): T | null => {
+  (): T | undefined => {
     const trace = getRequestTrace();
-    return trace ? read(trace) : null;
+    return trace ? read(trace) : undefined;
   };
 
 /**
- * The route name an error report is grouped under, or null outside a request.
+ * The route name an error report is grouped under, or nothing outside one.
  * Reads like the request log line: `GET /admin/listings/[id]`.
  */
-export const getTracedRoute: () => string | null = fromTrace(
+export const getTracedRoute: () => string | undefined = fromTrace(
   (trace) => `${trace.method} ${trace.route}`,
 );
 
@@ -53,6 +56,6 @@ export const getTracedRoute: () => string | null = fromTrace(
  * The public URL an error report happened on, with every secret removed. The
  * query string is dropped whole, because it carries tokens on some routes.
  */
-export const getTracedUrl: () => string | null = fromTrace(
+export const getTracedUrl: () => string | undefined = fromTrace(
   (trace) => `https://${trace.host}${trace.route}`,
 );

--- a/src/shared/request-trace.ts
+++ b/src/shared/request-trace.ts
@@ -1,0 +1,55 @@
+/**
+ * Which request an error report belongs to.
+ *
+ * An error is reported from deep inside a request, long after the route and the
+ * log-correlation id are out of reach. Recording them once at the request
+ * boundary lets the report name the route it happened on, and lets a reader
+ * find the console lines that were printed beside it.
+ */
+
+import { redactPath } from "#shared/redact-path.ts";
+import { createScopedValue } from "#shared/request-scoped.ts";
+
+/** The safe-to-report identity of one request. */
+export type RequestTrace = {
+  /** The public host the visitor asked for. */
+  host: string;
+  method: string;
+  /** The path with its secrets removed. Names the route, never the person. */
+  route: string;
+};
+
+const requestTrace = createScopedValue<RequestTrace | null>(() => null);
+
+/** Record the request being served, for as long as it is being served. */
+export const runWithRequestTrace = <T>(
+  request: Request,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const url = new URL(request.url);
+  return requestTrace.run(
+    { host: url.host, method: request.method, route: redactPath(url.pathname) },
+    fn,
+  );
+};
+
+/** The request being served, or null when nothing is being served. */
+export const getRequestTrace = (): RequestTrace | null => requestTrace.read();
+
+/**
+ * The route name an error report is grouped under, or null outside a request.
+ * Reads like the request log line: `GET /admin/listings/[id]`.
+ */
+export const getTracedRoute = (): string | null => {
+  const trace = getRequestTrace();
+  return trace && `${trace.method} ${trace.route}`;
+};
+
+/**
+ * The public URL an error report happened on, with every secret removed. The
+ * query string is dropped whole, because it carries tokens on some routes.
+ */
+export const getTracedUrl = (): string | null => {
+  const trace = getRequestTrace();
+  return trace && `https://${trace.host}${trace.route}`;
+};

--- a/src/shared/request-trace.ts
+++ b/src/shared/request-trace.ts
@@ -22,10 +22,7 @@ export type RequestTrace = {
 const requestTrace = createScopedValue<RequestTrace | null>(() => null);
 
 /** Record the request being served, for as long as it is being served. */
-export const runWithRequestTrace = <T>(
-  request: Request,
-  fn: () => Promise<T>,
-): Promise<T> => {
+export const runWithRequestTrace = <T>(request: Request, fn: () => T): T => {
   const url = new URL(request.url);
   return requestTrace.run(
     { host: url.host, method: request.method, route: redactPath(url.pathname) },
@@ -36,20 +33,26 @@ export const runWithRequestTrace = <T>(
 /** The request being served, or null when nothing is being served. */
 export const getRequestTrace = (): RequestTrace | null => requestTrace.read();
 
+/** Read one fact off the request being served, or null when none is. */
+const fromTrace =
+  <T>(read: (trace: RequestTrace) => T) =>
+  (): T | null => {
+    const trace = getRequestTrace();
+    return trace ? read(trace) : null;
+  };
+
 /**
  * The route name an error report is grouped under, or null outside a request.
  * Reads like the request log line: `GET /admin/listings/[id]`.
  */
-export const getTracedRoute = (): string | null => {
-  const trace = getRequestTrace();
-  return trace && `${trace.method} ${trace.route}`;
-};
+export const getTracedRoute: () => string | null = fromTrace(
+  (trace) => `${trace.method} ${trace.route}`,
+);
 
 /**
  * The public URL an error report happened on, with every secret removed. The
  * query string is dropped whole, because it carries tokens on some routes.
  */
-export const getTracedUrl = (): string | null => {
-  const trace = getRequestTrace();
-  return trace && `https://${trace.host}${trace.route}`;
-};
+export const getTracedUrl: () => string | null = fromTrace(
+  (trace) => `https://${trace.host}${trace.route}`,
+);

--- a/src/shared/sentry-breadcrumbs.ts
+++ b/src/shared/sentry-breadcrumbs.ts
@@ -1,0 +1,31 @@
+/**
+ * Keep a report's breadcrumbs to the request that made it.
+ *
+ * The SDK collects console lines onto one shared scope, and it ships no
+ * async-context strategy for Deno, so `withIsolationScope` cannot separate one
+ * request from another. An edge isolate serves many requests, so a report would
+ * arrive carrying the lines of whichever requests ran beside it.
+ *
+ * Every line the logger prints starts with the request's own id, so the report
+ * can simply keep the lines that are its own. This module is pure: it takes the
+ * id and the lines, and returns the lines to keep.
+ */
+
+/** The part of a breadcrumb this module reads. */
+export type LoggedLine = { message?: string | undefined };
+
+/** How `getLogPrefix` in the logger stamps a line with its request id. */
+const prefixFor = (requestId: string): string => `[${requestId}] `;
+
+/**
+ * The lines belonging to one request. Outside a request there is no id to
+ * match on, so every line is kept — a boot or scheduled-run report has no
+ * other request to be confused with.
+ */
+export const linesForRequest = <T extends LoggedLine>(
+  requestId: string | undefined,
+  lines: T[],
+): T[] =>
+  requestId === undefined
+    ? lines
+    : lines.filter((line) => line.message?.startsWith(prefixFor(requestId)));

--- a/src/shared/sentry-sdk.ts
+++ b/src/shared/sentry-sdk.ts
@@ -9,8 +9,10 @@ import {
   createStackParser,
   createTransport,
   nodeStackLineParser,
+  type Scope,
 } from "@sentry/core";
 import {
+  breadcrumbsIntegration,
   captureException,
   captureMessage,
   DenoClient,
@@ -19,6 +21,7 @@ import {
   getGlobalScope,
   getIsolationScope,
   isInitialized,
+  linkedErrorsIntegration,
 } from "@sentry/deno";
 import { countExternalSubrequest } from "#shared/subrequest-budget.ts";
 
@@ -50,10 +53,31 @@ const makeFetchTransport: ConstructorParameters<
     };
   });
 
+/**
+ * Constructing `DenoClient` directly adds no integrations at all, so the two
+ * that put information into a report are named here. Both are pure event
+ * shaping: they read the event and the console, never Deno globals or source
+ * files on disk, which is all the edge runtime supports.
+ *
+ * `linkedErrors` walks an error's `cause` chain. Without it a report names the
+ * wrapper — "libsql execute failed" — and drops the failure underneath it.
+ *
+ * `breadcrumbs` keeps the console lines printed before the error, which carry
+ * the request id, so a report leads back to its own log.
+ *
+ * Deliberately absent: `dedupe` drops an error that repeats, and two requests
+ * hitting one bug are two real occurrences, not a duplicate. `fetch`
+ * breadcrumbs are off because an outbound URL can carry a session id.
+ */
+const eventShapingIntegrations = [
+  breadcrumbsIntegration({ console: true, fetch: false, sentry: false }),
+  linkedErrorsIntegration(),
+];
+
 const init = (options: InitOptions): DenoClient => {
   const client = new DenoClient({
     ...options,
-    integrations: [],
+    integrations: eventShapingIntegrations,
     stackParser: createStackParser(nodeStackLineParser()),
     tracesSampleRate: 0,
     transport: makeFetchTransport,
@@ -63,9 +87,43 @@ const init = (options: InitOptions): DenoClient => {
   return client;
 };
 
+/** One classified server error, in the shape the SDK wants it. */
+export type ServerReport = {
+  /** The original exception when there is one. Carries the stack trace. */
+  error: unknown;
+  /** Safe extra detail, shown beside the report. */
+  extra: Record<string, string>;
+  /** What to group the report under. Empty leaves the SDK's own grouping. */
+  fingerprint: string[];
+  /** Used only when no exception is attached. */
+  message: string;
+  tags: Record<string, string>;
+  /** The route the report happened on, or undefined outside a request. */
+  transactionName: string | undefined;
+};
+
+/**
+ * Capture one report with its whole scope set, and return its event id. Keeps
+ * every Scope call in this adapter, so the reporter above stays SDK-free.
+ */
+const captureReport = (report: ServerReport): string => {
+  const applyScope = (scope: Scope): Scope => {
+    scope.setLevel("error");
+    scope.setTags(report.tags);
+    scope.setExtras(report.extra);
+    scope.setTransactionName(report.transactionName);
+    if (report.fingerprint.length > 0) scope.setFingerprint(report.fingerprint);
+    return scope;
+  };
+  return report.error === undefined
+    ? captureMessage(report.message, applyScope)
+    : captureException(report.error, applyScope);
+};
+
 export const sentrySdk = {
   captureException,
   captureMessage,
+  captureReport,
   flush,
   getCurrentScope,
   getGlobalScope,

--- a/src/shared/sentry-sdk.ts
+++ b/src/shared/sentry-sdk.ts
@@ -5,6 +5,7 @@
  * unused Sentry exports without evaluating the SDK during module load.
  */
 
+import type { ErrorEvent } from "@sentry/core";
 import {
   createStackParser,
   createTransport,
@@ -23,6 +24,7 @@ import {
   isInitialized,
   linkedErrorsIntegration,
 } from "@sentry/deno";
+import { linesForRequest } from "#shared/sentry-breadcrumbs.ts";
 import { countExternalSubrequest } from "#shared/subrequest-budget.ts";
 
 type InitOptions = {
@@ -74,9 +76,30 @@ const eventShapingIntegrations = [
   linkedErrorsIntegration(),
 ];
 
+/**
+ * Drop the console lines that belong to other requests. The SDK collects them
+ * onto one shared scope, so without this a report on a busy isolate carries
+ * whatever ran beside it. `requestId` is the tag the reporter sets.
+ */
+const keepOwnBreadcrumbs = (event: ErrorEvent): ErrorEvent => {
+  // A tag is typed as any primitive, but the reporter only ever sets strings.
+  // Anything else leaves no id to match on, so every line is kept.
+  const requestId = event.tags?.requestId;
+  return event.breadcrumbs === undefined
+    ? event
+    : {
+        ...event,
+        breadcrumbs: linesForRequest(
+          typeof requestId === "string" ? requestId : undefined,
+          event.breadcrumbs,
+        ),
+      };
+};
+
 const init = (options: InitOptions): DenoClient => {
   const client = new DenoClient({
     ...options,
+    beforeSend: keepOwnBreadcrumbs,
     integrations: eventShapingIntegrations,
     stackParser: createStackParser(nodeStackLineParser()),
     tracesSampleRate: 0,

--- a/src/shared/sentry.ts
+++ b/src/shared/sentry.ts
@@ -120,24 +120,24 @@ export const sendSentryTest = async (): Promise<boolean> => {
  * console lines carry, so a report leads back to the log beside it. Empty and
  * missing values are dropped rather than sent as blanks.
  */
-const eventTags = (context: ErrorContext): Record<string, string> =>
-  Object.fromEntries(
+const eventTags = (context: ErrorContext): Record<string, string> => {
+  const trace = getRequestTrace();
+  return Object.fromEntries(
     Object.entries({
       attendeeId: context.attendeeId,
       code: context.code,
       listingId: context.listingId,
       requestId: getRequestId(),
       // The host the visitor actually asked for. Outside a request — boot, a
-      // scheduled run — fall back to the site's own configured domain, the
-      // same one the ntfy notification titles use.
-      site: getRequestTrace()?.host ?? getEffectiveDomain(),
+      // scheduled run — the site's own configured domain, which is the one
+      // the ntfy notification titles already use.
+      site: trace ? trace.host : getEffectiveDomain(),
       url: getTracedUrl(),
     })
-      .filter(
-        ([, value]) => value !== undefined && value !== null && value !== "",
-      )
+      .filter(([, value]) => value !== undefined && value !== "")
       .map(([key, value]) => [key, String(value)]),
   );
+};
 
 /**
  * How to group a report that carries no exception.
@@ -176,7 +176,7 @@ export const captureServerError = async (
     fingerprint: messageFingerprint(context),
     message: formatErrorMessage(context),
     tags: eventTags(context),
-    transactionName: getTracedRoute() ?? undefined,
+    transactionName: getTracedRoute(),
   });
 
   await Sentry.flush(FLUSH_TIMEOUT_MS);

--- a/src/shared/sentry.ts
+++ b/src/shared/sentry.ts
@@ -10,16 +10,29 @@
  * named-import adapter is dynamically imported on the first `initSentry` call
  * with a DSN configured, never at module load. The adapter lets the production
  * build remove unused SDK exports while a deployment without `SENTRY_URL`
- * skips evaluating the retained code entirely. All default integrations are
- * disabled (`integrations: []`): they read Deno-specific globals and source files we
- * don't need, and turning them off keeps the SDK to its core capture + fetch
- * transport, which is exactly what the edge runtime supports.
+ * skips evaluating the retained code entirely. It also names the handful of
+ * integrations a report needs, because constructing the client directly adds
+ * none of them.
+ *
+ * Every report names the site it came from, the route it happened on, and the
+ * request id the console lines carry, so one Sentry endpoint can serve many
+ * sites and a report still leads back to the request that made it.
  */
 
 import { lazyRef } from "#fp";
 import { BUILD_COMMIT } from "#shared/build-info.ts";
+import { getEffectiveDomain } from "#shared/config.ts";
 import { getEnv } from "#shared/env.ts";
-import { type ErrorContext, formatErrorMessage } from "#shared/logger.ts";
+import {
+  type ErrorContext,
+  formatErrorMessage,
+  getRequestId,
+} from "#shared/logger.ts";
+import {
+  getRequestTrace,
+  getTracedRoute,
+  getTracedUrl,
+} from "#shared/request-trace.ts";
 
 type SentrySdk = typeof import("#shared/sentry-sdk.ts")["sentrySdk"];
 type LoadedSentry = {
@@ -100,16 +113,48 @@ export const sendSentryTest = async (): Promise<boolean> => {
   });
 };
 
-/** Per-event tags so errors can be filtered by class in the Sentry UI. */
-const eventTags = (context: ErrorContext): Record<string, string> => {
-  const tags: Record<string, string> = { code: context.code };
-  if (context.listingId !== undefined) {
-    tags.listingId = String(context.listingId);
-  }
-  if (context.attendeeId !== undefined) {
-    tags.attendeeId = String(context.attendeeId);
-  }
-  return tags;
+/**
+ * Per-event tags, so a report can be filtered by class, by site, and by
+ * request. `site` names which of our sites reported it, because many sites
+ * share one Sentry endpoint. `requestId` is the same four characters the
+ * console lines carry, so a report leads back to the log beside it. Empty and
+ * missing values are dropped rather than sent as blanks.
+ */
+const eventTags = (context: ErrorContext): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries({
+      attendeeId: context.attendeeId,
+      code: context.code,
+      listingId: context.listingId,
+      requestId: getRequestId(),
+      // The host the visitor actually asked for. Outside a request — boot, a
+      // scheduled run — fall back to the site's own configured domain, the
+      // same one the ntfy notification titles use.
+      site: getRequestTrace()?.host ?? getEffectiveDomain(),
+      url: getTracedUrl(),
+    })
+      .filter(
+        ([, value]) => value !== undefined && value !== null && value !== "",
+      )
+      .map(([key, value]) => [key, String(value)]),
+  );
+
+/**
+ * How to group a report that carries no exception.
+ *
+ * A message report has no stack, so Sentry groups it by the message text — and
+ * our text ends with a detail that names the image, the session, or the
+ * amount. That made one issue per detail: forty separate "Broken image"
+ * issues, none of them a place to look. Grouping by the error code and the
+ * route puts every one of them in a single issue with forty events.
+ *
+ * A report that carries an exception keeps the SDK's own stack grouping, which
+ * is already the right answer.
+ */
+const messageFingerprint = (context: ErrorContext): string[] => {
+  if (context.error !== undefined) return [];
+  const trace = getRequestTrace();
+  return trace ? [context.code, trace.method, trace.route] : [context.code];
 };
 
 /**
@@ -125,17 +170,14 @@ export const captureServerError = async (
   if (!loaded?.sdk.isInitialized()) return;
   const Sentry = loaded.sdk;
 
-  const captureContext = {
-    ...(context.detail ? { extra: { detail: context.detail } } : {}),
-    level: "error" as const,
+  Sentry.captureReport({
+    error: context.error,
+    extra: context.detail ? { detail: context.detail } : {},
+    fingerprint: messageFingerprint(context),
+    message: formatErrorMessage(context),
     tags: eventTags(context),
-  };
-
-  if (context.error !== undefined) {
-    Sentry.captureException(context.error, captureContext);
-  } else {
-    Sentry.captureMessage(formatErrorMessage(context), captureContext);
-  }
+    transactionName: getTracedRoute() ?? undefined,
+  });
 
   await Sentry.flush(FLUSH_TIMEOUT_MS);
 };

--- a/test/scripts/sentry-debug-ids.test.ts
+++ b/test/scripts/sentry-debug-ids.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { jsSiblingPath, runCommand } from "#scripts/sentry-debug-ids.ts";
+import { jsSiblingPath, runCommand } from "#scripts/sentry-debug-ids/run.ts";
 
 const BUNDLE = "code;\n//# sourceMappingURL=bundle.ts.map";
 const MAP = '{"version":3,"sources":[],"mappings":""}';

--- a/test/scripts/sentry-debug-ids.test.ts
+++ b/test/scripts/sentry-debug-ids.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { jsSiblingPath, runCommand } from "#scripts/sentry-debug-ids.ts";
+
+const BUNDLE = "code;\n//# sourceMappingURL=bundle.ts.map";
+const MAP = '{"version":3,"sources":[],"mappings":""}';
+
+describe("sentry debug ids", () => {
+  let dir: string;
+  let bundle: string;
+
+  beforeEach(async () => {
+    dir = await Deno.makeTempDir();
+    bundle = `${dir}/bundle.ts`;
+    await Deno.writeTextFile(bundle, BUNDLE);
+    await Deno.writeTextFile(`${bundle}.map`, MAP);
+  });
+
+  afterEach(async () => {
+    await Deno.remove(dir, { recursive: true });
+  });
+
+  describe("jsSiblingPath", () => {
+    // The Sentry CLI injects debug ids only into files it reads as JavaScript,
+    // and prints "Nothing to inject" for anything else.
+    test("swaps a TypeScript bundle name for a JavaScript one", () => {
+      expect(jsSiblingPath("bunny-script.ts")).toBe("bunny-script.js");
+    });
+
+    test("keeps a path that is already JavaScript", () => {
+      expect(jsSiblingPath("bundle.js")).toBe("bundle.js");
+    });
+
+    test("only strips a trailing extension", () => {
+      expect(jsSiblingPath("dist/v2.ts.build.ts")).toBe("dist/v2.ts.build.js");
+    });
+  });
+
+  describe("prepare", () => {
+    test("writes a JavaScript copy of the bundle and its map", async () => {
+      await runCommand("prepare", bundle);
+
+      expect(await Deno.readTextFile(`${dir}/bundle.js`)).toContain("code;");
+      expect(await Deno.readTextFile(`${dir}/bundle.js.map`)).toBe(MAP);
+    });
+
+    // The CLI finds the map to stamp by following this link. Pointing it at the
+    // TypeScript map leaves the map without a debug id, and an uploaded map
+    // with no debug id never matches an event.
+    test("points the copy at its own map, by name and not by path", async () => {
+      await runCommand("prepare", bundle);
+
+      expect(await Deno.readTextFile(`${dir}/bundle.js`)).toContain(
+        "//# sourceMappingURL=bundle.js.map",
+      );
+    });
+  });
+
+  describe("adopt", () => {
+    test("copies the injected code back onto the deployed bundle", async () => {
+      await runCommand("prepare", bundle);
+      await Deno.writeTextFile(
+        `${dir}/bundle.js`,
+        "code;\n//# sourceMappingURL=bundle.js.map\n//# debugId=abc",
+      );
+      await Deno.writeTextFile(`${dir}/bundle.js.map`, '{"debug_id":"abc"}');
+
+      await runCommand("adopt", bundle);
+
+      const deployed = await Deno.readTextFile(bundle);
+      expect(deployed).toContain("//# debugId=abc");
+      expect(deployed).toContain("//# sourceMappingURL=bundle.ts.map");
+      expect(await Deno.readTextFile(`${bundle}.map`)).toBe(
+        '{"debug_id":"abc"}',
+      );
+    });
+  });
+
+  describe("runCommand", () => {
+    test("names the JavaScript copy without touching a file", async () => {
+      expect(await runCommand("js-path", bundle)).toBe(`${dir}/bundle.js`);
+      await expect(Deno.stat(`${dir}/bundle.js`)).rejects.toThrow();
+    });
+
+    test("returns the path each command worked on", async () => {
+      expect(await runCommand("prepare", bundle)).toBe(`${dir}/bundle.js`);
+      expect(await runCommand("adopt", bundle)).toBe(`${dir}/bundle.js`);
+    });
+
+    test("refuses a command it does not know", async () => {
+      await expect(runCommand("upload", bundle)).rejects.toThrow(
+        'Unknown command "upload"',
+      );
+    });
+  });
+});

--- a/test/shared/logger/error-codes.test.ts
+++ b/test/shared/logger/error-codes.test.ts
@@ -1,0 +1,107 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { ErrorCode, errorCodeLabel } from "#shared/logger.ts";
+
+// The wire code is what an operator filters an error report by, in Bugsink and
+// in the activity log, so renaming one quietly breaks their saved searches.
+// The label is what the activity log shows them. Both are pinned whole here:
+// a changed, dropped, or emptied entry fails this test rather than reaching
+// production and stranding a search that used to work.
+describe("error codes", () => {
+  test("every code keeps its wire string", () => {
+    expect(ErrorCode).toEqual({
+      ADDRESS_LOOKUP: "E_ADDRESS_LOOKUP",
+      AUTH_CSRF_MISMATCH: "E_AUTH_CSRF_MISMATCH",
+      AUTH_EXPIRED: "E_AUTH_EXPIRED",
+      AUTH_INVALID_SESSION: "E_AUTH_INVALID_SESSION",
+      AUTH_RATE_LIMITED: "E_AUTH_RATE_LIMITED",
+      BOTPOISON_VERIFY: "E_BOTPOISON_VERIFY",
+      CAPACITY_EXCEEDED: "E_CAPACITY_EXCEEDED",
+      CDN_REQUEST: "E_CDN_REQUEST",
+      CONFIG_MISSING: "E_CONFIG_MISSING",
+      DATA_INVALID: "E_DATA_INVALID",
+      DB_BUSY: "E_DB_BUSY",
+      DB_CONNECTION: "E_DB_CONNECTION",
+      DB_QUERY: "E_DB_QUERY",
+      DECRYPT_FAILED: "E_DECRYPT_FAILED",
+      DOMAIN_REJECTED: "E_DOMAIN_REJECTED",
+      EMAIL_SEND: "E_EMAIL_SEND",
+      IMAGE_BROKEN: "E_IMAGE_BROKEN",
+      INVARIANT_REPORTED: "E_INVARIANT_REPORTED",
+      KEY_DERIVATION: "E_KEY_DERIVATION",
+      LEDGER_POST: "E_LEDGER_POST",
+      NOT_FOUND_ATTENDEE: "E_NOT_FOUND_ATTENDEE",
+      NOT_FOUND_LISTING: "E_NOT_FOUND_LISTING",
+      PAYMENT_CHECKOUT: "E_PAYMENT_CHECKOUT",
+      PAYMENT_REFUND: "E_PAYMENT_REFUND",
+      PAYMENT_SESSION: "E_PAYMENT_SESSION",
+      PAYMENT_SIGNATURE: "E_PAYMENT_SIGNATURE",
+      PAYMENT_WEBHOOK_SETUP: "E_PAYMENT_WEBHOOK_SETUP",
+      REGISTRATION_DELIVERY: "E_REGISTRATION_DELIVERY",
+      SQUARE_CHECKOUT: "E_SQUARE_CHECKOUT",
+      SQUARE_ORDER: "E_SQUARE_ORDER",
+      SQUARE_REFUND: "E_SQUARE_REFUND",
+      SQUARE_SESSION: "E_SQUARE_SESSION",
+      SQUARE_SIGNATURE: "E_SQUARE_SIGNATURE",
+      STORAGE_DELETE: "E_STORAGE_DELETE",
+      STORAGE_UPLOAD: "E_STORAGE_UPLOAD",
+      STRIPE_CHECKOUT: "E_STRIPE_CHECKOUT",
+      STRIPE_REFUND: "E_STRIPE_REFUND",
+      STRIPE_SESSION: "E_STRIPE_SESSION",
+      STRIPE_SIGNATURE: "E_STRIPE_SIGNATURE",
+      STRIPE_WEBHOOK_SETUP: "E_STRIPE_WEBHOOK_SETUP",
+      VALIDATION_CONTENT_TYPE: "E_VALIDATION_CONTENT_TYPE",
+      VALIDATION_FORM: "E_VALIDATION_FORM",
+      WEBHOOK_PRICE_SIGNATURE: "E_WEBHOOK_PRICE_SIGNATURE",
+    });
+  });
+
+  test("every wire string keeps its label", () => {
+    expect(errorCodeLabel).toEqual({
+      E_ADDRESS_LOOKUP: "Address lookup failed",
+      E_AUTH_CSRF_MISMATCH: "CSRF mismatch",
+      E_AUTH_EXPIRED: "Session expired",
+      E_AUTH_INVALID_SESSION: "Invalid session",
+      E_AUTH_RATE_LIMITED: "Rate limited",
+      E_BOTPOISON_VERIFY: "Botpoison verification failed",
+      E_CAPACITY_EXCEEDED: "Capacity exceeded",
+      E_CDN_REQUEST: "CDN request failed",
+      E_CONFIG_MISSING: "Configuration missing",
+      E_DATA_INVALID: "Invalid data",
+      E_DB_BUSY: "Database busy",
+      E_DB_CONNECTION: "Database connection failed",
+      E_DB_QUERY: "Database query failed",
+      E_DECRYPT_FAILED: "Decryption failed",
+      E_DOMAIN_REJECTED: "Domain rejected",
+      E_EMAIL_SEND: "Email send failed",
+      E_IMAGE_BROKEN: "Broken image",
+      E_INVARIANT_REPORTED: "System invariant broken",
+      E_KEY_DERIVATION: "Key derivation failed",
+      E_LEDGER_POST: "Ledger post failed",
+      E_NOT_FOUND_ATTENDEE: "Attendee not found",
+      E_NOT_FOUND_LISTING: "Listing not found",
+      E_PAYMENT_CHECKOUT: "Payment checkout failed",
+      E_PAYMENT_REFUND: "Payment refund failed",
+      E_PAYMENT_SESSION: "Payment session error",
+      E_PAYMENT_SIGNATURE: "Payment signature verification failed",
+      E_PAYMENT_WEBHOOK_SETUP: "Payment webhook setup failed",
+      E_REGISTRATION_DELIVERY: "Registration notification delivery failed",
+      E_SQUARE_CHECKOUT: "Square checkout failed",
+      E_SQUARE_ORDER: "Square order validation failed",
+      E_SQUARE_REFUND: "Square refund failed",
+      E_SQUARE_SESSION: "Square session retrieval failed",
+      E_SQUARE_SIGNATURE: "Square signature verification failed",
+      E_STORAGE_DELETE: "Storage delete failed",
+      E_STORAGE_UPLOAD: "Storage upload failed",
+      E_STRIPE_CHECKOUT: "Stripe checkout failed",
+      E_STRIPE_REFUND: "Stripe refund failed",
+      E_STRIPE_SESSION: "Stripe session retrieval failed",
+      E_STRIPE_SIGNATURE: "Stripe signature verification failed",
+      E_STRIPE_WEBHOOK_SETUP: "Stripe webhook setup failed",
+      E_VALIDATION_CONTENT_TYPE: "Invalid content type",
+      E_VALIDATION_FORM: "Form validation error",
+      E_WEBHOOK_PRICE_SIGNATURE:
+        "Webhook price signature invalid, missing, or charge differs from it",
+    });
+  });
+});

--- a/test/shared/logger/error-fan-out.test.ts
+++ b/test/shared/logger/error-fan-out.test.ts
@@ -1,0 +1,100 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { type Spy, spy } from "@std/testing/mock";
+import {
+  ErrorCode,
+  logError,
+  runWithRequestId,
+  withDeferredErrorReports,
+} from "#shared/logger.ts";
+import { withEnv } from "#test-utils/env.ts";
+import { stubFetch } from "#test-utils/fetch-stub.ts";
+
+const NTFY_URL = "https://ntfy.example.test/errors";
+
+/**
+ * An error report fans out to the notifier, the activity log, and Sentry. The
+ * ntfy call is the one visible from a unit test without a database, so it
+ * stands in for "the report went out".
+ */
+describe("error fan-out", () => {
+  let fetchStub: ReturnType<typeof stubFetch>;
+  let errorSpy: Spy;
+
+  beforeEach(() => {
+    fetchStub = stubFetch(() => new Response("ok", { status: 200 }));
+    errorSpy = spy(console, "error");
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+    errorSpy.restore();
+  });
+
+  const ntfyCalls = (): number =>
+    fetchStub.calls.filter((call) => String(call.args[0]).includes("ntfy"))
+      .length;
+
+  test("writes the console line for every error", () => {
+    logError({ code: ErrorCode.DB_QUERY, detail: "select failed" });
+
+    expect(errorSpy.calls.length).toBe(1);
+  });
+
+  // Without the spaces the line reads "[Error] E_DB_QUERYlisting=7", which no
+  // log search would match on either half.
+  test("separates the parts of the console line with spaces", () => {
+    logError({ code: ErrorCode.DB_QUERY, detail: "boom", listingId: 7 });
+
+    expect(String(errorSpy.calls[0]?.args[0])).toBe(
+      '[Error] E_DB_QUERY listing=7 detail="boom"',
+    );
+  });
+
+  test("sends the report out from inside a request", async () => {
+    using _env = withEnv({ NTFY_URL });
+
+    await runWithRequestId(async () => {
+      logError({ code: ErrorCode.DB_QUERY });
+    });
+
+    expect(ntfyCalls()).toBe(1);
+  });
+
+  // Outside a request there is no queue to hold the work, and Bunny kills a
+  // fetch made after the response, so the report stays on the console.
+  test("does not send the report out when there is no request", () => {
+    using _env = withEnv({ NTFY_URL });
+
+    logError({ code: ErrorCode.DB_QUERY });
+
+    expect(ntfyCalls()).toBe(0);
+    expect(errorSpy.calls.length).toBe(1);
+  });
+
+  test("holds a deferred report until the critical work has finished", async () => {
+    using _env = withEnv({ NTFY_URL });
+
+    await runWithRequestId(async () => {
+      await withDeferredErrorReports(async () => {
+        logError({ code: ErrorCode.DB_QUERY });
+        expect(ntfyCalls()).toBe(0);
+      });
+    });
+
+    expect(ntfyCalls()).toBe(1);
+  });
+
+  test("sends every deferred report, not just the last", async () => {
+    using _env = withEnv({ NTFY_URL });
+
+    await runWithRequestId(async () => {
+      await withDeferredErrorReports(async () => {
+        logError({ code: ErrorCode.DB_QUERY });
+        logError({ code: ErrorCode.EMAIL_SEND });
+      });
+    });
+
+    expect(ntfyCalls()).toBe(2);
+  });
+});

--- a/test/shared/redact-path.test.ts
+++ b/test/shared/redact-path.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { redactPath } from "#shared/logger.ts";
+import { redactPath } from "#shared/redact-path.ts";
 
 describe("redactPath", () => {
   test("redacts ticket slugs", () => {
@@ -67,5 +67,24 @@ describe("redactPath", () => {
 
   test("handles trailing slashes with IDs", () => {
     expect(redactPath("/admin/listings/123/")).toBe("/admin/listings/[id]/");
+  });
+
+  // Regression: the live ticket route is `/t/:token`, not `/ticket/:slug`.
+  // The token is the whole credential for that ticket, and it was reaching the
+  // logs and the error reporter in full.
+  test("redacts the token on the live ticket route", () => {
+    expect(redactPath("/t/9D5F57B232")).toBe("/t/[redacted]");
+  });
+
+  test("redacts every token on a multi-ticket URL", () => {
+    expect(redactPath("/t/9D5F57B232+A1B2C3D4E5")).toBe("/t/[redacted]");
+  });
+
+  test("keeps the bare ticket route, which carries no token", () => {
+    expect(redactPath("/t")).toBe("/t");
+  });
+
+  test("leaves routes that only start with the same letter alone", () => {
+    expect(redactPath("/terms")).toBe("/terms");
   });
 });

--- a/test/shared/request-trace.test.ts
+++ b/test/shared/request-trace.test.ts
@@ -65,8 +65,8 @@ describe("request trace", () => {
 
   test("reads as no request at all outside a request", () => {
     expect(getRequestTrace()).toBe(null);
-    expect(getTracedRoute()).toBe(null);
-    expect(getTracedUrl()).toBe(null);
+    expect(getTracedRoute()).toBe(undefined);
+    expect(getTracedUrl()).toBe(undefined);
   });
 
   test("does not leak one request's trace into the next", async () => {

--- a/test/shared/request-trace.test.ts
+++ b/test/shared/request-trace.test.ts
@@ -1,0 +1,79 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  getRequestTrace,
+  getTracedRoute,
+  getTracedUrl,
+  runWithRequestTrace,
+} from "#shared/request-trace.ts";
+
+const trace = <T>(url: string, method: string, read: () => T): Promise<T> =>
+  runWithRequestTrace(new Request(url, { method }), () =>
+    Promise.resolve(read()),
+  );
+
+describe("request trace", () => {
+  test("records the host the visitor asked for", async () => {
+    expect(
+      await trace("https://venue.example.com/listings", "GET", getRequestTrace),
+    ).toEqual({
+      host: "venue.example.com",
+      method: "GET",
+      route: "/listings",
+    });
+  });
+
+  test("keeps the port, so two local sites stay apart", async () => {
+    const traced = await trace(
+      "http://localhost:8081/",
+      "GET",
+      getRequestTrace,
+    );
+    expect(traced?.host).toBe("localhost:8081");
+  });
+
+  test("names the route the way the request log does", async () => {
+    expect(
+      await trace(
+        "https://venue.example.com/admin/listings/42",
+        "POST",
+        getTracedRoute,
+      ),
+    ).toBe("POST /admin/listings/[id]");
+  });
+
+  test("builds a public URL with the route's secrets removed", async () => {
+    expect(
+      await trace(
+        "https://venue.example.com/t/9D5F57B232",
+        "GET",
+        getTracedUrl,
+      ),
+    ).toBe("https://venue.example.com/t/[redacted]");
+  });
+
+  // A query string carries a token on some routes, so it is dropped whole
+  // rather than filtered key by key.
+  test("drops the query string whole", async () => {
+    const url = await trace(
+      "https://venue.example.com/checkout?session=cs_live_abc&email=a@b.test",
+      "GET",
+      getTracedUrl,
+    );
+    expect(url).toBe("https://venue.example.com/checkout");
+  });
+
+  test("reads as no request at all outside a request", () => {
+    expect(getRequestTrace()).toBe(null);
+    expect(getTracedRoute()).toBe(null);
+    expect(getTracedUrl()).toBe(null);
+  });
+
+  test("does not leak one request's trace into the next", async () => {
+    await trace("https://a.example.com/one", "GET", getRequestTrace);
+    expect(
+      await trace("https://b.example.com/two", "GET", getTracedRoute),
+    ).toBe("GET /two");
+    expect(getRequestTrace()).toBe(null);
+  });
+});

--- a/test/shared/sentry-breadcrumbs.test.ts
+++ b/test/shared/sentry-breadcrumbs.test.ts
@@ -1,0 +1,53 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { linesForRequest } from "#shared/sentry-breadcrumbs.ts";
+
+const line = (message: string) => ({ message });
+
+describe("linesForRequest", () => {
+  // An edge isolate serves many requests, and the SDK collects every console
+  // line onto one shared scope. A report that carried its neighbours' lines
+  // would send a reader down the wrong request.
+  test("keeps only the lines the request printed", () => {
+    expect(
+      linesForRequest("ab12", [
+        line("[ab12] [Error] E_DB_QUERY"),
+        line("[cd34] [Error] E_EMAIL_SEND"),
+        line("[ab12] [Request] GET /listings 200 5ms"),
+      ]),
+    ).toEqual([
+      line("[ab12] [Error] E_DB_QUERY"),
+      line("[ab12] [Request] GET /listings 200 5ms"),
+    ]);
+  });
+
+  test("matches the id at the start, never further along the line", () => {
+    expect(
+      linesForRequest("ab12", [line('[cd34] [Error] detail="saw ab12 here"')]),
+    ).toEqual([]);
+  });
+
+  // A short id must not match a longer one that starts the same way.
+  test("does not treat one id as the start of another", () => {
+    expect(linesForRequest("ab1", [line("[ab12] [Error] E_DB_QUERY")])).toEqual(
+      [],
+    );
+  });
+
+  // Boot and scheduled runs report with no request id, and have no neighbour
+  // to be confused with, so their lines are all worth keeping.
+  test("keeps every line when there is no request", () => {
+    const lines = [line("[Setup] App started"), line("[ab12] [Error] E_DB")];
+    expect(linesForRequest(undefined, lines)).toEqual(lines);
+  });
+
+  test("drops a line with no message at all", () => {
+    expect(linesForRequest("ab12", [{}, line("[ab12] ok")])).toEqual([
+      line("[ab12] ok"),
+    ]);
+  });
+
+  test("returns nothing when the request printed nothing", () => {
+    expect(linesForRequest("ab12", [line("[cd34] other")])).toEqual([]);
+  });
+});

--- a/test/shared/sentry-sdk.test.ts
+++ b/test/shared/sentry-sdk.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 import { ErrorCode } from "#shared/logger.ts";
+import { runWithRequestTrace } from "#shared/request-trace.ts";
 import "#shared/sentry-sdk.ts";
 import { captureServerError, initSentry } from "#shared/sentry.ts";
 import {
@@ -123,5 +124,89 @@ describe("Sentry SDK transport", () => {
         ),
       ),
     ).rejects.toThrow("Blocked external operation: Sentry transport");
+  });
+
+  /**
+   * The scope carries everything that makes a report findable: what happened,
+   * where, on which site, and how to group it. Each of these assertions fails
+   * if the matching scope call stops running.
+   */
+  describe("the scope a report carries", () => {
+    const captureAndRead = async (
+      capture: () => Promise<void>,
+    ): Promise<string> => {
+      using fetchStub = stubFetch(() => new Response("{}", { status: 200 }));
+      await initSentry();
+      await capture();
+      const options = fetchStub.calls[0]!.args[1] as RequestInit;
+      return typeof options.body === "string"
+        ? options.body
+        : new TextDecoder().decode(options.body as Uint8Array);
+    };
+
+    /** A report with no exception: the 72-of-82 call sites that pass a code. */
+    const messageReportBody = (): Promise<string> =>
+      captureAndRead(() => captureServerError({ code: ErrorCode.DB_QUERY }));
+
+    /** A report that carries the exception that caused it. */
+    const errorReportBody = (): Promise<string> =>
+      captureAndRead(() =>
+        captureServerError({
+          code: ErrorCode.DB_QUERY,
+          error: new Error("kaboom"),
+        }),
+      );
+
+    test("marks the report as an error, tags it, and names its route", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+
+      const body = await captureAndRead(() =>
+        runWithRequestTrace(
+          new Request("https://venue.example.com/admin/listings/42"),
+          () =>
+            captureServerError({
+              code: ErrorCode.DB_QUERY,
+              detail: "select failed",
+              listingId: 42,
+            }),
+        ),
+      );
+
+      expect(body).toContain('"level":"error"');
+      expect(body).toContain('"code":"E_DB_QUERY"');
+      expect(body).toContain('"listingId":"42"');
+      expect(body).toContain('"extra":{"detail":"select failed"}');
+      expect(body).toContain('"transaction":"GET /admin/listings/[id]"');
+    });
+
+    test("groups a report with no stack even outside a request", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+
+      expect(await messageReportBody()).toContain(
+        '"fingerprint":["E_DB_QUERY"]',
+      );
+    });
+
+    test("leaves a report that carries a stack trace ungrouped", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+
+      expect(await errorReportBody()).not.toContain("fingerprint");
+    });
+
+    test("sends an attached error as an exception, not as prose", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+
+      const body = await errorReportBody();
+      expect(body).toContain('"stacktrace"');
+      expect(body).not.toContain('"message":"Error: Database query failed"');
+    });
+
+    test("sends a report with no error as a message", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+
+      const body = await messageReportBody();
+      expect(body).toContain('"message":"Error: Database query failed"');
+      expect(body).not.toContain('"stacktrace"');
+    });
   });
 });

--- a/test/shared/sentry-sdk/breadcrumbs.test.ts
+++ b/test/shared/sentry-sdk/breadcrumbs.test.ts
@@ -3,7 +3,7 @@
 // another suite decide that before this file installs its fetch stub.
 import { expect } from "@std/expect";
 import { afterEach, describe, it as test } from "@std/testing/bdd";
-import { ErrorCode } from "#shared/logger.ts";
+import { ErrorCode, logDebug, runWithRequestId } from "#shared/logger.ts";
 import { captureServerError, initSentry } from "#shared/sentry.ts";
 import { withEnv } from "#test-utils/env.ts";
 import { stubFetch } from "#test-utils/fetch-stub.ts";
@@ -51,5 +51,26 @@ describe("report breadcrumbs", () => {
 
     const body = String((fetchStub.calls[1]!.args[1] as RequestInit).body);
     expect(body).not.toContain('"category":"sentry"');
+  });
+
+  // The SDK collects console lines onto one shared scope and ships no
+  // async-context strategy for Deno, so a report on a busy isolate would
+  // otherwise carry whatever ran beside it and none of its own.
+  test("carries the lines of its own request and no other", async () => {
+    using _env = withEnv({ SENTRY_URL: DSN });
+    using fetchStub = stubFetch(() => new Response("{}", { status: 200 }));
+    await initSentry();
+
+    await runWithRequestId(async () => {
+      logDebug("Setup", "the neighbouring request");
+    });
+    await runWithRequestId(async () => {
+      logDebug("Setup", "the reporting request");
+      await captureServerError({ code: ErrorCode.DB_QUERY });
+    });
+
+    const body = String((fetchStub.calls.at(-1)!.args[1] as RequestInit).body);
+    expect(body).toContain("the reporting request");
+    expect(body).not.toContain("the neighbouring request");
   });
 });

--- a/test/shared/sentry-sdk/breadcrumbs.test.ts
+++ b/test/shared/sentry-sdk/breadcrumbs.test.ts
@@ -1,0 +1,55 @@
+// test-groups: run-alone — the SDK instruments the global fetch once per
+// process, on the first client it sets up. Sharing an isolate would let
+// another suite decide that before this file installs its fetch stub.
+import { expect } from "@std/expect";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
+import { ErrorCode } from "#shared/logger.ts";
+import { captureServerError, initSentry } from "#shared/sentry.ts";
+import { withEnv } from "#test-utils/env.ts";
+import { stubFetch } from "#test-utils/fetch-stub.ts";
+import { resetSentry } from "#test-utils/sentry.ts";
+
+const DSN = "https://key@bugs.example.test/1";
+
+/**
+ * The SDK instruments the global fetch once per process, on the first client
+ * it sets up. These tests therefore live in their own file: a suite that had
+ * already started a client would have instrumented — or not instrumented — the
+ * global fetch before the stub below was ever installed, and the assertions
+ * would stop meaning anything.
+ */
+describe("report breadcrumbs", () => {
+  afterEach(resetSentry);
+
+  // An outbound URL can carry a checkout session id, so the calls we make are
+  // deliberately not recorded. The console lines are.
+  test("keeps the console lines but not the outbound calls", async () => {
+    using _env = withEnv({ SENTRY_URL: DSN });
+    using fetchStub = stubFetch(() => new Response("{}", { status: 200 }));
+    await initSentry();
+
+    console.debug("a line worth keeping");
+    await fetch("https://provider.example.test/checkout/cs_live_secret");
+    await captureServerError({ code: ErrorCode.DB_QUERY });
+
+    const sentryCall = fetchStub.calls.find((call) =>
+      String(call.args[0]).includes("bugs.example.test"),
+    );
+    const body = String((sentryCall!.args[1] as RequestInit).body);
+    expect(body).toContain("a line worth keeping");
+    expect(body).not.toContain("cs_live_secret");
+    expect(body).not.toContain('"category":"fetch"');
+  });
+
+  test("does not record its own reports as breadcrumbs", async () => {
+    using _env = withEnv({ SENTRY_URL: DSN });
+    using fetchStub = stubFetch(() => new Response("{}", { status: 200 }));
+    await initSentry();
+
+    await captureServerError({ code: ErrorCode.EMAIL_SEND });
+    await captureServerError({ code: ErrorCode.DB_QUERY });
+
+    const body = String((fetchStub.calls[1]!.args[1] as RequestInit).body);
+    expect(body).not.toContain('"category":"sentry"');
+  });
+});

--- a/test/shared/sentry.test.ts
+++ b/test/shared/sentry.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
+import { getEffectiveDomain } from "#shared/config.ts";
 import {
   ErrorCode,
   formatErrorMessage,
@@ -288,6 +289,35 @@ describe("sentry", () => {
       expect(body).not.toContain("9D5F57B232");
       expect(body).not.toContain("a@b.test");
       expect(body).toContain('"transaction":"GET /t/[redacted]"');
+    });
+
+    // A blank tag is worse than a missing one: it shows up in the tag list and
+    // filters to nothing. Outside a request there is no id, route, or URL.
+    test("leaves out the tags it has no value for", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await captureServerError({ code: ErrorCode.DB_QUERY });
+
+      const body = firstFetchBody();
+      expect(body).not.toContain("requestId");
+      expect(body).not.toContain('"url"');
+      expect(body).not.toContain("listingId");
+      expect(body).not.toContain("attendeeId");
+      expect(body).toContain('"code":"E_DB_QUERY"');
+    });
+
+    // Boot and scheduled runs report outside any request, and still have to say
+    // which site they came from.
+    test("names the site from its own settings when there is no request", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await captureServerError({ code: ErrorCode.DB_QUERY });
+
+      expect(firstFetchBody()).toContain(
+        `"site":${JSON.stringify(getEffectiveDomain())}`,
+      );
     });
 
     test("carries the request id the console lines carry", async () => {

--- a/test/shared/sentry.test.ts
+++ b/test/shared/sentry.test.ts
@@ -116,14 +116,14 @@ describe("sentry", () => {
     // Constructing DenoClient directly adds no integrations, so the two that
     // put information into a report have to be named. A deployment that loads
     // neither reports wrapper errors with no cause and no console trail.
-    test("loads the integrations that add information to a report", () => {
+    test("loads the integrations that add information to a report", async () => {
       using _env = withEnv({ SENTRY_URL: DSN });
-      return initSentry().then(() => {
-        const names = (Sentry.getClient()?.getOptions().integrations ?? []).map(
-          (integration) => integration.name,
-        );
-        expect(names).toEqual(["Breadcrumbs", "LinkedErrors"]);
-      });
+      await initSentry();
+
+      const names = (Sentry.getClient()?.getOptions().integrations ?? []).map(
+        (integration) => integration.name,
+      );
+      expect(names).toEqual(["Breadcrumbs", "LinkedErrors"]);
     });
 
     // Dedupe drops an error that repeats. Two requests hitting one bug are two
@@ -295,7 +295,7 @@ describe("sentry", () => {
       await initSentry();
 
       await runWithRequestId(() =>
-        captureServerError({ code: ErrorCode.DB_QUERY })
+        captureServerError({ code: ErrorCode.DB_QUERY }),
       );
 
       const requestIds =

--- a/test/shared/sentry.test.ts
+++ b/test/shared/sentry.test.ts
@@ -3,7 +3,12 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
-import { ErrorCode, formatErrorMessage } from "#shared/logger.ts";
+import {
+  ErrorCode,
+  formatErrorMessage,
+  runWithRequestId,
+} from "#shared/logger.ts";
+import { runWithRequestTrace } from "#shared/request-trace.ts";
 import {
   captureServerError,
   initSentry,
@@ -108,10 +113,29 @@ describe("sentry", () => {
       expect(Sentry.getClient()?.getOptions().tracesSampleRate).toBe(0);
     });
 
-    test("loads no default integrations", async () => {
+    // Constructing DenoClient directly adds no integrations, so the two that
+    // put information into a report have to be named. A deployment that loads
+    // neither reports wrapper errors with no cause and no console trail.
+    test("loads the integrations that add information to a report", () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      return initSentry().then(() => {
+        const names = (Sentry.getClient()?.getOptions().integrations ?? []).map(
+          (integration) => integration.name,
+        );
+        expect(names).toEqual(["Breadcrumbs", "LinkedErrors"]);
+      });
+    });
+
+    // Dedupe drops an error that repeats. Two requests hitting one bug are two
+    // real occurrences, so dropping the second undercounts the problem.
+    test("does not load the integration that drops repeated errors", async () => {
       using _env = withEnv({ SENTRY_URL: DSN });
       await initSentry();
-      expect(Sentry.getClient()?.getOptions().integrations).toEqual([]);
+
+      await captureServerError({ code: ErrorCode.DB_QUERY });
+      await captureServerError({ code: ErrorCode.DB_QUERY });
+
+      expect(fetchStub.calls.length).toBe(2);
     });
   });
 
@@ -203,6 +227,114 @@ describe("sentry", () => {
         (await captureDbErrorBody()).match(/"level":"[^"]*"/g) ?? [];
       expect(levels).toContain('"level":"error"');
       expect(levels).not.toContain('"level":"info"');
+    });
+
+    // Regression: an error's cause was dropped, so every database failure was
+    // reported as the wrapper that caught it, with the real failure missing.
+    test("keeps the root cause of a wrapped error", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      const cause = new Error("connection reset by peer");
+      await captureServerError({
+        code: ErrorCode.DB_QUERY,
+        error: new Error("libsql execute failed", { cause }),
+      });
+
+      const body = firstFetchBody();
+      expect(body).toContain("libsql execute failed");
+      expect(body).toContain("connection reset by peer");
+    });
+
+    test("keeps the console lines printed before the error", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      console.debug("a line worth keeping");
+      await captureServerError({ code: ErrorCode.DB_QUERY });
+
+      expect(firstFetchBody()).toContain("a line worth keeping");
+    });
+
+    test("names the site and the route the error happened on", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await runWithRequestTrace(
+        new Request("https://venue.example.com/admin/listings/42"),
+        () => captureServerError({ code: ErrorCode.DB_QUERY }),
+      );
+
+      const body = firstFetchBody();
+      expect(body).toContain('"transaction":"GET /admin/listings/[id]"');
+      expect(body).toContain('"site":"venue.example.com"');
+      expect(body).toContain(
+        '"url":"https://venue.example.com/admin/listings/[id]"',
+      );
+    });
+
+    // The ticket token is the whole credential for that ticket. It must never
+    // reach the reporter, in the route, the URL, or the query string.
+    test("never reports a ticket token", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await runWithRequestTrace(
+        new Request("https://venue.example.com/t/9D5F57B232?email=a@b.test"),
+        () => captureServerError({ code: ErrorCode.NOT_FOUND_ATTENDEE }),
+      );
+
+      const body = firstFetchBody();
+      expect(body).not.toContain("9D5F57B232");
+      expect(body).not.toContain("a@b.test");
+      expect(body).toContain('"transaction":"GET /t/[redacted]"');
+    });
+
+    test("carries the request id the console lines carry", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await runWithRequestId(() =>
+        captureServerError({ code: ErrorCode.DB_QUERY })
+      );
+
+      const requestIds =
+        firstFetchBody().match(/"requestId":"([0-9a-f]{4})"/) ?? [];
+      expect(requestIds[1]).toMatch(/^[0-9a-f]{4}$/);
+    });
+
+    // Grouping a message report by its text made one issue per varying detail:
+    // forty "Broken image" issues instead of one issue with forty events.
+    test("groups message reports by code and route, not by their detail", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await runWithRequestTrace(
+        new Request("https://venue.example.com/admin/listings/42"),
+        () =>
+          captureServerError({
+            code: ErrorCode.IMAGE_BROKEN,
+            detail: "image 4821 missing",
+          }),
+      );
+
+      expect(firstFetchBody()).toContain(
+        '"fingerprint":["E_IMAGE_BROKEN","GET","/admin/listings/[id]"]',
+      );
+    });
+
+    // A stack trace groups better than anything we could invent, so an error
+    // report must keep the SDK's own grouping.
+    test("leaves grouping alone for a report that carries a stack trace", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await captureServerError({
+        code: ErrorCode.DB_QUERY,
+        error: new Error("kaboom"),
+      });
+
+      expect(firstFetchBody()).not.toContain('"fingerprint"');
     });
 
     test("does not add empty extra context", async () => {


### PR DESCRIPTION
## Why

Error reports reached Bugsink with almost none of the context needed to act on
them. Reading the 1,075 stored events showed four separate faults.

- 48 of 77 issues held no stack trace at all.
- `transaction` was empty on **every** issue, so no report named its route.
- 41% of issues had exactly one event. "Broken image" alone was 40 issues.
- Every in-app stack frame read `/mod.ts:100836 in \`Sft\`` with no source.

## What changed

### Report content

Constructing `DenoClient` directly adds no integrations. Since the SDK adapter
landed, every report lost its error `cause` and its console trail. Comparing an
event from before with one from after shows it:

| | before | after the adapter |
| --- | --- | --- |
| `sdk.integrations` | 12 | `[]` |
| breadcrumbs | present | 0 |
| exception chain | 2 (root cause kept) | 1 (root cause dropped) |

A database failure was therefore reported as the wrapper that caught it, with
the real failure missing. The client now names the two integrations that put
information into a report: `linkedErrors` walks the `cause` chain, and
`breadcrumbs` keeps the console lines, which carry the request id.

`dedupe` is deliberately left out. It drops an error that repeats, and two
requests hitting one bug are two occurrences, not a duplicate.

Every report now also carries:

- `site` — the host the visitor asked for, so one Sentry endpoint can serve
  many sites and each report says which one it came from.
- `transaction` — the route, redacted: `GET /admin/listings/[id]`.
- `url` — the public URL, redacted.
- `requestId` — the same four characters the console lines carry.

A report with no stack is grouped by its code and route. The message text ends
with a detail naming an image or a session, so grouping by the text made one
issue per detail. A report that carries a stack keeps the SDK's own grouping.

### Breadcrumbs belong to one request

The SDK collects console lines onto one shared scope, and it ships no
async-context strategy for Deno, so `withIsolationScope` cannot separate one
request from another. An edge isolate serves many requests, so a report arrived
carrying whatever ran beside it: a live test report whose own request id was
`862b` held two breadcrumbs, both from earlier requests and neither its own.

Every line the logger prints starts with its request id, so `beforeSend` keeps
the lines whose id matches the report's own. All server-side console output goes
through the logger, so no real line is lost — the only raw console calls left in
`src/` are strings served to a browser.

### Source maps

`sentry-cli sourcemaps inject` writes debug ids only into files it reads as
JavaScript. For `bunny-script.ts` it printed "Nothing to inject" and exited 0,
so no report carried `debug_meta`, every uploaded map went unmatched, and
production traces stayed minified. The deploy log said so on every run.

`scripts/sentry-debug-ids.ts` writes a JavaScript copy for the CLI to inject,
then puts the injected code back on the deployed bundle, so the bundle and the
map carry the same debug id. The step now fails if no debug id lands. The
deployed file keeps its name, because the self-update path matches the release
asset by name.

### Privacy

Redaction covered `/ticket/:slug`, but the live route is `/t/:token`, so ticket
tokens reached the logs and the reporter in full. A token opens the ticket it
belongs to, and one is in Bugsink now. The query string is dropped from a
reported URL as well, because it carries tokens on some routes.

## Checks

`deno task precommit` passes. `deno task precommit:mutation` reports a 100% kill
rate over 226 mutants; it found 61 survivors in these files first, including 42
error codes that no test pinned.

Real errors were sent to the Tickets project and read back through the API. Two
reports with different details landed in **one** issue with two events, where
before they would have been two issues. Both reports named their route
(`GET /admin/listings/[id]` and `GET /t/[redacted]`), carried the site, the
public URL, and the request id, and the exception kept its root cause. The
ticket token, its query string, and the email in it appear nowhere in the stored
payload.