### PR TITLE
Remove one dead export and one comment about replaced code

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2485,6 +2485,31 @@ scope so intermediate applies never touch tables the migration does not declare.
 The empty-rows guard in `clearDormantPaymentTables` is the model for the drop;
 keep the loud refusal on non-empty tables.
 
+## Split the three oversized e2e-payments files
+
+_Origin: a self-review of PR #2116 against AGENTS.md._
+
+Three harness files are above the ~400-line guideline, and two of them crossed
+it in that pull request:
+
+| File                                         | Lines |
+| -------------------------------------------- | ----- |
+| `e2e-payments/src/cucumber/steps/booking.ts` | 484   |
+| `e2e-payments/src/browser.ts`                | 430   |
+| `e2e-payments/src/flow.ts`                   | 404   |
+
+The splits are already visible in the code. `browser.ts` carries the
+click-witness helpers (`armClickWitness`, `armWitnessedAttempt`, and the
+`Witnessed` shape) above `launchAppBrowser`, and they depend on nothing else in
+the file, so they move to their own module whole. `booking.ts` carries the
+webhook-evidence block (`WEBHOOK_DID`, `WEBHOOK_HELD`, `callbackLine`,
+`webhookEvidenceThen`), which is one concept and reads as one. `flow.ts` is four
+lines over, so it needs no split of its own once the ledger reader has somewhere
+better to live.
+
+Do this when the harness is next open for other work, so the split lands with a
+real run rather than on its own.
+
 ## Give the live payment harness direct tests through injectable seams
 
 _Origin: the coverage-exclusion thread of the Codex review on PR #2065._

--- a/e2e-payments/src/browser.ts
+++ b/e2e-payments/src/browser.ts
@@ -373,10 +373,9 @@ export const launchAppBrowser = async (
           new Promise((resolve) => setTimeout(resolve, 5_000)),
         ]);
         if (browser.isConnected()) {
-          // Playwright exposes no process handle to kill, so the leak is
-          // raised instead of logged: the cleanup sweep reports it and fails
-          // an otherwise-green scenario rather than letting the zombie
-          // Chromium quietly consume the runner.
+          // Playwright exposes no process handle to kill, so a surviving
+          // browser is raised: the cleanup sweep fails the scenario rather
+          // than leave a zombie Chromium on the runner.
           throw new Error(
             "Chromium did not close after the bounded graceful close and CDP Browser.close",
           );

--- a/e2e-payments/src/server.ts
+++ b/e2e-payments/src/server.ts
@@ -16,7 +16,7 @@ import { probeSignal, sleep, stopChild } from "./util.ts";
 /* jscpd:ignore-end */
 
 const here = dirname(fileURLToPath(import.meta.url));
-export const repoRoot = resolve(here, "..", "..");
+const repoRoot = resolve(here, "..", "..");
 
 /** The one artifact root every harness module writes under — screenshots,
  * journals, Cucumber reports, and server logs all derive from the configured


### PR DESCRIPTION
## What this changes

A self-review of PR #2116 against `AGENTS.md`, run after that pull request was reviewed, found three breaches of the repository's own rules. This pull request fixes the two small ones and records the third. Everything is in `e2e-payments/`. No behaviour changes.

## The two fixes

**A dead export.** PR #2116 gave the harness one `artifactsRoot`, and every module outside `server.ts` now reaches the artifacts directory through it. That left `repoRoot` exported with no importer anywhere in the repository. `AGENTS.md` says an unused export is dead code and must be deleted, so `repoRoot` becomes a module-local constant. It is still used four times inside `server.ts`.

**A comment about replaced code.** The teardown guard in `browser.ts` said the leak is "raised instead of logged", which describes what the code replaced rather than what it does. `AGENTS.md`: "Do not leave comments that compare current code with an old implementation." Git history keeps the old version. The comment now states the current constraint only, and is a line shorter.

## The third finding, recorded not fixed

Three harness files are above the ~400-line guideline, and two crossed it in #2116: `cucumber/steps/booking.ts` at 484, `browser.ts` at 430, and `flow.ts` at 404. The splits are clean and already visible in the code — the click-witness helpers leave `browser.ts` whole, and the webhook-evidence block is one concept in `booking.ts`. They are churn without a live run to prove them, so `TODO.md` now carries the entry with the file list and the seams, for the next change that opens the harness.

## How it was checked

- `deno check` on both changed modules, `deno task lint:ci`, `deno task cpd`, and `deno task check:comments` all pass.
- No test or run was needed: one export loses a keyword and one comment loses a clause, so no code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016P57K88JA6T9Z1UPiFjqtc

---
_Generated by [Claude Code](https://claude.ai/code/session_016P57K88JA6T9Z1UPiFjqtc)_