### PR TITLE
Pin the child-state voucher that the test split left unwatched

### DIFF
--- a/test/shared/db/groups/membership/validate.test.ts
+++ b/test/shared/db/groups/membership/validate.test.ts
@@ -3,10 +3,14 @@
  *  `hasChildren: false`, and the validation must trust the voucher instead of
  *  the stored edges it is about to remove. */
 
+import { assert } from "@std/assert";
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { withTransaction } from "#db/client.ts";
-import { validateListingGroupMembershipTx } from "#db/groups/membership.ts";
+import {
+  type ListingGroupMembershipValidation,
+  validateListingGroupMembershipTx,
+} from "#db/groups/membership.ts";
 import { listingChildren } from "#db/listing-parents.ts";
 import { t } from "#i18n";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -17,6 +21,13 @@ describeWithEnv(
   "db > groups > membership child-state override",
   { db: true },
   () => {
+    const requireChecked = (
+      validation: ListingGroupMembershipValidation,
+    ): string | null => {
+      assert(!validation.listingMissing, "Expected the listing to exist");
+      return validation.error;
+    };
+
     const hiddenPackageParent = async (name: string) => {
       const group = await createHiddenPackageGroup(name);
       const parent = await createTestListing({ name: `${name} parent` });
@@ -32,7 +43,7 @@ describeWithEnv(
         validateListingGroupMembershipTx(tx)(parent.id, [group.id], false),
       );
 
-      expect(validation.error).toBeNull();
+      expect(requireChecked(validation)).toBeNull();
     });
 
     test("reads the stored child edges when no caller vouches", async () => {
@@ -42,7 +53,7 @@ describeWithEnv(
         validateListingGroupMembershipTx(tx)(parent.id, [group.id]),
       );
 
-      expect(validation.error).toBe(
+      expect(requireChecked(validation)).toBe(
         t("error.package_member_gates_children_hidden", { name: parent.name }),
       );
     });

--- a/test/shared/db/groups/membership/validate.test.ts
+++ b/test/shared/db/groups/membership/validate.test.ts
@@ -1,0 +1,50 @@
+/** validateListingGroupMembershipTx's child-state override: a caller that is
+ *  clearing the listing's children in the same write vouches for that with
+ *  `hasChildren: false`, and the validation must trust the voucher instead of
+ *  the stored edges it is about to remove. */
+
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { withTransaction } from "#db/client.ts";
+import { validateListingGroupMembershipTx } from "#db/groups/membership.ts";
+import { listingChildren } from "#db/listing-parents.ts";
+import { t } from "#i18n";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createHiddenPackageGroup } from "#test-utils/db-helpers/groups.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+
+describeWithEnv(
+  "db > groups > membership child-state override",
+  { db: true },
+  () => {
+    const hiddenPackageParent = async (name: string) => {
+      const group = await createHiddenPackageGroup(name);
+      const parent = await createTestListing({ name: `${name} parent` });
+      const child = await createTestListing({ name: `${name} child` });
+      await listingChildren.setIds(parent.id, [child.id]);
+      return { group, parent };
+    };
+
+    test("trusts a caller that vouches the children are being cleared", async () => {
+      const { group, parent } = await hiddenPackageParent("Vouched clear");
+
+      const validation = await withTransaction((tx) =>
+        validateListingGroupMembershipTx(tx)(parent.id, [group.id], false),
+      );
+
+      expect(validation.error).toBeNull();
+    });
+
+    test("reads the stored child edges when no caller vouches", async () => {
+      const { group, parent } = await hiddenPackageParent("Stored edges");
+
+      const validation = await withTransaction((tx) =>
+        validateListingGroupMembershipTx(tx)(parent.id, [group.id]),
+      );
+
+      expect(validation.error).toBe(
+        t("error.package_member_gates_children_hidden", { name: parent.name }),
+      );
+    });
+  },
+);


### PR DESCRIPTION
## What changed

The branch mutation gate for PR #2122 finished after that PR merged, and it found one survivor: swapping the arms of the `hasChildren` ternary in `validateListingGroupMembershipTx` (`src/shared/db/groups/membership.ts`) went unnoticed. The test that exercised the voucher moved to `set-groups.test.ts` in that PR, and `groups.ts` owns that file — so `membership.ts`'s own mirror suite lost its only kill for this mutant.

Two direct cases in `test/shared/db/groups/membership/validate.test.ts` now hold both directions. A caller that vouches `hasChildren: false` — because it clears the listing's children in the same write — is trusted, and the hidden-package rule stays quiet. A caller that does not vouch gets the stored child edges read, and the rule refuses the membership. A small `requireChecked` helper narrows the validation union before the tests read its error.

## Checks

- `deno task mutation` over `src/shared/db/groups/membership.ts` with its full mirror suite: **100% — 88/88 mutants detected**.
- `deno task test:files test/shared/db/groups/membership/validate.test.ts`, `deno task lint`, and `deno check` on the test file passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Ve7CEwp4N5YhvfgumG7KN