### PR TITLE
Fail the SumUp e2e at once when the sandbox declines the payment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,32 @@
 # TODO — remaining follow-ups
 
+## Browser test for the SumUp decline banner wiring (from PR #2135)
+
+Codex asked for an in-process test of the SumUp decline path. The wait loop has
+direct tests (`test/e2e-payments/providers/post-pay.test.ts`), but two pieces
+run only in the nightly: the "Payment Declined" locator, and the `declined`
+action that throws (`AFTER_PAY_ACTIONS` in
+`e2e-payments/src/providers/sumup.ts`). A unit test cannot present a real hosted
+page, and the main suite must run without a browser, so the ask was declined on
+that PR. The idea is still good as a Chromium-gated test, beside
+`deno task test:screenshot-contract`.
+
+To build it:
+
+1. Serve a canned page for a `checkout.sumup.com` URL with `page.route`.
+2. Copy the decline banner markup from the run 32807391290 artifacts.
+3. Drive the post-pay wait against that page.
+4. Make sure that it fails at once with the "Payment Declined" error.
+
+One decision is open. The wait lives in the module-private `returnToMerchant`,
+so the test needs an export for it, or the canned page must carry card fields so
+`payHostedCheckout` can drive the whole journey.
+
+Review thread:
+<https://github.com/chobbledotcom/tickets/pull/2135#discussion_r3852742287>
+
+---
+
 ## Name the culprit per date in a multi-date refusal (from PR #2127)
 
 `refusedOrderUnfitListingIds` (`src/shared/db/attendees/capacity/checks.ts`)

--- a/e2e-payments/src/providers/post-pay.ts
+++ b/e2e-payments/src/providers/post-pay.ts
@@ -1,0 +1,52 @@
+/**
+ * The wait loop for a provider's hosted page after Pay was clicked. The loop
+ * is pure policy: the page probes, the clock and the waits come in as
+ * functions, so the order and the cadence have direct tests. The provider
+ * file keeps only the Playwright wiring (sumup.ts).
+ */
+
+/** What the provider's page did after Pay was clicked. */
+export type AfterPayOutcome =
+  | "left_provider"
+  | "declined"
+  | "clicked_back"
+  | "timed_out";
+
+/** How the loop asks the page what it shows now. */
+export interface AfterPayProbes {
+  /** Click the "back to the app" control when it is there. True when clicked. */
+  clickBack: () => Promise<boolean>;
+  /** Is the provider's decline banner visible? */
+  declineVisible: () => Promise<boolean>;
+  /** Is the browser still on the provider's origin? */
+  onProvider: () => boolean;
+}
+
+/** The clock the loop runs on. Production passes Date.now and the page's own
+ * wait, and tests pass a scripted clock, so no test sleeps for real. */
+export interface AfterPayClock {
+  now: () => number;
+  wait: (ms: number) => Promise<void>;
+}
+
+const POLL_MS = 500;
+
+/**
+ * Watch the page until it leaves the provider, shows a decline, offers a way
+ * back, or the deadline passes. A decline outranks the back control: a
+ * declined page never goes home, so there is nothing to wait for.
+ */
+export const watchAfterPay = async (
+  probes: AfterPayProbes,
+  clock: AfterPayClock,
+  deadlineMs: number,
+): Promise<AfterPayOutcome> => {
+  const deadline = clock.now() + deadlineMs;
+  while (clock.now() < deadline) {
+    if (!probes.onProvider()) return "left_provider";
+    if (await probes.declineVisible()) return "declined";
+    if (await probes.clickBack()) return "clicked_back";
+    await clock.wait(POLL_MS);
+  }
+  return "timed_out";
+};

--- a/e2e-payments/src/providers/post-pay.ts
+++ b/e2e-payments/src/providers/post-pay.ts
@@ -46,7 +46,8 @@ export const watchAfterPay = async (
     if (!probes.onProvider()) return "left_provider";
     if (await probes.declineVisible()) return "declined";
     if (await probes.clickBack()) return "clicked_back";
-    await clock.wait(POLL_MS);
+    // The last wait shrinks to the time left, so the deadline holds exactly.
+    await clock.wait(Math.min(POLL_MS, deadline - clock.now()));
   }
   return "timed_out";
 };

--- a/e2e-payments/src/providers/post-pay.ts
+++ b/e2e-payments/src/providers/post-pay.ts
@@ -46,8 +46,12 @@ export const watchAfterPay = async (
     if (!probes.onProvider()) return "left_provider";
     if (await probes.declineVisible()) return "declined";
     if (await probes.clickBack()) return "clicked_back";
-    // The last wait shrinks to the time left, so the deadline holds exactly.
-    await clock.wait(Math.min(POLL_MS, deadline - clock.now()));
+    // Probes spend real time too, so the time left can already be gone here.
+    // The last wait shrinks to the time left, and a spent deadline skips the
+    // wait so the loop can end. Every probe still gets its full iteration:
+    // a late click that goes home is better than a timeout.
+    const remaining = deadline - clock.now();
+    if (remaining > 0) await clock.wait(Math.min(POLL_MS, remaining));
   }
   return "timed_out";
 };

--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -1,5 +1,5 @@
 /* jscpd:ignore-start */
-import type { Page } from "playwright";
+import type { Locator, Page } from "playwright";
 import type { BrowserSession } from "#e2e/browser.ts";
 import { log, warn } from "#e2e/log.ts";
 import { clickFirst, fillCard, fillFirst, fillFrameInput } from "./card.ts";
@@ -282,6 +282,16 @@ export const sumup: PaymentProvider = {
   setupCountry: "GB",
 };
 
+/** Is this locator visible right now? A probe that lands mid-navigation or on
+ * a detached node reads as "not visible yet", and the caller's loop asks again. */
+const visibleNow = async (target: Locator): Promise<boolean> => {
+  try {
+    return await target.isVisible({ timeout: 500 });
+  } catch {
+    return false;
+  }
+};
+
 /**
  * SumUp's sandbox checkout does NOT auto-redirect after a successful payment: it
  * parks on a "Payment successful" confirmation page (still on checkout.sumup.com)
@@ -290,8 +300,12 @@ export const sumup: PaymentProvider = {
  * stalls on the SumUp page and dies as a misleading "did not land on a success
  * page" timeout even though the payment (and its webhook) already succeeded.
  *
- * Best-effort and non-fatal: if a future SumUp variant auto-redirects, the
- * button never appears (or the browser has already left the SumUp origin) and we
+ * A refused payment parks here too, on a "Payment Declined" banner whose only
+ * button is "Try Again", so no return home can ever come. Fail at once with
+ * the true cause instead of a missing-return-URL timeout two minutes later.
+ *
+ * Best-effort and non-fatal otherwise: if a future SumUp variant auto-redirects,
+ * the button never appears (or the browser has already left the SumUp origin) and we
  * simply return, letting the caller's return-URL wait confirm the landing.
  */
 const returnToMerchant = async (page: Page): Promise<void> => {
@@ -300,6 +314,9 @@ const returnToMerchant = async (page: Page): Promise<void> => {
     .getByRole("link", { name: namePattern })
     .or(page.getByRole("button", { name: namePattern }))
     .first();
+  // The visible headline of SumUp's decline page. Its other occurrence sits in
+  // a script-tag i18n bundle, which text matching never reads.
+  const declined = page.getByText(/payment declined/i).first();
 
   // SumUp serves its hosted checkout from more than one host — the docs return
   // checkout.sumup.com, but pay.sumup.com is also used (the app's CSP allows
@@ -318,16 +335,24 @@ const returnToMerchant = async (page: Page): Promise<void> => {
   while (Date.now() < deadline) {
     // Already redirected away from SumUp's checkout — nothing to click.
     if (!onSumUp()) return;
-    try {
-      if (await link.isVisible({ timeout: 500 })) {
+    if (await visibleNow(declined)) {
+      throw new Error(
+        'SumUp\'s hosted checkout says "Payment Declined" — the sandbox refused the payment, ' +
+          "so the browser can never return to the app. The harness sent the documented " +
+          "approved test card, so this decline is SumUp-side. A decline that repeats " +
+          "across nights means the sandbox rules changed.",
+      );
+    }
+    if (await visibleNow(link)) {
+      try {
         await link.click({ timeout: 5_000 });
         log(
           "  clicked SumUp's 'Back to merchant website' to return to the app",
         );
         return;
+      } catch {
+        // Node detached between the probe and the click; ask again next loop.
       }
-    } catch {
-      // Page navigating or the node detached mid-check; re-evaluate next loop.
     }
     await page.waitForTimeout(500);
   }

--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -3,6 +3,7 @@ import type { Locator, Page } from "playwright";
 import type { BrowserSession } from "#e2e/browser.ts";
 import { log, warn } from "#e2e/log.ts";
 import { clickFirst, fillCard, fillFirst, fillFrameInput } from "./card.ts";
+import { type AfterPayOutcome, watchAfterPay } from "./post-pay.ts";
 import {
   awaitReturnToApp,
   configureProvider,
@@ -292,6 +293,43 @@ const visibleNow = async (target: Locator): Promise<boolean> => {
   }
 };
 
+/** Click the control when it is visible. False when it is absent, or when the
+ * click lost a race with a navigation, so the loop asks again. */
+const clickIfVisible = async (link: Locator): Promise<boolean> => {
+  if (!(await visibleNow(link))) return false;
+  try {
+    await link.click({ timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** How long the harness watches the paid page for a way home. */
+const RETURN_WATCH_MS = 30_000;
+
+/** What each watch outcome does. "declined" fails at once with the true cause
+ * instead of a missing-return-URL timeout two minutes later. */
+const AFTER_PAY_ACTIONS: Record<AfterPayOutcome, () => void> = {
+  clicked_back: () =>
+    log("  clicked SumUp's 'Back to merchant website' to return to the app"),
+  declined: () => {
+    throw new Error(
+      'SumUp\'s hosted checkout says "Payment Declined" — the sandbox refused the payment, ' +
+        "so the browser can never return to the app. The harness sent the approved test " +
+        "card. If the charged total is a documented decline amount (11.00, 42.01, 42.76, " +
+        "42.91), this run configured the decline. Any other total means a SumUp-side fault.",
+    );
+  },
+  // Already redirected home — nothing to click and nothing to report.
+  left_provider: () => undefined,
+  timed_out: () =>
+    warn(
+      "  SumUp: no 'Back to merchant website' button appeared after paying — " +
+        "relying on an auto-redirect that may not happen.",
+    ),
+};
+
 /**
  * SumUp's sandbox checkout does NOT auto-redirect after a successful payment: it
  * parks on a "Payment successful" confirmation page (still on checkout.sumup.com)
@@ -301,12 +339,13 @@ const visibleNow = async (target: Locator): Promise<boolean> => {
  * page" timeout even though the payment (and its webhook) already succeeded.
  *
  * A refused payment parks here too, on a "Payment Declined" banner whose only
- * button is "Try Again", so no return home can ever come. Fail at once with
- * the true cause instead of a missing-return-URL timeout two minutes later.
+ * button is "Try Again", so no return home can ever come.
  *
- * Best-effort and non-fatal otherwise: if a future SumUp variant auto-redirects,
- * the button never appears (or the browser has already left the SumUp origin) and we
- * simply return, letting the caller's return-URL wait confirm the landing.
+ * The loop itself is `watchAfterPay` (post-pay.ts), which holds the order and
+ * the cadence under direct tests. This wrapper owns only the SumUp locators
+ * and what each outcome does. A timeout stays best-effort and non-fatal: if a
+ * future SumUp variant auto-redirects, the caller's return-URL wait confirms
+ * the landing.
  */
 const returnToMerchant = async (page: Page): Promise<void> => {
   const namePattern = /back to merchant|return to merchant|merchant website/i;
@@ -331,33 +370,14 @@ const returnToMerchant = async (page: Page): Promise<void> => {
     }
   };
 
-  const deadline = Date.now() + 30_000;
-  while (Date.now() < deadline) {
-    // Already redirected away from SumUp's checkout — nothing to click.
-    if (!onSumUp()) return;
-    if (await visibleNow(declined)) {
-      throw new Error(
-        'SumUp\'s hosted checkout says "Payment Declined" — the sandbox refused the payment, ' +
-          "so the browser can never return to the app. The harness sent the documented " +
-          "approved test card, so this decline is SumUp-side. A decline that repeats " +
-          "across nights means the sandbox rules changed.",
-      );
-    }
-    if (await visibleNow(link)) {
-      try {
-        await link.click({ timeout: 5_000 });
-        log(
-          "  clicked SumUp's 'Back to merchant website' to return to the app",
-        );
-        return;
-      } catch {
-        // Node detached between the probe and the click; ask again next loop.
-      }
-    }
-    await page.waitForTimeout(500);
-  }
-  warn(
-    "  SumUp: no 'Back to merchant website' button appeared after paying — " +
-      "relying on an auto-redirect that may not happen.",
+  const outcome = await watchAfterPay(
+    {
+      clickBack: () => clickIfVisible(link),
+      declineVisible: () => visibleNow(declined),
+      onProvider: onSumUp,
+    },
+    { now: Date.now, wait: (ms) => page.waitForTimeout(ms) },
+    RETURN_WATCH_MS,
   );
+  AFTER_PAY_ACTIONS[outcome]();
 };

--- a/e2e-payments/src/providers/sumup.ts
+++ b/e2e-payments/src/providers/sumup.ts
@@ -284,11 +284,13 @@ export const sumup: PaymentProvider = {
 };
 
 /** Is this locator visible right now? A probe that lands mid-navigation or on
- * a detached node reads as "not visible yet", and the caller's loop asks again. */
+ * a detached node reads as "not visible yet", and the caller's loop asks
+ * again. A closed page can never answer later, so that fault propagates. */
 const visibleNow = async (target: Locator): Promise<boolean> => {
   try {
-    return await target.isVisible({ timeout: 500 });
-  } catch {
+    return await target.isVisible();
+  } catch (error) {
+    if (target.page().isClosed()) throw error;
     return false;
   }
 };

--- a/test/e2e-payments/providers/post-pay.test.ts
+++ b/test/e2e-payments/providers/post-pay.test.ts
@@ -1,0 +1,108 @@
+/** Direct tests for the after-pay watch loop. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  type AfterPayClock,
+  type AfterPayProbes,
+  watchAfterPay,
+} from "#e2e/providers/post-pay.ts";
+
+/** A clock that only moves when the loop waits, so no test sleeps for real. */
+const scriptedClock = (): AfterPayClock & { waits: number[] } => {
+  const waits: number[] = [];
+  let time = 0;
+  return {
+    now: () => time,
+    wait: (ms) => {
+      waits.push(ms);
+      time += ms;
+      return Promise.resolve();
+    },
+    waits,
+  };
+};
+
+/** Probes that answer from scripted lists. A probe asked past the end of its
+ * script answers "nothing changed" — off-script is a fact of the fake, not a
+ * suppressed failure. */
+const scriptedProbes = (script: {
+  back?: boolean[];
+  decline?: boolean[];
+  onProvider?: boolean[];
+}): AfterPayProbes & { asks: { back: number; decline: number } } => {
+  const asks = { back: 0, decline: 0 };
+  let onProviderAsks = 0;
+  return {
+    asks,
+    clickBack: () => {
+      const answer = script.back?.[asks.back] ?? false;
+      asks.back += 1;
+      return Promise.resolve(answer);
+    },
+    declineVisible: () => {
+      const answer = script.decline?.[asks.decline] ?? false;
+      asks.decline += 1;
+      return Promise.resolve(answer);
+    },
+    onProvider: () => {
+      const answer = script.onProvider?.[onProviderAsks] ?? true;
+      onProviderAsks += 1;
+      return answer;
+    },
+  };
+};
+
+describe("watching the page after Pay", () => {
+  it("reports left_provider as soon as the browser is off the provider", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({ onProvider: [false] });
+    expect(await watchAfterPay(probes, clock, 30_000)).toBe("left_provider");
+    expect(probes.asks.decline).toBe(0);
+    expect(clock.waits).toEqual([]);
+  });
+
+  it("reports declined without asking for the back control", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({ decline: [true] });
+    expect(await watchAfterPay(probes, clock, 30_000)).toBe("declined");
+    expect(probes.asks.back).toBe(0);
+  });
+
+  it("reports clicked_back when the back control was clicked", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({ back: [true] });
+    expect(await watchAfterPay(probes, clock, 30_000)).toBe("clicked_back");
+    expect(clock.waits).toEqual([]);
+  });
+
+  it("waits between asks until the back control appears", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({ back: [false, false, true] });
+    expect(await watchAfterPay(probes, clock, 30_000)).toBe("clicked_back");
+    expect(clock.waits).toEqual([500, 500]);
+  });
+
+  it("reports a decline that only appears on a later ask", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({ decline: [false, false, true] });
+    expect(await watchAfterPay(probes, clock, 30_000)).toBe("declined");
+    expect(probes.asks.back).toBe(2);
+  });
+
+  it("times out when nothing happens before the deadline", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({});
+    expect(await watchAfterPay(probes, clock, 1_500)).toBe("timed_out");
+    expect(clock.waits).toEqual([500, 500, 500]);
+    expect(clock.now()).toBe(1_500);
+  });
+
+  it("times out at once on a zero deadline, with no asks", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({});
+    expect(await watchAfterPay(probes, clock, 0)).toBe("timed_out");
+    expect(probes.asks.decline).toBe(0);
+    expect(clock.waits).toEqual([]);
+  });
+});

--- a/test/e2e-payments/providers/post-pay.test.ts
+++ b/test/e2e-payments/providers/post-pay.test.ts
@@ -98,6 +98,14 @@ describe("watching the page after Pay", () => {
     expect(clock.now()).toBe(1_500);
   });
 
+  it("never waits past a deadline that is not a multiple of the poll step", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({});
+    expect(await watchAfterPay(probes, clock, 750)).toBe("timed_out");
+    expect(clock.waits).toEqual([500, 250]);
+    expect(clock.now()).toBe(750);
+  });
+
   it("times out at once on a zero deadline, with no asks", async () => {
     const clock = scriptedClock();
     const probes = scriptedProbes({});

--- a/test/e2e-payments/providers/post-pay.test.ts
+++ b/test/e2e-payments/providers/post-pay.test.ts
@@ -8,11 +8,18 @@ import {
   watchAfterPay,
 } from "#e2e/providers/post-pay.ts";
 
-/** A clock that only moves when the loop waits, so no test sleeps for real. */
-const scriptedClock = (): AfterPayClock & { waits: number[] } => {
+/** A clock that only moves when the loop waits, so no test sleeps for real.
+ * `advance` stands in for the real time a slow probe spends. */
+const scriptedClock = (): AfterPayClock & {
+  advance: (ms: number) => void;
+  waits: number[];
+} => {
   const waits: number[] = [];
   let time = 0;
   return {
+    advance: (ms) => {
+      time += ms;
+    },
     now: () => time,
     wait: (ms) => {
       waits.push(ms);
@@ -104,6 +111,21 @@ describe("watching the page after Pay", () => {
     expect(await watchAfterPay(probes, clock, 750)).toBe("timed_out");
     expect(clock.waits).toEqual([500, 250]);
     expect(clock.now()).toBe(750);
+  });
+
+  it("skips the wait when a slow probe already spent the deadline", async () => {
+    const clock = scriptedClock();
+    const probes = scriptedProbes({});
+    const slowProbes = {
+      ...probes,
+      declineVisible: () => {
+        clock.advance(800);
+        return Promise.resolve(false);
+      },
+    };
+    expect(await watchAfterPay(slowProbes, clock, 750)).toBe("timed_out");
+    expect(probes.asks.back).toBe(1);
+    expect(clock.waits).toEqual([]);
   });
 
   it("times out at once on a zero deadline, with no asks", async () => {


### PR DESCRIPTION
## What happened

The nightly [Payment sandbox e2e run 32807391290](https://github.com/chobbledotcom/tickets/actions/runs/32807391290) failed on its sumup leg. Both SumUp scenarios failed on the same step with the same error: `sumup's response is missing the documented field "the return URL the browser came back on"`.

## What the investigation found

The saved failure artifacts show the true cause. SumUp's hosted checkout answered "Payment Declined" to both payment attempts. The two failure screenshots are byte-for-byte identical, about four minutes apart.

The decline was not caused by this repository:

- The harness sent SumUp's documented always-approve test card (4200 0000 0000 0091).
- The charged totals (£1.37 and £30.00) are not SumUp's documented decline-trigger amounts (11.00, 42.01, 42.76, 42.91).
- The app staged and created both checkouts correctly. It also answered SumUp's callbacks correctly ("Waiting for a completed payment").
- Four commits landed between the last green run and this one (#2130, #2131, #2132, #2133). None touches the pay path. The one e2e change (#2130) touches only the connection test, and that test passed in the failed run.
- A re-run of the failed job on the same commit passed. Run 32807391290 is green now.

So SumUp's sandbox refused a valid payment for a window of some hours, and then recovered.

## What this changes

A declined payment parks the checkout on a "Payment Declined" page whose only button is "Try Again". No redirect back to the app can come. The harness then spent a 30-second button wait plus a 90-second return wait per scenario. It then failed with the missing-return-URL error above, which hides the cause.

Three changes make that failure honest and fast:

- `e2e-payments/src/providers/post-pay.ts` holds the post-pay wait loop as `watchAfterPay`, a pure function over injected probes and a clock. The outcome is one word: `left_provider`, `declined`, `clicked_back`, or `timed_out`. The loop never waits past its deadline, and it skips the wait when a slow probe already spent the time left. `test/e2e-payments/providers/post-pay.test.ts` pins each outcome, the retry cadence, the deadline behaviour, and the rule that a decline outranks the back control.
- `returnToMerchant` in `e2e-payments/src/providers/sumup.ts` keeps only the SumUp locators and an exhaustive map from each outcome to its action. The `declined` action fails at once and tells the operator how to read it: a charged total on SumUp's documented decline list means the run configured the decline, and any other total means a SumUp-side fault.
- The visibility probe classifies its failures by page state. A probe that fails on a live page reads as "not visible yet", because the success-path redirect causes that race on purpose. A probe that fails on a closed page rethrows, because that page can never answer.

A green run is unchanged. A future decline reads as what it is, two minutes sooner per scenario.

TODO.md gains one entry from review: a Chromium-gated test that presents the decline banner through the production locator. That test belongs beside `deno task test:screenshot-contract`, because the main suite must run without a browser.

## Checks

- `deno task precommit` passed on the final tree: lint, typecheck (app and e2e configs, test files included), cpd, the copy, comment, import, and equivalents checks, the edge build, and the full test suite with 100% coverage.
- CI is green on the head commit: `merge-check`, `checks`, and `test` all passed, and both Deno Deploy builds succeeded.
- Two on-demand Payment sandbox e2e runs on this branch passed against the real provider sandboxes: [run #113](https://github.com/chobbledotcom/tickets/actions/runs/32843977605) and [run #114](https://github.com/chobbledotcom/tickets/actions/runs/32844881254).
- All review threads from Codex and CodeRabbit are answered and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01813vhk7nCHtY2A8JJ2XxfT