### PR TITLE
Run the test suite once per merge queue branch, not twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,13 @@
 name: Test
 
+# A merge queue builds its branch by pushing it, so `push` and `merge_group`
+# both fire on one queue branch and the suite runs twice on the same commit.
+# The queue waits for every check on the ref, so the second run only adds cost
+# and one more chance for a stalled runner to time the queue out. `merge_group`
+# still reports both check names there, which is what the queue gates on.
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore: [main, "gh-readonly-queue/**"]
   merge_group:
 
 env:

--- a/test/scripts/test-workflow.test.ts
+++ b/test/scripts/test-workflow.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+
+const TEST_WORKFLOW_PATH = ".github/workflows/test.yml";
+
+const readWorkflow = (): Promise<string> =>
+  Deno.readTextFile(TEST_WORKFLOW_PATH);
+
+/** The `on:` block, which ends at the next top-level key. */
+const triggers = (workflow: string): string => {
+  const start = workflow.indexOf("\non:\n");
+  if (start < 0) throw new Error(`${TEST_WORKFLOW_PATH} declares no triggers`);
+  const body = workflow.slice(start + 1);
+  const end = body.search(/\n[a-z]/);
+  return end < 0 ? body : body.slice(0, end);
+};
+
+describe("Test workflow triggers", () => {
+  test("does not run the suite twice on a merge queue branch", async () => {
+    // A queue branch arrives as a push, so without this the suite runs once
+    // for `push` and again for `merge_group`. The queue waits for both, and a
+    // stalled duplicate once timed the queue out an hour after the real run
+    // had passed.
+    expect(triggers(await readWorkflow())).toContain(
+      'branches-ignore: [main, "gh-readonly-queue/**"]',
+    );
+  });
+
+  test("still reports on a merge queue branch, which the queue gates on", async () => {
+    // The pair matters: ignoring queue branches without this leaves the queue
+    // waiting for checks that never arrive, which is worse than the duplicate.
+    expect(triggers(await readWorkflow())).toContain("merge_group:");
+  });
+
+  test("still runs on every branch a person pushes", async () => {
+    expect(triggers(await readWorkflow())).toContain("push:");
+  });
+});


### PR DESCRIPTION
## What changed

`test.yml` ran the whole suite twice on every merge queue branch. A merge
queue builds its branch by pushing it, so the `push` trigger and the
`merge_group` trigger both fired on the same commit. The `push` trigger now
ignores `gh-readonly-queue/**`.

## Why it matters

The queue waits for every check on its branch, so the duplicate run bought
nothing and doubled the cost of every merge.

It also doubled the exposure to a stalled runner, which is how this was found.
On #2117 the two runs started 1 second apart on the same commit:

| run | trigger | result |
| --- | --- | --- |
| [32281550427](https://github.com/chobbledotcom/tickets/actions/runs/32281550427) | `merge_group` | passed in 4 minutes 30 seconds |
| [32281550225](https://github.com/chobbledotcom/tickets/actions/runs/32281550225) | `push` | reached "Test with coverage" and stopped |

The duplicate never finished. The queue dropped the pull request an hour later
with `CI_TIMEOUT`, long after the real run was green. The suite itself was
fine: it passed on that commit in the pull request check, in the `merge_group`
run, and in `deno task precommit`.

## Why the queue loses nothing

`merge_group` still fires on a queue branch, and it reports both check names
(`checks` and `test`). Those are what the queue gates on, so removing the
`push` duplicate takes away a second copy, never the only copy. The regression
test pins that pair together, because ignoring queue branches *without*
`merge_group` would leave the queue waiting for a check that never arrives —
a worse version of the same failure.

## What is deliberately left alone

`merge-check.yml` also runs on queue branches, where it is a no-op: the queue
branch is already main plus the pull request, so merging main into it can
never conflict. It is left as it is, because it carries no `merge_group`
trigger. If it is a required check, ignoring queue branches there would leave
every queue run waiting for a check that never arrives. That risk is not worth
a 50-second job on a 2-core runner.

The other workflows that watch pushes (`bunny-deploy.yml`, `docs.yml`,
`spec-evidence.yml`) only watch `main`, so no queue branch reaches them.

## Checks

- `deno task precommit` passes.
- `test/scripts/test-workflow.test.ts` is new. It fails on the old trigger
  block for the right reason, and passes on the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWCBeDGaoKiVDSFvVXYWCE