### PR TITLE
Share one batch type, and give the primary read its plural

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1317,7 +1317,9 @@ query logging and table-scoped cache invalidation stay automatic.
   (writes, returns each `ResultSet` — ideal for cascading deletes and multi-step
   writes), `queryBatch` (reads in one round-trip), or `queryBatchPrimary` (reads
   pinned to the primary when you must read your own just-committed writes).
-  `deleteByFieldBatch` is a ready-made multi-table delete.
+  `deleteByFieldBatch` is a ready-made multi-table delete. One statement is not
+  a batch: for a single read pinned to the primary, use `queryAllPrimary` for
+  its rows or `queryOnePrimary` for the first one, never a batch of one.
 
 - **Interactive transaction — logic between steps.** When a later statement
   depends on the result of an earlier one, use `withTransaction`. One example is

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -240,7 +240,9 @@ src/shared/db/listings/attendees.ts::getListingWithAttendeeRaw.attendeeRaw~0x3k1
 src/shared/db/client.ts::extractUpdateColumns.addAssignment~17cdcum  0 → 1   # an "=" at the very start leaves an empty column name, which the `if (col)` guard drops, so returning early adds the same nothing
 src/shared/db/client.ts::writeSqlOf~1begzdu  ?? → ||   # the captured tail has to start with INSERT, UPDATE, DELETE, REPLACE or SELECT, so the group is never the empty string
 src/shared/db/client.ts::GUARDED_CLIENT~1cajdnv  guarded-db-client → ""   # a symbol's description only names it in a debugger; the guard compares symbol identity, which the description cannot change
+src/shared/db/client.ts::queryAll.args~0hs5u5i  ?? → ||   # args is an InValue[] when present, and an array is always truthy
 src/shared/db/client.ts::queryOne~1hu7rck  ?? → ||   # a result row is always an object, so the only falsy first element is the missing one the fallback is there for
+src/shared/db/client.ts::queryOnePrimary~0qbwuku  ?? → ||   # a result row is always an object, so the only falsy first element is the missing one the fallback is there for
 
 # crypto/hashing.ts — the explicit radix on the stored round count. The line
 # above it now refuses any count that is not pure decimal digits, and for such a

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -17,7 +17,6 @@ src/features/api/payment-processing/create.ts::saveSessionAnswers.existing~1keal
 src/features/api/payment-processing/create.ts::saveSessionAnswers.textAnswerIds~1ex96yt  ?? → ||   # existing text answer ids are an array when present, and arrays are always truthy
 src/shared/logistics-filter.ts::parseAgentFilter.n~03f157n  ?? → ||   # raw: string|null, only falsy string "" === fallback ""
 src/shared/config.ts::getBunnyDnsSubdomainSuffix~1pvt5gw  ?? → ||   # getEnv(): string|undefined, only falsy string "" === fallback ""
-src/shared/config.ts::isPaymentsEnabled~02tsswb  ?? → ||   # providerValue returns boolean or null, and false stays false with either fallback operator
 src/shared/config.ts::getDebugKey~036uuok  ?? → ||   # getEnv(): string|undefined, only falsy string "" === fallback ""
 src/shared/config.ts::getBotpoisonPublicKey~0v606rk  ?? → ||   # getEnv(): string|undefined, only falsy string "" === fallback ""
 src/shared/config.ts::getBotpoisonSecretKey~0yy1bjh  ?? → ||   # getEnv(): string|undefined, only falsy string "" === fallback ""
@@ -241,7 +240,6 @@ src/shared/db/listings/attendees.ts::getListingWithAttendeeRaw.attendeeRaw~0x3k1
 src/shared/db/client.ts::extractUpdateColumns.addAssignment~17cdcum  0 → 1   # an "=" at the very start leaves an empty column name, which the `if (col)` guard drops, so returning early adds the same nothing
 src/shared/db/client.ts::writeSqlOf~1begzdu  ?? → ||   # the captured tail has to start with INSERT, UPDATE, DELETE, REPLACE or SELECT, so the group is never the empty string
 src/shared/db/client.ts::GUARDED_CLIENT~1cajdnv  guarded-db-client → ""   # a symbol's description only names it in a debugger; the guard compares symbol identity, which the description cannot change
-src/shared/db/client.ts::executeRead.args~0hs5u5i  ?? → ||   # args is an array or a named-args object when present, and both are always truthy
 src/shared/db/client.ts::queryOne~1hu7rck  ?? → ||   # a result row is always an object, so the only falsy first element is the missing one the fallback is there for
 
 # crypto/hashing.ts — the explicit radix on the stored round count. The line

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -149,6 +149,14 @@ src/shared/db/payment-claim.ts::settleAttendeeRows~1iaqh2o Refund settlement los
 src/shared/db/payment-claim.ts::assertRefundRowsHeld.phase~19s22mv Refund confirmation lost a payment-row phase→""   # unreachable: the rows are read by this same map's keys, so every row has a phase
 src/shared/db/payment-claim.ts::paymentClaimRowsSql~1oy3usg charge.→""   # the work test reads refund_state_name and refund_local_state, which only payment_charges carries in this join, so the bare names resolve to the same columns
 
+# refund-all-candidates.ts — table aliases the reader needs and SQLite does
+# not: each column below is on exactly one table in its query, so dropping the
+# alias resolves to the same column.
+src/shared/db/refund-all-candidates.ts::providerRefundWork~1oy3usg charge.→""   # only payment_charges carries refund_state_name and refund_local_state in that query
+src/shared/db/refund-all-candidates.ts::refundCandidateCtes~195soyi payment.→""   # only processed_payments carries protected_state in that query
+src/shared/db/refund-all-candidates.ts::refundCandidateCtes~0uj3b4g payment.→""   # only processed_payments carries protected_state in that query
+src/shared/db/refund-all-candidates.ts::refundCandidateCtes~1unwmuv payment.→""   # only processed_payments carries protected_state in that query
+
 # backup dump (shared/db/backup-snapshot.ts) — exportTable internals whose
 # intermediate values are overwritten or type-guaranteed before any read.
 src/shared/db/backup-snapshot.ts::exportTable.colList~1el369a   → "mutated"   # colList is only read when INSERT statements are built, which happens after the first non-empty page assigned it in the rowCount === 0 branch; the initializer is overwritten before every read (an empty table breaks out before any read)

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -146,6 +146,8 @@ src/shared/sumup/transaction.ts::readSumupTransaction.events~0aphohd  ?? → || 
 # sessionId that is a key of that same map. requiredMapValue can never miss
 # there, and no input can observe the message on that unreachable throw.
 src/shared/db/payment-claim.ts::settleAttendeeRows~1iaqh2o Refund settlement lost a payment row→""   # unreachable: the IN-clause is built from the same map's keys
+src/shared/db/payment-claim.ts::assertRefundRowsHeld.phase~19s22mv Refund confirmation lost a payment-row phase→""   # unreachable: the rows are read by this same map's keys, so every row has a phase
+src/shared/db/payment-claim.ts::paymentClaimRowsSql~1oy3usg charge.→""   # the work test reads refund_state_name and refund_local_state, which only payment_charges carries in this join, so the bare names resolve to the same columns
 
 # backup dump (shared/db/backup-snapshot.ts) — exportTable internals whose
 # intermediate values are overwritten or type-guaranteed before any read.

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -157,6 +157,8 @@ src/shared/db/refund-all-candidates.ts::refundCandidateCtes~195soyi payment.→"
 src/shared/db/refund-all-candidates.ts::refundCandidateCtes~0uj3b4g payment.→""   # only processed_payments carries protected_state in that query
 src/shared/db/refund-all-candidates.ts::refundCandidateCtes~1unwmuv payment.→""   # only processed_payments carries protected_state in that query
 
+src/shared/db/payment-admit-move.ts::moveSnapshot.refusalFor~1l6lh30  ?? → ||   # every refusal is a declared sentence, never the empty string, so only null reaches the second reader
+
 # backup dump (shared/db/backup-snapshot.ts) — exportTable internals whose
 # intermediate values are overwritten or type-guaranteed before any read.
 src/shared/db/backup-snapshot.ts::exportTable.colList~1el369a   → "mutated"   # colList is only read when INSERT statements are built, which happens after the first non-empty page assigned it in the rowCount === 0 branch; the initializer is overwritten before every read (an empty table breaks out before any read)

--- a/src/features/api/payment-processing/committed-entries.ts
+++ b/src/features/api/payment-processing/committed-entries.ts
@@ -36,8 +36,9 @@ export const committedEntries = async (
   intent: BookingIntent,
   validatedItems: ValidatedItem[],
 ): Promise<CreatedEntry[]> => {
-  const rows = await queryAllPrimary<CommittedBookingRow>(
-    `SELECT attendee.created,
+  const rows = await queryAllPrimary<CommittedBookingRow>({
+    args: [attendeeId],
+    sql: `SELECT attendee.created,
                    SUBSTR(listingAttendee.start_at, 1, 10) AS date,
                    SUBSTR(listingAttendee.end_at, 1, 10) AS end_date,
                    attendee.kind,
@@ -58,8 +59,7 @@ export const committedEntries = async (
               ON listingAttendee.attendee_id = attendee.id
             WHERE attendee.id = ?
             ORDER BY listingAttendee.id`,
-    [attendeeId],
-  );
+  });
   const attendees: CreatedEntry["attendee"][] = rows.map((row) => ({
     ...contactFields(intent),
     attachment_downloads: 0,

--- a/src/features/api/payment-processing/committed-entries.ts
+++ b/src/features/api/payment-processing/committed-entries.ts
@@ -4,7 +4,7 @@ import {
   pricePaidFromLedger,
   remainingBalanceFromLedger,
 } from "#db/attendees/select.ts";
-import { queryBatchPrimary, resultRows } from "#db/client.ts";
+import { queryAllPrimary } from "#db/client.ts";
 import {
   type CreatedEntry,
   pairEntriesByListing,
@@ -36,10 +36,8 @@ export const committedEntries = async (
   intent: BookingIntent,
   validatedItems: ValidatedItem[],
 ): Promise<CreatedEntry[]> => {
-  const [result] = await queryBatchPrimary([
-    {
-      args: [attendeeId],
-      sql: `SELECT attendee.created,
+  const rows = await queryAllPrimary<CommittedBookingRow>(
+    `SELECT attendee.created,
                    SUBSTR(listingAttendee.start_at, 1, 10) AS date,
                    SUBSTR(listingAttendee.end_at, 1, 10) AS end_date,
                    attendee.kind,
@@ -60,11 +58,9 @@ export const committedEntries = async (
               ON listingAttendee.attendee_id = attendee.id
             WHERE attendee.id = ?
             ORDER BY listingAttendee.id`,
-    },
-  ]);
-  const attendees: CreatedEntry["attendee"][] = resultRows<CommittedBookingRow>(
-    result!,
-  ).map((row) => ({
+    [attendeeId],
+  );
+  const attendees: CreatedEntry["attendee"][] = rows.map((row) => ({
     ...contactFields(intent),
     attachment_downloads: 0,
     checked_in: false,

--- a/src/shared/accounting/manual-entries.ts
+++ b/src/shared/accounting/manual-entries.ts
@@ -10,9 +10,9 @@
 import * as v from "valibot";
 import { WORLD, WRITEOFF } from "#accounting/accounts.ts";
 import { eventGroup, legReference } from "#accounting/refs.ts";
-import { fromDb, selectById } from "#accounting/rows.ts";
+import { selectById } from "#accounting/rows.ts";
 import { postTransfers } from "#accounting/store.ts";
-import { execute, executeUpdate } from "#db/client.ts";
+import { execute, executeUpdate, queryBatch } from "#db/client.ts";
 import type {
   AccountRef,
   Transfer,
@@ -222,7 +222,7 @@ export const postManualLedgerEntry = async (
 };
 
 export const getTransferById = (id: number): Promise<Transfer | null> =>
-  selectById(fromDb, id);
+  selectById(queryBatch, id);
 
 /**
  * The ledger is append-only except for owner-entered rows, and this module IS

--- a/src/shared/accounting/queries.ts
+++ b/src/shared/accounting/queries.ts
@@ -30,14 +30,11 @@ import {
   signedSumCase,
 } from "#accounting/projection-sql.ts";
 import { type LedgerRange, occurredAtRange } from "#accounting/range.ts";
-import {
-  fromDb,
-  selectByEventGroup,
-  selectTransfers,
-} from "#accounting/rows.ts";
+import { selectByEventGroup, selectTransfers } from "#accounting/rows.ts";
 import {
   inPlaceholders,
   queryAll,
+  queryBatch,
   requireOne,
   resultRows,
   rowExists,
@@ -83,7 +80,7 @@ export const transfersByAccounts = async (
   const requested = uniqueBy(accountKey)([...accounts]);
   if (requested.length === 0) return new Map();
   const wanted = new Set(requested.map(accountKey));
-  const transfers = await selectTransfers(fromDb, {
+  const transfers = await selectTransfers(queryBatch, {
     where: [accountsScope(requested)],
   });
   const touching = transfers.flatMap((transfer) =>
@@ -113,7 +110,7 @@ export const transfersByAccount = async (
 /** Every leg of one business event (booking, refund, …). */
 export const transfersByEventGroup = (
   eventGroup: string,
-): Promise<Transfer[]> => selectByEventGroup(fromDb, eventGroup);
+): Promise<Transfer[]> => selectByEventGroup(queryBatch, eventGroup);
 
 /**
  * True when the ledger already holds at least one leg for this business event —
@@ -130,14 +127,15 @@ export const eventGroupHasLegs = (eventGroup: string): Promise<boolean> =>
 
 /** The whole ledger. For tests and small reports; scoped reads are preferred on
  *  hot paths. */
-export const allTransfers = (): Promise<Transfer[]> => selectTransfers(fromDb);
+export const allTransfers = (): Promise<Transfer[]> =>
+  selectTransfers(queryBatch);
 
 /** The most recent `limit` transfers, newest first (by business time then id, so
  *  ties are stable). The ordering + limit run in SQL so the whole ledger is never
  *  loaded into memory; `occurred_at` is the stored INTEGER epoch, so DESC is
  *  newest-first. */
 export const recentTransfers = (limit: number): Promise<Transfer[]> =>
-  selectTransfers(fromDb, { limit, order: NEWEST_FIRST });
+  selectTransfers(queryBatch, { limit, order: NEWEST_FIRST });
 
 /** Legs shown on the operator-facing ledger list. Routine checkout cash
  * plumbing ("Card / bank → <attendee>" and its refund mirror) stays hidden, but
@@ -198,7 +196,11 @@ export const visibleTransfers = (
     ...occurredAtRange(range),
     ...listingLegScope(listingIds),
   ];
-  return selectTransfers(fromDb, { limit, order: NEWEST_FIRST, where: parts });
+  return selectTransfers(queryBatch, {
+    limit,
+    order: NEWEST_FIRST,
+    where: parts,
+  });
 };
 
 /** Distinct-day bounds (earliest/latest `occurred_at`) over the whole ledger, or

--- a/src/shared/accounting/rows.ts
+++ b/src/shared/accounting/rows.ts
@@ -196,7 +196,7 @@ export const bookingLegBatchInsert = (
     ),
   );
 
-/** The transfers one answered query holds. */
+/** The transfers held by one answered query. */
 const transfersIn = (result: ResultSet): Transfer[] =>
   resultRows<TransferRow>(result).map(rowToTransfer);
 
@@ -213,13 +213,12 @@ type TransfersPerQuery<Queries extends readonly TransferRead[]> = {
   [Index in keyof Queries]: Transfer[];
 };
 
-/** Select several sets of transfers at once, each saying which rows it wants
- * and in what order rather than writing the query. `read` decides where the
- * rows come from — the client's `queryBatch`, or an open transaction's own
- * `batch` for the write path, whose write lock makes concurrent posters of one
- * event take turns — and answers them all in one round trip. A query that can
- * match no row is answered as empty without being asked, so wanting none of
- * something still costs nothing. */
+/** Select several sets of transfers at once, in one round trip. Each set names
+ * the rows it wants and their order instead of the SQL. `read` decides where
+ * the rows come from: the client's `queryBatch`, or an open transaction's own
+ * `batch`. The write path reads through its transaction, so the write lock
+ * makes two posters of one event take turns. A query that can match no row is
+ * answered as empty without a trip to the database. */
 export const selectTransfersMany = async <
   const Queries extends readonly TransferRead[],
 >(

--- a/src/shared/accounting/rows.ts
+++ b/src/shared/accounting/rows.ts
@@ -10,11 +10,10 @@
 import type { InValue, ResultSet } from "@libsql/client";
 import { ATTENDEE } from "#accounting/accounts.ts";
 import {
+  type BatchExecutor,
   orIgnore,
-  queryBatch,
   resultRows,
   type SqlStatement,
-  type TxScope,
 } from "#db/client.ts";
 import { type Read, readStatement } from "#db/read.ts";
 import { equals, matchesNoRows } from "#db/where-clauses.ts";
@@ -197,28 +196,9 @@ export const bookingLegBatchInsert = (
     ),
   );
 
-/**
- * Answers a set of transfer queries together, in one round trip, and hands back
- * one batch of rows per query in the order asked. Reading either from the global
- * client or from an open transaction: the write path reads through its own
- * transaction, so the database write lock makes concurrent posters of the same
- * event take turns and the second one sees the first one's rows and replays
- * instead of double-posting.
- */
-export type RowReader = (
-  statements: readonly SqlStatement[],
-) => Promise<TransferRow[][]>;
-
-const rowsPerStatement = (results: readonly ResultSet[]): TransferRow[][] =>
-  results.map((result) => resultRows<TransferRow>(result));
-
-export const fromDb: RowReader = async (statements) =>
-  rowsPerStatement(await queryBatch([...statements]));
-
-export const fromTx =
-  (tx: TxScope): RowReader =>
-  async (statements) =>
-    rowsPerStatement(await tx.batch([...statements]));
+/** The transfers one answered query holds. */
+const transfersIn = (result: ResultSet): Transfer[] =>
+  resultRows<TransferRow>(result).map(rowToTransfer);
 
 /** Which transfers to read, in what order, how many — everything but the
  * columns and the table, which a transfer read always knows. */
@@ -235,13 +215,15 @@ type TransfersPerQuery<Queries extends readonly TransferRead[]> = {
 
 /** Select several sets of transfers at once, each saying which rows it wants
  * and in what order rather than writing the query. `read` decides where the
- * rows come from — the client, or an open transaction — and answers them all in
- * one round trip. A query that can match no row is answered as empty without
- * being asked, so wanting none of something still costs nothing. */
+ * rows come from — the client's `queryBatch`, or an open transaction's own
+ * `batch` for the write path, whose write lock makes concurrent posters of one
+ * event take turns — and answers them all in one round trip. A query that can
+ * match no row is answered as empty without being asked, so wanting none of
+ * something still costs nothing. */
 export const selectTransfersMany = async <
   const Queries extends readonly TransferRead[],
 >(
-  read: RowReader,
+  read: BatchExecutor,
   queries: Queries,
 ): Promise<TransfersPerQuery<Queries>> => {
   const asked = queries
@@ -254,10 +236,9 @@ export const selectTransfersMany = async <
   const rowsByQuery = new Map(
     asked.map(({ index }, position) => [
       index,
-      requireValue(
-        answers[position],
-        `Ledger read ${index} went unanswered`,
-      ).map(rowToTransfer),
+      transfersIn(
+        requireValue(answers[position], `Ledger read ${index} went unanswered`),
+      ),
     ]),
   );
   // Built by mapping the queries, so it is one set per query by construction —
@@ -270,7 +251,7 @@ export const selectTransfersMany = async <
 /** Select transfers, saying which rows and in what order rather than writing
  * the query. Pass nothing to read the whole table. */
 export const selectTransfers = async (
-  read: RowReader,
+  read: BatchExecutor,
   query: TransferRead = {},
 ): Promise<Transfer[]> => {
   const [rows] = await selectTransfersMany(read, [query]);
@@ -279,14 +260,14 @@ export const selectTransfers = async (
 
 /** Every leg of one business event (booking, refund, …). */
 export const selectByEventGroup = (
-  read: RowReader,
+  read: BatchExecutor,
   eventGroup: string,
 ): Promise<Transfer[]> =>
   selectTransfers(read, { where: equals("event_group", eventGroup) });
 
 /** The stored transfer with this id, or null when none exists. */
 export const selectById = async (
-  read: RowReader,
+  read: BatchExecutor,
   id: number,
 ): Promise<Transfer | null> =>
   (await selectTransfers(read, { where: equals("id", id) }))[0] ?? null;

--- a/src/shared/accounting/store.ts
+++ b/src/shared/accounting/store.ts
@@ -24,16 +24,15 @@ import {
   reversalConflict,
 } from "#accounting/conflicts.ts";
 import {
-  fromDb,
-  fromTx,
   insertStatement,
-  type RowReader,
   selectTransfersMany,
   type TransferRead,
 } from "#accounting/rows.ts";
 import {
+  type BatchExecutor,
   executeBatch,
   orIgnore,
+  queryBatch,
   type SqlStatement,
   type TxScope,
 } from "#db/client.ts";
@@ -120,7 +119,7 @@ export const postTransfersTx = async (
 ): Promise<PostResult> => {
   if (inputs.length === 0) return EMPTY_RESULT;
   assertPostable(inputs);
-  const snapshot = await loadBatchSnapshot([inputs], fromTx(tx));
+  const snapshot = await loadBatchSnapshot([inputs], tx.batch);
   const planned = planGroup(inputs, snapshot, nowIso());
   if (planned.kind === "conflict") throw planned.error;
   const { inserts, result } = planned;
@@ -177,7 +176,7 @@ const byColumnIn = (
  *  makes the read authoritative). */
 const loadBatchSnapshot = async (
   groups: TransferInput[][],
-  read: RowReader,
+  read: BatchExecutor,
 ): Promise<BatchSnapshot> => {
   const eventGroups = unique(groups.map(eventGroupOf));
   const references = allReferences(groups);
@@ -366,7 +365,7 @@ export const postTransferGroupBatches = async <
     return batches.map(nothingToPost) as ResultPerBatch<Batches>;
   }
   assertUniqueGroups(groups);
-  const snapshot = await loadBatchSnapshot(nonEmpty, fromDb);
+  const snapshot = await loadBatchSnapshot(nonEmpty, queryBatch);
   const recordedAt = nowIso();
   const planned = batches.map((batch) =>
     planTransferBatch(batch, snapshot, recordedAt),

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -370,16 +370,15 @@ const firstRowOrNull = <T>(result: ResultSet): T | null => {
 };
 
 /**
- * Query all rows of one statement on the primary, for a caller that must read
- * its own writes — a plain {@link queryAll} can be served by a lagging replica
- * and miss them. See {@link queryBatchPrimary}. `args` is required: a read-back
- * always keys on the rows the write just put there.
+ * {@link queryAll} for a caller that must read its own writes: the same rows,
+ * pinned to the primary, because a replica can lag behind the write and miss
+ * them. See {@link queryBatchPrimary}. It takes the statement whole — the shape
+ * a batch runs — so a caller holding one hands it over as it is.
  */
 export const queryAllPrimary = async <T>(
-  sql: string,
-  args: InValue[],
+  statement: SqlStatement,
 ): Promise<T[]> => {
-  const [result] = await queryBatchPrimary([{ args, sql }]);
+  const [result] = await queryBatchPrimary([statement]);
   return resultRows<T>(result!);
 };
 
@@ -387,7 +386,7 @@ export const queryAllPrimary = async <T>(
  *  read-your-writes goes to the primary instead. */
 export const queryAll = async <T>(...[sql, args]: SqlArgs): Promise<T[]> =>
   mustReadFromPrimary() && primaryReadMode() !== "read"
-    ? queryAllPrimary<T>(sql, args ?? [])
+    ? queryAllPrimary<T>({ args: args ?? [], sql })
     : resultRows<T>(await execute(sql, args));
 
 /** Query one row, or null when the query returns none. */
@@ -411,11 +410,12 @@ export const requireOne = <T>(...[sql, args]: SqlArgs): Promise<T> =>
   requireQueryRow(queryOne<T>(sql, args), sql, "Required");
 
 /** Query an optional row on the primary — the singular of
- *  {@link queryAllPrimary}, as {@link queryOne} is of {@link queryAll}. */
+ *  {@link queryAllPrimary}, as {@link queryOne} is of {@link queryAll}. `args`
+ *  is required here: every read-back keys on the row the write just made. */
 export const queryOnePrimary = async <T>(
   sql: string,
   args: InValue[],
-): Promise<T | null> => (await queryAllPrimary<T>(sql, args))[0] ?? null;
+): Promise<T | null> => (await queryAllPrimary<T>({ args, sql }))[0] ?? null;
 
 /** Query one required row from the primary. */
 export const requireOnePrimary = <T>(...[sql, args]: SqlWithArgs): Promise<T> =>

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -370,10 +370,10 @@ const firstRowOrNull = <T>(result: ResultSet): T | null => {
 };
 
 /**
- * {@link queryAll} for a caller that must read its own writes: the same rows,
+ * {@link queryAll} for a caller that must read its own writes. The same rows,
  * pinned to the primary, because a replica can lag behind the write and miss
- * them. See {@link queryBatchPrimary}. It takes the statement whole — the shape
- * a batch runs — so a caller holding one hands it over as it is.
+ * them. See {@link queryBatchPrimary}. It takes the statement whole, which is
+ * the shape a batch runs, so a caller that holds one hands it over as it is.
  */
 export const queryAllPrimary = async <T>(
   statement: SqlStatement,
@@ -382,7 +382,7 @@ export const queryAllPrimary = async <T>(
   return resultRows<T>(result!);
 };
 
-/** Query all rows, returning a typed array. A read whose cache refill requires
+/** Query all rows as a typed array. A read whose cache refill requires
  *  read-your-writes goes to the primary instead. */
 export const queryAll = async <T>(...[sql, args]: SqlArgs): Promise<T[]> =>
   mustReadFromPrimary() && primaryReadMode() !== "read"

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -369,18 +369,26 @@ const firstRowOrNull = <T>(result: ResultSet): T | null => {
   return rows.length === 0 ? null : rows[0]!;
 };
 
-/** Run a read on the primary when its cache refill requires read-your-writes. */
-const executeRead = async (...[sql, args]: SqlArgs): Promise<ResultSet> => {
-  if (!mustReadFromPrimary() || primaryReadMode() === "read") {
-    return execute(sql, args);
-  }
-  const [result] = await queryBatchPrimary([{ args: args ?? [], sql }]);
-  return result!;
+/**
+ * Query all rows of one statement on the primary, for a caller that must read
+ * its own writes — a plain {@link queryAll} can be served by a lagging replica
+ * and miss them. See {@link queryBatchPrimary}. `args` is required: a read-back
+ * always keys on the rows the write just put there.
+ */
+export const queryAllPrimary = async <T>(
+  sql: string,
+  args: InValue[],
+): Promise<T[]> => {
+  const [result] = await queryBatchPrimary([{ args, sql }]);
+  return resultRows<T>(result!);
 };
 
-/** Query all rows, returning a typed array. */
+/** Query all rows, returning a typed array. A read whose cache refill requires
+ *  read-your-writes goes to the primary instead. */
 export const queryAll = async <T>(...[sql, args]: SqlArgs): Promise<T[]> =>
-  resultRows<T>(await executeRead(sql, args));
+  mustReadFromPrimary() && primaryReadMode() !== "read"
+    ? queryAllPrimary<T>(sql, args ?? [])
+    : resultRows<T>(await execute(sql, args));
 
 /** Query one row, or null when the query returns none. */
 export const queryOne = async <T>(...[sql, args]: SqlArgs): Promise<T | null> =>
@@ -402,19 +410,12 @@ const requireQueryRow = async <T>(
 export const requireOne = <T>(...[sql, args]: SqlArgs): Promise<T> =>
   requireQueryRow(queryOne<T>(sql, args), sql, "Required");
 
-/**
- * Query an optional row on the primary, for reading a row back immediately after
- * committing its own write — a plain {@link queryOne} can be served by a lagging
- * replica and miss it. See {@link queryBatchPrimary}. `args` is required, every
- * read-back keying on the written row's id.
- */
+/** Query an optional row on the primary — the singular of
+ *  {@link queryAllPrimary}, as {@link queryOne} is of {@link queryAll}. */
 export const queryOnePrimary = async <T>(
   sql: string,
   args: InValue[],
-): Promise<T | null> => {
-  const [result] = await queryBatchPrimary([{ args, sql }]);
-  return firstRowOrNull<T>(result!);
-};
+): Promise<T | null> => (await queryAllPrimary<T>(sql, args))[0] ?? null;
 
 /** Query one required row from the primary. */
 export const requireOnePrimary = <T>(...[sql, args]: SqlWithArgs): Promise<T> =>
@@ -552,8 +553,13 @@ export const executeBatchWithoutCacheInvalidation = async (
   await runBatch(statements, "write", false, false);
 };
 
-/** A read/write batch with a fixed mode, or one chosen when it runs. */
-type BatchExecutor = (statements: SqlStatement[]) => Promise<ResultSet[]>;
+/** Runs several statements as one batch and answers each in turn: the shape
+ *  {@link queryBatch} and {@link executeBatchWithResults} have, and the one
+ *  {@link TxScope}'s `batch` fits. A caller that reads either from the client
+ *  or through an open transaction takes one of these instead of naming both. */
+export type BatchExecutor = (
+  statements: SqlStatement[],
+) => Promise<ResultSet[]>;
 
 /** What makes a read batch safe to retry: a write smuggled into one is rejected
  *  loudly here, so every statement really is a side-effect-free SELECT. */

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -21,8 +21,8 @@ import {
   executeBatch,
   inPlaceholders,
   queryAll,
-  queryBatchPrimary,
   queryIdColumn,
+  queryOnePrimary,
   type TxScope,
 } from "#db/client.ts";
 import { requireTouchingRelationshipsTx } from "#db/listing-parents.ts";
@@ -401,12 +401,9 @@ export const syncListingPricesForIds = async (
  * lagging replica. A missing listing is a no-op. Day-count rows are written from
  * input by the write paths, not re-derived here. */
 export const syncListingPrices = async (listingId: number): Promise<void> => {
-  const [result] = await queryBatchPrimary([
-    {
-      args: [listingId],
-      sql: "SELECT id, unit_price FROM listings WHERE id = ?",
-    },
-  ]);
-  const row = (result?.rows as unknown as ListingPriceSourceRow[])[0];
+  const row = await queryOnePrimary<ListingPriceSourceRow>(
+    "SELECT id, unit_price FROM listings WHERE id = ?",
+    [listingId],
+  );
   if (row) await executeBatch(sourceRowStatements(row));
 };

--- a/src/shared/db/migrations/2026-07-28_note_entities.ts
+++ b/src/shared/db/migrations/2026-07-28_note_entities.ts
@@ -1,4 +1,4 @@
-import { queryBatchPrimary } from "#db/client.ts";
+import { queryAllPrimary } from "#db/client.ts";
 import { errorMessage } from "#shared/error-message.ts";
 import { bareSchemaMigration } from "./define.ts";
 
@@ -63,10 +63,11 @@ export default bareSchemaMigration(
   "2026-07-28_note_entities",
   "Replace system_notes.attendee_id with entity_type + entity_id, so notes can be about any record and not only an attendee. Existing notes become notes about an attendee",
   async ({ getDb, recreateTable, syncIndexes }) => {
-    const [info] = await queryBatchPrimary([
-      { args: [], sql: "SELECT name FROM pragma_table_info('system_notes')" },
-    ]);
-    const columns = new Set(info!.rows.map((row) => String(row.name)));
+    const info = await queryAllPrimary<{ name: string }>(
+      "SELECT name FROM pragma_table_info('system_notes')",
+      [],
+    );
+    const columns = new Set(info.map((row) => row.name));
     if (!columns.has("attendee_id")) {
       // The columns are already moved, but a run that died right after the
       // rebuild never reached the index. Asking for it again is cheap.

--- a/src/shared/db/migrations/2026-07-28_note_entities.ts
+++ b/src/shared/db/migrations/2026-07-28_note_entities.ts
@@ -63,10 +63,10 @@ export default bareSchemaMigration(
   "2026-07-28_note_entities",
   "Replace system_notes.attendee_id with entity_type + entity_id, so notes can be about any record and not only an attendee. Existing notes become notes about an attendee",
   async ({ getDb, recreateTable, syncIndexes }) => {
-    const info = await queryAllPrimary<{ name: string }>(
-      "SELECT name FROM pragma_table_info('system_notes')",
-      [],
-    );
+    const info = await queryAllPrimary<{ name: string }>({
+      args: [],
+      sql: "SELECT name FROM pragma_table_info('system_notes')",
+    });
     const columns = new Set(info.map((row) => row.name));
     if (!columns.has("attendee_id")) {
       // The columns are already moved, but a run that died right after the

--- a/src/shared/db/migrations/2026-08-10_refund_authority_records.ts
+++ b/src/shared/db/migrations/2026-08-10_refund_authority_records.ts
@@ -25,11 +25,12 @@ const tableSlots = DORMANT_PAYMENT_TABLES.map(() => "?").join(", ");
 
 /** How many rows each dormant table that still exists is holding. */
 const storedRowCounts = async (): Promise<Map<string, number>> => {
-  const present = await queryAllPrimary<{ name: string }>(
-    "SELECT name FROM sqlite_master " +
+  const present = await queryAllPrimary<{ name: string }>({
+    args: [...DORMANT_PAYMENT_TABLES],
+    sql:
+      "SELECT name FROM sqlite_master " +
       `WHERE type = 'table' AND name IN (${tableSlots})`,
-    [...DORMANT_PAYMENT_TABLES],
-  );
+  });
   const names = present.map((row) => row.name);
   if (names.length === 0) return new Map();
   const counts = await queryBatchPrimary(

--- a/src/shared/db/migrations/2026-08-10_refund_authority_records.ts
+++ b/src/shared/db/migrations/2026-08-10_refund_authority_records.ts
@@ -1,4 +1,8 @@
-import { executeBatch, queryBatchPrimary } from "#db/client.ts";
+import {
+  executeBatch,
+  queryAllPrimary,
+  queryBatchPrimary,
+} from "#db/client.ts";
 import { noArgStatements } from "./schema-sync.ts";
 import type { MigrationBuilder } from "./types.ts";
 
@@ -21,15 +25,12 @@ const tableSlots = DORMANT_PAYMENT_TABLES.map(() => "?").join(", ");
 
 /** How many rows each dormant table that still exists is holding. */
 const storedRowCounts = async (): Promise<Map<string, number>> => {
-  const [present] = await queryBatchPrimary([
-    {
-      args: [...DORMANT_PAYMENT_TABLES],
-      sql:
-        "SELECT name FROM sqlite_master " +
-        `WHERE type = 'table' AND name IN (${tableSlots})`,
-    },
-  ]);
-  const names = present!.rows.map((row) => String(row.name));
+  const present = await queryAllPrimary<{ name: string }>(
+    "SELECT name FROM sqlite_master " +
+      `WHERE type = 'table' AND name IN (${tableSlots})`,
+    [...DORMANT_PAYMENT_TABLES],
+  );
+  const names = present.map((row) => row.name);
   if (names.length === 0) return new Map();
   const counts = await queryBatchPrimary(
     names.map((name) => ({

--- a/src/shared/db/payment-admit-move.ts
+++ b/src/shared/db/payment-admit-move.ts
@@ -96,10 +96,10 @@ const readPaymentMoveSnapshot = (
  * primary. The rows contain no attendee PII and are bounded by attendee id. */
 export const loadPaymentMoveSnapshot = async (
   attendeeIds: readonly number[],
-): Promise<PaymentMoveSnapshot> => {
-  const { args, sql } = moveWorkStatement(attendeeIds);
-  return moveSnapshot(await queryAllPrimary<StoredMoveWork>(sql, args));
-};
+): Promise<PaymentMoveSnapshot> =>
+  moveSnapshot(
+    await queryAllPrimary<StoredMoveWork>(moveWorkStatement(attendeeIds)),
+  );
 
 /** Raised when payment rows are in the middle of work the operator has to
  *  settle first. The message is written for whoever asked for the merge or the

--- a/src/shared/db/payment-admit-move.ts
+++ b/src/shared/db/payment-admit-move.ts
@@ -8,7 +8,7 @@
 
 import {
   inPlaceholders,
-  queryBatchPrimary,
+  queryAllPrimary,
   resultRows,
   type SqlStatement,
   type TxScope,
@@ -27,7 +27,6 @@ import {
   type RefundAuthorityState,
   readRefundAuthorityState,
 } from "#payment/refund-authority-state.ts";
-import { requireValue } from "#shared/required-value.ts";
 
 interface StoredMoveWork {
   readonly protected_state: string;
@@ -98,12 +97,8 @@ const readPaymentMoveSnapshot = (
 export const loadPaymentMoveSnapshot = async (
   attendeeIds: readonly number[],
 ): Promise<PaymentMoveSnapshot> => {
-  const [read] = await queryBatchPrimary([moveWorkStatement(attendeeIds)]);
-  return moveSnapshot(
-    resultRows<StoredMoveWork>(
-      requireValue(read, "Payment move snapshot returned no result"),
-    ),
-  );
+  const { args, sql } = moveWorkStatement(attendeeIds);
+  return moveSnapshot(await queryAllPrimary<StoredMoveWork>(sql, args));
 };
 
 /** Raised when payment rows are in the middle of work the operator has to

--- a/src/shared/db/payment-admit-move.ts
+++ b/src/shared/db/payment-admit-move.ts
@@ -27,6 +27,7 @@ import {
   type RefundAuthorityState,
   readRefundAuthorityState,
 } from "#payment/refund-authority-state.ts";
+import { namedError } from "#shared/named-error.ts";
 
 interface StoredMoveWork {
   readonly protected_state: string;
@@ -104,12 +105,7 @@ export const loadPaymentMoveSnapshot = async (
 /** Raised when payment rows are in the middle of work the operator has to
  *  settle first. The message is written for whoever asked for the merge or the
  *  delete, so it can be shown as-is. */
-export class PaymentRowsBusyError extends Error {
-  constructor(refusal: string) {
-    super(refusal);
-    this.name = "PaymentRowsBusyError";
-  }
-}
+export class PaymentRowsBusyError extends namedError("PaymentRowsBusyError") {}
 
 /** Stop the caller's transaction unless every one of these attendees' payment
  *  rows is free to move. Throwing rather than answering means a caller that

--- a/src/shared/db/payment-anchor/held-work.ts
+++ b/src/shared/db/payment-anchor/held-work.ts
@@ -1,6 +1,6 @@
 /** Find the anchor rows a payment's money work could still be sitting on. */
 
-import { inPlaceholders, queryBatchPrimary, resultRows } from "#db/client.ts";
+import { inPlaceholders, queryAllPrimary } from "#db/client.ts";
 import {
   asPaymentRowRecord,
   type PaymentRowRecord,
@@ -28,16 +28,13 @@ export const loadAnchorRowWork = async (
   payment: TaggedPaymentReference,
 ): Promise<AnchorRowWork[]> => {
   const indexes = await matchingPaymentReferenceIndexes(payment);
-  const [read] = await queryBatchPrimary([
-    {
-      args: [...indexes],
-      sql: paymentClaimRowsSql(
-        `payment.payment_session_id LIKE 'legacy:%'
+  const rows = await queryAllPrimary<StoredPaymentClaimRow>(
+    paymentClaimRowsSql(
+      `payment.payment_session_id LIKE 'legacy:%'
            AND payment.payment_reference_index IN (${inPlaceholders(indexes)})`,
-      ),
-    },
-  ]);
-  const rows = resultRows<StoredPaymentClaimRow>(read!);
+    ),
+    [...indexes],
+  );
   return Promise.all(
     rows.map(async (row) => ({
       record: await asPaymentRowRecord(row),

--- a/src/shared/db/payment-anchor/held-work.ts
+++ b/src/shared/db/payment-anchor/held-work.ts
@@ -28,13 +28,13 @@ export const loadAnchorRowWork = async (
   payment: TaggedPaymentReference,
 ): Promise<AnchorRowWork[]> => {
   const indexes = await matchingPaymentReferenceIndexes(payment);
-  const rows = await queryAllPrimary<StoredPaymentClaimRow>(
-    paymentClaimRowsSql(
+  const rows = await queryAllPrimary<StoredPaymentClaimRow>({
+    args: [...indexes],
+    sql: paymentClaimRowsSql(
       `payment.payment_session_id LIKE 'legacy:%'
            AND payment.payment_reference_index IN (${inPlaceholders(indexes)})`,
     ),
-    [...indexes],
-  );
+  });
   return Promise.all(
     rows.map(async (row) => ({
       record: await asPaymentRowRecord(row),

--- a/src/shared/db/payment-claim.ts
+++ b/src/shared/db/payment-claim.ts
@@ -10,7 +10,7 @@ import type { EnvKeyEncrypted } from "#crypto/sealed.ts";
 import {
   executeBatch,
   inPlaceholders,
-  queryBatchPrimary,
+  queryAllPrimary,
   resultRows,
   type SqlStatement,
   type TxScope,
@@ -129,17 +129,13 @@ export const readAttendeeRowStates = async (
 /** Read payment-row work from the primary without opening a write transaction. */
 export const loadAttendeeRowStates = async (
   attendeeIds: readonly number[],
-): Promise<PaymentRowRecord[]> => {
-  const [read] = await queryBatchPrimary([
-    {
-      args: [...attendeeIds],
-      sql: paymentClaimRowsSql(
-        `attendee_id IN (${inPlaceholders(attendeeIds)})`,
-      ),
-    },
-  ]);
-  return asPaymentRowRecords(resultRows<StoredPaymentClaimRow>(read!));
-};
+): Promise<PaymentRowRecord[]> =>
+  asPaymentRowRecords(
+    await queryAllPrimary<StoredPaymentClaimRow>(
+      paymentClaimRowsSql(`attendee_id IN (${inPlaceholders(attendeeIds)})`),
+      [...attendeeIds],
+    ),
+  );
 
 /** Fail when a confirmer no longer owns every payment row it started with. */
 export const assertRefundRowsHeld = async (
@@ -238,17 +234,13 @@ const rewriteRows = async (
   // write depends on it, and each write is conditioned on the exact record it
   // read. Pinned to the primary because a caller may be reading its own claim
   // — a lagging replica would match no write and leave the claim standing.
-  const [read] = await queryBatchPrimary([
-    {
-      args: [...sessionIds],
-      sql: paymentClaimRowsSql(
-        `payment_session_id IN (${inPlaceholders(sessionIds)})`,
-      ),
-    },
-  ]);
-  const rows = await asPaymentRowRecords(
-    resultRows<StoredPaymentClaimRow>(read!),
+  const stored = await queryAllPrimary<StoredPaymentClaimRow>(
+    paymentClaimRowsSql(
+      `payment_session_id IN (${inPlaceholders(sessionIds)})`,
+    ),
+    [...sessionIds],
   );
+  const rows = await asPaymentRowRecords(stored);
   const writes = await Promise.all(
     mapNotNullish((row: PaymentRowRecord) => {
       const state = next(row);

--- a/src/shared/db/payment-claim.ts
+++ b/src/shared/db/payment-claim.ts
@@ -131,10 +131,12 @@ export const loadAttendeeRowStates = async (
   attendeeIds: readonly number[],
 ): Promise<PaymentRowRecord[]> =>
   asPaymentRowRecords(
-    await queryAllPrimary<StoredPaymentClaimRow>(
-      paymentClaimRowsSql(`attendee_id IN (${inPlaceholders(attendeeIds)})`),
-      [...attendeeIds],
-    ),
+    await queryAllPrimary<StoredPaymentClaimRow>({
+      args: [...attendeeIds],
+      sql: paymentClaimRowsSql(
+        `attendee_id IN (${inPlaceholders(attendeeIds)})`,
+      ),
+    }),
   );
 
 /** Fail when a confirmer no longer owns every payment row it started with. */
@@ -234,12 +236,12 @@ const rewriteRows = async (
   // write depends on it, and each write is conditioned on the exact record it
   // read. Pinned to the primary because a caller may be reading its own claim
   // — a lagging replica would match no write and leave the claim standing.
-  const stored = await queryAllPrimary<StoredPaymentClaimRow>(
-    paymentClaimRowsSql(
+  const stored = await queryAllPrimary<StoredPaymentClaimRow>({
+    args: [...sessionIds],
+    sql: paymentClaimRowsSql(
       `payment_session_id IN (${inPlaceholders(sessionIds)})`,
     ),
-    [...sessionIds],
-  );
+  });
   const rows = await asPaymentRowRecords(stored);
   const writes = await Promise.all(
     mapNotNullish((row: PaymentRowRecord) => {

--- a/src/shared/db/processed-payments.ts
+++ b/src/shared/db/processed-payments.ts
@@ -16,7 +16,7 @@ import type { EnvKeyEncrypted, OwnerKeyEncrypted } from "#crypto/sealed.ts";
 import {
   execute,
   executeBatchWithResults,
-  queryBatchPrimary,
+  queryOnePrimary,
   resultRows,
   type SqlStatement,
   withTransaction,
@@ -261,14 +261,11 @@ export const prepareSessionFailure = async (
 const readStoredOutcome = async (
   sessionId: string,
 ): Promise<EnvKeyEncrypted | "" | null> => {
-  const [read] = await queryBatchPrimary([
-    {
-      args: [sessionId],
-      sql: "SELECT failure_data FROM processed_payments WHERE payment_session_id = ? AND attendee_id IS NULL",
-    },
-  ]);
-  const row = resultRows<{ failure_data: EnvKeyEncrypted | "" }>(read!)[0];
-  return row === undefined ? null : row.failure_data;
+  const row = await queryOnePrimary<{ failure_data: EnvKeyEncrypted | "" }>(
+    "SELECT failure_data FROM processed_payments WHERE payment_session_id = ? AND attendee_id IS NULL",
+    [sessionId],
+  );
+  return row === null ? null : row.failure_data;
 };
 
 const unexpectedOutcomeMove = (sessionId: string): Error =>

--- a/src/shared/db/refund-all-candidates.ts
+++ b/src/shared/db/refund-all-candidates.ts
@@ -240,10 +240,10 @@ const answered = <Row>(result: ResultSet | undefined, what: string): Row[] =>
 /** Count the complete refundable set and report its visible send blockers. */
 export const getRefundAllSummary = async (
   listingId: number,
-): Promise<RefundAllSummary> => {
-  const { args, sql } = summaryStatement(listingId);
-  return readSummary(await queryAllPrimary<RefundAllSummaryRow>(sql, args));
-};
+): Promise<RefundAllSummary> =>
+  readSummary(
+    await queryAllPrimary<RefundAllSummaryRow>(summaryStatement(listingId)),
+  );
 
 /** Check complete safety facts and select only one claim-first candidate batch. */
 export const loadRefundAllBatch = async (

--- a/src/shared/db/refund-all-candidates.ts
+++ b/src/shared/db/refund-all-candidates.ts
@@ -12,6 +12,7 @@ import type { OwnerKeyEncrypted } from "#crypto/sealed.ts";
 import { ATTENDEE_KIND } from "#db/attendees/kind.ts";
 import { refundedForBooking } from "#db/attendees/select.ts";
 import {
+  queryAllPrimary,
   queryBatchPrimary,
   resultRows,
   type SqlStatement,
@@ -206,11 +207,8 @@ const batchStatement = (listingId: number): SqlStatement => ({
      ORDER BY selectedAttendee.has_claim DESC, selectedAttendee.id ASC`,
 });
 
-const readSummary = (result: ResultSet): RefundAllSummary => {
-  const row = requireValue(
-    resultRows<RefundAllSummaryRow>(result)[0],
-    "Refund All admission returned no summary",
-  );
+const readSummary = (rows: RefundAllSummaryRow[]): RefundAllSummary => {
+  const row = requireValue(rows[0], "Refund All admission returned no summary");
   const blockedBy = row.unrecorded_money
     ? "unrecorded_money"
     : row.provider_refund
@@ -223,22 +221,28 @@ const readSummary = (result: ResultSet): RefundAllSummary => {
   return { blockedBy, total: Number(row.total) };
 };
 
-const readAttendees = (result: ResultSet): RefundAllCandidateAttendee[] =>
-  resultRows<RefundAllCandidateRow>(result).map((row) => ({
+const readAttendees = (
+  rows: RefundAllCandidateRow[],
+): RefundAllCandidateAttendee[] =>
+  rows.map((row) => ({
     id: Number(row.id),
     pii_blob: row.pii_blob,
     quantity: 1,
     refunded: Boolean(row.refunded),
   }));
 
+/** The rows of one statement the admission batch answered. */
+const answered = <Row>(result: ResultSet | undefined, what: string): Row[] =>
+  resultRows<Row>(
+    requireValue(result, `Refund All admission returned no ${what} result`),
+  );
+
 /** Count the complete refundable set and report its visible send blockers. */
 export const getRefundAllSummary = async (
   listingId: number,
 ): Promise<RefundAllSummary> => {
-  const [summary] = await queryBatchPrimary([summaryStatement(listingId)]);
-  return readSummary(
-    requireValue(summary, "Refund All admission returned no result"),
-  );
+  const { args, sql } = summaryStatement(listingId);
+  return readSummary(await queryAllPrimary<RefundAllSummaryRow>(sql, args));
 };
 
 /** Check complete safety facts and select only one claim-first candidate batch. */
@@ -250,11 +254,9 @@ export const loadRefundAllBatch = async (
     batchStatement(listingId),
   ]);
   return {
-    ...readSummary(
-      requireValue(summary, "Refund All admission returned no summary result"),
-    ),
+    ...readSummary(answered<RefundAllSummaryRow>(summary, "summary")),
     attendees: readAttendees(
-      requireValue(attendees, "Refund All admission returned no batch result"),
+      answered<RefundAllCandidateRow>(attendees, "batch"),
     ),
   };
 };

--- a/test/shared/accounting/manual-entries.test.ts
+++ b/test/shared/accounting/manual-entries.test.ts
@@ -11,6 +11,7 @@ import {
   MANUAL_MODIFIER_INCOME,
   MANUAL_MODIFIER_REDUCTION,
   type ManualLedgerEntryType,
+  ManualLedgerEntryTypeSchema,
   manualEntrySpecByType,
   manualLedgerEntryOptionsFor,
   postManualLedgerEntry,
@@ -171,6 +172,22 @@ describe("db > accounting > manual ledger entries", () => {
     ];
     expect(stored!.eventGroup).toBe(await eventGroup(parts));
     expect(stored!.reference).toBe(await legReference([...parts, "transfer"]));
+  });
+
+  test("keeps the stored word for every entry type, in the order shown", () => {
+    // Each word is written into transfers.kind and finds that row again, so a
+    // changed word orphans every entry a site already stored. The literals are
+    // the point: the constants would move with the change and hide it. The
+    // order is what the owner sees in the add-entry menu.
+    expect(ManualLedgerEntryTypeSchema.options).toEqual([
+      "manual_attendee_payment",
+      "manual_attendee_charge",
+      "manual_attendee_writeoff",
+      "manual_listing_income",
+      "manual_listing_cost",
+      "manual_modifier_income",
+      "manual_modifier_reduction",
+    ]);
   });
 
   test("every entry type's user-facing keys have translations", () => {

--- a/test/shared/accounting/manual-entries.test.ts
+++ b/test/shared/accounting/manual-entries.test.ts
@@ -22,6 +22,7 @@ import { postTransfers } from "#accounting/store.ts";
 import { t } from "#i18n";
 import { account } from "#shared/ledger/account.ts";
 import type { AccountRef, Transfer } from "#shared/ledger/types.ts";
+import { humanAmount } from "#templates/admin/ledger/formatting.tsx";
 import { tx, useTransactionalDb } from "#test-utils/ledger.ts";
 
 const world = account("external", "world");
@@ -30,79 +31,117 @@ const writeoff = account("writeoff", "default");
 type ManualEntryCase = {
   type: ManualLedgerEntryType;
   account: AccountRef;
+  amount: number;
   source: AccountRef;
   destination: AccountRef;
+};
+
+const attendee = account("attendee", 1);
+const revenue = account("revenue", 2);
+const modifier = account("modifier", 3);
+
+/** Every entry type once, each with the legs it must post and its own amount,
+ *  so a row read back by kind cannot be another row wearing the same figure. */
+const ENTRY_CASES: ManualEntryCase[] = [
+  {
+    account: attendee,
+    amount: 100,
+    destination: attendee,
+    source: world,
+    type: MANUAL_ATTENDEE_PAYMENT,
+  },
+  {
+    account: attendee,
+    amount: 101,
+    destination: writeoff,
+    source: attendee,
+    type: MANUAL_ATTENDEE_CHARGE,
+  },
+  {
+    account: attendee,
+    amount: 102,
+    destination: attendee,
+    source: writeoff,
+    type: MANUAL_ATTENDEE_WRITEOFF,
+  },
+  {
+    account: revenue,
+    amount: 103,
+    destination: revenue,
+    source: world,
+    type: MANUAL_LISTING_INCOME,
+  },
+  {
+    account: revenue,
+    amount: 104,
+    destination: world,
+    source: revenue,
+    type: MANUAL_LISTING_COST,
+  },
+  {
+    account: modifier,
+    amount: 105,
+    destination: modifier,
+    source: writeoff,
+    type: MANUAL_MODIFIER_INCOME,
+  },
+  {
+    account: modifier,
+    amount: 106,
+    destination: writeoff,
+    source: modifier,
+    type: MANUAL_MODIFIER_REDUCTION,
+  },
+];
+
+/** The entry types an operator reads as money given back, so the ledger shows
+ *  the amount as a reduction. Nothing in the legs says which these are: an
+ *  attendee writeoff and an option income both put money into their account. */
+const GIVES_MONEY_BACK = new Set<ManualLedgerEntryType>([
+  MANUAL_ATTENDEE_WRITEOFF,
+  MANUAL_LISTING_COST,
+  MANUAL_MODIFIER_REDUCTION,
+]);
+
+/** Post one entry of every type and read back what each one stored. */
+const postEveryEntryType = async (): Promise<Map<string, Transfer>> => {
+  for (const entry of ENTRY_CASES) {
+    await postManualLedgerEntry({
+      account: entry.account,
+      amount: entry.amount,
+      occurredAt: "2026-06-22T09:30:00.000Z",
+      postedBy: "1",
+      type: entry.type,
+    });
+  }
+  const stored = await allTransfers();
+  return new Map(stored.map((transfer) => [transfer.kind ?? "", transfer]));
 };
 
 describe("db > accounting > manual ledger entries", () => {
   useTransactionalDb();
 
   test("posts each owner-entered entry type to the expected ledger legs", async () => {
-    const attendee = account("attendee", 1);
-    const revenue = account("revenue", 2);
-    const modifier = account("modifier", 3);
-    const cases: ManualEntryCase[] = [
-      {
-        account: attendee,
-        destination: attendee,
-        source: world,
-        type: MANUAL_ATTENDEE_PAYMENT,
-      },
-      {
-        account: attendee,
-        destination: writeoff,
-        source: attendee,
-        type: MANUAL_ATTENDEE_CHARGE,
-      },
-      {
-        account: attendee,
-        destination: attendee,
-        source: writeoff,
-        type: MANUAL_ATTENDEE_WRITEOFF,
-      },
-      {
-        account: revenue,
-        destination: revenue,
-        source: world,
-        type: MANUAL_LISTING_INCOME,
-      },
-      {
-        account: revenue,
-        destination: world,
-        source: revenue,
-        type: MANUAL_LISTING_COST,
-      },
-      {
-        account: modifier,
-        destination: modifier,
-        source: writeoff,
-        type: MANUAL_MODIFIER_INCOME,
-      },
-      {
-        account: modifier,
-        destination: writeoff,
-        source: modifier,
-        type: MANUAL_MODIFIER_REDUCTION,
-      },
-    ];
+    const rows = await postEveryEntryType();
 
-    for (const [index, entry] of cases.entries()) {
-      await postManualLedgerEntry({
-        account: entry.account,
-        amount: 100 + index,
-        occurredAt: "2026-06-22T09:30:00.000Z",
-        postedBy: "1",
-        type: entry.type,
-      });
+    for (const entry of ENTRY_CASES) {
+      expect(rows.get(entry.type)?.amount).toBe(entry.amount);
+      expect(rows.get(entry.type)?.source).toEqual(entry.source);
+      expect(rows.get(entry.type)?.destination).toEqual(entry.destination);
     }
+  });
 
-    const rowsByKind = Object.fromEntries(
-      (await allTransfers()).map((transfer) => [transfer.kind, transfer]),
-    );
-    for (const [index, entry] of cases.entries()) {
-      expect(rowsByKind[entry.type]?.amount).toBe(100 + index);
-      expect(rowsByKind[entry.type]?.source).toEqual(entry.source);
-      expect(rowsByKind[entry.type]?.destination).toEqual(entry.destination);
+  test("shows an entry that gives money back as a reduction on the ledger", async () => {
+    const rows = await postEveryEntryType();
+
+    // humanAmount is the figure the operator reads on the row, so a writeoff,
+    // a cost, and an option reduction must all come back below zero.
+    for (const entry of ENTRY_CASES) {
+      const stored = rows.get(entry.type);
+      expect(stored).toBeDefined();
+      expect(humanAmount(stored!)).toBe(
+        GIVES_MONEY_BACK.has(entry.type) ? -entry.amount : entry.amount,
+      );
     }
   });
 

--- a/test/shared/accounting/rows.test.ts
+++ b/test/shared/accounting/rows.test.ts
@@ -2,17 +2,16 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   bookingLegBatchInsert,
-  fromDb,
-  fromTx,
   insertStatement,
-  type RowReader,
   selectByEventGroup,
   selectById,
   selectTransfers,
   selectTransfersMany,
 } from "#accounting/rows.ts";
 import {
+  type BatchExecutor,
   executeBatch,
+  queryBatch,
   queryOne,
   type SqlStatement,
   type TxScope,
@@ -21,6 +20,7 @@ import {
 import { inList } from "#db/where-clauses.ts";
 import { account } from "#shared/ledger/account.ts";
 import type { TransferInput } from "#shared/ledger/types.ts";
+import { emptyResultSet } from "#test-utils/db-helpers/result-set.ts";
 import { useTransactionalDb } from "#test-utils/ledger.ts";
 
 /** The value bound to `column` in a built INSERT, by pairing the SQL's leading
@@ -100,12 +100,12 @@ describe("accounting > rows > bookingLegBatchInsert", () => {
 /** A reader that answers nothing but remembers what it was handed. */
 const recordingReader = (): {
   asked: SqlStatement[][];
-  reader: RowReader;
+  reader: BatchExecutor;
 } => {
   const asked: SqlStatement[][] = [];
-  const reader: RowReader = (statements) => {
+  const reader: BatchExecutor = (statements) => {
     asked.push([...statements]);
-    return Promise.resolve(statements.map(() => []));
+    return Promise.resolve(statements.map(() => emptyResultSet()));
   };
   return { asked, reader };
 };
@@ -146,7 +146,7 @@ describe("accounting > rows > selectTransfersMany", () => {
   test("gives each set of rows back to the query that asked for it", async () => {
     await storeTwoLegs();
 
-    const [byGroup, byReference] = await selectTransfersMany(fromDb, [
+    const [byGroup, byReference] = await selectTransfersMany(queryBatch, [
       { where: inList("event_group", ["evt-b"]) },
       { where: inList("reference", ["ref-a"]) },
     ]);
@@ -198,7 +198,7 @@ describe("accounting > rows > selectTransfersMany", () => {
           return scope.execute(statement);
         },
       };
-      return selectTransfersMany(fromTx(counted), [
+      return selectTransfersMany(counted.batch, [
         { where: inList("event_group", ["evt-a"]) },
         { where: inList("reference", ["ref-b"]) },
       ]);
@@ -219,7 +219,7 @@ describe("accounting > rows > readers for one event and one row", () => {
   test("selectByEventGroup reads that event's legs and not its neighbour's", async () => {
     await storeTwoLegs();
 
-    const legs = await selectByEventGroup(fromDb, "evt-a");
+    const legs = await selectByEventGroup(queryBatch, "evt-a");
 
     expect(legs.map((row) => row.reference)).toEqual(["ref-a"]);
   });
@@ -228,7 +228,7 @@ describe("accounting > rows > readers for one event and one row", () => {
     await storeTwoLegs();
     const id = await storedIdFor("ref-b");
 
-    const found = await selectById(fromDb, id);
+    const found = await selectById(queryBatch, id);
 
     expect(found?.id).toBe(id);
     expect(found?.reference).toBe("ref-b");
@@ -237,7 +237,7 @@ describe("accounting > rows > readers for one event and one row", () => {
   test("selectById answers null when no transfer has that id", async () => {
     await storeTwoLegs();
 
-    expect(await selectById(fromDb, 999_999)).toBeNull();
+    expect(await selectById(queryBatch, 999_999)).toBeNull();
   });
 });
 
@@ -270,7 +270,7 @@ describe("accounting > rows > stored-row round-trip", () => {
       insertStatement(voiding, recordedAt),
     ]);
 
-    const all = await selectTransfers(fromDb, { order: "id" });
+    const all = await selectTransfers(queryBatch, { order: "id" });
     expect(all.length).toBe(2);
     const [first, second] = all;
 
@@ -299,7 +299,7 @@ describe("accounting > rows > stored-row round-trip", () => {
       source: account("attendee", 3),
     };
     await executeBatch([insertStatement(kindless, recordedAt)]);
-    const [stored] = await selectTransfers(fromDb);
+    const [stored] = await selectTransfers(queryBatch);
     // Omitted, not "": a stored transfer and a never-stored input must agree
     // on what "no kind" looks like (mirroring reverses_id).
     expect(stored!.kind).toBeUndefined();
@@ -317,7 +317,7 @@ describe("accounting > rows > stored-row round-trip", () => {
     };
     await executeBatch([insertStatement(memoless, recordedAt)]);
 
-    const [stored] = await selectTransfers(fromDb);
+    const [stored] = await selectTransfers(queryBatch);
 
     // Unlike kind, memo keeps its "" — so the absence must be stored as empty
     // rather than as any filler a reader would later show to an operator.

--- a/test/shared/db/client.test.ts
+++ b/test/shared/db/client.test.ts
@@ -276,10 +276,10 @@ describeWithEnv("db > client", { db: true }, () => {
       "INSERT INTO settings (key, value) VALUES" +
         " ('query_all_primary_a', 'first'), ('query_all_primary_b', 'second')",
     );
-    const rows = await queryAllPrimary<{ value: string }>(
-      "SELECT value FROM settings WHERE key LIKE ? ORDER BY key",
-      ["query_all_primary_%"],
-    );
+    const rows = await queryAllPrimary<{ value: string }>({
+      args: ["query_all_primary_%"],
+      sql: "SELECT value FROM settings WHERE key LIKE ? ORDER BY key",
+    });
     // Every match in order: a plural that answered with the first row alone
     // would be the singular wearing the wrong name.
     expect(rows.map(({ value }) => value)).toEqual(["first", "second"]);

--- a/test/shared/db/client.test.ts
+++ b/test/shared/db/client.test.ts
@@ -206,13 +206,25 @@ describeWithEnv("db > client", { db: true }, () => {
     expect(client1).toBe(client2);
   });
 
-  test("primary read scopes use remote write mode and local read mode", async () => {
+  /** The transaction modes the client is asked for while `read` runs. An empty
+   *  list means the read never went out as a batch at all. */
+  const batchModesWhile = async <T>(
+    read: () => Promise<T>,
+  ): Promise<{ modes: unknown[]; result: T }> => {
     const modes: unknown[] = [];
     const batchStub = stub(getDb(), "batch", (_statements, mode) => {
       modes.push(mode);
       return Promise.resolve([emptyResultSet()]);
     });
     try {
+      return { modes, result: await read() };
+    } finally {
+      batchStub.restore();
+    }
+  };
+
+  test("primary read scopes use remote write mode and local read mode", async () => {
+    const { modes, result } = await batchModesWhile(async () => {
       await queryBatch([{ args: [], sql: "SELECT 1" }]);
       {
         using _env = withEnv({ DB_URL: "libsql://primary.test" });
@@ -221,14 +233,23 @@ describeWithEnv("db > client", { db: true }, () => {
           queryBatch([{ args: [], sql: "SELECT 1" }]),
         );
       }
-      const localRows = await runWithPrimaryReads(() =>
+      return await runWithPrimaryReads(() =>
         queryAll<{ one: number }>("SELECT 1 AS one"),
       );
-      expect(localRows).toEqual([{ one: 1 }]);
-      expect(modes).toEqual(["read", "write", "write"]);
-    } finally {
-      batchStub.restore();
-    }
+    });
+    expect(result).toEqual([{ one: 1 }]);
+    expect(modes).toEqual(["read", "write", "write"]);
+  });
+
+  test("a read outside a primary scope is left to a replica", async () => {
+    const { modes, result } = await batchModesWhile(async () => {
+      using _env = withEnv({ DB_URL: "libsql://primary.test" });
+      return await queryAll<{ one: number }>("SELECT 1 AS one");
+    });
+    // One plain statement, which any replica can answer. A batch here would
+    // pin every ordinary read to the primary and take its write-mode lock.
+    expect(result).toEqual([{ one: 1 }]);
+    expect(modes).toEqual([]);
   });
 
   test("queryOne returns null for an expected miss", async () => {

--- a/test/shared/db/client.test.ts
+++ b/test/shared/db/client.test.ts
@@ -14,6 +14,7 @@ import {
   insert,
   orIgnore,
   queryAll,
+  queryAllPrimary,
   queryBatch,
   queryOne,
   queryOnePrimary,
@@ -268,6 +269,20 @@ describeWithEnv("db > client", { db: true }, () => {
     );
     // Exactly one row must surface as that row (not null, not the next one).
     expect(row?.value).toBe("found");
+  });
+
+  test("queryAllPrimary returns every matching row from the primary", async () => {
+    await execute(
+      "INSERT INTO settings (key, value) VALUES" +
+        " ('query_all_primary_a', 'first'), ('query_all_primary_b', 'second')",
+    );
+    const rows = await queryAllPrimary<{ value: string }>(
+      "SELECT value FROM settings WHERE key LIKE ? ORDER BY key",
+      ["query_all_primary_%"],
+    );
+    // Every match in order: a plural that answered with the first row alone
+    // would be the singular wearing the wrong name.
+    expect(rows.map(({ value }) => value)).toEqual(["first", "second"]);
   });
 
   test("deleteByFieldStatement builds the DELETE for one table, field and value", () => {

--- a/test/shared/db/client/batch.test.ts
+++ b/test/shared/db/client/batch.test.ts
@@ -4,6 +4,7 @@ import { it as test } from "@std/testing/bdd";
 import { returnsNext, stub } from "@std/testing/mock";
 import {
   getDb,
+  queryAllPrimary,
   queryBatch,
   queryBatchPrimary,
   withTransaction,
@@ -100,6 +101,16 @@ describeWithEnv("db > client batch", { db: true }, () => {
     // "write" mode is the read-your-writes guarantee: Turso always serves it
     // from the primary, so a just-committed row is visible.
     expect(await captureBatchModes(queryBatchPrimary)).toEqual(["write"]);
+  });
+
+  test("queryAllPrimary pins its one statement to the primary", async () => {
+    // The plural of queryOnePrimary carries the same promise: read-your-writes,
+    // so it must never be answered by a replica that lags behind the write.
+    expect(
+      await captureBatchModes(([statement]) =>
+        queryAllPrimary(statement!.sql, statement!.args),
+      ),
+    ).toEqual(["write"]);
   });
 
   test("a :memory: database reads through in read mode even for primary reads", async () => {

--- a/test/shared/db/client/batch.test.ts
+++ b/test/shared/db/client/batch.test.ts
@@ -107,9 +107,7 @@ describeWithEnv("db > client batch", { db: true }, () => {
     // The plural of queryOnePrimary carries the same promise: read-your-writes,
     // so it must never be answered by a replica that lags behind the write.
     expect(
-      await captureBatchModes(([statement]) =>
-        queryAllPrimary(statement!.sql, statement!.args),
-      ),
+      await captureBatchModes(([statement]) => queryAllPrimary(statement!)),
     ).toEqual(["write"]);
   });
 

--- a/test/shared/db/migrations/2026-08-10_refund_authority_records.test.ts
+++ b/test/shared/db/migrations/2026-08-10_refund_authority_records.test.ts
@@ -8,6 +8,16 @@ import { buildMigrationContext } from "#test-utils/migrations.ts";
 
 const QUEUE_INDEX = "idx_processed_payments_protected_attendee";
 
+/** The dormant payment-record tables besides payment_charges, which the
+ *  one-table case drops so only the charge table is left to rebuild. */
+const OTHER_DORMANT_TABLES = [
+  "payment_sessions",
+  "payment_completion_effects",
+  "payment_completion_deliveries",
+  "payment_cases",
+  "payment_case_decisions",
+];
+
 const context = buildMigrationContext({ applySchemaChanges, syncIndexes });
 const migration = () => refundAuthorityRecords(context);
 
@@ -99,10 +109,27 @@ describeWithEnv(
       });
 
       await expect(migration().up()).rejects.toThrow(
-        "payment_charges is not empty",
+        "payment_charges is not empty; refusing to reinterpret stored payment " +
+          "history as refund-authority state",
       );
 
       await getDb().execute("DELETE FROM payment_charges");
+    });
+
+    test("rebuilds the last dormant table when it is the only one left", async () => {
+      // A part-upgraded site can be down to one dormant table. Counting its
+      // rows and dropping it must still happen, or the release keeps the old
+      // shape and the apply has nothing to rebuild from.
+      for (const table of OTHER_DORMANT_TABLES) {
+        await getDb().execute(`DROP TABLE IF EXISTS ${table}`);
+      }
+      await givenReleasedChargeTable();
+
+      await migration().up();
+
+      const columns = await columnsOf("payment_charges");
+      expect(columns.has("capability")).toBe(true);
+      expect(columns.has("legacy_source")).toBe(false);
     });
 
     test("gives the owner recovery queue its partial index", async () => {
@@ -147,6 +174,12 @@ describeWithEnv(
         ],
       });
       expect(migration().id).toBe("2026-08-10_refund_authority_records");
+      expect(migration().description).toBe(
+        "Build the durable refund authority: rebuild the dormant payment-record " +
+          "tables into their refund shape, record refund confirmations and named " +
+          "notes, mark which payment row proves an attendee's payment id, and " +
+          "index the owner recovery queue",
+      );
     });
   },
 );

--- a/test/shared/db/payment-admit-move.test.ts
+++ b/test/shared/db/payment-admit-move.test.ts
@@ -63,6 +63,16 @@ const addAuthorityFor = async (
   await addProviderRefundTestCase(reference, state, "stripe");
 };
 
+/** What a refused delete raised, or null when it went through. */
+const deleteFailure = async (attendeeId: number): Promise<unknown> => {
+  try {
+    await deleteAttendee(attendeeId);
+    return null;
+  } catch (error) {
+    return error;
+  }
+};
+
 /** What a refused delete says, or null when it went through. */
 const deleteRefusal = async (attendeeId: number): Promise<string | null> => {
   try {
@@ -120,6 +130,22 @@ describeWithEnv(
         work: { recoveryAction: "refresh-payment", status: "moving" },
       });
       expect(await deleteRefusal(attendeeId)).toBe(CLAIM_REFUSAL);
+    });
+
+    test("the refusal is raised as a named error, so a log can tell it apart", async () => {
+      const attendeeId = await bookedWithPayment("sess-named", "pi_named");
+      await putRowState(
+        "sess-named",
+        await freshClaimSlot(attendeeId),
+        CLAIM_MIRROR,
+      );
+
+      const raised = await deleteFailure(attendeeId);
+
+      // The name is what a log line and an error report show, so a busy row
+      // has to read as one rather than as a plain Error.
+      expect(raised).toBeInstanceOf(PaymentRowsBusyError);
+      expect((raised as Error).name).toBe("PaymentRowsBusyError");
     });
 
     test("the refused delete leaves the attendee and the payment where they were", async () => {

--- a/test/shared/db/payment-admit-move.test.ts
+++ b/test/shared/db/payment-admit-move.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { deleteAttendee } from "#db/attendees/delete.ts";
-import { queryOne, withTransaction } from "#db/client.ts";
+import { execute, queryOne, withTransaction } from "#db/client.ts";
 import {
   assertRowsFreeToMove,
   loadPaymentMoveSnapshot,
@@ -73,6 +73,19 @@ const deleteRefusal = async (attendeeId: number): Promise<string | null> => {
     return error.message;
   }
 };
+
+/** A charge row the table's own checks still accept, holding a record the
+ *  reader cannot make sense of. */
+const givenUnreadableRefundState = (): Promise<unknown> =>
+  execute(
+    `UPDATE payment_charges
+        SET refund_state = '{"kind":"ready","local":{"kind":"not_due"},` +
+      `"request":{"capability":"keyed"},"nextActionAt":10}',
+            refund_state_name = 'ready',
+            refund_local_state = 'not_due',
+            capability = 'keyed',
+            next_refund_action_at = 10`,
+  );
 
 const attendeeStillThere = async (attendeeId: number): Promise<boolean> =>
   (await queryOne<{ id: number }>("SELECT id FROM attendees WHERE id = ?", [
@@ -178,6 +191,21 @@ describeWithEnv(
           status: "needs_money_record",
         },
       });
+    });
+
+    test("names the column when a stored refund state will not read", async () => {
+      const attendeeId = await bookedWithPayment(
+        "sess-unreadable",
+        "pi_unread",
+      );
+      await addAuthorityFor("pi_unread", readyAuthority("request-unread"));
+      await givenUnreadableRefundState();
+
+      // The charge is corrupt, and the refusal has to say where it was read
+      // from, or the owner cannot find the row to repair.
+      await expect(snapshotFor(attendeeId)).rejects.toThrow(
+        "payment_charges.refund_state",
+      );
     });
 
     test("a payment that already ended does not hold the delete up", async () => {

--- a/test/shared/db/payment-claim.test.ts
+++ b/test/shared/db/payment-claim.test.ts
@@ -1,10 +1,13 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
+import { encrypt } from "#crypto/encryption.ts";
+import type { EnvKeyEncrypted } from "#crypto/sealed.ts";
 import { withTransaction } from "#db/client.ts";
 import {
   asPaymentRowRecord,
   assertRefundRowsHeld,
   readAttendeeRowStates,
+  type StoredPaymentClaimRow,
 } from "#db/payment-claim.ts";
 import type { PaymentReviewReason } from "#payment/review.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -50,18 +53,45 @@ const reviewOf = async (attendeeId: number) =>
   (await withTransaction((tx) => readAttendeeRowStates(tx, [attendeeId])))[0]
     ?.state.review;
 
+/** One stored row as the claim query returns it, with nothing on it yet. */
+const storedRow = (): StoredPaymentClaimRow => ({
+  attendee_id: 1,
+  failure_data: "",
+  payment_reference_index: "reference-index",
+  payment_session_id: "session-one",
+  provider_refund_work: 0,
+  refund_state_name: null,
+});
+
 describeWithEnv("db > payment claim", { db: true, encryptionKey: true }, () => {
   test("rejects an invalid provider-work projection at the database boundary", async () => {
     await expect(
-      asPaymentRowRecord({
-        attendee_id: 1,
-        failure_data: "",
-        payment_reference_index: "reference-index",
-        payment_session_id: "session-one",
-        provider_refund_work: 2,
-        refund_state_name: null,
-      }),
+      asPaymentRowRecord({ ...storedRow(), provider_refund_work: 2 }),
     ).rejects.toThrow("Provider refund work projection is invalid");
+  });
+
+  test("reads the provider-work projection the way the query means it", async () => {
+    // 1 is the charge still owing refund work and 0 is none. Read the two the
+    // other way round and a refund runs against a charge that is already done.
+    expect(
+      (await asPaymentRowRecord({ ...storedRow(), provider_refund_work: 1 }))
+        .providerRefundWork,
+    ).toBe(true);
+    expect(
+      (await asPaymentRowRecord({ ...storedRow(), provider_refund_work: 0 }))
+        .providerRefundWork,
+    ).toBe(false);
+  });
+
+  test("names the column when a stored record will not read", async () => {
+    // The slot decrypts but holds no record, which is corruption. The message
+    // must name where it was read from, or nobody can find the broken row.
+    await expect(
+      asPaymentRowRecord({
+        ...storedRow(),
+        failure_data: (await encrypt("not-a-record")) as EnvKeyEncrypted,
+      }),
+    ).rejects.toThrow("Invalid stored JSON in processed_payments.failure_data");
   });
 
   describe("releasing", () => {

--- a/test/shared/db/refund-all-candidates.test.ts
+++ b/test/shared/db/refund-all-candidates.test.ts
@@ -84,12 +84,7 @@ const resultWithRows = (rows: ResultSet["rows"]): ResultSet => ({
 });
 
 describeWithEnv("db > Refund All candidates", { db: true }, () => {
-  test("fails loudly when the summary query omits either result layer", async () => {
-    setDb(databaseReturning([]));
-    await expect(getRefundAllSummary(7)).rejects.toThrow(
-      "Refund All admission returned no result",
-    );
-
+  test("fails loudly when the summary query answers with no row", async () => {
     setDb(databaseReturning([emptyResultSet()]));
     await expect(getRefundAllSummary(7)).rejects.toThrow(
       "Refund All admission returned no summary",


### PR DESCRIPTION
Two small merges in the database layer. Both remove a second way to say
something the client already says once. The mutation gate over the touched
files then found real test gaps, and those are closed here too.

## One name for a batch runner

`src/shared/db/client.ts` had a `BatchExecutor` type — "runs several statements
as one batch, answers each in turn" — but kept it private. The ledger needed
that idea, could not reach it, and declared its own: a `RowReader` type in
`src/shared/accounting/rows.ts`, plus a `fromDb` reader and a `fromTx` factory
to build one from the client or from an open transaction.

`BatchExecutor` is exported now, and the ledger reads take one directly. A
caller hands over `queryBatch` for the client, or an open transaction's own
`batch`:

```ts
const snapshot = await loadBatchSnapshot([inputs], tx.batch); // was fromTx(tx)
const legs = await selectByEventGroup(queryBatch, eventGroup); // was fromDb
```

`RowReader`, `fromDb`, and `fromTx` are gone. The write path still reads through
its own transaction, so two posters of one event still take turns and the second
one replays instead of a double post.

## A plural for the primary read

`queryOnePrimary` reads one row from the primary, for a caller that must see the
write it just made. There was no plural, so eleven readers wrote the same
one-statement batch by hand and unpacked the answer themselves:

```ts
const [read] = await queryBatchPrimary([{ args, sql }]);
const rows = resultRows<Row>(read!);
```

`queryAllPrimary` is that read. It takes the `{ sql, args }` statement whole,
because that is the shape a batch runs and the shape its callers already hold:

```ts
const rows = await queryAllPrimary<Row>({ args, sql });
const snapshot = moveSnapshot(await queryAllPrimary(moveWorkStatement(ids)));
```

`queryOnePrimary` is now the first row of `queryAllPrimary`, as `queryOne` is of
`queryAll`, and `queryAll` reaches for it when a request must read its own
writes. Every migrated reader takes the one that says how many rows it wants:
`queryAllPrimary` for many, `queryOnePrimary` for one. The `queryBatchPrimary`
calls that remain all send more than one statement. `AGENTS.md` now says so
beside the batch helpers, so the next reader finds them first.

## Test gaps the mutation gate found

Mutating every changed file surfaced six places where a real change to
behaviour passed every test. Each one now has an assertion:

- **The ledger's stored words.** Every test compared a manual entry's kind
  against the same constant it came from, so renaming one moved the
  expectation with it. A renamed word orphans every row a site already stored,
  so the seven words are now spelled out.
- **The sign on an owner-entered row.** The spec table decides whether a manual
  entry reads as an addition or as money given back. Flipping the attendee
  writeoff to positive kept every test green.
- **The payment claim's provider-work flag.** A record that read the projection
  backwards passed, which would let a refund run against a charge that is done.
- **Two error messages that name where a corrupt record was read from** — the
  payment row's slot and the charge's refund state. Both said nothing and
  nothing failed.
- **`PaymentRowsBusyError` named itself by hand**, so nothing held it to its
  name. It extends the shared `namedError` now, like every other named error.
- **The refund-authority migration**: its refusal message is asserted whole, its
  description is pinned the way its siblings are, and a new test covers a
  part-upgraded site left with one dormant table.

Eight further mutants cannot be told apart by any test, so they are recorded in
`scripts/mutation/equivalent-mutants/` with the proof: two fallbacks whose left
side is never falsy-but-present, a lookup that reads the same map the rows were
read by, and five table aliases SQLite does not need because each column is on
one table in its query. Two stale records were removed — one for `executeRead`,
which `queryAllPrimary` replaced, and one for `isPaymentsEnabled`, whose
expression went earlier and left `check:equivalents` red on `main`.

## What this means for people who use the site

Nothing changes on screen. Every read runs the same SQL against the same
database, and a read that was pinned to the primary is still pinned to it.

## Files

- `src/shared/db/client.ts` — exports `BatchExecutor`, adds `queryAllPrimary`,
  derives `queryOnePrimary` and `queryAll`'s primary branch from it.
- `src/shared/accounting/rows.ts`, `store.ts`, `queries.ts`,
  `manual-entries.ts` — the ledger reads take a `BatchExecutor`.
- `src/shared/db/payment-claim.ts`, `payment-admit-move.ts`,
  `payment-anchor/held-work.ts`, `refund-all-candidates.ts`,
  `processed-payments.ts`, `listing-prices.ts`, two migrations, and
  `src/features/api/payment-processing/committed-entries.ts` — the hand-written
  one-statement batches.
- Tests for the gaps above, and `scripts/mutation/equivalent-mutants/`.

## Checks

- `deno task precommit` passes.
- Every changed `src/` file was mutation-tested against its own tests; each one
  now kills every mutant it can.
- New direct tests: `queryAllPrimary` answers with every matching row, it pins
  its statement to the primary, and a read outside a primary-read scope stays
  one plain statement a replica can answer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved database read reliability and consistency across payments, refunds, listings, and accounting data.
  * Preserved read-your-writes behavior while streamlining primary-database access.
  * Improved error reporting for missing refund information and corrupted payment records.
  * Enhanced migration handling for existing payment-related data.

* **Tests**
  * Expanded coverage for database reads, accounting entry types, payment claims, refunds, migrations, and encrypted data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->