### PR TITLE
Declare each fact once, and read it from there

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-m-z.txt
+++ b/scripts/mutation/equivalent-mutants/shared-m-z.txt
@@ -302,3 +302,9 @@ src/shared/db/modifier-resolve.ts::childOnlyAddOnNameWithScopes~0vgtyif  ?? → 
 # every code modifier. It changes no answer, because both readers drop a 0
 # again, and no negative quantity ever reaches it.
 src/shared/db/modifier-resolve.ts::eligibleCandidates~1oaufcv  1 → 0   # resolveModifiers keeps only a stocked quantity of 1 or more, and an oversubscribed tier needs a quantity above the stock left, which 0 never is
+
+# payment-provider-status.ts: settings.<provider>.keyMode ?? "unknown" —
+# keyModeOf returns "test" | "live" | null, so the only value ?? and || can
+# disagree on, "", is one the type does not allow.
+src/shared/payment-provider-status.ts::providerMode.stripe~0bfh0wn  ?? → ||   # keyMode is "test"|"live"|null; no falsy-non-null value exists
+src/shared/payment-provider-status.ts::providerMode.sumup~109o082  ?? → ||   # keyMode is "test"|"live"|null; no falsy-non-null value exists

--- a/src/features/admin/catalog-transfer/membership.ts
+++ b/src/features/admin/catalog-transfer/membership.ts
@@ -13,7 +13,12 @@
  */
 
 import type { InValue } from "@libsql/client";
-import { queryAll, type SqlStatement, type TxScope } from "#db/client.ts";
+import {
+  inPlaceholders,
+  queryAll,
+  type SqlStatement,
+  type TxScope,
+} from "#db/client.ts";
 import { PRICE_TYPE_GROUP, PRICE_TYPE_GROUP_DAY } from "#db/listing-prices.ts";
 import { type DayPrices, type GroupListing, parseDayPrices } from "#types";
 
@@ -55,7 +60,7 @@ const multiRowInsert = (
   rows: readonly InValue[][],
 ): SqlStatement | null => {
   if (rows.length === 0) return null;
-  const placeholder = `(${columns.map(() => "?").join(", ")})`;
+  const placeholder = `(${inPlaceholders(columns)})`;
   return {
     args: rows.flat(),
     sql: `INSERT INTO ${table} (${columns.join(", ")}) VALUES ${rows

--- a/src/features/admin/debug.ts
+++ b/src/features/admin/debug.ts
@@ -40,6 +40,10 @@ import {
 } from "#shared/env.ts";
 import { LIMIT_ENTRIES } from "#shared/limits.ts";
 import { nowIso } from "#shared/now.ts";
+import {
+  type PaymentProviderMode,
+  paymentProviderMode,
+} from "#shared/payment-provider-status.ts";
 import { fail, ok } from "#shared/response.ts";
 import { getRuntimeInfo } from "#shared/runtime.ts";
 import { sendSentryTest } from "#shared/sentry.ts";
@@ -49,6 +53,7 @@ import {
   type DebugPageState,
   SENTRY_TEST_FORM_ID,
 } from "#templates/admin/debug.tsx";
+import type { PaymentProviderType } from "#types";
 
 /* jscpd:ignore-end */
 
@@ -158,7 +163,9 @@ const validateGooglePrivateKey = async (
 };
 
 /** Whether the configured payment provider has its webhook config set. */
-const webhookConfiguredFor = (provider: string | null): boolean => {
+const webhookConfiguredFor = (
+  provider: PaymentProviderType | null,
+): boolean => {
   const configured = providerValue(provider, {
     square: settings.square.webhookSignatureKey !== EMPTY_DEBUG_VALUE,
     stripe: settings.stripe.webhookEndpointId !== EMPTY_DEBUG_VALUE,
@@ -167,23 +174,20 @@ const webhookConfiguredFor = (provider: string | null): boolean => {
   return configured === true;
 };
 
-/** Map a `sk_test_`/`sk_live_` key mode to a display label; "" if unrecognized. */
-const paymentModeLabel = (mode: "test" | "live" | null): string =>
-  mode === "live" ? "Live" : mode === "test" ? "Test" : EMPTY_DEBUG_VALUE;
-
-/**
- * Resolve the active payment provider's environment (Test/Live/Sandbox) for
- * display. Derived from the key prefix (Stripe/SumUp) or the sandbox flag
- * (Square) — never exposes the key itself.
- */
-const resolvePaymentMode = (provider: string | null): string => {
-  if (provider === "stripe") return paymentModeLabel(settings.stripe.keyMode);
-  if (provider === "sumup") return paymentModeLabel(settings.sumup.keyMode);
-  if (provider === "square") {
-    return settings.square.sandbox ? "Sandbox" : "Live";
-  }
-  return EMPTY_DEBUG_VALUE;
+/** The word shown for each estate a provider's stored credentials can point
+ * at. The estate itself is read once, by `paymentProviderMode`. */
+const PAYMENT_MODE_LABELS: Record<PaymentProviderMode, string> = {
+  live: "Live",
+  sandbox: "Sandbox",
+  test: "Test",
+  unknown: EMPTY_DEBUG_VALUE,
 };
+
+/** The active provider's estate, for display. Never exposes the key itself. */
+const resolvePaymentMode = (provider: PaymentProviderType | null): string =>
+  provider === null
+    ? EMPTY_DEBUG_VALUE
+    : PAYMENT_MODE_LABELS[paymentProviderMode(provider)];
 
 /** Resolve the site's write-access state from the read-only env flags. */
 const resolveAvailabilityState =

--- a/src/features/admin/refunds/attempt.ts
+++ b/src/features/admin/refunds/attempt.ts
@@ -10,6 +10,7 @@ import {
 import {
   type ProviderRefundResult,
   type RefundAuthorityReceipt,
+  type RefundEngineProvider,
   requestProviderRefund,
 } from "#shared/provider-refunds.ts";
 import {
@@ -19,7 +20,6 @@ import {
 import { mapProviderRequests } from "./provider-requests.ts";
 import type {
   ReadyRefundCandidate,
-  ReadyRefundProvider,
   ReadyRefundReference,
 } from "./readiness.ts";
 import { readyRefundAdmission } from "./ready-admission.ts";
@@ -33,7 +33,7 @@ type ObservedWithheldRefund = WithheldRefund;
 type RefundReportFacts = {
   readonly attendeeId: number;
   readonly listingId: number;
-  readonly provider: ReadyRefundProvider["type"];
+  readonly provider: RefundEngineProvider["type"];
 };
 
 /** One reference's result. A returned result names the durable authority that

--- a/src/features/admin/refunds/attempt.ts
+++ b/src/features/admin/refunds/attempt.ts
@@ -96,6 +96,24 @@ const standDownResult = (
     ? { outcome: "failed" }
     : withheldResult(admission, report);
 
+/** What each engine answer comes to for the reference the operator asked
+ * about. `returned` is absent from both sides: it is the one answer that
+ * carries a receipt, so it can never be a bare outcome, and `refunded` can
+ * never be reported without one. Every other answer is a key here, and a new
+ * one stops this compiling until somebody says what it means for the money. */
+const ENGINE_OUTCOME: Record<
+  Exclude<ProviderRefundResult["kind"], "returned">,
+  Exclude<RefundOutcome, "refunded">
+> = {
+  changed: "withheld",
+  needs_owner_choice: "pending",
+  needs_provider_check: "pending",
+  pending: "pending",
+  ready: "withheld",
+  unchanged: "withheld",
+  withheld: "pending",
+};
+
 const engineResult = (
   result: ProviderRefundResult,
   attendeeId: number,
@@ -104,27 +122,18 @@ const engineResult = (
   if (result.kind === "returned") {
     return { authority: result.authority, outcome: "refunded" };
   }
-  if (result.kind === "pending") {
-    return { outcome: "pending" };
+  // A provider that turned the request down is a failure the owner sees now,
+  // not a wait — every other reason they must answer is still in flight.
+  if (
+    result.kind === "needs_owner_choice" &&
+    result.reason === "provider_rejected"
+  ) {
+    return { outcome: "failed" };
   }
   if (result.kind === "withheld") {
-    reportProviderWithheldRefund(result, {
-      attendeeId,
-      listingId,
-    });
-    return { outcome: "pending" };
+    reportProviderWithheldRefund(result, { attendeeId, listingId });
   }
-  if (result.kind === "needs_owner_choice") {
-    return {
-      outcome: result.reason === "provider_rejected" ? "failed" : "pending",
-    };
-  }
-  if (result.kind === "needs_provider_check") {
-    return { outcome: "pending" };
-  }
-  if (result.kind === "changed") return { outcome: "withheld" };
-  if (result.kind === "unchanged") return { outcome: "withheld" };
-  return { outcome: "withheld" };
+  return { outcome: ENGINE_OUTCOME[result.kind] };
 };
 
 const askAuthority = async (

--- a/src/features/admin/refunds/readiness.ts
+++ b/src/features/admin/refunds/readiness.ts
@@ -3,21 +3,17 @@ import { requiredMapValue, uniqueBy } from "#fp";
 import type { ProviderRead } from "#payment/provider-read.ts";
 import type { TaggedPaymentReference } from "#payment/provider-reference.ts";
 import type { ChargeMoney } from "#payment/resources.ts";
-import type { PaymentProvider } from "#shared/payments.ts";
-import { loadRefundProvider } from "#shared/provider-refunds.ts";
+import {
+  loadRefundProvider,
+  type RefundEngineProvider,
+} from "#shared/provider-refunds.ts";
 import type { PaymentProviderType } from "#types";
 import type { RefundCandidate } from "./candidates.ts";
 import type { HeldRefundClaim } from "./claim.ts";
 import { mapProviderRequests } from "./provider-requests.ts";
 
-/** The provider surface an already-read refund attempt still needs. */
-export type ReadyRefundProvider = Pick<
-  PaymentProvider,
-  "readCharge" | "refundCapability" | "refundCharge" | "type"
->;
-
 type ReadyRefundReferenceBase = {
-  provider: ReadyRefundProvider;
+  provider: RefundEngineProvider;
   reference: TaggedRefundPaymentReference;
 };
 
@@ -65,7 +61,7 @@ export type RefundReadinessResult =
 export type RefundReadinessDependencies = {
   loadProvider: (
     reference: TaggedPaymentReference,
-  ) => Promise<ReadyRefundProvider>;
+  ) => Promise<RefundEngineProvider>;
 };
 
 const DEFAULT_DEPENDENCIES: RefundReadinessDependencies = {
@@ -129,7 +125,7 @@ const evidenceFailed = (
 
 const readReference = async (
   reference: TaggedRefundPaymentReference,
-  providers: ReadonlyMap<PaymentProviderType, ReadyRefundProvider>,
+  providers: ReadonlyMap<PaymentProviderType, RefundEngineProvider>,
 ): Promise<PreparedEvidence> => {
   const read = await requiredMapValue(
     providers,
@@ -160,7 +156,7 @@ const readReference = async (
 
 const readReferences = (
   references: readonly TaggedRefundPaymentReference[],
-  providers: ReadonlyMap<PaymentProviderType, ReadyRefundProvider>,
+  providers: ReadonlyMap<PaymentProviderType, RefundEngineProvider>,
 ): Promise<PreparedEvidence[]> =>
   mapProviderRequests(references, (reference) =>
     readReference(reference, providers),
@@ -173,7 +169,7 @@ const alreadyReturnedReference = (
 const loadProviders = async (
   references: readonly TaggedRefundPaymentReference[],
   loadProvider: RefundReadinessDependencies["loadProvider"],
-): Promise<ReadonlyMap<PaymentProviderType, ReadyRefundProvider>> => {
+): Promise<ReadonlyMap<PaymentProviderType, RefundEngineProvider>> => {
   const providerReferences = uniqueBy(
     ({ provider }: TaggedRefundPaymentReference) => provider,
   )([...references]);
@@ -182,7 +178,7 @@ const loadProviders = async (
       providerReferences.map(
         async (
           reference,
-        ): Promise<readonly [PaymentProviderType, ReadyRefundProvider]> => [
+        ): Promise<readonly [PaymentProviderType, RefundEngineProvider]> => [
           reference.provider,
           await loadProvider(reference),
         ],
@@ -193,7 +189,7 @@ const loadProviders = async (
 
 const readyReference = (
   prepared: PreparedReference,
-  provider: ReadyRefundProvider,
+  provider: RefundEngineProvider,
   reference: TaggedRefundPaymentReference,
 ): ReadyRefundReference =>
   prepared.kind === "already_returned"
@@ -208,7 +204,7 @@ const readyReference = (
 const readyCandidates = (
   candidates: readonly RefundCandidate[],
   preparedByIndex: ReadonlyMap<string, PreparedReference>,
-  providers: ReadonlyMap<PaymentProviderType, ReadyRefundProvider>,
+  providers: ReadonlyMap<PaymentProviderType, RefundEngineProvider>,
 ): ReadyRefundCandidate[] =>
   candidates.map((candidate) => ({
     attendee: candidate.attendee,

--- a/src/features/admin/settings-provider-credentials.ts
+++ b/src/features/admin/settings-provider-credentials.ts
@@ -14,6 +14,7 @@ import {
 } from "#routes/admin/settings-helpers.ts";
 import { redirect } from "#routes/response.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { paymentProviderHasCredentials } from "#shared/payment-provider-status.ts";
 import type { PaymentProviderType } from "#types";
 
 /**
@@ -29,8 +30,6 @@ type ProviderCredentialsConfig<T> = {
   formId: string;
   /** Form field name of the masked secret. */
   secretField: string;
-  /** Whether a secret is already stored (drives the "required" guard). */
-  hasSecret: () => boolean;
   /** Error shown when the secret is cleared and none is stored. */
   secretRequiredError: string;
   /** Flash message + activity-log entry on a successful save. */
@@ -93,7 +92,7 @@ export const defineProviderCredentialsRoute = <T>(
   test: (request: Request) => Promise<Response>;
 } => {
   const save = settingsRoute(async (form, errorPage) => {
-    const activateFromMissing = !cfg.hasSecret();
+    const activateFromMissing = !paymentProviderHasCredentials(cfg.provider);
     const secret = processSecretField(form, cfg.secretField);
     const fields = cfg.extraFields
       ? cfg.extraFields(form)
@@ -105,7 +104,10 @@ export const defineProviderCredentialsRoute = <T>(
     // Provider validation + the "secret required unless already stored" guard.
     const invalid = await cfg.validate(fields, secret);
     if (invalid) return errorPage(invalid, cfg.formId);
-    if (secret.action === "cleared" && !cfg.hasSecret()) {
+    if (
+      secret.action === "cleared" &&
+      !paymentProviderHasCredentials(cfg.provider)
+    ) {
       return errorPage(cfg.secretRequiredError, cfg.formId);
     }
 

--- a/src/features/admin/settings-square.ts
+++ b/src/features/admin/settings-square.ts
@@ -29,7 +29,6 @@ export const squareRoutes = defineProviderCredentialsRoute<SquareFields>({
     sandbox: form.get("square_sandbox") === "on",
   }),
   formId: "settings-square",
-  hasSecret: () => settings.square.hasToken,
   logMessage: "Square credentials updated",
   provider: "square",
   saveFields: async ({ locationId, sandbox }) => {

--- a/src/features/admin/settings-stripe.ts
+++ b/src/features/admin/settings-stripe.ts
@@ -12,7 +12,6 @@ import { detectStripeKeyMode, stripeApi } from "#shared/stripe.ts";
 
 export const stripeRoutes = defineProviderCredentialsRoute<undefined>({
   formId: "settings-stripe",
-  hasSecret: () => settings.stripe.hasKey,
   logMessage: "Stripe key configured",
   provider: "stripe",
   saveSecret: async (value) => {

--- a/src/features/admin/settings-sumup.ts
+++ b/src/features/admin/settings-sumup.ts
@@ -21,7 +21,6 @@ export const sumupRoutes = defineProviderCredentialsRoute<SumupFields>({
     merchantCode: form.getString("sumup_merchant_code"),
   }),
   formId: "settings-sumup",
-  hasSecret: () => settings.sumup.hasKey,
   logMessage: "SumUp credentials updated",
   provider: "sumup",
   saveFields: ({ merchantCode }) =>

--- a/src/features/api/webhooks.ts
+++ b/src/features/api/webhooks.ts
@@ -36,7 +36,10 @@ import {
   logDebug,
   logError,
 } from "#shared/logger.ts";
-import { WEBHOOK_SIGNATURE_HEADERS } from "#shared/payment-providers.ts";
+import {
+  providerWebhook,
+  WEBHOOK_SIGNATURE_HEADERS,
+} from "#shared/payment-providers.ts";
 import { getPaymentWebhookUrl } from "#shared/payment-webhook-url.ts";
 import {
   type ExistingPaymentProvider,
@@ -212,7 +215,7 @@ const authenticateWebhook = async (
   }
 
   const signature = getWebhookSignatureHeader(request) ?? "";
-  if (provider.requiresWebhookSignature && !signature) {
+  if (providerWebhook(provider.type) !== null && !signature) {
     logError({
       code: ErrorCode.PAYMENT_SESSION,
       detail: "Webhook missing signature header",

--- a/src/features/middleware.ts
+++ b/src/features/middleware.ts
@@ -11,7 +11,7 @@ import {
   isSecureMode,
 } from "#shared/config.ts";
 import { buildFrameAncestors } from "#shared/embed-hosts.ts";
-import { paymentProviderMode } from "#shared/payment-provider-status.ts";
+import { paymentProviderUsesSandbox } from "#shared/payment-provider-status.ts";
 import { providerCheckoutFormOrigins } from "#shared/payment-providers.ts";
 import type { PaymentProviderType } from "#types";
 
@@ -235,8 +235,7 @@ export const applySecurityHeaders = async (
   embeddable: boolean,
 ): Promise<Response> => {
   const provider = settings.paymentProvider;
-  const sandbox =
-    provider !== null && paymentProviderMode(provider) === "sandbox";
+  const sandbox = provider !== null && paymentProviderUsesSandbox(provider);
   const baseCsp = buildCspHeader(
     embeddable,
     { provider, sandbox },

--- a/src/features/middleware.ts
+++ b/src/features/middleware.ts
@@ -11,6 +11,8 @@ import {
   isSecureMode,
 } from "#shared/config.ts";
 import { buildFrameAncestors } from "#shared/embed-hosts.ts";
+import { paymentProviderMode } from "#shared/payment-provider-status.ts";
+import { providerCheckoutFormOrigins } from "#shared/payment-providers.ts";
 import type { PaymentProviderType } from "#types";
 
 /**
@@ -33,10 +35,9 @@ export type PaymentCspConfig = {
  * Non-embeddable pages get frame-ancestors 'none' to prevent clickjacking.
  * Embeddable pages omit frame-ancestors here; it's added by applySecurityHeaders
  * if embed host restrictions are configured.
- * Payment-specific directives are included only when a provider is configured.
- * Stripe, Square and SumUp all use server-side redirect flows (not embedded
- * SDKs), so only form-action needs provider-specific domains — without the
- * provider's checkout host the browser blocks the redirect to it.
+ * Every provider uses a server-side redirect flow rather than an embedded SDK,
+ * so form-action is the only directive that names provider hosts. It takes
+ * them from the provider registry.
  * When Botpoison is enabled, connect-src allows the contact form's browser
  * widget to reach the Botpoison challenge API.
  * img-src additionally allows OpenStreetMap tiles — the attendee Logistics
@@ -66,24 +67,16 @@ export const buildCspHeader = (
     directives.push("connect-src 'self' https://api.botpoison.com");
   }
 
-  if (payment?.provider === "square") {
-    const sq = payment.sandbox
-      ? "https://connect.squareupsandbox.com https://pci-connect.squareupsandbox.com https://api.squareupsandbox.com"
-      : "https://connect.squareup.com https://pci-connect.squareup.com https://api.squareup.com";
-    directives.push(
-      `form-action 'self' https://square.link https://checkout.square.site https://*.squarecdn.com https://geoissuer.cardinalcommerce.com ${sq}`,
-    );
-  } else if (payment?.provider === "stripe") {
-    directives.push("form-action 'self' https://checkout.stripe.com");
-  } else if (payment?.provider === "sumup") {
-    // SumUp hosted checkout redirects the booking form to its hosted page.
-    // Docs return checkout.sumup.com; pay.sumup.com is also used, so allow both.
-    directives.push(
-      "form-action 'self' https://checkout.sumup.com https://pay.sumup.com",
-    );
-  } else {
-    directives.push("form-action 'self'");
-  }
+  // The buyer's form posts straight to the provider's hosted checkout, so the
+  // policy must name that provider's origins or the browser blocks the
+  // redirect. The registry declares them, so a new provider cannot reach here
+  // and silently get a policy that blocks its own checkout.
+  const provider = payment?.provider ?? null;
+  const checkoutOrigins =
+    provider === null
+      ? []
+      : providerCheckoutFormOrigins(provider, payment?.sandbox === true);
+  directives.push(["form-action 'self'", ...checkoutOrigins].join(" "));
 
   if (!embeddable) {
     directives.unshift("frame-ancestors 'none'");
@@ -242,7 +235,8 @@ export const applySecurityHeaders = async (
   embeddable: boolean,
 ): Promise<Response> => {
   const provider = settings.paymentProvider;
-  const sandbox = provider === "square" ? settings.square.sandbox : undefined;
+  const sandbox =
+    provider !== null && paymentProviderMode(provider) === "sandbox";
   const baseCsp = buildCspHeader(
     embeddable,
     { provider, sandbox },

--- a/src/shared/attendee-list-controls.ts
+++ b/src/shared/attendee-list-controls.ts
@@ -9,7 +9,12 @@
  */
 
 import * as v from "valibot";
-import { compact, mapNotNullish, sort } from "#fp";
+import { compact, sort } from "#fp";
+import {
+  filterHref,
+  filterParams,
+  type ParamWriter,
+} from "#shared/filter-href.ts";
 import { isListingFilter, type ListingFilter } from "#shared/listing-filter.ts";
 import { isIsoDate } from "#shared/validation/date.ts";
 import { guardFor } from "#shared/validation/guard.ts";
@@ -118,38 +123,38 @@ export const readAttendeeListState = <Sort extends AttendeeSort | null>(
   };
 };
 
-/** One query parameter: its name, and its value — or null when the state sits
- *  at the parameter's default, which keeps default choices out of addresses. */
-type ParamWriter = {
-  name: string;
-  value: (setup: AttendeeListSetup, state: AttendeeListState) => string | null;
+/** A list's state read together with the setup that says what its defaults
+ *  are, since a parameter is written only when it differs from one. */
+type AttendeeListView = {
+  readonly setup: AttendeeListSetup;
+  readonly state: AttendeeListState;
 };
 
-const PARAM_WRITERS: ParamWriter[] = [
+const PARAM_WRITERS: ParamWriter<AttendeeListView>[] = [
   {
     name: "listing",
-    value: (_setup, state) =>
+    value: ({ state }) =>
       state.listingId === null ? null : String(state.listingId),
   },
   {
     name: "type",
-    value: (_setup, state) => (state.type === "all" ? null : state.type),
+    value: ({ state }) => (state.type === "all" ? null : state.type),
   },
   {
     name: "sort",
-    value: (setup, state) =>
+    value: ({ setup, state }) =>
       state.sort !== null && state.sort !== setup.defaultSort
         ? state.sort
         : null,
   },
   {
     name: "filter",
-    value: (_setup, state) => (state.checkin === "all" ? null : state.checkin),
+    value: ({ state }) => (state.checkin === "all" ? null : state.checkin),
   },
-  { name: "date", value: (_setup, state) => state.date },
+  { name: "date", value: ({ state }) => state.date },
   {
     name: "page",
-    value: (_setup, state) => (state.page > 0 ? String(state.page) : null),
+    value: ({ state }) => (state.page > 0 ? String(state.page) : null),
   },
 ];
 
@@ -158,21 +163,14 @@ export const attendeeListParams = (
   setup: AttendeeListSetup,
   state: AttendeeListState,
 ): [name: string, value: string][] =>
-  mapNotNullish((writer: ParamWriter): [string, string] | null => {
-    const value = writer.value(setup, state);
-    return value === null ? null : [writer.name, value];
-  })(PARAM_WRITERS);
+  filterParams(PARAM_WRITERS, { setup, state });
 
 /** The address for a state — the setup's base path unless another is given. */
 export const attendeeListHref = (
   setup: AttendeeListSetup,
   state: AttendeeListState,
   path: string = setup.basePath,
-): string => {
-  const query = new URLSearchParams(attendeeListParams(setup, state));
-  const qs = query.toString();
-  return qs === "" ? path : `${path}?${qs}`;
-};
+): string => filterHref(PARAM_WRITERS, path, { setup, state });
 
 /** A link that changes some of the current choices. Any change starts back at
  *  the first page — only an explicit `page` keeps a page number. */

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -6,34 +6,26 @@
 
 import { settings } from "#db/settings.ts";
 import { getEnv, requireEnv } from "#shared/env.ts";
+import { paymentProviderHasCredentials } from "#shared/payment-provider-status.ts";
 import { slugify } from "#shared/slug.ts";
+import type { PaymentProviderType } from "#types";
 
 /**
  * Pick the value for the active payment provider from a per-provider set, or
- * `null` when no known provider is active. The one place the stripe/square/sumup
- * dispatch lives, so every per-provider flag is read the same way.
+ * `null` when no provider is active. The set is keyed by the provider union,
+ * so a caller cannot forget a provider: leaving one out is a compile error at
+ * the call site rather than a silent `null` on a live site.
  */
 export const providerValue = <T>(
-  provider: string | null,
-  values: { stripe: T; square: T; sumup: T },
-): T | null =>
-  provider === "stripe"
-    ? values.stripe
-    : provider === "square"
-      ? values.square
-      : provider === "sumup"
-        ? values.sumup
-        : null;
+  provider: PaymentProviderType | null,
+  values: Readonly<Record<PaymentProviderType, T>>,
+): T | null => (provider === null ? null : values[provider]);
 
-/**
- * Check if payments are enabled (any provider configured with valid keys)
- */
-export const isPaymentsEnabled = (): boolean =>
-  providerValue(settings.paymentProvider, {
-    square: settings.square.hasToken,
-    stripe: settings.stripe.hasKey,
-    sumup: settings.sumup.hasKey,
-  }) ?? false;
+/** Whether an active provider has the credentials a sale needs. */
+export const isPaymentsEnabled = (): boolean => {
+  const provider = settings.paymentProvider;
+  return provider !== null && paymentProviderHasCredentials(provider);
+};
 
 /**
  * Get booking fee percentage from database.

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -165,9 +165,9 @@ export const removeListingGroupPricesStatement = (
   return {
     args: [listingId, ...idText, ...globs],
     sql: `DELETE FROM listing_prices WHERE listing_id = ? AND (
-        (price_type = '${PRICE_TYPE_GROUP}' AND price_id IN (${idText
-          .map(() => "?")
-          .join(", ")}))
+        (price_type = '${PRICE_TYPE_GROUP}' AND price_id IN (${inPlaceholders(
+          idText,
+        )}))
         OR (price_type = '${PRICE_TYPE_GROUP_DAY}' AND (${globs
           .map(() => "price_id LIKE ?")
           .join(" OR ")}))

--- a/src/shared/db/provider-refund-authority.ts
+++ b/src/shared/db/provider-refund-authority.ts
@@ -19,7 +19,7 @@ import {
   refundStateMirror,
   writeRefundAuthorityState,
 } from "#payment/refund-authority-state.ts";
-import { REFUND_PROVIDER_CAPABILITIES } from "#payment/refund-provider-authorization.ts";
+import { PAYMENT_PROVIDERS } from "#shared/payment-providers.ts";
 import { requireValue } from "#shared/required-value.ts";
 import type { PaymentProviderType } from "#types";
 /* jscpd:ignore-end */
@@ -181,7 +181,7 @@ export interface PreparedRefundAuthority {
 
 const requireCreateFacts = (input: CreateRefundAuthority): void => {
   if (
-    REFUND_PROVIDER_CAPABILITIES[input.reference.provider] !==
+    PAYMENT_PROVIDERS[input.reference.provider].refundCapability !==
     input.state.request.capability
   ) {
     throw new Error("Refund authority facts disagree");

--- a/src/shared/db/provider-refund-cases.ts
+++ b/src/shared/db/provider-refund-cases.ts
@@ -23,7 +23,7 @@ import type {
   RefundConflictDecision,
   RefundOwnerDecision,
 } from "#payment/refund-conflict-decision.ts";
-import { REFUND_PROVIDER_CAPABILITIES } from "#payment/refund-provider-authorization.ts";
+import { PAYMENT_PROVIDERS } from "#shared/payment-providers.ts";
 import { writeProviderRefundCursor } from "#shared/provider-refund-cursor.ts";
 import { isPaymentProvider, type PaymentProviderType } from "#types";
 
@@ -173,7 +173,9 @@ export const readProviderRefundCaseState = (
     throw new Error("Payment charge refund-state mirrors do not match");
   }
   const provider = providerFrom(row.provider);
-  if (state.request.capability !== REFUND_PROVIDER_CAPABILITIES[provider]) {
+  if (
+    state.request.capability !== PAYMENT_PROVIDERS[provider].refundCapability
+  ) {
     throw new Error("Payment charge refund capability does not match provider");
   }
   return state;

--- a/src/shared/db/prune.ts
+++ b/src/shared/db/prune.ts
@@ -5,6 +5,7 @@ import { addressCachePruneStatement } from "#db/address-cache.ts";
 import { attendeeRemovalStatements } from "#db/attendees/delete.ts";
 import {
   executeBatchWithResults,
+  inPlaceholders,
   queryAll,
   type SqlStatement,
 } from "#db/client.ts";
@@ -221,7 +222,7 @@ const expiredInvitePage = async (
 
 const inviteStatements = (ids: number[]): PruneStatement[] => {
   if (ids.length === 0) return [];
-  const inIds = ids.map(() => "?").join(", ");
+  const inIds = inPlaceholders(ids);
   const unactivatedIds = `SELECT id FROM users
     WHERE id IN (${inIds})
       AND wrapped_data_key IS NULL

--- a/src/shared/db/schema-anomaly-scan.ts
+++ b/src/shared/db/schema-anomaly-scan.ts
@@ -1,7 +1,8 @@
 /** Find stored rows that do not fit their declared machine rules. */
 
+import type { ResultSet } from "@libsql/client";
 import * as v from "valibot";
-import { queryBatch, resultRows } from "#db/client.ts";
+import { inPlaceholders, queryBatch, resultRows } from "#db/client.ts";
 import { uniqueBy } from "#fp";
 import { CLAIM_MIRROR } from "#payment/admit-move.ts";
 import { ILLEGAL_JOINT_STATES } from "#payment/joint-state.ts";
@@ -33,67 +34,75 @@ export type SchemaAnomaly =
 /** Enough rows to show the problem without an unbounded read — a healthy
  * site returns none at all. */
 const SCAN_LIMIT = 25;
-const SUMUP_STATE_SLOTS = SumupRecoveryStateSchema.options
-  .map(() => "?")
-  .join(", ");
-const SUMUP_CHECKABLE_SLOTS = RECOVERY_CHECKABLE_NODES.map(() => "?").join(
-  ", ",
-);
+const SUMUP_STATE_SLOTS = inPlaceholders(SumupRecoveryStateSchema.options);
+const SUMUP_CHECKABLE_SLOTS = inPlaceholders(RECOVERY_CHECKABLE_NODES);
 
 type DeclaredAuthority = (typeof ILLEGAL_JOINT_STATES)[number]["authority"];
 
+/** One declared impossibility and the query that finds it. Each scan reads
+ * its own rows, so a query never selects a column it does not need to make
+ * another scan's shape fit. */
 interface DeclaredScan {
-  readonly anomalyOf: (row: ScanRow) => SchemaAnomaly;
   readonly args: readonly (number | string)[];
+  readonly read: (result: ResultSet) => SchemaAnomaly[];
   readonly sql: string;
 }
 
-interface ScanRow {
+const declaredScan = <Row>(
+  sql: string,
+  args: readonly (number | string)[],
+  anomalyOf: (row: Row) => SchemaAnomaly,
+): DeclaredScan => ({
+  args,
+  read: (result) => resultRows<Row>(result).map(anomalyOf),
+  sql,
+});
+
+interface PaymentScanRow {
+  readonly record_id: string;
+}
+
+interface SumupScanRow {
   readonly record_id: string;
   readonly recovery_state: string;
   readonly sumup_id: string;
 }
 
-const paymentAnomaly =
-  (key: PaymentAnomalyKey) =>
-  (row: ScanRow): SchemaAnomaly => ({
+const paymentScan = (key: PaymentAnomalyKey, sql: string): DeclaredScan =>
+  declaredScan<PaymentScanRow>(sql, [CLAIM_MIRROR, SCAN_LIMIT], (row) => ({
     key,
     kind: "payment",
     recordId: row.record_id,
-  });
+  }));
 
 /** One query per declared authority. The record is keyed by the declaration
  * table's own literals, so adding an illegal combination is a compile error
  * here until the scan learns how to look for it. */
 const SCAN_OF: Record<DeclaredAuthority, DeclaredScan> = {
-  absent: {
-    anomalyOf: paymentAnomaly("claim_without_charge"),
-    args: [CLAIM_MIRROR, SCAN_LIMIT],
-    sql: `SELECT payment.payment_session_id AS record_id,
-                 '' AS recovery_state, '' AS sumup_id
-            FROM processed_payments AS payment
-           WHERE payment.protected_state = ?
-             AND NOT EXISTS (
-               SELECT 1 FROM payment_charges AS charge
-                WHERE charge.reference_index = payment.payment_reference_index
-             )
-           LIMIT ?`,
-  },
-  send_armed: {
-    anomalyOf: paymentAnomaly("armed_without_claim"),
-    args: [CLAIM_MIRROR, SCAN_LIMIT],
-    sql: `SELECT payment.payment_session_id AS record_id,
-                 '' AS recovery_state, '' AS sumup_id
-            FROM payment_charges AS charge
-            JOIN processed_payments AS payment
-              ON payment.payment_reference_index = charge.reference_index
-           WHERE charge.refund_state_name = 'send_armed'
-             AND payment.protected_state != ?
-           LIMIT ?`,
-  },
+  absent: paymentScan(
+    "claim_without_charge",
+    `SELECT payment.payment_session_id AS record_id
+       FROM processed_payments AS payment
+      WHERE payment.protected_state = ?
+        AND NOT EXISTS (
+          SELECT 1 FROM payment_charges AS charge
+           WHERE charge.reference_index = payment.payment_reference_index
+        )
+      LIMIT ?`,
+  ),
+  send_armed: paymentScan(
+    "armed_without_claim",
+    `SELECT payment.payment_session_id AS record_id
+       FROM payment_charges AS charge
+       JOIN processed_payments AS payment
+         ON payment.payment_reference_index = charge.reference_index
+      WHERE charge.refund_state_name = 'send_armed'
+        AND payment.protected_state != ?
+      LIMIT ?`,
+  ),
 };
 
-const sumupAnomaly = (row: ScanRow): SchemaAnomaly => {
+const sumupAnomaly = (row: SumupScanRow): SchemaAnomaly => {
   let key: SumupAnomalyKey = "sumup_unknown_state";
   if (v.is(SumupRecoveryStateSchema, row.recovery_state)) {
     const hasCheckoutId = row.sumup_id !== "";
@@ -111,15 +120,8 @@ const sumupAnomaly = (row: ScanRow): SchemaAnomaly => {
   };
 };
 
-const SUMUP_SCAN: DeclaredScan = {
-  anomalyOf: sumupAnomaly,
-  args: [
-    ...SumupRecoveryStateSchema.options,
-    RECOVERY_STATE_WITHOUT_CHECKOUT_ID,
-    ...RECOVERY_CHECKABLE_NODES,
-    SCAN_LIMIT,
-  ],
-  sql: `SELECT reference_index AS record_id, recovery_state, sumup_id
+const SUMUP_SCAN: DeclaredScan = declaredScan<SumupScanRow>(
+  `SELECT reference_index AS record_id, recovery_state, sumup_id
           FROM sumup_checkouts
          WHERE recovery_state NOT IN (${SUMUP_STATE_SLOTS})
             OR (recovery_state = ?) != (sumup_id = '')
@@ -132,7 +134,14 @@ const SUMUP_SCAN: DeclaredScan = {
                  ELSE next_check_at IS NOT NULL
                END
          LIMIT ?`,
-};
+  [
+    ...SumupRecoveryStateSchema.options,
+    RECOVERY_STATE_WITHOUT_CHECKOUT_ID,
+    ...RECOVERY_CHECKABLE_NODES,
+    SCAN_LIMIT,
+  ],
+  sumupAnomaly,
+);
 
 /** Scan the stored rows for every declared impossible state. */
 export const scanSchemaAnomalies = async (): Promise<SchemaAnomaly[]> => {
@@ -143,7 +152,5 @@ export const scanSchemaAnomalies = async (): Promise<SchemaAnomaly[]> => {
   const results = await queryBatch(
     scans.map((scan) => ({ args: [...scan.args], sql: scan.sql })),
   );
-  return scans.flatMap((scan, index) =>
-    resultRows<ScanRow>(results[index]!).map(scan.anomalyOf),
-  );
+  return scans.flatMap((scan, index) => scan.read(results[index]!));
 };

--- a/src/shared/db/settings/load.ts
+++ b/src/shared/db/settings/load.ts
@@ -12,7 +12,7 @@
  * tests) puts the next reader back on a clean footing.
  */
 
-import { queryAll } from "#db/client.ts";
+import { inPlaceholders, queryAll } from "#db/client.ts";
 import { applyKeys } from "#db/settings/apply.ts";
 import {
   currentVersion,
@@ -51,9 +51,7 @@ export const loadKeys = async (keys: readonly string[]): Promise<void> => {
   if (missing.length === 0) return;
   const rows = await settingsReadRefill.fetch(() =>
     queryAll<{ key: string; value: string }>(
-      `SELECT key, value FROM settings WHERE key IN (${missing
-        .map(() => "?")
-        .join(", ")})`,
+      `SELECT key, value FROM settings WHERE key IN (${inPlaceholders(missing)})`,
       missing,
     ),
   );

--- a/src/shared/db/sumup-recovery.ts
+++ b/src/shared/db/sumup-recovery.ts
@@ -9,7 +9,7 @@
  * SQL that carries it out.
  */
 
-import { execute, queryAll } from "#db/client.ts";
+import { execute, inPlaceholders, queryAll } from "#db/client.ts";
 import {
   parseSumupRecoveryState,
   RECOVERY_CHECKABLE_NODES,
@@ -33,7 +33,7 @@ export type DueSumupCheckout = {
   readonly sumupId: string;
 };
 
-const CHECKABLE_SLOTS = RECOVERY_CHECKABLE_NODES.map(() => "?").join(", ");
+const CHECKABLE_SLOTS = inPlaceholders(RECOVERY_CHECKABLE_NODES);
 
 /**
  * The oldest checkouts whose check time has come, newest-last so a row that

--- a/src/shared/db/table.ts
+++ b/src/shared/db/table.ts
@@ -12,6 +12,7 @@ import type { InValue } from "@libsql/client";
 import * as v from "valibot";
 import {
   execute,
+  inPlaceholders,
   insertedRowId,
   queryOne,
   queryOnePrimary,
@@ -251,7 +252,7 @@ const buildInsertSql = (
   returningColumns: string,
   condition?: string,
 ): string => {
-  const placeholders = columns.map(() => "?").join(", ");
+  const placeholders = inPlaceholders(columns);
   const values = condition
     ? `SELECT ${placeholders} WHERE ${condition}`
     : `VALUES (${placeholders})`;

--- a/src/shared/existing-payment-provider.ts
+++ b/src/shared/existing-payment-provider.ts
@@ -1,19 +1,9 @@
 import { settings } from "#db/settings.ts";
 import { compact, map, pipe } from "#fp";
+import { paymentProviderHasCredentials } from "#shared/payment-provider-status.ts";
 import { PAYMENT_PROVIDER_IDS } from "#shared/payment-providers.ts";
 import { CONFIG_KEYS } from "#shared/settings/keys.ts";
 import type { PaymentProviderType } from "#types";
-
-const providerHasCredentials: Record<PaymentProviderType, () => boolean> = {
-  square: () => settings.square.hasToken,
-  stripe: () => settings.stripe.hasKey,
-  sumup: () => settings.sumup.hasKey,
-};
-
-/** Whether this provider has the stored credentials needed for an API read. */
-export const paymentProviderHasCredentials = (
-  provider: PaymentProviderType,
-): boolean => providerHasCredentials[provider]();
 
 const configuredPaymentProviderTypes = (): PaymentProviderType[] =>
   pipe(

--- a/src/shared/filter-href.ts
+++ b/src/shared/filter-href.ts
@@ -1,0 +1,41 @@
+/**
+ * A page's filter state, and the addresses that change one part of it.
+ *
+ * A link that spells out its own query string carries only the filters
+ * whoever wrote it remembered. Declaring the parameters once, and building
+ * every link from the whole state, makes a link change one filter instead of
+ * replacing the set of them — so a page cannot grow a filter that some of its
+ * own links silently drop.
+ */
+
+import { mapNotNullish } from "#fp";
+
+/** One query parameter of a filter state: its name, and the value for a
+ * state — or null when the state sits at the parameter's default, which keeps
+ * default choices out of addresses. */
+export type ParamWriter<State> = {
+  readonly name: string;
+  readonly value: (state: State) => string | null;
+};
+
+/** The non-default query parameters for a state, in declared order. */
+export const filterParams = <State>(
+  writers: readonly ParamWriter<State>[],
+  state: State,
+): [name: string, value: string][] =>
+  mapNotNullish((writer: ParamWriter<State>): [string, string] | null => {
+    const value = writer.value(state);
+    return value === null ? null : [writer.name, value];
+  })(writers);
+
+/** The address for a filter state: a path, the parameters that are not at
+ * their default, and the anchor the page's links land on. */
+export const filterHref = <State>(
+  writers: readonly ParamWriter<State>[],
+  path: string,
+  state: State,
+  hash = "",
+): string => {
+  const query = new URLSearchParams(filterParams(writers, state)).toString();
+  return `${path}${query === "" ? "" : `?${query}`}${hash}`;
+};

--- a/src/shared/payment-provider-status.ts
+++ b/src/shared/payment-provider-status.ts
@@ -17,15 +17,43 @@ import type { PaymentProviderType } from "#types";
 export type PaymentProviderMode = "live" | "sandbox" | "test" | "unknown";
 
 const providerMode: Record<PaymentProviderType, () => PaymentProviderMode> = {
-  square: () => (settings.square.sandbox ? "sandbox" : "live"),
+  square: () => (paymentProviderUsesSandbox("square") ? "sandbox" : "live"),
   stripe: () => settings.stripe.keyMode ?? "unknown",
   sumup: () => settings.sumup.keyMode ?? "unknown",
 };
 
-/** The estate this site's stored credentials for one provider point at. */
+/** The estate this site's stored credentials for one provider point at. This
+ * reads that provider's stored key, so a route that calls it must declare the
+ * key in its settings bundle. */
 export const paymentProviderMode = (
   provider: PaymentProviderType,
 ): PaymentProviderMode => providerMode[provider]();
+
+/** How to tell whether the site points at a provider's separate test estate,
+ * or null for a provider that has only one. A test key for Stripe or SumUp
+ * talks to the same hosts as a live one, which is why neither declares its own
+ * `checkoutFormOrigins.sandbox`. */
+const providerSandboxSwitch: Record<
+  PaymentProviderType,
+  (() => boolean) | null
+> = {
+  square: () => settings.square.sandbox,
+  stripe: null,
+  sumup: null,
+};
+
+/** Whether the site points at this provider's separate test estate.
+ *
+ * The security policy asks this on every response, so it must never reach for
+ * a provider's stored credentials — only the routes that declare those keys
+ * may read them. A provider with one estate answers without reading anything.
+ */
+export const paymentProviderUsesSandbox = (
+  provider: PaymentProviderType,
+): boolean =>
+  // No switch is the answer for a provider with one estate: it is never in a
+  // sandbox, and nothing about it is read to say so.
+  providerSandboxSwitch[provider]?.() ?? false;
 
 const providerHasCredentials: Record<PaymentProviderType, () => boolean> = {
   square: () => settings.square.hasToken,

--- a/src/shared/payment-provider-status.ts
+++ b/src/shared/payment-provider-status.ts
@@ -1,0 +1,39 @@
+/**
+ * What the stored settings say about one payment provider.
+ *
+ * The registry in `payment-providers.ts` holds the facts that are true of a
+ * provider anywhere. These are the facts that are true of it *on this site*,
+ * and each one is an exhaustive `Record<PaymentProviderType, …>`, so a new
+ * provider is a compile error here rather than a page that quietly shows a
+ * blank or reaches for the wrong hosts.
+ */
+
+import { settings } from "#db/settings.ts";
+import type { PaymentProviderType } from "#types";
+
+/** Which of a provider's estates the stored credentials point at. A provider
+ * with a separate test estate reports `sandbox`. The card providers report
+ * the kind of secret key that is stored, and `unknown` when no key is. */
+export type PaymentProviderMode = "live" | "sandbox" | "test" | "unknown";
+
+const providerMode: Record<PaymentProviderType, () => PaymentProviderMode> = {
+  square: () => (settings.square.sandbox ? "sandbox" : "live"),
+  stripe: () => settings.stripe.keyMode ?? "unknown",
+  sumup: () => settings.sumup.keyMode ?? "unknown",
+};
+
+/** The estate this site's stored credentials for one provider point at. */
+export const paymentProviderMode = (
+  provider: PaymentProviderType,
+): PaymentProviderMode => providerMode[provider]();
+
+const providerHasCredentials: Record<PaymentProviderType, () => boolean> = {
+  square: () => settings.square.hasToken,
+  stripe: () => settings.stripe.hasKey,
+  sumup: () => settings.sumup.hasKey,
+};
+
+/** Whether this provider has the stored credentials needed for an API read. */
+export const paymentProviderHasCredentials = (
+  provider: PaymentProviderType,
+): boolean => providerHasCredentials[provider]();

--- a/src/shared/payment-provider-status.ts
+++ b/src/shared/payment-provider-status.ts
@@ -53,7 +53,7 @@ export const paymentProviderUsesSandbox = (
 ): boolean =>
   // No switch is the answer for a provider with one estate: it is never in a
   // sandbox, and nothing about it is read to say so.
-  providerSandboxSwitch[provider]?.() ?? false;
+  providerSandboxSwitch[provider]?.() === true;
 
 const providerHasCredentials: Record<PaymentProviderType, () => boolean> = {
   square: () => settings.square.hasToken,

--- a/src/shared/payment-providers.ts
+++ b/src/shared/payment-providers.ts
@@ -1,26 +1,54 @@
 /**
  * Payment-provider metadata registry.
  *
- * Provider *behaviour* already lives behind the `PaymentProvider` interface and
- * its per-type loader `Record`. This registry does the same for provider
- * *metadata* — the display label, the radio value, and the webhook signature
- * header — that used to be re-spelled by hand in the settings radio list, the
- * webhook header chain, and each settings route.
+ * Provider *behaviour* lives behind the `PaymentProvider` interface, which is
+ * loaded on demand because it carries the provider SDK. Every provider fact
+ * that does not need that SDK lives here instead, so a caller can ask what a
+ * provider is like without paying to load it.
  *
  * One exhaustive `Record<PaymentProviderType, …>` means adding a provider is a
  * single compile error here rather than a hunt through scattered literals.
+ * Nothing outside this file may branch on a provider name: a fact that differs
+ * between providers is a column here, and the caller reads the column.
  */
 
+import { mapNotNullish } from "#fp";
 import { t } from "#i18n";
 import type { PaymentProviderType } from "#types";
 
+/** Whether one exact refund request may safely be repeated. A keyed provider
+ * takes an idempotency key and lands a repeat on the original refund; a
+ * keyless one has no such key, so asking twice pays twice. */
+export type RefundProviderCapability = "keyed" | "keyless";
+
 export type PaymentProviderMeta = {
+  /** Origins the provider's hosted checkout posts to, so the page's
+   * `form-action` policy lets the buyer leave for it. `sandbox` is named only
+   * where the provider hosts its test checkout somewhere else; without it the
+   * live origins serve both. */
+  readonly checkoutFormOrigins: {
+    readonly live: readonly string[];
+    readonly sandbox?: readonly string[];
+  };
   /** Human-readable display name — radio label and prose. */
   readonly label: string;
-  /** Request header carrying the webhook signature, or null for providers whose
-   * webhooks are unsigned (authenticity is re-established via the provider API
-   * instead — see `PaymentProvider.requiresWebhookSignature`). */
-  readonly webhookSignatureHeader: string | null;
+  /** Whether one exact refund request may safely be repeated. A keyed
+   * provider lands a repeat on the original refund; a keyless one pays
+   * twice. */
+  readonly refundCapability: RefundProviderCapability;
+  /** How this provider's webhook is wired, or null when it sends none.
+   *
+   * One nullable column, because the three facts that hang off it must never
+   * disagree: the header a signature arrives in, whether the endpoint refuses
+   * an unsigned request, and whether an operator has a webhook to repoint
+   * after the site's domain changes. A provider whose webhooks are unsigned
+   * re-establishes authenticity by reading its own API back instead. */
+  readonly webhook: {
+    /** Request header carrying the signature. */
+    readonly signatureHeader: string;
+    /** Catalog key naming what the operator must redo after a domain change. */
+    readonly domainChangeFixKey: string;
+  } | null;
   /** Upper-case ISO 4217 codes, or `null` when it takes every currency. */
   readonly currencies: ReadonlySet<string> | null;
   /** The provider's checkout-metadata caps: the longest value it accepts, an
@@ -34,25 +62,55 @@ export type PaymentProviderMeta = {
   };
 };
 
+/** Square's buyer-facing checkout hosts are the same in both environments.
+ * Only the three API hosts move, so the environment is one word. */
+const squareCheckoutOrigins = (apiDomain: string): readonly string[] => [
+  "https://square.link",
+  "https://checkout.square.site",
+  "https://*.squarecdn.com",
+  "https://geoissuer.cardinalcommerce.com",
+  `https://connect.${apiDomain}`,
+  `https://pci-connect.${apiDomain}`,
+  `https://api.${apiDomain}`,
+];
+
 /** Provider metadata keyed by identifier. Declaration order drives the settings
  * radio list, so keep it in the order operators should see. */
 export const PAYMENT_PROVIDERS = {
   square: {
+    checkoutFormOrigins: {
+      live: squareCheckoutOrigins("squareup.com"),
+      sandbox: squareCheckoutOrigins("squareupsandbox.com"),
+    },
     currencies: null,
     label: "Square",
     // Square allows only 10 metadata entries of 255 characters each — the
     // tightest caps of any provider, and the reason small fields are packed
     // into one `b` entry (see packMetadata in payment-helpers.ts).
     metadata: { maxEntries: 10, maxValueLength: 255, packs: true },
-    webhookSignatureHeader: "x-square-hmacsha256-signature",
+    refundCapability: "keyed",
+    webhook: {
+      domainChangeFixKey: "settings.domain_warning.square",
+      signatureHeader: "x-square-hmacsha256-signature",
+    },
   },
   stripe: {
+    checkoutFormOrigins: { live: ["https://checkout.stripe.com"] },
     currencies: null,
     label: "Stripe",
     metadata: { maxEntries: 50, maxValueLength: 500, packs: false },
-    webhookSignatureHeader: "stripe-signature",
+    refundCapability: "keyed",
+    webhook: {
+      domainChangeFixKey: "settings.domain_warning.stripe",
+      signatureHeader: "stripe-signature",
+    },
   },
   sumup: {
+    // The docs return checkout.sumup.com; pay.sumup.com is also used, so the
+    // policy allows both.
+    checkoutFormOrigins: {
+      live: ["https://checkout.sumup.com", "https://pay.sumup.com"],
+    },
     // Mirrors the SumUp SDK's Currency union.
     currencies: new Set([
       "BGN",
@@ -76,7 +134,8 @@ export const PAYMENT_PROVIDERS = {
     // SumUp carries no provider metadata: the booking fields are stored
     // locally (db/sumup-checkouts.ts), so nothing is capped or packed.
     metadata: { maxValueLength: Number.POSITIVE_INFINITY, packs: false },
-    webhookSignatureHeader: null,
+    refundCapability: "keyless",
+    webhook: null,
   },
 } as const satisfies Record<PaymentProviderType, PaymentProviderMeta>;
 
@@ -101,6 +160,25 @@ export const providerCurrencyBlock = (
 };
 
 /** Webhook signature headers of every provider that signs its webhooks. */
-export const WEBHOOK_SIGNATURE_HEADERS: string[] = PAYMENT_PROVIDER_IDS.map(
-  (id) => PAYMENT_PROVIDERS[id].webhookSignatureHeader,
-).filter((header) => header !== null);
+export const WEBHOOK_SIGNATURE_HEADERS: string[] = mapNotNullish(
+  (id: PaymentProviderType) => PAYMENT_PROVIDERS[id].webhook?.signatureHeader,
+)(PAYMENT_PROVIDER_IDS);
+
+/** How one provider's webhook is wired, or null when it sends none. */
+export const providerWebhook = (
+  id: PaymentProviderType,
+): PaymentProviderMeta["webhook"] => PAYMENT_PROVIDERS[id].webhook;
+
+/** The origins one provider's hosted checkout posts to, in the environment
+ * the site is set up for. A provider without its own sandbox checkout uses
+ * its live origins in both. */
+export const providerCheckoutFormOrigins = (
+  id: PaymentProviderType,
+  sandbox: boolean,
+): readonly string[] => {
+  // Read through the declared shape: `as const` narrows each entry to its own
+  // literal, and only the declaration says a sandbox list is optional.
+  const meta: PaymentProviderMeta = PAYMENT_PROVIDERS[id];
+  const { live, sandbox: sandboxOrigins } = meta.checkoutFormOrigins;
+  return sandbox && sandboxOrigins !== undefined ? sandboxOrigins : live;
+};

--- a/src/shared/payment/refund-provider-authorization.ts
+++ b/src/shared/payment/refund-provider-authorization.ts
@@ -1,25 +1,12 @@
 /** The unforgeable permit carried by every provider refund call. */
 
-import * as v from "valibot";
 import type { RefundRequest } from "#payment/refund-attempt.ts";
 import { requireRefundGeneration } from "#payment/refund-generation.ts";
+import { PAYMENT_PROVIDERS } from "#shared/payment-providers.ts";
 import type { PaymentProviderType } from "#types";
 
-/** Whether one exact provider request may safely be repeated. */
-export const RefundProviderCapabilitySchema = v.picklist(["keyed", "keyless"]);
-export type RefundProviderCapability = v.InferOutput<
-  typeof RefundProviderCapabilitySchema
->;
-
-/** Each provider declares the kind of durable retry authority it supports. */
-export const REFUND_PROVIDER_CAPABILITIES = {
-  square: "keyed",
-  stripe: "keyed",
-  sumup: "keyless",
-} as const satisfies Record<PaymentProviderType, RefundProviderCapability>;
-
 type KeyedProvider = {
-  [Provider in PaymentProviderType]: (typeof REFUND_PROVIDER_CAPABILITIES)[Provider] extends "keyed"
+  [Provider in PaymentProviderType]: (typeof PAYMENT_PROVIDERS)[Provider]["refundCapability"] extends "keyed"
     ? Provider
     : never;
 }[PaymentProviderType];
@@ -45,15 +32,15 @@ export type KeylessRefundAuthorization<
   readonly capability: "keyless";
 };
 
-interface RefundAuthorizationByProvider {
-  readonly square: KeyedRefundAuthorization<"square">;
-  readonly stripe: KeyedRefundAuthorization<"stripe">;
-  readonly sumup: KeylessRefundAuthorization<"sumup">;
-}
-
+/** The permit shape one provider takes, read off its declared capability: a
+ * keyed provider must carry an idempotency key, a keyless one must not. */
 export type RefundAuthorization<
   Provider extends PaymentProviderType = PaymentProviderType,
-> = RefundAuthorizationByProvider[Provider];
+> = Provider extends KeyedProvider
+  ? KeyedRefundAuthorization<Provider>
+  : Provider extends KeylessProvider
+    ? KeylessRefundAuthorization<Provider>
+    : never;
 
 const durableRefundPermit: unique symbol = Symbol("durable refund permit");
 
@@ -86,7 +73,7 @@ export const authorizeDurableRefundSend = <
   requireText(authorization.identityIndex, "identity index");
   if (
     authorization.capability !==
-    REFUND_PROVIDER_CAPABILITIES[authorization.provider]
+    PAYMENT_PROVIDERS[authorization.provider].refundCapability
   ) {
     throw new Error("Refund authorization does not match its provider");
   }
@@ -119,7 +106,8 @@ export function requireProviderRefundAuthorization<
   if (
     request[durableRefundPermit] !== true ||
     request.authorization.provider !== provider ||
-    request.authorization.capability !== REFUND_PROVIDER_CAPABILITIES[provider]
+    request.authorization.capability !==
+      PAYMENT_PROVIDERS[provider].refundCapability
   ) {
     throw new Error(`Refund authorization does not permit ${provider}`);
   }

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -7,10 +7,7 @@ import { settings } from "#db/settings.ts";
 import type { Currency } from "#payment/money.ts";
 import type { ProviderRead } from "#payment/provider-read.ts";
 import type { RefundAttemptResult } from "#payment/refund-attempt.ts";
-import type {
-  AuthorizedRefundRequest,
-  RefundProviderCapability,
-} from "#payment/refund-provider-authorization.ts";
+import type { AuthorizedRefundRequest } from "#payment/refund-provider-authorization.ts";
 import type { ChargeMoney } from "#payment/resources.ts";
 import type { SessionRejection } from "#payment/validated-session.ts";
 import type { ListingAnswerRefs } from "#shared/booking-intent.ts";
@@ -270,21 +267,9 @@ export interface PaymentProvider {
    */
   readCharge(paymentReference: string): Promise<ProviderRead<ChargeMoney>>;
 
-  /** Whether a refund this provider accepted can safely be asked for twice.
-   *  An idempotency key lands a repeat call on the original refund; SumUp has
-   *  no such key, so asking twice pays twice. Every adapter says which kind it
-   *  is rather than being assumed. */
-  readonly refundCapability: RefundProviderCapability;
-
   /** Ask for the observed charge to be refunded and preserve the provider's
    * exact completed, accepted, rejected, unsent, or uncertain answer. */
   refundCharge(request: AuthorizedRefundRequest): Promise<RefundAttemptResult>;
-
-  /** Whether incoming webhooks carry a verifiable signature. Providers that
-   * sign their webhooks (Stripe, Square) set this true so the endpoint rejects
-   * unsigned requests. Providers whose webhooks are unsigned (SumUp) set this
-   * false and instead establish authenticity by re-fetching from the API. */
-  readonly requiresWebhookSignature: boolean;
 
   /**
    * Resolve a validated session from a webhook event.

--- a/src/shared/provider-refunds.ts
+++ b/src/shared/provider-refunds.ts
@@ -88,9 +88,12 @@ export type ProviderRefundTarget =
   | DirectRefundTarget
   | OwnerRecoveryRefundTarget;
 
+/** The provider surface a durable refund needs: read the money, send the
+ * return, and say which provider it is. Everything else about the provider is
+ * declared in the registry, so nothing here has to be loaded to know it. */
 export type RefundEngineProvider = Pick<
   PaymentProvider,
-  "readCharge" | "refundCapability" | "refundCharge" | "type"
+  "readCharge" | "refundCharge" | "type"
 >;
 
 /** The facts shared by every step reconciling one durable refund. */

--- a/src/shared/provider-refunds/state.ts
+++ b/src/shared/provider-refunds/state.ts
@@ -32,10 +32,13 @@ import {
   type RefundConflictDecision,
   refundConflictDecision,
 } from "#payment/refund-conflict-decision.ts";
-import { REFUND_PROVIDER_CAPABILITIES } from "#payment/refund-provider-authorization.ts";
 import { refundReplayUntil } from "#payment/refund-replay-window.ts";
 import { refundRequestIdentityIndex } from "#payment/refund-request-identity.ts";
 import { type ChargeMoney, returnedRefundMoney } from "#payment/resources.ts";
+import {
+  PAYMENT_PROVIDERS,
+  type RefundProviderCapability,
+} from "#shared/payment-providers.ts";
 import type {
   ProviderRefundResult,
   ProviderRefundTarget,
@@ -124,7 +127,7 @@ export const refundAfterTransition = async (
 
 const requestGeneration = async (
   reference: TaggedPaymentReference,
-  capability: RefundEngineProvider["refundCapability"],
+  capability: RefundProviderCapability,
   generation: number,
   now: number,
 ): Promise<RefundRequestGeneration> => {
@@ -145,7 +148,7 @@ export const initialRefundState = async (
 ): Promise<Extract<RefundAuthorityState, { kind: "ready" }>> => {
   const request = await requestGeneration(
     reference,
-    REFUND_PROVIDER_CAPABILITIES[reference.provider],
+    PAYMENT_PROVIDERS[reference.provider].refundCapability,
     1,
     now,
   );
@@ -161,11 +164,7 @@ export const requireMatchingRefundProvider = (
   provider: RefundEngineProvider,
   reference: TaggedPaymentReference,
 ): void => {
-  if (
-    provider.type !== reference.provider ||
-    provider.refundCapability !==
-      REFUND_PROVIDER_CAPABILITIES[reference.provider]
-  ) {
+  if (provider.type !== reference.provider) {
     throw new Error("Refund provider does not match its durable identity");
   }
 };

--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -265,7 +265,6 @@ export const squarePaymentProvider: PaymentProvider = {
     const returned = squareMoneyReturned(refunded, captured);
     return chargeMoneyRead(captured?.amount, captured?.currency, returned);
   },
-  refundCapability: "keyed",
 
   refundCharge: refundWithOneReread(
     (request) => {
@@ -274,7 +273,6 @@ export const squarePaymentProvider: PaymentProvider = {
     },
     (reference) => squarePaymentProvider.readCharge(reference),
   ),
-  requiresWebhookSignature: true,
 
   async resolveWebhookSession(
     listing: WebhookEvent,

--- a/src/shared/stripe-provider.ts
+++ b/src/shared/stripe-provider.ts
@@ -102,7 +102,6 @@ export const stripePaymentProvider: PaymentProvider = {
   createCheckoutSession: createStripeCheckoutSession,
 
   readCharge: readStripeCharge,
-  refundCapability: "keyed",
 
   refundCharge: refundWithOneReread(
     (request) => {
@@ -111,7 +110,6 @@ export const stripePaymentProvider: PaymentProvider = {
     },
     (reference) => stripePaymentProvider.readCharge(reference),
   ),
-  requiresWebhookSignature: true,
 
   async resolveWebhookSession({
     data: { object: obj },

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -6,9 +6,9 @@
  * Key differences from Stripe/Square:
  * - Hosted Checkout; our checkout_reference is the session id throughout
  * - Booking metadata is staged locally, encrypted (db/sumup-checkouts.ts)
- * - Webhooks are unsigned (requiresWebhookSignature = false): listings are
- *   pre-filtered against our staging rows, then the checkout is re-fetched
- *   from SumUp to establish authenticity and payment status
+ * - Webhooks are unsigned (no signature header in the provider registry):
+ *   listings are pre-filtered against our staging rows, then the checkout is
+ *   re-fetched from SumUp to establish authenticity and payment status
  * - No webhook endpoint to set up (return_url is set per checkout)
  */
 
@@ -52,7 +52,6 @@ export const sumupPaymentProvider: PaymentProvider = {
   createCheckoutSession: createSumupCheckoutSession,
 
   readCharge: readSumupCharge,
-  refundCapability: "keyless",
 
   async refundCharge(
     request: AuthorizedRefundRequest,
@@ -77,7 +76,6 @@ export const sumupPaymentProvider: PaymentProvider = {
         })
       : sumupRefundOutcome(submission, request, freshRead);
   },
-  requiresWebhookSignature: false,
 
   async resolveWebhookSession(
     webhookEvent: WebhookEvent,

--- a/src/ui/templates/admin/calendar.tsx
+++ b/src/ui/templates/admin/calendar.tsx
@@ -9,6 +9,7 @@ import { Raw } from "#jsx/jsx-runtime.ts";
 import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
 /* jscpd:ignore-end */
 import { formatDateLabel } from "#shared/dates.ts";
+import { filterHref, type ParamWriter } from "#shared/filter-href.ts";
 import {
   type AgentFilter,
   agentFilterParam,
@@ -31,6 +32,31 @@ import type {
   AttendeeTableRow,
   LogisticsAgent,
 } from "#types";
+
+/** What the calendar is showing: the day, who is assigned, and the month the
+ * date picker is browsing. */
+type CalendarView = {
+  readonly agent: AgentFilter;
+  readonly date: string | null;
+  readonly month: string | null;
+};
+
+const CALENDAR_PARAMS: ParamWriter<CalendarView>[] = [
+  { name: "date", value: ({ date }) => date },
+  {
+    name: "agent",
+    value: ({ agent }) => agentFilterParam(agent) || null,
+  },
+  { name: "cal", value: ({ month }) => month },
+];
+
+/** An address for the calendar with some of what it is showing changed. Every
+ * link goes through this, so choosing another day or month keeps the agent
+ * the operator picked instead of quietly returning the whole site's list. */
+const calendarLink =
+  (view: CalendarView) =>
+  (changes: Partial<CalendarView>, hash: string, path = "/admin/calendar") =>
+    filterHref(CALENDAR_PARAMS, path, { ...view, ...changes }, hash);
 
 /** Attendee row with listing context for display */
 export type CalendarAttendeeRow = Attendee & {
@@ -65,28 +91,25 @@ export const adminCalendarPage = (
     ),
   )(attendees);
 
-  const returnUrl = dateFilter
-    ? `/admin/calendar?date=${dateFilter}#attendees`
-    : "/admin/calendar#attendees";
+  const view: CalendarView = {
+    agent: agentFilter,
+    date: dateFilter,
+    month: viewMonth,
+  };
+  const link = calendarLink(view);
+  // The picker browses months, so a link out of the list leaves it behind.
+  const returnUrl = link({ month: null }, "#attendees");
 
   const emptyMessage = dateFilter
     ? t("admin.calendar.no_attendees")
     : t("admin.calendar.select_date_prompt");
 
-  const agentHref = (f: AgentFilter): string => {
-    const params = new URLSearchParams();
-    if (dateFilter) params.set("date", dateFilter);
-    const param = agentFilterParam(f);
-    if (param) params.set("agent", param);
-    return `/admin/calendar?${params.toString()}#attendees`;
-  };
+  const agentHref = (agent: AgentFilter): string =>
+    link({ agent, month: null }, "#attendees");
 
   // The export carries the active agent filter so it matches the on-screen
   // list — i.e. a per-agent run sheet.
-  const agentParam = agentFilterParam(agentFilter);
-  const exportHref = `/admin/calendar/export?date=${dateFilter}${
-    agentParam ? `&agent=${agentParam}` : ""
-  }`;
+  const exportHref = link({ month: null }, "", "/admin/calendar/export");
 
   const sharedRows =
     dateFilter && attendees.length > 0
@@ -108,14 +131,13 @@ export const adminCalendarPage = (
       <article id="attendees">
         <DatePicker
           ariaLabel="Select a date"
-          clearHref="/admin/calendar#attendees"
+          clearHref={link(
+            { agent: "all", date: null, month: null },
+            "#attendees",
+          )}
           dates={availableDates}
-          dayHref={(value) => `/admin/calendar?date=${value}#attendees`}
-          monthHref={(month) =>
-            `/admin/calendar?${
-              dateFilter ? `date=${dateFilter}&` : ""
-            }cal=${month}#calendar`
-          }
+          dayHref={(value) => link({ date: value, month: null }, "#attendees")}
+          monthHref={(month) => link({ month }, "#calendar")}
           selected={dateFilter}
           today={today}
           viewMonth={viewMonth}

--- a/src/ui/templates/admin/settings/domain-payment-warning.tsx
+++ b/src/ui/templates/admin/settings/domain-payment-warning.tsx
@@ -1,21 +1,23 @@
 /**
  * Warning shown in the domain settings forms: changing the site's domain
- * changes the payment webhook URL, so webhook-based payment providers
- * (Square and Stripe) must be reconfigured afterwards or payments stop
- * being confirmed.
+ * changes the payment webhook URL, so a provider that sends webhooks must be
+ * set up again afterwards or payments stop being confirmed.
  *
- * SumUp has no webhook, so the warning is hidden for it (and when no
- * provider is configured).
+ * Which providers those are, and what each one's operator must redo, come
+ * from the provider registry. A provider that sends no webhook has nothing to
+ * repoint, so it gets no warning.
  */
 
 import { t } from "#i18n";
+import { providerWebhook } from "#shared/payment-providers.ts";
 import { rawParagraph } from "#templates/components/raw-paragraph.tsx";
+import type { PaymentProviderType } from "#types";
 
 export const DomainPaymentWebhookWarning = ({
   existingPaymentProvider,
   paymentProviderRecoveryNeeded,
 }: {
-  existingPaymentProvider: string | null;
+  existingPaymentProvider: PaymentProviderType | null;
   paymentProviderRecoveryNeeded: boolean;
 }): JSX.Element | null => {
   if (paymentProviderRecoveryNeeded) {
@@ -33,11 +35,11 @@ export const DomainPaymentWebhookWarning = ({
       </article>
     );
   }
-  if (
-    existingPaymentProvider !== "square" &&
-    existingPaymentProvider !== "stripe"
-  )
-    return null;
+  const webhook =
+    existingPaymentProvider === null
+      ? null
+      : providerWebhook(existingPaymentProvider);
+  if (webhook === null) return null;
   return (
     <article>
       <aside role="alert">
@@ -45,9 +47,7 @@ export const DomainPaymentWebhookWarning = ({
           <strong>{t("settings.domain_warning.title")}</strong>{" "}
           {t("settings.domain_warning.body")}
         </p>
-        {existingPaymentProvider === "square"
-          ? rawParagraph("settings.domain_warning.square")
-          : rawParagraph("settings.domain_warning.stripe")}
+        {rawParagraph(webhook.domainChangeFixKey)}
       </aside>
     </article>
   );

--- a/test/features/admin/catalog-transfer/membership.test.ts
+++ b/test/features/admin/catalog-transfer/membership.test.ts
@@ -1,0 +1,126 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { PRICE_TYPE_GROUP, PRICE_TYPE_GROUP_DAY } from "#db/listing-prices.ts";
+import {
+  type ImportedMembership,
+  membershipStatements,
+} from "#routes/admin/catalog-transfer/membership.ts";
+
+const membership = (
+  overrides: Partial<ImportedMembership> = {},
+): ImportedMembership => ({
+  dayPrices: {},
+  groupId: 4,
+  listingId: 9,
+  packagePrice: null,
+  quantity: 1,
+  ...overrides,
+});
+
+/** The statement writing `table`, or undefined when nothing writes to it. */
+const statementFor = (
+  statements: ReturnType<typeof membershipStatements>,
+  table: string,
+) => statements.find(({ sql }) => sql.startsWith(`INSERT INTO ${table} `));
+
+describe("catalog transfer memberships", () => {
+  test("writes nothing when there are no memberships", () => {
+    expect(membershipStatements([])).toEqual([]);
+  });
+
+  test("writes only the membership row when nothing is overridden", () => {
+    const statements = membershipStatements([membership()]);
+
+    expect(statements).toEqual([
+      {
+        args: [4, 9, 1],
+        sql: "INSERT INTO group_listings (group_id, listing_id, quantity) VALUES (?, ?, ?)",
+      },
+    ]);
+  });
+
+  test("puts a flat override in the group price dimension", () => {
+    const prices = statementFor(
+      membershipStatements([membership({ packagePrice: 2500 })]),
+      "listing_prices",
+    );
+
+    expect(prices?.args).toEqual([9, PRICE_TYPE_GROUP, "4", 2500]);
+  });
+
+  test("keys a per-day override by its group and day count", () => {
+    const prices = statementFor(
+      membershipStatements([membership({ dayPrices: { 1: 1000, 2: 1800 } })]),
+      "listing_prices",
+    );
+
+    expect(prices?.args).toEqual([
+      9,
+      PRICE_TYPE_GROUP_DAY,
+      "4/1",
+      1000,
+      9,
+      PRICE_TYPE_GROUP_DAY,
+      "4/2",
+      1800,
+    ]);
+  });
+
+  test("drops a day price the stored shape does not allow", () => {
+    const prices = statementFor(
+      membershipStatements([
+        membership({ dayPrices: { 0: 500, 2: 1800 } as never }),
+      ]),
+      "listing_prices",
+    );
+
+    expect(prices?.args).toEqual([9, PRICE_TYPE_GROUP_DAY, "4/2", 1800]);
+  });
+
+  test("writes the flat override before the per-day ones", () => {
+    const prices = statementFor(
+      membershipStatements([
+        membership({ dayPrices: { 1: 1000 }, packagePrice: 2500 }),
+      ]),
+      "listing_prices",
+    );
+
+    expect(prices?.args.slice(0, 4)).toEqual([9, PRICE_TYPE_GROUP, "4", 2500]);
+    expect(prices?.args.slice(4)).toEqual([
+      9,
+      PRICE_TYPE_GROUP_DAY,
+      "4/1",
+      1000,
+    ]);
+  });
+
+  // A statement per member would blow past the transaction's round-trip cap
+  // for a group of any size, so many members must still be two statements.
+  test("batches every member into one statement per table", () => {
+    const members = Array.from({ length: 30 }, (_, index) =>
+      membership({
+        listingId: index + 1,
+        packagePrice: 100 * (index + 1),
+        quantity: index + 1,
+      }),
+    );
+
+    const statements = membershipStatements(members);
+    const rows = statementFor(statements, "group_listings");
+    const prices = statementFor(statements, "listing_prices");
+
+    expect(statements).toHaveLength(2);
+    expect(rows?.args).toHaveLength(90);
+    expect(rows?.sql.match(/\(\?, \?, \?\)/gu)).toHaveLength(30);
+    expect(prices?.args).toHaveLength(120);
+  });
+
+  test("gives every argument its own placeholder", () => {
+    for (const { args, sql } of membershipStatements([
+      membership({ dayPrices: { 3: 2400 }, packagePrice: 2500 }),
+      membership({ groupId: 5, listingId: 10, quantity: 2 }),
+    ])) {
+      expect(sql.match(/\?/gu)).toHaveLength(args.length);
+    }
+  });
+});

--- a/test/features/admin/catalog-transfer/membership.test.ts
+++ b/test/features/admin/catalog-transfer/membership.test.ts
@@ -45,7 +45,15 @@ describe("catalog transfer memberships", () => {
       "listing_prices",
     );
 
-    expect(prices?.args).toEqual([9, PRICE_TYPE_GROUP, "4", 2500]);
+    // The column list is asserted whole: a price row that names its columns
+    // wrongly writes the override into the wrong dimension, and the values
+    // alone cannot show that.
+    expect(prices).toEqual({
+      args: [9, PRICE_TYPE_GROUP, "4", 2500],
+      sql:
+        "INSERT INTO listing_prices " +
+        "(listing_id, price_type, price_id, unit_price) VALUES (?, ?, ?, ?)",
+    });
   });
 
   test("keys a per-day override by its group and day count", () => {
@@ -113,6 +121,24 @@ describe("catalog transfer memberships", () => {
     expect(rows?.args).toHaveLength(90);
     expect(rows?.sql.match(/\(\?, \?, \?\)/gu)).toHaveLength(30);
     expect(prices?.args).toHaveLength(120);
+  });
+
+  test("separates one row's placeholders from the next", () => {
+    const rows = statementFor(
+      membershipStatements([
+        membership(),
+        membership({ groupId: 5, listingId: 10, quantity: 2 }),
+      ]),
+      "group_listings",
+    );
+
+    // Run the row groups together and SQLite reads one row of six columns
+    // against a three-column insert, so the whole write is refused.
+    expect(rows?.sql).toBe(
+      "INSERT INTO group_listings (group_id, listing_id, quantity) " +
+        "VALUES (?, ?, ?), (?, ?, ?)",
+    );
+    expect(rows?.args).toEqual([4, 9, 1, 5, 10, 2]);
   });
 
   test("gives every argument its own placeholder", () => {

--- a/test/features/admin/refunds/provider/engine-outcomes.test.ts
+++ b/test/features/admin/refunds/provider/engine-outcomes.test.ts
@@ -1,0 +1,180 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import type { RefundCandidate } from "#routes/admin/refunds/candidates.ts";
+import type { RefundCounts } from "#routes/admin/refunds/provider.ts";
+import type {
+  ProviderRefundResult,
+  RefundAuthorityReceipt,
+} from "#shared/provider-refunds.ts";
+import {
+  finishedCounts,
+  processRefundBatchAt,
+  provider,
+  rowBackedCandidate,
+} from "#test/features/admin/refunds/provider/helpers.ts";
+import { recordEveryRefund } from "#test/features/admin/refunds/provider/ledger-results.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { setupErrorSpy } from "#test-utils/error-spy.ts";
+import { grantingRowClaim } from "#test-utils/refund-routes.ts";
+
+const ATTENDEE_ID = 91;
+const LISTING_ID = 7;
+const SESSION_ID = "session_engine_outcome";
+
+const RECEIPT: RefundAuthorityReceipt = {
+  id: 1,
+  referenceIndex: "index_engine_outcome",
+  revision: 1,
+};
+
+type Reference = ProviderRefundResult["reference"];
+
+/**
+ * What the operator is told for each answer the refund engine can give.
+ *
+ * A `withheld` outcome is tallied as a failure, so the three answers that come
+ * to "no money was sent" all reach the operator as one.
+ */
+const ANSWERS: ReadonlyArray<{
+  readonly counts: Partial<RefundCounts>;
+  readonly kind: ProviderRefundResult["kind"];
+  readonly name: string;
+  readonly result: (reference: Reference) => ProviderRefundResult;
+}> = [
+  {
+    counts: { refundedCount: 1 },
+    kind: "returned",
+    name: "returned",
+    result: (reference) => ({
+      authority: RECEIPT,
+      kind: "returned",
+      local: "recorded",
+      reference,
+    }),
+  },
+  {
+    counts: { pendingCount: 1 },
+    kind: "pending",
+    name: "pending",
+    result: (reference) => ({
+      authority: RECEIPT,
+      kind: "pending",
+      reference,
+      state: "observing",
+    }),
+  },
+  {
+    counts: { pendingCount: 1 },
+    kind: "needs_provider_check",
+    name: "needs_provider_check",
+    result: (reference) => ({
+      authority: RECEIPT,
+      kind: "needs_provider_check",
+      reason: "provider_conflict",
+      reference,
+    }),
+  },
+  {
+    counts: { pendingCount: 1 },
+    kind: "needs_owner_choice",
+    name: "needs_owner_choice, possibly_sent",
+    result: (reference) => ({
+      authority: RECEIPT,
+      kind: "needs_owner_choice",
+      reason: "possibly_sent",
+      reference,
+    }),
+  },
+  {
+    counts: { failedCount: 1 },
+    kind: "needs_owner_choice",
+    name: "needs_owner_choice, provider_rejected",
+    result: (reference) => ({
+      authority: RECEIPT,
+      kind: "needs_owner_choice",
+      reason: "provider_rejected",
+      reference,
+    }),
+  },
+  {
+    counts: { pendingCount: 1 },
+    kind: "withheld",
+    name: "withheld",
+    result: (reference) => ({
+      admission: {
+        kind: "read_failed",
+        read: { reason: "network_error", status: "unavailable" },
+      },
+      kind: "withheld",
+      reference,
+    }),
+  },
+  {
+    counts: { failedCount: 1 },
+    kind: "ready",
+    name: "ready",
+    result: (reference) => ({ authority: RECEIPT, kind: "ready", reference }),
+  },
+  {
+    counts: { failedCount: 1 },
+    kind: "changed",
+    name: "changed",
+    result: (reference) => ({ kind: "changed", reference }),
+  },
+  {
+    counts: { failedCount: 1 },
+    kind: "unchanged",
+    name: "unchanged",
+    result: (reference) => ({ kind: "unchanged", reference }),
+  },
+];
+
+/** Every answer the engine can give. Growing `ProviderRefundResult` stops
+ * this compiling until the new answer is listed, and the test below fails
+ * until it also has a row in ANSWERS saying what the operator is told. */
+const ANSWER_KINDS: Record<ProviderRefundResult["kind"], true> = {
+  changed: true,
+  needs_owner_choice: true,
+  needs_provider_check: true,
+  pending: true,
+  ready: true,
+  returned: true,
+  unchanged: true,
+  withheld: true,
+};
+
+const emptyCounts: RefundCounts = {
+  failedCount: 0,
+  notRecordedCount: 0,
+  pendingCount: 0,
+  refundedCount: 0,
+};
+
+const candidate = (): RefundCandidate =>
+  rowBackedCandidate(ATTENDEE_ID, SESSION_ID);
+
+describeWithEnv("refund engine answers", { db: true }, () => {
+  setupErrorSpy();
+
+  test("says what the operator is told for every answer", () => {
+    expect(new Set(ANSWERS.map(({ kind }) => kind))).toEqual(
+      new Set(Object.keys(ANSWER_KINDS)),
+    );
+  });
+
+  for (const { counts, name, result } of ANSWERS) {
+    test(`reports a ${name} answer`, async () => {
+      const source = provider();
+
+      expect(
+        finishedCounts(
+          await processRefundBatchAt(source, [candidate()], LISTING_ID, {
+            claim: grantingRowClaim(new Map([[ATTENDEE_ID, [SESSION_ID]]])),
+            record: recordEveryRefund,
+            request: ({ reference }) => Promise.resolve(result(reference)),
+          }),
+        ),
+      ).toEqual({ ...emptyCounts, ...counts });
+    });
+  }
+});

--- a/test/features/admin/refunds/provider/helpers.ts
+++ b/test/features/admin/refunds/provider/helpers.ts
@@ -7,7 +7,6 @@ import type {
 } from "#payment/refund-attempt.ts";
 import {
   type AuthorizedRefundRequest,
-  type RefundProviderCapability,
   requireProviderRefundAuthorization,
 } from "#payment/refund-provider-authorization.ts";
 import type { RefundState } from "#payment/refund-state.ts";
@@ -22,9 +21,10 @@ import {
 import {
   prepareRefundReadiness,
   type ReadyRefundCandidate,
-  type ReadyRefundProvider,
   type ReadyRefundReference,
 } from "#routes/admin/refunds/readiness.ts";
+import type { RefundProviderCapability } from "#shared/payment-providers.ts";
+import type { RefundEngineProvider } from "#shared/provider-refunds.ts";
 import {
   acceptedRefund,
   chargeMoney,
@@ -37,7 +37,7 @@ type Reference = {
   reference: string;
   refundState?: RefundState;
 };
-export type RecordingProvider = ReadyRefundProvider & {
+export type RecordingProvider = RefundEngineProvider & {
   readCharge: (reference: string) => Promise<ProviderRead<ChargeMoney>>;
   reads: string[];
   refunds: string[];
@@ -209,7 +209,6 @@ export const provider = ({
         : ({ resource: charge, status: "found" } as const);
     },
     reads,
-    refundCapability,
     refundCharge: (request: AuthorizedRefundRequest) => {
       requireProviderRefundAuthorization(request, paymentProvider);
       return answerRefund(request);

--- a/test/features/admin/refunds/provider/readiness-helpers.ts
+++ b/test/features/admin/refunds/provider/readiness-helpers.ts
@@ -1,12 +1,12 @@
 import type { RowSettlement } from "#db/payment-claim.ts";
 import type { RefundPaymentReference } from "#db/payment-references.ts";
-import type { RefundProviderCapability } from "#payment/refund-provider-authorization.ts";
 import type { RowClaim } from "#routes/admin/refunds/claim.ts";
 import type { RefundRunDependencies } from "#routes/admin/refunds/provider.ts";
 import type {
   ReadyRefundCandidate,
   RefundReadinessResult,
 } from "#routes/admin/refunds/readiness.ts";
+import type { RefundProviderCapability } from "#shared/payment-providers.ts";
 import { requestProviderRefund } from "#shared/provider-refunds.ts";
 import { completedRefund } from "#test-utils/payment-state.ts";
 import type { PaymentProviderType } from "#types";

--- a/test/features/admin/refunds/readiness-capability.test.ts
+++ b/test/features/admin/refunds/readiness-capability.test.ts
@@ -36,12 +36,12 @@ test("keeps each tagged provider capability with its exact reference", async () 
   expect(result.candidates[0]?.references).toMatchObject([
     {
       kind: "observed",
-      provider: { refundCapability: "keyed", type: "stripe" },
+      provider: { type: "stripe" },
       reference: stripeReference,
     },
     {
       kind: "observed",
-      provider: { refundCapability: "keyless", type: "sumup" },
+      provider: { type: "sumup" },
       reference: sumupReference,
     },
   ]);

--- a/test/features/admin/refunds/readiness/helpers.ts
+++ b/test/features/admin/refunds/readiness/helpers.ts
@@ -7,11 +7,12 @@ import type { ProviderRead } from "#payment/provider-read.ts";
 import type { ChargeMoney } from "#payment/resources.ts";
 import type { RefundCandidate } from "#routes/admin/refunds/candidates.ts";
 import type { HeldRefundClaim } from "#routes/admin/refunds/claim.ts";
-import type {
-  ReadyRefundProvider,
-  RefundReadinessDependencies,
-} from "#routes/admin/refunds/readiness.ts";
-import { provider as recordingProvider } from "#test/features/admin/refunds/provider/helpers.ts";
+import type { RefundReadinessDependencies } from "#routes/admin/refunds/readiness.ts";
+import type { RefundProviderCapability } from "#shared/payment-providers.ts";
+import {
+  type RecordingProvider,
+  provider as recordingProvider,
+} from "#test/features/admin/refunds/provider/helpers.ts";
 import type { PaymentProviderType } from "#types";
 
 export const charge = (): ChargeMoney => ({
@@ -83,8 +84,8 @@ export const heldClaim: HeldRefundClaim = {
 
 export const provider = (
   type: PaymentProviderType,
-  refundCapability: ReadyRefundProvider["refundCapability"] = "keyed",
-): ReadyRefundProvider =>
+  refundCapability: RefundProviderCapability = "keyed",
+): RecordingProvider =>
   recordingProvider({ paymentProvider: type, refundCapability });
 
 export const stripeReadiness = (

--- a/test/features/admin/refunds/refresh/helpers.ts
+++ b/test/features/admin/refunds/refresh/helpers.ts
@@ -4,10 +4,7 @@ import type { ChargeMoney } from "#payment/resources.ts";
 import type { PaymentReviewReason } from "#payment/review.ts";
 import type { PaymentReviewChange } from "#payment/row-transitions.ts";
 import type { RefundCandidate } from "#routes/admin/refunds/candidates.ts";
-import type {
-  ReadyRefundProvider,
-  RefundReadinessResult,
-} from "#routes/admin/refunds/readiness.ts";
+import type { RefundReadinessResult } from "#routes/admin/refunds/readiness.ts";
 import {
   type RefreshPaymentDependencies,
   type RefreshPaymentResult,
@@ -16,6 +13,7 @@ import {
 import {
   type ProviderRefundTarget,
   type RefundAuthorityReceipt,
+  type RefundEngineProvider,
   requestProviderRefund,
 } from "#shared/provider-refunds.ts";
 import type { RefundLedgerResult } from "#shared/refund-ledger/result.ts";
@@ -46,7 +44,7 @@ const readyResult = (
     observed: ChargeMoney | null;
     reference: Extract<RefundPaymentReference, { kind: "tagged" }>;
   }[],
-  provider: ReadyRefundProvider,
+  provider: RefundEngineProvider,
 ): Extract<RefundReadinessResult, { kind: "ready" }> => ({
   candidates: [
     {

--- a/test/features/admin/settings-provider-credentials.test.ts
+++ b/test/features/admin/settings-provider-credentials.test.ts
@@ -15,6 +15,11 @@ import { testCookie, testCsrfToken } from "#test-utils/session.ts";
 type Fields = { merchant: string };
 type Config = Parameters<typeof defineProviderCredentialsRoute<Fields>>[0];
 
+/** The route reads "a secret is already stored" from the provider's own
+ * settings, so a test that needs that state stores a real key. */
+const storeProviderSecret = (): Promise<void> =>
+  settings.update.stripe.secretKey("sk_test_stored_key");
+
 const makeProviderRoute = (overrides: Partial<Config> = {}) => {
   const saveSecret = fn((_value: string, _activateFromMissing: boolean) =>
     Promise.resolve(null),
@@ -25,7 +30,6 @@ const makeProviderRoute = (overrides: Partial<Config> = {}) => {
   const routes = defineProviderCredentialsRoute<Fields>({
     extraFields: (form) => ({ merchant: form.getString("merchant") }),
     formId: "settings-test-provider",
-    hasSecret: () => false,
     logMessage: "Test provider credentials updated",
     provider: "stripe",
     saveFields,
@@ -144,7 +148,8 @@ describeWithEnv("provider credential route", { db: true }, () => {
 
   test("keeps sales off when the legacy provider setting is missing", async () => {
     await settings.update.clearPaymentProvider();
-    const { routes } = makeProviderRoute({ hasSecret: () => true });
+    await storeProviderSecret();
+    const { routes } = makeProviderRoute();
     await post(routes.save, { merchant: "merchant-1", secret: "" });
 
     expect(settings.paymentProvider).toBeNull();
@@ -152,9 +157,8 @@ describeWithEnv("provider credential route", { db: true }, () => {
   });
 
   test("allows an empty field when a secret is already stored", async () => {
-    const { routes, saveFields, saveSecret } = makeProviderRoute({
-      hasSecret: () => true,
-    });
+    await storeProviderSecret();
+    const { routes, saveFields, saveSecret } = makeProviderRoute();
     const response = await post(routes.save, {
       merchant: "updated-merchant",
       secret: "",

--- a/test/features/middleware.test.ts
+++ b/test/features/middleware.test.ts
@@ -17,6 +17,10 @@ import {
   resetEffectiveDomain,
   setEffectiveDomainForTest,
 } from "#shared/config.ts";
+import {
+  PAYMENT_PROVIDER_IDS,
+  providerCheckoutFormOrigins,
+} from "#shared/payment-providers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 
 const BASE_CSP =
@@ -78,6 +82,25 @@ describe("buildCspHeader", () => {
     expect(csp).toContain("https://api.squareupsandbox.com");
     expect(csp).not.toContain("https://connect.squareup.com");
   });
+
+  // A provider the chain never learned about used to fall through to a bare
+  // `form-action 'self'`, and the browser then blocked every buyer's redirect
+  // to its hosted checkout. The policy now reads the registry, so this holds
+  // for whatever providers the registry declares.
+  for (const provider of PAYMENT_PROVIDER_IDS) {
+    for (const sandbox of [false, true]) {
+      test(`names every ${provider} checkout origin (sandbox: ${sandbox})`, () => {
+        const csp = buildCspHeader(true, { provider, sandbox });
+        const formAction = csp
+          .split("; ")
+          .find((directive) => directive.startsWith("form-action "));
+        expect(formAction).toBeDefined();
+        for (const origin of providerCheckoutFormOrigins(provider, sandbox)) {
+          expect(formAction).toContain(origin);
+        }
+      });
+    }
+  }
 });
 
 describe("JSON paths", () => {

--- a/test/features/settings-bundles.test.ts
+++ b/test/features/settings-bundles.test.ts
@@ -1,7 +1,15 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { afterEach, describe, it as test } from "@std/testing/bdd";
 import { CONFIG_KEYS } from "#db/settings.ts";
+import {
+  assertSettingsReadsDeclared,
+  recordSettingsLoaded,
+  runWithSettingsAudit,
+  setSettingsAuditEnabled,
+} from "#db/settings-audit.ts";
 import { getPrefix, settingsForPath } from "#routes/settings-bundles.ts";
+import { paymentProviderUsesSandbox } from "#shared/payment-provider-status.ts";
+import { PAYMENT_PROVIDER_IDS } from "#shared/payment-providers.ts";
 
 describe("settings bundles", () => {
   test("extracts the first path segment without its leading slash", () => {
@@ -28,5 +36,27 @@ describe("settings bundles", () => {
     expect(settingsForPath("/scheduled")).toContain(
       CONFIG_KEYS.APPLE_WALLET_SIGNING_KEY,
     );
+  });
+
+  describe("what every response reads", () => {
+    afterEach(() => {
+      setSettingsAuditEnabled(null);
+    });
+
+    // `applySecurityHeaders` rebuilds the policy on every routed response, so
+    // whatever it reads must be in the bundle of every route. Asking a
+    // provider whether the site points at its test estate must therefore
+    // never reach for that provider's stored key: the key is not declared on
+    // an ordinary page, and reading it turns the page into a 500.
+    for (const provider of PAYMENT_PROVIDER_IDS) {
+      test(`asks whether ${provider} is in a sandbox without an undeclared read`, () => {
+        setSettingsAuditEnabled(true);
+        runWithSettingsAudit(() => {
+          recordSettingsLoaded(settingsForPath("/listings"));
+          paymentProviderUsesSandbox(provider);
+          assertSettingsReadsDeclared("GET /listings");
+        });
+      });
+    }
   });
 });

--- a/test/integration/refund-authority-architecture-fixtures.ts
+++ b/test/integration/refund-authority-architecture-fixtures.ts
@@ -84,6 +84,7 @@ export const TEST_AUTHORITY_BUILDING_PATHS = [
   "features/admin/attendee-refunds/authorization.test.ts",
   "features/admin/refunds/attempt/outcomes.test.ts",
   "features/admin/refunds/attempt/unrecorded.test.ts",
+  "features/admin/refunds/provider/engine-outcomes.test.ts",
   "features/admin/refunds/provider/helpers.ts",
   "features/admin/refunds/readiness-findings/authority-failure.test.ts",
   "features/admin/refunds/refresh/helpers.ts",

--- a/test/integration/server/calendar-logistics.test.ts
+++ b/test/integration/server/calendar-logistics.test.ts
@@ -120,6 +120,38 @@ describeWithEnv(
       expect(html).not.toContain("Agent User");
     });
 
+    test("keeps the chosen agent in the links that change the day", async () => {
+      const { d, assigned } = await setup();
+      const html = await calendarHtml(
+        `/admin/calendar?date=${d}&agent=${assigned.id}`,
+      );
+      const withAgent = `/admin/calendar?date=${d}&amp;agent=${assigned.id}`;
+
+      // Picking another day, stepping a month, and the address an attendee
+      // page returns by all carried only the date. The operator landed on the
+      // whole site's list for that day with nothing to say the run sheet had
+      // gone.
+      expect(html).toContain(`href="${withAgent}#attendees"`);
+      expect(html).toContain(`value="${withAgent}#attendees"`);
+      expect(html).toContain(`${withAgent}&amp;cal=`);
+    });
+
+    test("keeps the agent out of the link that shows every agent", async () => {
+      const { d, assigned } = await setup();
+      const html = await calendarHtml(
+        `/admin/calendar?date=${d}&agent=${assigned.id}`,
+      );
+      expect(html).toContain(`href="/admin/calendar?date=${d}#attendees"`);
+    });
+
+    test("clears the agent with the date, since its bar goes too", async () => {
+      const { d, assigned } = await setup();
+      const html = await calendarHtml(
+        `/admin/calendar?date=${d}&agent=${assigned.id}`,
+      );
+      expect(html).toContain('value="/admin/calendar#attendees"');
+    });
+
     test("no filter bar when logistics is disabled", async () => {
       const { d } = await setup();
       settings.setForTest(featureSetting());

--- a/test/shared/filter-href.test.ts
+++ b/test/shared/filter-href.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  filterHref,
+  filterParams,
+  type ParamWriter,
+} from "#shared/filter-href.ts";
+
+type View = { agent: string; date: string | null; page: number };
+
+const WRITERS: ParamWriter<View>[] = [
+  { name: "date", value: ({ date }) => date },
+  { name: "agent", value: ({ agent }) => (agent === "all" ? null : agent) },
+  { name: "page", value: ({ page }) => (page > 0 ? String(page) : null) },
+];
+
+const view = (overrides: Partial<View> = {}): View => ({
+  agent: "all",
+  date: null,
+  page: 0,
+  ...overrides,
+});
+
+describe("filter href", () => {
+  test("writes nothing for a state at every default", () => {
+    expect(filterParams(WRITERS, view())).toEqual([]);
+  });
+
+  test("writes only the parameters that are off their default", () => {
+    expect(
+      filterParams(WRITERS, view({ agent: "3", date: "2026-07-06" })),
+    ).toEqual([
+      ["date", "2026-07-06"],
+      ["agent", "3"],
+    ]);
+  });
+
+  test("keeps the declared order rather than the state's", () => {
+    expect(
+      filterParams(WRITERS, view({ agent: "3", date: "2026-07-06", page: 2 })),
+    ).toEqual([
+      ["date", "2026-07-06"],
+      ["agent", "3"],
+      ["page", "2"],
+    ]);
+  });
+
+  test("gives a default state the bare path", () => {
+    expect(filterHref(WRITERS, "/admin/calendar", view())).toBe(
+      "/admin/calendar",
+    );
+  });
+
+  test("adds an anchor to a bare path without a question mark", () => {
+    expect(filterHref(WRITERS, "/admin/calendar", view(), "#attendees")).toBe(
+      "/admin/calendar#attendees",
+    );
+  });
+
+  test("puts the query before the anchor", () => {
+    expect(
+      filterHref(
+        WRITERS,
+        "/admin/calendar",
+        view({ agent: "3", date: "2026-07-06" }),
+        "#attendees",
+      ),
+    ).toBe("/admin/calendar?date=2026-07-06&agent=3#attendees");
+  });
+
+  test("escapes a value that would otherwise break the query", () => {
+    expect(
+      filterHref(WRITERS, "/admin/calendar", view({ agent: "a&b=c" })),
+    ).toBe("/admin/calendar?agent=a%26b%3Dc");
+  });
+
+  // The point of the whole module: a link states the change, and every other
+  // filter comes along because nobody has to remember it.
+  test("carries the filters a change does not name", () => {
+    const current = view({ agent: "3", date: "2026-07-06", page: 4 });
+
+    expect(
+      filterHref(
+        WRITERS,
+        "/admin/calendar",
+        { ...current, date: "2026-07-07" },
+        "#attendees",
+      ),
+    ).toBe("/admin/calendar?date=2026-07-07&agent=3&page=4#attendees");
+  });
+});

--- a/test/shared/payment-provider-status.test.ts
+++ b/test/shared/payment-provider-status.test.ts
@@ -1,0 +1,71 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { settings } from "#db/settings.ts";
+import {
+  paymentProviderHasCredentials,
+  paymentProviderMode,
+} from "#shared/payment-provider-status.ts";
+import { PAYMENT_PROVIDER_IDS } from "#shared/payment-providers.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+
+describeWithEnv("payment provider status", { db: true }, () => {
+  test("reports no credentials for any provider on a fresh site", () => {
+    for (const provider of PAYMENT_PROVIDER_IDS) {
+      expect(paymentProviderHasCredentials(provider)).toBe(false);
+    }
+  });
+
+  test("sees a stored Square token only for Square", async () => {
+    await settings.update.square.accessToken("sq0atp-token");
+    expect(paymentProviderHasCredentials("square")).toBe(true);
+    expect(paymentProviderHasCredentials("stripe")).toBe(false);
+    expect(paymentProviderHasCredentials("sumup")).toBe(false);
+  });
+
+  test("sees a stored Stripe key only for Stripe", async () => {
+    await settings.update.stripe.secretKey("sk_test_key");
+    expect(paymentProviderHasCredentials("stripe")).toBe(true);
+    expect(paymentProviderHasCredentials("square")).toBe(false);
+  });
+
+  test("sees a stored SumUp key only for SumUp", async () => {
+    await settings.update.sumup.apiKey("sk_test_key");
+    expect(paymentProviderHasCredentials("sumup")).toBe(true);
+    expect(paymentProviderHasCredentials("stripe")).toBe(false);
+  });
+
+  test("answers a mode for every provider, so no page shows a blank", () => {
+    for (const provider of PAYMENT_PROVIDER_IDS) {
+      expect(["live", "sandbox", "test", "unknown"]).toContain(
+        paymentProviderMode(provider),
+      );
+    }
+  });
+
+  test("reads Square's estate from its sandbox switch", async () => {
+    expect(paymentProviderMode("square")).toBe("live");
+    await settings.update.square.sandbox(true);
+    expect(paymentProviderMode("square")).toBe("sandbox");
+    await settings.update.square.sandbox(false);
+    expect(paymentProviderMode("square")).toBe("live");
+  });
+
+  test("reads a card provider's estate from the kind of key stored", async () => {
+    expect(paymentProviderMode("stripe")).toBe("unknown");
+    await settings.update.stripe.secretKey("sk_test_abc");
+    expect(paymentProviderMode("stripe")).toBe("test");
+    await settings.update.stripe.secretKey("sk_live_abc");
+    expect(paymentProviderMode("stripe")).toBe("live");
+  });
+
+  test("reads SumUp's estate from the kind of key stored", async () => {
+    expect(paymentProviderMode("sumup")).toBe("unknown");
+    await settings.update.sumup.apiKey("sk_test_abc");
+    expect(paymentProviderMode("sumup")).toBe("test");
+  });
+
+  test("reports an unknown estate for a key it cannot read", async () => {
+    await settings.update.stripe.secretKey("rk_live_restricted");
+    expect(paymentProviderMode("stripe")).toBe("unknown");
+  });
+});

--- a/test/shared/payment-provider-status.test.ts
+++ b/test/shared/payment-provider-status.test.ts
@@ -4,6 +4,7 @@ import { settings } from "#db/settings.ts";
 import {
   paymentProviderHasCredentials,
   paymentProviderMode,
+  paymentProviderUsesSandbox,
 } from "#shared/payment-provider-status.ts";
 import { PAYMENT_PROVIDER_IDS } from "#shared/payment-providers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -67,5 +68,30 @@ describeWithEnv("payment provider status", { db: true }, () => {
   test("reports an unknown estate for a key it cannot read", async () => {
     await settings.update.stripe.secretKey("rk_live_restricted");
     expect(paymentProviderMode("stripe")).toBe("unknown");
+  });
+
+  test("says a fresh site is not in any provider's sandbox", () => {
+    for (const provider of PAYMENT_PROVIDER_IDS) {
+      expect(paymentProviderUsesSandbox(provider)).toBe(false);
+    }
+  });
+
+  test("follows Square's sandbox switch", async () => {
+    await settings.update.square.sandbox(true);
+    expect(paymentProviderUsesSandbox("square")).toBe(true);
+    await settings.update.square.sandbox(false);
+    expect(paymentProviderUsesSandbox("square")).toBe(false);
+  });
+
+  // Stripe and SumUp host one estate, so a test key talks to the live hosts.
+  // Answering "yes" for either would point the security policy at origins
+  // neither provider declares.
+  test("says a card provider is never in a sandbox, whatever key is stored", async () => {
+    await settings.update.stripe.secretKey("sk_test_abc");
+    await settings.update.sumup.apiKey("sk_test_abc");
+    await settings.update.square.sandbox(true);
+
+    expect(paymentProviderUsesSandbox("stripe")).toBe(false);
+    expect(paymentProviderUsesSandbox("sumup")).toBe(false);
   });
 });

--- a/test/shared/payment-providers.test.ts
+++ b/test/shared/payment-providers.test.ts
@@ -3,9 +3,14 @@ import { describe, it as test } from "@std/testing/bdd";
 import {
   PAYMENT_PROVIDER_IDS,
   PAYMENT_PROVIDERS,
+  providerCheckoutFormOrigins,
   providerCurrencyBlock,
+  providerWebhook,
   WEBHOOK_SIGNATURE_HEADERS,
 } from "#shared/payment-providers.ts";
+import { allEnglishMessages } from "#test-utils/i18n.ts";
+
+const messages = await allEnglishMessages();
 
 describe("payment provider registry", () => {
   describe("providerCurrencyBlock", () => {
@@ -84,8 +89,8 @@ describe("payment provider registry", () => {
     expect(PAYMENT_PROVIDER_IDS).toEqual(["square", "stripe", "sumup"]);
   });
 
-  test("has no signature header for SumUp, whose webhooks are unsigned", () => {
-    expect(PAYMENT_PROVIDERS.sumup.webhookSignatureHeader).toBeNull();
+  test("declares no webhook for SumUp, which sends none", () => {
+    expect(PAYMENT_PROVIDERS.sumup.webhook).toBeNull();
   });
 
   test("lists the signature header of every provider that signs webhooks", () => {
@@ -93,5 +98,50 @@ describe("payment provider registry", () => {
       "x-square-hmacsha256-signature",
       "stripe-signature",
     ]);
+  });
+
+  describe("every provider fact is declared exactly once", () => {
+    test("names the checkout origins the buyer's form posts to", () => {
+      for (const id of PAYMENT_PROVIDER_IDS) {
+        // A provider with no origins would get `form-action 'self'`, and the
+        // browser would block the buyer's redirect to its hosted checkout.
+        expect(providerCheckoutFormOrigins(id, false).length).toBeGreaterThan(
+          0,
+        );
+        expect(providerCheckoutFormOrigins(id, true).length).toBeGreaterThan(0);
+      }
+    });
+
+    test("falls back to the live origins for a provider with no sandbox", () => {
+      expect(providerCheckoutFormOrigins("stripe", true)).toEqual(
+        providerCheckoutFormOrigins("stripe", false),
+      );
+      expect(providerCheckoutFormOrigins("square", true)).not.toEqual(
+        providerCheckoutFormOrigins("square", false),
+      );
+    });
+
+    test("declares a refund capability for every provider", () => {
+      for (const id of PAYMENT_PROVIDER_IDS) {
+        expect(["keyed", "keyless"]).toContain(
+          PAYMENT_PROVIDERS[id].refundCapability,
+        );
+      }
+    });
+
+    test("lists exactly the headers of the providers that send webhooks", () => {
+      const headers = PAYMENT_PROVIDER_IDS.map(
+        (id) => providerWebhook(id)?.signatureHeader,
+      ).filter((header) => header !== undefined);
+      expect(WEBHOOK_SIGNATURE_HEADERS).toEqual(headers);
+    });
+
+    test("gives every webhook provider real copy for a domain change", () => {
+      for (const id of PAYMENT_PROVIDER_IDS) {
+        const webhook = providerWebhook(id);
+        if (webhook === null) continue;
+        expect(messages[webhook.domainChangeFixKey]).toBeTruthy();
+      }
+    });
   });
 });

--- a/test/shared/payment-providers.test.ts
+++ b/test/shared/payment-providers.test.ts
@@ -112,6 +112,40 @@ describe("payment provider registry", () => {
       }
     });
 
+    // Pinned literally, not read back from the registry: these origins are
+    // what lets a buyer's form reach the hosted checkout, so a test that
+    // compares the registry with itself would pass on an empty one.
+    test("names Square's checkout hosts, and moves only the API ones", () => {
+      expect(providerCheckoutFormOrigins("square", false)).toEqual([
+        "https://square.link",
+        "https://checkout.square.site",
+        "https://*.squarecdn.com",
+        "https://geoissuer.cardinalcommerce.com",
+        "https://connect.squareup.com",
+        "https://pci-connect.squareup.com",
+        "https://api.squareup.com",
+      ]);
+      expect(providerCheckoutFormOrigins("square", true)).toEqual([
+        "https://square.link",
+        "https://checkout.square.site",
+        "https://*.squarecdn.com",
+        "https://geoissuer.cardinalcommerce.com",
+        "https://connect.squareupsandbox.com",
+        "https://pci-connect.squareupsandbox.com",
+        "https://api.squareupsandbox.com",
+      ]);
+    });
+
+    test("names the single checkout host of each card provider", () => {
+      expect(providerCheckoutFormOrigins("stripe", false)).toEqual([
+        "https://checkout.stripe.com",
+      ]);
+      expect(providerCheckoutFormOrigins("sumup", false)).toEqual([
+        "https://checkout.sumup.com",
+        "https://pay.sumup.com",
+      ]);
+    });
+
     test("falls back to the live origins for a provider with no sandbox", () => {
       expect(providerCheckoutFormOrigins("stripe", true)).toEqual(
         providerCheckoutFormOrigins("stripe", false),

--- a/test/shared/payment/refund-provider-authorization.test.ts
+++ b/test/shared/payment/refund-provider-authorization.test.ts
@@ -4,10 +4,13 @@ import type { RefundRequest } from "#payment/refund-attempt.ts";
 import {
   type AuthorizedRefundRequest,
   authorizeDurableRefundSend,
-  REFUND_PROVIDER_CAPABILITIES,
   type RefundAuthorization,
   requireProviderRefundAuthorization,
 } from "#payment/refund-provider-authorization.ts";
+import {
+  PAYMENT_PROVIDER_IDS,
+  PAYMENT_PROVIDERS,
+} from "#shared/payment-providers.ts";
 import { chargeMoney } from "#test-utils/payment-state.ts";
 
 const request: RefundRequest = {
@@ -96,12 +99,15 @@ describe("durable refund provider authorization", () => {
     );
   });
 
-  test("declares every provider capability exhaustively", () => {
-    expect(REFUND_PROVIDER_CAPABILITIES).toEqual({
-      square: "keyed",
-      stripe: "keyed",
-      sumup: "keyless",
-    });
+  test("takes every provider's capability from the one registry", () => {
+    expect(
+      Object.fromEntries(
+        PAYMENT_PROVIDER_IDS.map((id) => [
+          id,
+          PAYMENT_PROVIDERS[id].refundCapability,
+        ]),
+      ),
+    ).toEqual({ square: "keyed", stripe: "keyed", sumup: "keyless" });
   });
 });
 

--- a/test/shared/provider-refunds.test.ts
+++ b/test/shared/provider-refunds.test.ts
@@ -74,26 +74,17 @@ describeWithEnv("provider refund engine", { db: true }, () => {
     expect(refunding.sendCount()).toBe(1);
   });
 
-  for (const [name, raw, provider] of [
-    ["another provider", "wrong-provider", completingRefundProvider("sumup")],
-    [
-      "another capability",
-      "wrong-capability",
-      {
-        ...completingRefundProvider("stripe"),
-        refundCapability: "keyless" as const,
-      },
-    ],
-  ] as const) {
-    test(`refuses a loader returning ${name}`, async () => {
-      await expect(
-        requestProviderRefund(
-          sendRefundTarget(refundReference(`txn-${raw}`, "stripe")),
-          refundDependencies(provider),
-        ),
-      ).rejects.toThrow("Refund provider does not match its durable identity");
-    });
-  }
+  // A provider can no longer disagree with its own refund capability: the
+  // capability is a column on the provider registry, read by the id, so the
+  // only way a loader can contradict the stored identity is the id itself.
+  test("refuses a loader returning another provider", async () => {
+    await expect(
+      requestProviderRefund(
+        sendRefundTarget(refundReference("txn-wrong-provider", "stripe")),
+        refundDependencies(completingRefundProvider("sumup")),
+      ),
+    ).rejects.toThrow("Refund provider does not match its durable identity");
+  });
 
   test("a spent local-recording budget leaves returned money recoverable", async () => {
     const payment = refundReference("txn-record-budget");

--- a/test/shared/provider-refunds/engine-helpers.ts
+++ b/test/shared/provider-refunds/engine-helpers.ts
@@ -28,7 +28,6 @@ export const fakeRefundProvider = (
   ) => ReturnType<RefundEngineProvider["refundCharge"]>,
 ): RefundEngineProvider => ({
   readCharge: read,
-  refundCapability: provider === "sumup" ? "keyless" : "keyed",
   refundCharge: send,
   type: provider,
 });

--- a/test/shared/provider-refunds/state/contracts.test.ts
+++ b/test/shared/provider-refunds/state/contracts.test.ts
@@ -20,7 +20,6 @@ import {
   requireCurrentRefund,
   requireMatchingRefundProvider,
 } from "#shared/provider-refunds/state.ts";
-import type { RefundEngineProvider } from "#shared/provider-refunds.ts";
 import {
   notSentRefundProvider,
   refundReference,
@@ -61,13 +60,13 @@ test("pending provider evidence waits five minutes before another check", () => 
   expect(REFUND_OBSERVATION_DELAY_MS).toBe(300_000);
 });
 
-test("only the exact provider and its declared capability may use an authority", () => {
+test("only the exact provider may use an authority", () => {
   const stripe = notSentRefundProvider("stripe").provider;
-  const keyedSumUp = {
-    ...stripe,
-    type: "sumup",
-  } satisfies RefundEngineProvider;
 
+  // The capability half of this rule is now unrepresentable: a provider's
+  // refund capability is a column on the provider registry, read by the id,
+  // so a loaded adapter cannot carry one that contradicts its own reference.
+  // The id is the only thing left that can disagree.
   expect(() =>
     requireMatchingRefundProvider(
       stripe,
@@ -76,8 +75,8 @@ test("only the exact provider and its declared capability may use an authority",
   ).toThrow("Refund provider does not match its durable identity");
   expect(() =>
     requireMatchingRefundProvider(
-      keyedSumUp,
-      refundReference("sumup-reference"),
+      stripe,
+      refundReference("sumup-reference", "sumup"),
     ),
   ).toThrow("Refund provider does not match its durable identity");
 });

--- a/test/shared/square-provider.test.ts
+++ b/test/shared/square-provider.test.ts
@@ -99,7 +99,6 @@ describe("square-provider", () => {
     expect(squarePaymentProvider.checkoutCompletedEventType).toBe(
       "payment.updated",
     );
-    expect(squarePaymentProvider.requiresWebhookSignature).toBe(true);
   });
 
   describe("retrieveSession", () => {

--- a/test/shared/stripe-provider.test.ts
+++ b/test/shared/stripe-provider.test.ts
@@ -22,7 +22,6 @@ describeStripe("stripe-provider", () => {
     expect(stripePaymentProvider.checkoutCompletedEventType).toBe(
       "checkout.session.completed",
     );
-    expect(stripePaymentProvider.requiresWebhookSignature).toBe(true);
     expect(stripePaymentProvider.type).toBe("stripe");
   });
 

--- a/test/shared/sumup-provider.test.ts
+++ b/test/shared/sumup-provider.test.ts
@@ -29,9 +29,6 @@ describe("sumup-provider", () => {
     expect(sumupPaymentProvider.checkoutCompletedEventType).toBe(
       "CHECKOUT_STATUS_CHANGED",
     );
-    // SumUp does not sign its webhooks: authenticity comes from re-fetching
-    // the checkout, so the router must not demand a signature.
-    expect(sumupPaymentProvider.requiresWebhookSignature).toBe(false);
   });
 
   describe("retrieveSession", () => {

--- a/test/test-utils/payment-references.ts
+++ b/test/test-utils/payment-references.ts
@@ -11,9 +11,9 @@ import {
 import { createOrLoadRefundAuthority } from "#db/provider-refund-authority.ts";
 import { completeRefundAuthority } from "#db/provider-refund-authority-change.ts";
 import { readyRefund } from "#payment/refund-authority.ts";
-import { REFUND_PROVIDER_CAPABILITIES } from "#payment/refund-provider-authorization.ts";
 import { refundReplayUntil } from "#payment/refund-replay-window.ts";
 import { refundRequestIdentityIndex } from "#payment/refund-request-identity.ts";
+import { PAYMENT_PROVIDERS } from "#shared/payment-providers.ts";
 import { recordProviderRefunds } from "#shared/provider-refunds.ts";
 import { getTestPrivateKey } from "./crypto.ts";
 
@@ -25,7 +25,7 @@ export const markProviderRefundsReturned = async (
   local: "due" | "recorded" = "recorded",
 ): Promise<void> => {
   for (const reference of references) {
-    const capability = REFUND_PROVIDER_CAPABILITIES[reference.provider];
+    const capability = PAYMENT_PROVIDERS[reference.provider].refundCapability;
     const identityIndex = await refundRequestIdentityIndex(reference, 1);
     const request =
       capability === "keyless"

--- a/test/ui/templates/admin/settings/domain-payment-warning.test.tsx
+++ b/test/ui/templates/admin/settings/domain-payment-warning.test.tsx
@@ -1,8 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { DomainPaymentWebhookWarning } from "#templates/admin/settings/domain-payment-warning.tsx";
+import type { PaymentProviderType } from "#types";
 
-const renderWarning = (paymentProvider: string): string =>
+const renderWarning = (paymentProvider: PaymentProviderType): string =>
   String(
     DomainPaymentWebhookWarning({
       existingPaymentProvider: paymentProvider,


### PR DESCRIPTION
## What this is

A review of the last few weeks of work, looking for places where one fact
ended up written down more than once. Four of them are fixed here. Each
follows the same shape: find the copies, keep one, and make the copy a
compile error rather than a thing somebody must remember.

Two of the four close a bug a person could hit today.

---

## 1. Every payment provider fact

Facts about a provider lived in five places that could disagree:

| Fact | Was declared in |
| --- | --- |
| Refund capability | each adapter, `REFUND_PROVIDER_CAPABILITIES`, and `RefundAuthorizationByProvider` |
| Signed webhooks | each adapter (`requiresWebhookSignature`) and the registry (`webhookSignatureHeader`) |
| Checkout hosts | a provider-name chain in `buildCspHeader` |
| Stored credentials | five hand-written `{square, stripe, sumup}` maps |
| Test or live estate | a chain in `debug.ts` and a `square` literal in `middleware.ts` |

Seventeen more places compared a provider name with a literal.

Two copies had a runtime guard whose only job was to catch them disagreeing.
`authorizeDurableRefundSend` and `requireMatchingRefundProvider` both compared
the adapter's capability with the table's. A guard against two declarations of
one fact is the signal to keep one declaration.

`payment-providers.ts` now holds every provider fact that does not need the
provider SDK, as one `Record<PaymentProviderType, PaymentProviderMeta>`:

- **`refundCapability`** is a column. The adapters, the interface member, and
  `REFUND_PROVIDER_CAPABILITIES` are deleted, and the permit types derive from
  the column, so `RefundAuthorizationByProvider` goes too.
- **`webhook`** is one nullable column carrying the signature header and the
  catalog key for a domain change. A provider that sends no webhook has none
  of the three, so they cannot disagree. `requiresWebhookSignature` is deleted.
- **`checkoutFormOrigins`** names the origins each hosted checkout posts to.

`payment-provider-status.ts` is new, and answers the two questions that depend
on this site's settings: which estate a provider's key points at, and whether
it has credentials.

**The bug.** `buildCspHeader` picked its `form-action` origins with an if-chain
over provider names. A provider added to `PaymentProviderSchema` fell into the
`else` arm and got `form-action 'self'`. The browser then blocked the buyer's
redirect to that provider's hosted checkout, so every sale failed and nothing
in the code said why.

## 2. Every refund engine answer

`engineResult` turned one engine answer into what the operator is told. It was
an if-chain over seven of the eight members of `ProviderRefundResult`, ending
in a bare `return { outcome: "withheld" }` that named no member and read no
property.

That arm caught the eighth member, `ready`, and would catch a ninth. A
`withheld` outcome is tallied as a failure, so an answer nobody had considered
reached the operator as "this refund failed" — the reading that most invites a
person to try again with money.

The answers now come from `ENGINE_OUTCOME`, keyed by the answer's own kind.
`returned` stays separate on both sides of the record: it is the one answer
that carries a receipt, so it can never be a bare outcome, and `refunded` can
never be reported without one.

## 3. Every calendar link

On a per-agent run sheet — `/admin/calendar?date=2026-07-06&agent=3` — picking
another day in the date picker sent the operator to
`/admin/calendar?date=<new>`. The agent was gone, the page showed every
attendee on the site for that day, and nothing said the run sheet had been
dropped. Stepping a month did the same, and so did the address an attendee's
page returned by.

Five links, each spelling out its own query string, each carrying only the
filters whoever wrote it remembered. `agentHref` remembered the agent.
`dayHref`, `monthHref`, and `returnUrl` did not.

`attendee-list-controls.ts` already answered this for the attendee lists: one
table of parameter writers, and a link that changes part of the state and keeps
the rest. That shape is now `shared/filter-href.ts`, and both pages use it. The
calendar declares one `CalendarView` — the day, the agent, and the month the
picker is browsing — and every link says only what it changes.

Two links keep their own meaning, and now say so. The agent bar's "All" drops
the agent, because that is what it is for. The picker's clear drops the date
and the agent together, because the agent bar only loads once a date is chosen.

## 4. Every IN list, and every scan's rows

`inPlaceholders` in `db/client.ts` renders `?, ?, ?` for a list. Seven other
places rendered it again by hand. jscpd never saw the pair because the
expression is one line. `listing-prices.ts` is the clearest case: it imports
`inPlaceholders`, calls it three times, and hand-rolls it a fourth time in the
statement below. Shipped migrations keep their own copy — they ran against live
data, and rewriting finished history buys nothing.

`schema-anomaly-scan.ts` had the same problem one level up. Its two payment
queries selected `'' AS recovery_state, '' AS sumup_id` — columns neither query
has, invented so both row shapes would fit one type. A shared type padded with
blanks is not a shared interface. Each scan now reads its own rows.

---

## Tests

- `payment-provider-status.test.ts` (new) covers both readers against real
  stored settings.
- `payment-providers.test.ts` checks the registry answers for every declared
  provider, and that each webhook provider's domain-change key resolves to real
  copy.
- `middleware.test.ts` asserts the policy names every origin of every declared
  provider, in both estates. It fails for a provider the registry does not
  describe.
- `engine-outcomes.test.ts` (new) drives one refund batch per engine answer and
  pins the tally the operator sees. `ANSWER_KINDS` is an exhaustive record of
  the union, so a new member fails to compile and then fails the test until it
  has a row.
- `calendar-logistics.test.ts` pins that the day, month, and return links carry
  the agent, that "All" does not, and that clear drops both. The first fails
  against the old `dayHref`.
- `settings-provider-credentials.test.ts` stores a real key instead of stubbing
  `hasSecret`.

One test case is deleted rather than migrated. "refuses a loader returning
another capability" built a provider whose capability contradicted its own id.
The capability now comes from the id, so no loader can build that provider.

## For the people running a site

Two things get better and nothing else changes.

- A run sheet filtered to one delivery agent stays filtered when you pick
  another day, step a month, or come back from an attendee's page.
- A refund the system has no answer for can no longer be reported as "failed"
  by a branch nobody wrote.