### PR TITLE
Prove the SumUp decline wiring in a real browser

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,32 +1,5 @@
 # TODO — remaining follow-ups
 
-## Browser test for the SumUp decline banner wiring (from PR #2135)
-
-Codex asked for an in-process test of the SumUp decline path. The wait loop has
-direct tests (`test/e2e-payments/providers/post-pay.test.ts`), but two pieces
-run only in the nightly: the "Payment Declined" locator, and the `declined`
-action that throws (`AFTER_PAY_ACTIONS` in
-`e2e-payments/src/providers/sumup.ts`). A unit test cannot present a real hosted
-page, and the main suite must run without a browser, so the ask was declined on
-that PR. The idea is still good as a Chromium-gated test, beside
-`deno task test:screenshot-contract`.
-
-To build it:
-
-1. Serve a canned page for a `checkout.sumup.com` URL with `page.route`.
-2. Copy the decline banner markup from the run 32807391290 artifacts.
-3. Drive the post-pay wait against that page.
-4. Make sure that it fails at once with the "Payment Declined" error.
-
-One decision is open. The wait lives in the module-private `returnToMerchant`,
-so the test needs an export for it, or the canned page must carry card fields so
-`payHostedCheckout` can drive the whole journey.
-
-Review thread:
-<https://github.com/chobbledotcom/tickets/pull/2135#discussion_r3852742287>
-
----
-
 ## Name the culprit per date in a multi-date refusal (from PR #2127)
 
 `refusedOrderUnfitListingIds` (`src/shared/db/attendees/capacity/checks.ts`)

--- a/deno.json
+++ b/deno.json
@@ -17,7 +17,7 @@
     "test": "deno run --v8-flags=--expose-gc -A scripts/run-tests.ts",
     "test:coverage": "deno run --v8-flags=--expose-gc -A scripts/run-tests.ts --coverage",
     "test:files": "deno run --v8-flags=--expose-gc -A scripts/run-test-files.ts",
-    "test:screenshot-contract": "deno test --no-check -A test/scripts/*-browser.contract.ts",
+    "test:screenshot-contract": "deno test --no-check -A test/scripts/*-browser.contract.ts && deno test --no-check --config=e2e-payments/deno.json -A e2e-payments/src/providers/*-browser.contract.ts",
     "specs": "deno run --v8-flags=--expose-gc -A scripts/run-specs.ts",
     "specs:evidence": "deno run --v8-flags=--expose-gc -A scripts/run-spec-evidence.ts",
     "specs:check": "deno run --allow-read scripts/check-specs.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -2470,6 +2470,8 @@
     "members": {
       "e2e-payments": {
         "dependencies": [
+          "jsr:@std/expect@^1.0.18",
+          "jsr:@std/testing@^1.0.17",
           "npm:@cucumber/cucumber@13.2.0",
           "npm:@cucumber/gherkin@41.0.0",
           "npm:@cucumber/messages@34.0.1",

--- a/e2e-payments/deno.json
+++ b/e2e-payments/deno.json
@@ -19,6 +19,8 @@
     "@cucumber/messages": "npm:@cucumber/messages@34.0.1",
     "@cucumber/tag-expressions": "npm:@cucumber/tag-expressions@10.0.0",
     "@libsql/client": "npm:@libsql/client@^0.17.2",
+    "@std/expect": "jsr:@std/expect@^1.0.18",
+    "@std/testing": "jsr:@std/testing@^1.0.17",
     "playwright": "npm:playwright@1.61.1",
     "valibot": "npm:valibot@^1.4.1",
     "#fp": "../src/fp.ts",

--- a/e2e-payments/src/providers/sumup-decline-browser.contract.ts
+++ b/e2e-payments/src/providers/sumup-decline-browser.contract.ts
@@ -1,0 +1,99 @@
+/**
+ * Browser contract for the SumUp decline wiring in sumup.ts: the "Payment
+ * Declined" locator and the declined action that throws. The wait loop's
+ * policy has direct tests in test/e2e-payments/providers/post-pay.test.ts;
+ * this contract proves the Playwright half against a real page, without a
+ * provider sandbox.
+ *
+ * The canned page is shaped like the decline the nightly captured in run
+ * 32807391290: Braintree-titled card iframes, a cardholder input, the widget
+ * pay button, and — after Pay — the "Payment Declined" banner in place of
+ * the form. It is served on a checkout.sumup.com URL through request
+ * interception, so the origin check keeps the wait loop alive.
+ *
+ * The whole journey runs through `sumup.payHostedCheckout`, so nothing is
+ * exported for the test alone. The decline throws before the context is
+ * read, so the context carries unreachable stand-ins.
+ *
+ * Runs under `deno task test:screenshot-contract` (Chromium required),
+ * never in the main suite or the nightly harness.
+ */
+
+import { expect } from "@std/expect";
+import { afterAll, beforeAll, describe, it as test } from "@std/testing/bdd";
+import { type Browser, chromium, type Page } from "playwright";
+import { config } from "#e2e/config.ts";
+import { sumup } from "#e2e/providers/sumup.ts";
+import { browserLaunchOptions } from "#scripts/browser-options.ts";
+
+const DECLINE_URL = "https://checkout.sumup.com/pay/canned-decline";
+
+const CANNED_CHECKOUT = `<!doctype html>
+<title>Checkout for Chobble Sandbox</title>
+<div id="form">
+  <iframe title="Secure Credit Card Frame - Credit Card Number" srcdoc="<input>"></iframe>
+  <iframe title="Secure Credit Card Frame - Expiration Date" srcdoc="<input>"></iframe>
+  <iframe title="Secure Credit Card Frame - CVV" srcdoc="<input>"></iframe>
+  <input autocomplete="cc-name">
+  <button data-testid="widget-pay-button" type="button">Pay</button>
+</div>
+<div id="declined" hidden>
+  <h2><span>Payment Declined</span></h2>
+  <p>Please try again</p>
+  <button type="button">Try Again</button>
+</div>
+<script>
+  document
+    .querySelector('[data-testid="widget-pay-button"]')
+    .addEventListener("click", () => {
+      document.getElementById("form").hidden = true;
+      document.getElementById("declined").hidden = false;
+    });
+</script>`;
+
+/** Open the canned checkout on the SumUp origin and hand the page over. */
+const withCannedCheckout = async <T>(
+  browser: Browser,
+  run: (page: Page) => Promise<T>,
+): Promise<T> => {
+  const page = await browser.newPage();
+  try {
+    await page.route("**/*", (route) =>
+      route.fulfill({ body: CANNED_CHECKOUT, contentType: "text/html" }),
+    );
+    await page.goto(DECLINE_URL);
+    return await run(page);
+  } finally {
+    await page.close();
+  }
+};
+
+describe("SumUp decline banner browser contract", () => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    browser = await chromium.launch(
+      browserLaunchOptions(true, config.chromiumExecutable),
+    );
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  test("fails at once with the true cause when the page declines", async () => {
+    await withCannedCheckout(browser, async (page) => {
+      const startedAt = Date.now();
+      const paying = sumup.payHostedCheckout(page, {
+        baseUrl: "http://127.0.0.1:1",
+        secrets: {},
+        serverLogPath: "unreached-by-the-decline-path.log",
+      });
+
+      await expect(paying).rejects.toThrow(/says "Payment Declined"/);
+      // Well inside the 30-second watch window: the point is "at once",
+      // not another timeout.
+      expect(Date.now() - startedAt).toBeLessThan(10_000);
+    });
+  });
+});


### PR DESCRIPTION
## What this is

The follow-up that PR #2135 recorded in TODO.md. That PR moved the post-pay wait loop into a pure, directly tested module, but two pieces still ran only in the nightly: the "Payment Declined" locator, and the `declined` action that throws. This PR proves both in a real browser, without a provider sandbox.

## How the test works

`e2e-payments/src/providers/sumup-decline-browser.contract.ts` serves a canned checkout page on a `checkout.sumup.com` URL through request interception. The page carries the Braintree-titled card iframes, a cardholder input, and the widget pay button. After Pay it shows the "Payment Declined" banner in place of the form. That is the shape the nightly captured in run 32807391290.

The whole journey runs through `sumup.payHostedCheckout`, so nothing is exported for the test alone. The test asserts two things: the step rejects with the true-cause message, and it does so well inside the 30-second watch window.

## The regression proof

- Against the code before PR #2135, the test fails after two minutes with the old error: `sumup's response is missing the documented field "the return URL the browser came back on"`. That is the exact incident the decline guard exists to prevent.
- Against the current code, the test passes in under one second.

## Where it runs

The test needs Chromium, and the main suite must run without a browser. So it runs under `deno task test:screenshot-contract`, through a second `deno test` invocation with the e2e-payments config — the e2e provider files only type-check under that config. The `spec-evidence` workflow already runs this task with Playwright's pinned Chromium.

Two support changes come with it:

- `e2e-payments/deno.json` gains `@std/expect` and `@std/testing` at the root's pins.
- The finished TODO entry is deleted, per the "a finished job leaves TODO.md" rule.

## Checks

- The new contract passes locally in about one second, and the full `deno task test:screenshot-contract` task passes (all six screenshot suites plus this one).
- Typecheck (both configs), Biome, jscpd, `deno fmt`, and `check:imports` pass on the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01813vhk7nCHtY2A8JJ2XxfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01813vhk7nCHtY2A8JJ2XxfT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser coverage for declined SumUp payments, including immediate error handling and decline messaging.

* **Tests**
  * Expanded screenshot contract testing to include payment browser tests.
  * Added testing support for the payments end-to-end workspace.

* **Chores**
  * Removed completed and deferred items from the project TODO list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->