### PR TITLE
Name the rule behind each ledger exemption, or say there is none

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2753,7 +2753,8 @@ that some of them answer. The exemption list in
 that no rule asks for the export. `checkout-ledger.ts`, `accounting/store.ts`
 and `accounting/mappers.ts` gained production callers, so they left the list.
 
-Seven exports have test callers alone, and they are not alike:
+Eight exports have test callers alone, and they are not alike. The usage check
+flags seven of them. The blind spot below hides the eighth.
 
 - `reconcile.ts` (`reconcileExternal`, `reconcileLegs`) answer rule 2, which
   needs the refund total of the provider. `accounting/queries.ts`
@@ -2767,7 +2768,7 @@ Seven exports have test callers alone, and they are not alike:
 
 "Remove dead code" in `AGENTS.md` says to delete an export that only tests call,
 and to recover it from history when a caller arrives. Against that stands a
-contract that names a future caller for four of the seven. The person who owns
+contract that names a future caller for five of the eight. The person who owns
 the payment aggregate must settle that half. The three exports that answer no
 rule have no such defence, so delete them first.
 

--- a/TODO.md
+++ b/TODO.md
@@ -738,6 +738,10 @@ test corpus can only make an export look test-used (which then flags it,
 loudly). This is a long-standing property of the whole detector file, not new to
 the dynamic-import clauses.
 
+`reverseOf` in `src/shared/ledger/reverse.ts` is a live example of the masking
+case. The export has test callers alone, and the `{@link reverseOf}` in its own
+JSDoc hides that.
+
 Proposed fix (the reviewer suggested syntax-aware parsing): a code-only
 preprocessing pass before matching. The file already has the pieces — the
 call-site scanner's `skipString`/`skipComment` lexer helpers skip comments and
@@ -2736,20 +2740,39 @@ so it went with them.
 
 ---
 
-## The ledger's unreachable half, a decision for the repository owner
+## Two ledger reporting exports no rule has asked for
 
-_Origin: the consolidation review. This entry records a decision, not a job to
-pick up unread._
+_Origin: the consolidation review. That review claimed that about 500 lines of
+the ledger were unreachable, and it called the deletion an owner decision. Both
+claims were wrong. This entry replaces them._
 
-The ledger carries reconcilers, reversal builders, and four projections with no
-production caller. They stay alive through an exemption in the usage check. The
-house rule in `AGENTS.md` says to delete dead code and recover it from history.
-The exemption's own comment says the ledger is wired in a slice at a time, and
-asks the reader to wait.
+The ledger is not half dead. Someone wrote its unconsumed exports before the
+payment aggregate, on purpose, and `docs/payment-aggregate-acceptance.md` names
+the rules that they answer. Most of them are pending work, not dead code. The
+exemption list in `test/integration/code-quality.test.ts` now says which rule
+each module serves. `checkout-ledger.ts`, `accounting/store.ts` and
+`accounting/mappers.ts` gained production callers, so they left that list.
 
-About 500 lines sit on that disagreement. The two rules point opposite ways, so
-the call belongs to the repository owner and not to a reviewer. Starting point:
-the `LIBRARY_PATHS` exemption in `test/integration/code-quality.test.ts`.
+Seven exports still have test callers alone, and they are not alike:
+
+- `reconcile.ts` (`reconcileExternal`, `reconcileLegs`) and
+  `accounting/queries.ts` (`allTransfers`, `recentTransfers`, `accountBalance`)
+  answer named rules. Leave them.
+- `project.ts` (`profitOfListing`, `sumOfKind`) answer no rule. Profit per
+  listing, and totals by kind, appear in no rule and in no other entry here.
+  They are the only part of the ledger that looks speculative.
+
+The open question is about those two exports alone. Ask the person who wanted
+them what reads them. If the answer is a reports page one day, delete them. Git
+history holds them until that page is real, and a fold over `allBalances` is a
+few lines to write again. If a rule wants them, record the rule beside them, as
+the others now are.
+
+Read this before you change any of it. The usage check cannot see that
+`reverse.ts` exports a test-only `reverseOf`. The `{@link reverseOf}` in the
+JSDoc of that module reads as a production use. Do not treat the absence of a
+module from a failure list as proof that production code calls it. See
+"Dead-export scanner matches raw text" above.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -2740,38 +2740,41 @@ so it went with them.
 
 ---
 
-## Two ledger reporting exports no rule has asked for
+## Three ledger exports no rule has asked for
 
 _Origin: the consolidation review. That review claimed that about 500 lines of
 the ledger were unreachable, and it called the deletion an owner decision. Both
 claims were wrong. This entry replaces them._
 
 The ledger is not half dead. Someone wrote its unconsumed exports before the
-payment aggregate, on purpose, and `docs/payment-aggregate-acceptance.md` names
-the rules that they answer. Most of them are pending work, not dead code. The
-exemption list in `test/integration/code-quality.test.ts` now says which rule
-each module serves. `checkout-ledger.ts`, `accounting/store.ts` and
-`accounting/mappers.ts` gained production callers, so they left that list.
+payment aggregate, and `docs/payment-aggregate-acceptance.md` names the rule
+that some of them answer. The exemption list in
+`test/integration/code-quality.test.ts` now names that rule per module, or says
+that no rule asks for the export. `checkout-ledger.ts`, `accounting/store.ts`
+and `accounting/mappers.ts` gained production callers, so they left the list.
 
-Seven exports still have test callers alone, and they are not alike:
+Seven exports have test callers alone, and they are not alike:
 
-- `reconcile.ts` (`reconcileExternal`, `reconcileLegs`) and
-  `accounting/queries.ts` (`allTransfers`, `recentTransfers`, `accountBalance`)
-  answer named rules. Leave them.
-- `project.ts` (`profitOfListing`, `sumOfKind`) answer no rule. Profit per
-  listing, and totals by kind, appear in no rule and in no other entry here.
-  They are the only part of the ledger that looks speculative.
+- `reconcile.ts` (`reconcileExternal`, `reconcileLegs`) answer rule 2, which
+  needs the refund total of the provider. `accounting/queries.ts`
+  (`allTransfers`, `recentTransfers`, `accountBalance`) answer the owner review
+  pages of rules 1 and 3.
+- `project.ts` (`profitOfListing`, `sumOfKind`) and `reverse.ts` (`reverseOf`)
+  answer no rule. Profit per listing and totals by kind appear nowhere in the
+  contract. `reverseOf` builds an admin void or a correction, and the contract
+  names no such action. The refunds of rule 1 use a separate model of many rows
+  per original, which does not call it.
 
-The open question is about those two exports alone. Ask the person who wanted
-them what reads them. If the answer is a reports page one day, delete them. Git
-history holds them until that page is real, and a fold over `allBalances` is a
-few lines to write again. If a rule wants them, record the rule beside them, as
-the others now are.
+"Remove dead code" in `AGENTS.md` says to delete an export that only tests call,
+and to recover it from history when a caller arrives. Against that stands a
+contract that names a future caller for four of the seven. The person who owns
+the payment aggregate must settle that half. The three exports that answer no
+rule have no such defence, so delete them first.
 
-Read this before you change any of it. The usage check cannot see that
-`reverse.ts` exports a test-only `reverseOf`. The `{@link reverseOf}` in the
-JSDoc of that module reads as a production use. Do not treat the absence of a
-module from a failure list as proof that production code calls it. See
+Read this before you change any of it. The usage check cannot see that only
+tests call `reverseOf`, because the `{@link reverseOf}` in the JSDoc of that
+module reads as a production use. `isInverseOf` beside it has a live caller in
+`accounting/conflicts.ts`, so the module stays exempt either way. See
 "Dead-export scanner matches raw text" above.
 
 ---

--- a/test/integration/code-quality.test.ts
+++ b/test/integration/code-quality.test.ts
@@ -79,18 +79,21 @@ const LIBRARY_PATHS = [
   "shared/jsx/jsx-runtime.ts", // JSX compiler runtime
   "shared/jsx/jsx-dev-runtime.ts", // JSX dev runtime
   "shared/asset-paths.ts", // Build-time config consumed by .tsx templates
-  // The transfer ledger (src/shared/ledger + src/shared/accounting) is being
-  // wired in incrementally; like fp.ts, some exports have no production
-  // caller yet. account.ts and validate.ts are already consumed by the store
-  // adapter, so they are no longer exempt — the remaining modules lose their
-  // exemption as the event mappers and checkout wiring land.
-  "shared/ledger/project.ts",
+  // The transfer ledger (src/shared/ledger + src/shared/accounting) is built
+  // ahead of the payment aggregate that consumes it: the pure core and its
+  // coverage first, which is the lesson of the rewrite that closed without
+  // merging (PRs #1962/#1973). Each entry below names the rule it answers in
+  // docs/payment-aggregate-acceptance.md. A module leaves this list when its
+  // last unconsumed export gains a production caller, as account.ts,
+  // validate.ts, checkout-ledger.ts, accounting/store.ts and
+  // accounting/mappers.ts already did.
+  "shared/ledger/project.ts", // profitOfListing, sumOfKind: no rule yet
+  "shared/ledger/reconcile.ts", // reconcileExternal, reconcileLegs: rule 2
+  "shared/accounting/queries.ts", // whole-account reads: rules 1 and 3
+  // reverseOf answers rule 1's complete-or-refund choice. The scanner cannot
+  // see that tests alone call it, because the {@link reverseOf} in its own
+  // JSDoc reads as a production use. This entry is deliberate.
   "shared/ledger/reverse.ts",
-  "shared/ledger/reconcile.ts",
-  "shared/checkout-ledger.ts",
-  "shared/accounting/store.ts",
-  "shared/accounting/queries.ts",
-  "shared/accounting/mappers.ts",
   // The site-pages feature is being wired in incrementally,
   // foundation-first: the pure core + DB layer landed before the admin CRUD /
   // public route / recursive-nav slices that consume them, so — like the

--- a/test/integration/code-quality.test.ts
+++ b/test/integration/code-quality.test.ts
@@ -80,19 +80,17 @@ const LIBRARY_PATHS = [
   "shared/jsx/jsx-dev-runtime.ts", // JSX dev runtime
   "shared/asset-paths.ts", // Build-time config consumed by .tsx templates
   // The transfer ledger (src/shared/ledger + src/shared/accounting) is built
-  // ahead of the payment aggregate that consumes it: the pure core and its
-  // coverage first, which is the lesson of the rewrite that closed without
-  // merging (PRs #1962/#1973). Each entry below names the rule it answers in
-  // docs/payment-aggregate-acceptance.md. A module leaves this list when its
-  // last unconsumed export gains a production caller, as account.ts,
-  // validate.ts, checkout-ledger.ts, accounting/store.ts and
-  // accounting/mappers.ts already did.
-  "shared/ledger/project.ts", // profitOfListing, sumOfKind: no rule yet
+  // ahead of the payment aggregate that consumes it, so some exports have no
+  // production caller. Each entry below names the rule it answers in
+  // docs/payment-aggregate-acceptance.md, or says that no rule asks for it. A
+  // module leaves this list when its last unconsumed export gains a caller.
+  "shared/ledger/project.ts", // profitOfListing, sumOfKind: no rule
   "shared/ledger/reconcile.ts", // reconcileExternal, reconcileLegs: rule 2
   "shared/accounting/queries.ts", // whole-account reads: rules 1 and 3
-  // reverseOf answers rule 1's complete-or-refund choice. The scanner cannot
-  // see that tests alone call it, because the {@link reverseOf} in its own
-  // JSDoc reads as a production use. This entry is deliberate.
+  // Only tests call reverseOf, and no rule asks for it: reverse.ts scopes it to
+  // an admin void or correction, and refunds use a separate multi-row model.
+  // The usage check cannot see this, because the {@link reverseOf} in its own
+  // JSDoc reads as a production use. isInverseOf beside it has a live caller.
   "shared/ledger/reverse.ts",
   // The site-pages feature is being wired in incrementally,
   // foundation-first: the pure core + DB layer landed before the admin CRUD /


### PR DESCRIPTION
## What this changes

Two notes about the transfer ledger. No production code changes.

### The exemption list now names a rule per module

`LIBRARY_PATHS` in `test/integration/code-quality.test.ts` lets a module keep an
export that only tests call. Seven ledger and accounting modules sat behind one
note that said the ledger was "being wired in incrementally". That note gave the
next reader no way to tell a pending export from a dead one.

Three of the seven gained production callers, so they come off the list:
`shared/checkout-ledger.ts`, `shared/accounting/store.ts` and
`shared/accounting/mappers.ts`. The four that remain each say which rule in
`docs/payment-aggregate-acceptance.md` the export answers, or say that no rule
asks for it:

| Module | Exports with test callers alone | Rule |
| --- | --- | --- |
| `ledger/reconcile.ts` | `reconcileExternal`, `reconcileLegs` | 2, the refund total of the provider |
| `accounting/queries.ts` | `allTransfers`, `recentTransfers`, `accountBalance` | 1 and 3, the owner review pages |
| `ledger/project.ts` | `profitOfListing`, `sumOfKind` | none |
| `ledger/reverse.ts` | `reverseOf` | none |

`reverse.ts` stays on the list for a different reason from the other three. Only
tests call `reverseOf`, but the usage check cannot see that: the
`{@link reverseOf}` in the JSDoc of that module reads to the scanner as a
production use. Without the entry the module would pass by accident. This is the
known scanner bug that `TODO.md` describes under "Dead-export scanner matches
raw text", so this pull request records the instance there. `isInverseOf` beside
it has a live caller in `src/shared/accounting/conflicts.ts`.

### The TODO entry about the ledger was wrong

The consolidation review left an entry called "The ledger's unreachable half, a
decision for the repository owner". It said that about 500 lines were
unreachable, and it asked the repository owner to decide about a deletion. Both
claims were wrong:

- The unused code is nearer 150 to 200 lines, and it is mixed with live code
  inside the same files. No file is dead.
- Five of the eight test-only exports answer a rule that the acceptance contract
  names, so they are pending work rather than a free choice.

The replacement entry, "Three ledger exports no rule has asked for", names
`profitOfListing`, `sumOfKind` and `reverseOf`. Those three appear in no rule and
in no other entry. It also states the tension the old note hid: "Remove dead
code" in `AGENTS.md` says to delete an export that only tests call, while the
contract names a future caller for the other five. The three with no rule have no
such defence, so the entry says to delete them first.

## Review found two errors, and both are fixed

Neither was caught by any check, and both are worth naming.

The first version mapped `reverseOf` to rule 1, the complete-or-refund choice.
That was wrong, and commit `ec7e975` corrects it.
`src/shared/ledger/reverse.ts` scopes `reverseOf` to an admin void or a
correction, and states that refunds need many rows per original, so they do not
use its one-time `reversesId` link. The contract names no void and no
correction. A note that points future work at the wrong ledger operation is the
same fault this pull request set out to remove.

The second was a count. The entry said seven test-only exports where its own
list held eight, and said a contract defended four where it defends five. Seven
is what the usage check reports, because the check cannot see `reverseOf`.
Commit `a8b3766` corrects both numbers and says which number the check reports.

`ec7e975` also trimmed closed pull request numbers and a list of departed
modules out of the comment, because a comment describes current code.

## Why it matters

The vague note cost an hour of reading to work out whether the ledger was
drifting or built to a plan. It is built to a plan, and three exports sit outside
that plan. Anyone who reads the list now sees which is which.

## How it was checked

- `deno task test:files test/integration/code-quality.test.ts` — 19 passed. The
  three removed modules pass the unused-export check without an exemption.
- `deno task precommit` — passed.
- Every rule mapping above was read back from
  `docs/payment-aggregate-acceptance.md` and from the module that exports the
  function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which exported functionality is covered by automated code-quality rules.
  - Added guidance for known limitations and documented a tracked false-positive scenario.

- **Tests**
  - Updated code-quality validation to reflect current module coverage.
  - Removed outdated exemptions and added more specific explanations for supported accounting and ledger areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->