### PR TITLE
Ask SumUp for its merchant in the live journey

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2779,11 +2779,11 @@ written once in the admin surface declaration.
 
 _Origin: the consolidation review. PR #2128 closed the rest of this entry._
 
-`sourceRowsFor` in `src/shared/db/listing-prices.ts:357` ends with
+`readSourceRows` in `src/shared/db/listing-prices.ts:349` ends with
 `rows.rows as unknown as ListingPriceSourceRow[]`. The cast claims a shape the
-code never checks, so a column renamed in the SELECT above it reaches callers as
-`undefined` rather than failing at the read. Parse the rows instead, the way the
-boundary schemas elsewhere do.
+code never checks, so a column renamed in the SELECT above it reaches its two
+callers as `undefined` rather than failing at the read. Parse the rows instead,
+the way the boundary schemas elsewhere do.
 
 The other three parts of this entry are done. `BatchExecutor` is exported and
 the ledger's `RowReader` twin is gone, and `queryAllPrimary` and

--- a/TODO.md
+++ b/TODO.md
@@ -2775,27 +2775,21 @@ written once in the admin surface declaration.
 
 ---
 
-## Fold D, batched database reads
+## A listing price row is claimed, never checked
 
-_Origin: the consolidation review._
+_Origin: the consolidation review. PR #2128 closed the rest of this entry._
 
-- **Export `BatchExecutor` and delete its twin.** The slot exists but is not
-  exported, so `src/shared/accounting/rows.ts:208` declares its own `RowReader`
-  for the same job. Export the shared type and delete the twin. About 18 lines.
-- **A plural read, so a batch of one stops being the idiom.** 15 call sites wrap
-  a single statement in `queryBatchPrimary([...])` and then destructure the one
-  result, for example `src/shared/db/listing-prices.ts:404`,
-  `src/shared/db/payment-claim.ts:133`, and
-  `src/shared/db/processed-payments.ts:264`. Give the client the plural read
-  those sites want. About 45 lines.
-- **Fix the cast at `src/shared/db/listing-prices.ts:409`.**
-  `(result?.rows as unknown as ListingPriceSourceRow[])[0]` claims a shape it
-  never checks, and `?.` hides a missing result. This is a one-line offensive
-  programming fix and needs no framework, so land it on its own.
-- **A typed co-read instead of `results[i]`.** One read destructures eleven
-  names from a batch that nothing ties back to its builder. Give the batch
-  builder and its reader one shared shape, so the names come from the
-  declaration. About 45 lines. Needs the `BatchExecutor` item above.
+`sourceRowsFor` in `src/shared/db/listing-prices.ts:357` ends with
+`rows.rows as unknown as ListingPriceSourceRow[]`. The cast claims a shape the
+code never checks, so a column renamed in the SELECT above it reaches callers as
+`undefined` rather than failing at the read. Parse the rows instead, the way the
+boundary schemas elsewhere do.
+
+The other three parts of this entry are done. `BatchExecutor` is exported and
+the ledger's `RowReader` twin is gone, and `queryAllPrimary` and
+`queryOnePrimary` now give the primary read its plural, all in PR #2128. The
+eleven-name co-read the entry described cannot be found in the current source,
+so it went with them.
 
 ---
 

--- a/e2e-payments/src/providers/shared.ts
+++ b/e2e-payments/src/providers/shared.ts
@@ -296,6 +296,54 @@ export const hostedCheckout =
     return await drive(page, ctx);
   };
 
+/** What one provider's connection test must say to count as passed. */
+export type ConnectionCheck = {
+  /** The line logged when it passes. */
+  passed: string;
+  /** Lines the answer must carry. */
+  require: readonly string[];
+  /** One more rule the provider owns, naming what is wrong, or null. */
+  alsoWrong?: ((text: string) => string | null) | undefined;
+};
+
+/**
+ * Ask a provider's "Test Connection" button, and read what it answered.
+ *
+ * A provider says only which lines its own answer must carry, and can add one
+ * rule of its own. The click, the wait, the success class, the log line and
+ * the dumped page on failure are the same for every provider.
+ */
+export const testProviderConnection = async (
+  session: BrowserSession,
+  provider: ProviderName,
+  check: ConnectionCheck,
+): Promise<void> => {
+  const result = session.page.locator(`#${provider}-test-result`);
+  await session.page.evaluate((id) => {
+    const button = document.getElementById(id);
+    if (button) button.click();
+  }, `${provider}-test-btn`);
+  await result.waitFor({ state: "visible", timeout: config.navTimeoutMs });
+
+  const text = await result.innerText();
+  const missing = check.require.filter((line) => !text.includes(line));
+  const alsoWrong = check.alsoWrong?.(text) ?? null;
+  const succeeded = await result.evaluate((element) =>
+    element.classList.contains("success"),
+  );
+  if (succeeded && missing.length === 0 && alsoWrong === null) {
+    log(`  ${check.passed}`);
+    return;
+  }
+
+  await session.dumpPage(`${provider}-connection-test-failed`);
+  throw new Error(
+    `The ${provider} connection test did not pass. ` +
+      `Missing: ${missing.join(", ") || "none"}. ` +
+      `${alsoWrong === null ? "" : `${alsoWrong}. `}Result:\n${text}`,
+  );
+};
+
 /** The honest no-op cleanup for providers whose sandbox resources are all
  * append-only (payments, refunds) with nothing ephemeral to remove. */
 export const noProviderCleanup = (): Promise<void> => Promise.resolve();

--- a/e2e-payments/src/providers/stripe.ts
+++ b/e2e-payments/src/providers/stripe.ts
@@ -1,6 +1,5 @@
 /* jscpd:ignore-start */
 import type { BrowserSession } from "#e2e/browser.ts";
-import { config } from "#e2e/config.ts";
 import { log } from "#e2e/log.ts";
 import { clickFirst, fillFirst } from "./card.ts";
 import {
@@ -10,6 +9,7 @@ import {
   providerFetch,
   refundObservationVia,
   requiredField,
+  testProviderConnection,
 } from "./shared.ts";
 import type { PaidSandboxCheckout, PaymentProvider } from "./types.ts";
 
@@ -34,36 +34,22 @@ const saveStripeKey = async (
   await session.clickButton("Update Stripe Key");
 };
 
-const testStripeConnection = async (session: BrowserSession): Promise<void> => {
-  const result = session.page.locator("#stripe-test-result");
-  await session.page.evaluate(() => {
-    const btn = document.getElementById("stripe-test-btn");
-    if (btn) btn.click();
-  });
-  await result.waitFor({ state: "visible", timeout: config.navTimeoutMs });
-
-  const text = await result.innerText();
+/** Ask the owner's "Test Connection" button about Stripe. Beyond the key, it
+ * proves the rotation left exactly one of our webhook endpoints behind. */
+const testStripeConnection = (session: BrowserSession): Promise<void> => {
   const webhookUrl = `${session.baseUrl}/payment/webhook`;
-  const missing = [
-    "API Key: Valid (test mode)",
-    `${webhookUrl} (tickets)`,
-    "Events: checkout.session.completed",
-  ].filter((expected) => !text.includes(expected));
-  const webhookCount = text.split(webhookUrl).length - 1;
-  const passed = await result.evaluate((element) =>
-    element.classList.contains("success"),
-  );
-  if (passed && missing.length === 0 && webhookCount === 1) {
-    log("  Stripe connection, webhook listing, and endpoint rotation passed");
-    return;
-  }
-
-  await session.dumpPage("stripe-connection-test-failed");
-  throw new Error(
-    "Stripe connection test did not confirm one current webhook endpoint. " +
-      `Missing: ${missing.join(", ") || "none"}; ` +
-      `current endpoint count: ${webhookCount}. Result:\n${text}`,
-  );
+  return testProviderConnection(session, "stripe", {
+    alsoWrong: (text) => {
+      const endpoints = text.split(webhookUrl).length - 1;
+      return endpoints === 1 ? null : `current endpoint count: ${endpoints}`;
+    },
+    passed: "Stripe connection, webhook listing, and endpoint rotation passed",
+    require: [
+      "API Key: Valid (test mode)",
+      `${webhookUrl} (tickets)`,
+      "Events: checkout.session.completed",
+    ],
+  });
 };
 
 /** The checkout session id embedded in the hosted page's URL (cs_test_…). */

--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -1,5 +1,6 @@
 /* jscpd:ignore-start */
 import type { Page } from "playwright";
+import type { BrowserSession } from "#e2e/browser.ts";
 import { log, warn } from "#e2e/log.ts";
 import { clickFirst, fillCard, fillFirst, fillFrameInput } from "./card.ts";
 import {
@@ -11,6 +12,7 @@ import {
   readLoggedId,
   refundObservationVia,
   requiredField,
+  testProviderConnection,
 } from "./shared.ts";
 import type { PaidSandboxCheckout, PaymentProvider } from "./types.ts";
 
@@ -97,6 +99,23 @@ const transactionIdOf = async (
   );
 };
 
+/**
+ * Ask the owner's "Test Connection" button about SumUp.
+ *
+ * This is the only journey that asks SumUp for the merchant behind the key, so
+ * it is the only proof that the merchant read works against the real API. The
+ * merchant line appears only when that read succeeded, so asserting the real
+ * merchant code proves the call and not just the page.
+ */
+const testSumupConnection = (
+  session: BrowserSession,
+  merchantCode: string,
+): Promise<void> =>
+  testProviderConnection(session, "sumup", {
+    passed: "SumUp connection and merchant lookup passed",
+    require: ["API Key: Valid", `Merchant: ${merchantCode}`],
+  });
+
 export const sumup: PaymentProvider = {
   // SumUp sets its return URL per checkout and registers no webhook endpoint;
   // payments and refunds are append-only sandbox resources.
@@ -105,6 +124,7 @@ export const sumup: PaymentProvider = {
     await session.fill("sumup_api_key", secrets.apiKey);
     await session.fill("sumup_merchant_code", secrets.merchantCode);
     await session.clickButton("Update SumUp Credentials");
+    await testSumupConnection(session, secrets.merchantCode);
   }),
   name: "sumup",
 


### PR DESCRIPTION
PR #2129 moved two SumUp calls off the vendor SDK: checkout creation and the
merchant read behind the API key check. The live payment journey drove the
first one and never the second, so this adds the step that drives it.

## Why this call and not another

The merchant read is the only SumUp call the app makes that no sandbox journey
touched. It is also where #2129 changed more than the transport: the connection
test used to decide "SumUp rejected this key" by reading the start of an error
message, and now reads the answer's status code. Unit tests pin that, but
nothing proved the live SumUp API answers in the shape the new code expects.

The SumUp leg configured its credentials and stopped. It now clicks Test
Connection and asserts the real merchant code came back. That line appears only
when the merchant read succeeded, so it proves the call rather than the page.

## One connection test, not two

Stripe already had this step written out. Both providers now go through
`testProviderConnection` in `e2e-payments/src/providers/shared.ts`: a provider
says which lines its answer must carry, and may add one rule of its own. The
click, the wait, the success class, the log line, and the dumped page on
failure are written once.

Stripe keeps its own rule, that the endpoint rotation left exactly one of our
webhook endpoints behind, and its behaviour is unchanged: the same three
required lines, the same count check, the same log line, and the same dumped
page name.

## A TODO entry that main overtook

`TODO.md` carried a four-part entry about batched database reads. PR #2128
exported `BatchExecutor`, deleted the ledger's `RowReader` twin, and gave the
primary read its plural, so three of the four parts are done, and the
eleven-name co-read the entry described is not in the current source. The entry
is trimmed to what is still open: the unchecked cast in `readSourceRows` at
`listing-prices.ts:349`, which also moved. The `?.` that hid a missing result
is gone, and the cast now sits on the many-row read that two callers share.

## What was checked

The Payment sandbox e2e ran against this branch, and every leg passed: sumup,
square, stripe, and free. The SumUp leg's log carries the new step's own line,
between saving the credentials and creating the listing:

```
17:06:07  submit "Update SumUp Credentials"
17:06:09  SumUp connection and merchant lookup passed
17:06:09  sumup credentials accepted
```

That line prints only when the result carries the success class and both
required lines, so the live SumUp API did answer with `API Key: Valid` and the
real merchant code. The Stripe leg passing shows the shared helper left its
existing check alone.

`deno task precommit` passes, `deno task cpd` finds 0 clones, and CI is green.