### PR TITLE
Ask every payment provider through one shell, and read every answer through one ladder

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2457,9 +2457,11 @@ terminally misclassify an older damaged checkout as foreign.
 Preserve the other live Square boundary too: payment webhook status is exactly
 `APPROVED | PENDING | COMPLETED | CANCELED | FAILED`. Missing, non-text, empty,
 or unknown values throw; only a known non-completed status may be acknowledged
-without processing, and `COMPLETED` requires an Order id. M6 must reuse or
-replace that declaration atomically, never leave a permissive legacy webhook
-parser beside its observer.
+without processing, and `COMPLETED` requires an Order id. That declaration is
+`webhookPayment` in `src/shared/square-provider.ts`, written as bare throws
+rather than a schema, and it is the one webhook door the provider fold left
+hand-rolled. M6 must reuse or replace it atomically, never leave a permissive
+legacy webhook parser beside its observer.
 
 Reads must be bounded and fenced on an evidence revision or fingerprint. A
 provider-controlled sibling list cannot cause an unbounded request; evidence
@@ -2952,47 +2954,6 @@ No test imports `#shared/sumup/money.ts` at all today. Its exports
 `src/shared/sumup-provider.ts`, so this is a missing direct suite rather than a
 file to move. Write `test/shared/sumup/money.test.ts` against the two exports,
 then run `deno task precommit:mutation` on the module and close its survivors.
-
----
-
-## Fold the last hand-rolled provider judges onto the shared ladders
-
-_Origin: the payment-plans architecture review (August 2026). PR #2129 built
-`readProviderResource`, `judgeThrough`, and `parsedBy` as the one read shell,
-and PR #2131 moved Square's answers onto them. These call sites still hand-roll
-the same shapes beside the shared ones._
-
-Each item is one mechanical fold. Do them one at a time, and run the targeted
-mutation gate on each touched module.
-
-- **`classifySumupCheckout` is an `if` chain beside the ladder it predates.**
-  `src/shared/sumup-observation.ts:201-232` runs `v.safeParse` and six
-  sequential `if (…) return invalidRead(…)` arms, and `checkChildren` (`:148`)
-  re-implements "first rule to name a reason wins". `readSumupTransaction`
-  (`src/shared/sumup/transaction.ts:118`) already shows the target shape:
-  `judgeThrough` + `parsedBy` + a declared rung ladder.
-- **Square's `readCharge` open-codes `mapProviderReader`.**
-  `src/shared/square-provider.ts:249-264` hand-writes the found-branch mapping
-  that Stripe (`stripe-provider.ts:78`) and SumUp (`sumup/money.ts:103`) get
-  from the combinator.
-- **Three refund-send shells do the same four steps.**
-  `src/shared/square/payment-outcomes.ts:103-132`, `src/shared/sumup.ts`
-  (`refundTransaction`), and `withStripeClient` in `src/shared/stripe.ts` each
-  do account → null-check → try/catch → known-failure mapping, and all three
-  return the identical `{ kind: "not_sent", reason: "not_configured" }`. A
-  `sendProviderResource` beside `readProviderResource`
-  (`src/shared/payment/provider-resource-read.ts:47`) collapses them.
-- **SumUp's webhook door parses by hand.** `verifyWebhookSignature` in
-  `src/shared/sumup-provider.ts:125-146` runs its own `JSON.parse` while
-  `parseWebhookPayload` (`src/shared/payment-helpers.ts:701`) is the shared door
-  both signing providers use. Square's `webhookPayment`
-  (`src/shared/square-provider.ts:104-125`) reads its body with bare throws
-  rather than a schema; M6's observer must reuse or replace that declaration
-  atomically (see "Build whole-checkout diagnosis" above).
-
-Out of scope for the machine-declaration work that recorded this: each fold
-touches a live money path and needs its own targeted mutation runs, and the send
-shell changes three providers at once.
 
 ---
 

--- a/scripts/mutation/equivalent-mutants/shared-m-z.txt
+++ b/scripts/mutation/equivalent-mutants/shared-m-z.txt
@@ -336,3 +336,21 @@ src/shared/payment/refund-machine-spec.ts::REFUND_NODES.reps~1hsgkm2 keyed_windo
 # refund-provider-authorization.ts: the permit is the symbol's identity;
 # the description only names it in debugger output.
 src/shared/payment/refund-provider-authorization.ts::durableRefundPermit~0u81rxu durable refund permit→""   # the permit is checked by symbol identity; the description is diagnostic text
+
+# sumup-observation.ts: a child verdict names a refusal or vouches for the
+# money, and only the accept step reads the vouching. The ladder refuses on any
+# verdict carrying a failure, so the flag on those arms is never read.
+src/shared/sumup-observation.ts::UNRECORDED_CHILD.moneyVouchedFor~1767ixx  false → true   # this verdict always names a failure, so the ladder refuses before the accept step reads the flag
+src/shared/sumup-observation.ts::paidChildVerdict.moneyVouchedFor~1767ixx  false → true   # this arm names a failure, so the ladder refuses before the accept step reads the flag
+src/shared/sumup-observation.ts::paidChildVerdict~0w4963m  ?? → ||   # transaction_id is string|undefined; its only falsy string is "", and "" ?? "" = "" || "" = ""
+src/shared/sumup-observation.ts::toSumupCheckout.transactionId~0w4963m  ?? → ||   # transaction_id is string|undefined; its only falsy string is "", and "" ?? "" = "" || "" = ""
+src/shared/sumup-observation.ts::checkChildren~1hpzcer  ?? → ||   # transactions is an array when present, and every array is truthy
+
+# The reference and lifecycle rungs run before the accept step, so requireValue
+# there can never throw and no test can read the message it would carry.
+src/shared/sumup-observation.ts::toSumupCheckout.reference~1wcwgho  The ladder accepted a SumUp checkout with no reference of ours → ""   # the reference rung refuses a null reference first, so this throw is unreachable
+src/shared/sumup-observation.ts::toSumupCheckout.status~1l27hu1  The ladder accepted a SumUp checkout with no known lifecycle → ""   # the lifecycle rung refuses a null status first, so this throw is unreachable
+
+# sumup-provider.ts: the webhook schema types both fields as optional text.
+src/shared/sumup-provider.ts::sumupWebhookEvent.id~0ma0qwq  ?? → ||   # the schema types id as string|undefined; its only falsy string is "", and "" ?? "" = "" || "" = ""
+src/shared/sumup-provider.ts::sumupWebhookEvent.type~1axukkq  ?? → ||   # the schema types event_type as string|undefined; its only falsy string is "", and "" ?? "" = "" || "" = ""

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -162,6 +162,10 @@ const ERROR_DEFS = {
     "E_STRIPE_WEBHOOK_SETUP",
     "Stripe webhook setup failed",
   ],
+
+  // SumUp does not sign its callbacks, so an unreadable body is all its door
+  // can refuse.
+  SUMUP_WEBHOOK: ["E_SUMUP_WEBHOOK", "SumUp webhook could not be read"],
   VALIDATION_CONTENT_TYPE: [
     "E_VALIDATION_CONTENT_TYPE",
     "Invalid content type",

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -698,15 +698,22 @@ export const extractSessionMetadata = (
   };
 };
 
+/** The one door every webhook body comes through. A body that is not JSON is
+ * refused the same way for every provider. What the body then means differs —
+ * a signed provider posts the event itself, SumUp posts two fields we build one
+ * from — so each provider passes its own reading, run outside the catch so a
+ * bug in it never reads as bad JSON. */
 export const parseWebhookPayload = (
   payload: string,
   errorCode: ErrorCodeType,
+  toEvent: (body: unknown) => WebhookEvent,
 ): WebhookVerifyResult => {
+  let body: unknown;
   try {
-    const listing = JSON.parse(payload) as WebhookEvent;
-    return { listing, valid: true };
+    body = JSON.parse(payload);
   } catch (err) {
     logError({ code: errorCode, detail: `invalid JSON: ${err}` });
     return { error: "Invalid JSON payload", valid: false };
   }
+  return { listing: toEvent(body), valid: true };
 };

--- a/src/shared/payment-helpers.ts
+++ b/src/shared/payment-helpers.ts
@@ -698,22 +698,33 @@ export const extractSessionMetadata = (
   };
 };
 
+const UNREADABLE_WEBHOOK: WebhookVerifyResult = {
+  error: "Invalid JSON payload",
+  valid: false,
+};
+
 /** The one door every webhook body comes through. A body that is not JSON is
  * refused the same way for every provider. What the body then means differs —
  * a signed provider posts the event itself, SumUp posts two fields we build one
  * from — so each provider passes its own reading, run outside the catch so a
- * bug in it never reads as bad JSON. */
+ * bug in it never reads as bad JSON. A reading that answers nothing means the
+ * body is JSON this provider cannot read, which earns the same refusal. */
 export const parseWebhookPayload = (
   payload: string,
   errorCode: ErrorCodeType,
-  toEvent: (body: unknown) => WebhookEvent,
+  toEvent: (body: unknown) => WebhookEvent | null,
 ): WebhookVerifyResult => {
   let body: unknown;
   try {
     body = JSON.parse(payload);
   } catch (err) {
     logError({ code: errorCode, detail: `invalid JSON: ${err}` });
-    return { error: "Invalid JSON payload", valid: false };
+    return UNREADABLE_WEBHOOK;
   }
-  return { listing: toEvent(body), valid: true };
+  const listing = toEvent(body);
+  if (listing === null) {
+    logError({ code: errorCode, detail: "JSON payload is not an event" });
+    return UNREADABLE_WEBHOOK;
+  }
+  return { listing, valid: true };
 };

--- a/src/shared/payment/provider-call.ts
+++ b/src/shared/payment/provider-call.ts
@@ -1,0 +1,45 @@
+/**
+ * The one shell every payment provider call runs inside.
+ *
+ * Asking a provider for its records and telling it to move money are the same
+ * four steps: check that the provider is configured at all, ask it, read what
+ * it answered, and give a failed call its meaning. Only asking and reading the
+ * answer differ per call, so only those two are passed in.
+ */
+
+/** What one provider call needs to know beyond the call itself. */
+export type ProviderCall<Account, Answer, Result> = {
+  /** The account facts the call needs, or null when nothing is configured. */
+  account: Account | null;
+  /** Ask the provider. */
+  ask: (account: Account) => Promise<Answer>;
+  /** The meaning of a caught provider failure, or nothing when the error is a
+   *  bug of ours rather than the provider's. */
+  failure: (error: unknown) => Result | undefined;
+  /** What the answer means. */
+  judge: (answer: Answer, account: Account) => Result;
+  /** The answer when this provider is not configured at all. */
+  unconfigured: Result;
+};
+
+/** Ask one provider one thing. Only the call itself is caught: a bug in the
+ * reading step stays an internal error rather than becoming a provider
+ * answer. */
+export const askProvider = async <Account, Answer, Result>({
+  account,
+  ask,
+  failure,
+  judge,
+  unconfigured,
+}: ProviderCall<Account, Answer, Result>): Promise<Result> => {
+  if (account === null) return unconfigured;
+  let answer: Answer;
+  try {
+    answer = await ask(account);
+  } catch (error) {
+    const result = failure(error);
+    if (result === undefined) throw error;
+    return result;
+  }
+  return judge(answer, account);
+};

--- a/src/shared/payment/provider-resource-read.ts
+++ b/src/shared/payment/provider-resource-read.ts
@@ -1,15 +1,12 @@
 /**
- * The one shell every provider read runs inside.
+ * Reading a provider's records: the shared call shell bound to what a read
+ * means, and the ladder each answer is judged by.
  *
- * A read of a provider's records is the same four steps for all three
- * providers: check that the provider is configured at all, ask it, judge the
- * answer against facts we hold independently, and give a failed call its
- * {@link ProviderRead} meaning. Only asking and judging differ per provider,
- * so only those two are passed in.
- *
- * "Absent" means one thing here, for every provider: a call that comes back
- * with nothing is a documented resource the provider did not send, never a
- * provider that is not configured and never a malformed answer.
+ * A read is {@link askProvider} with two answers fixed for every provider. A
+ * provider nothing is configured for is unavailable. "Absent" means one thing
+ * too: a call that comes back with nothing is a documented resource the
+ * provider did not send, never a provider that is not configured and never a
+ * malformed answer.
  *
  * The judging step is declared as a ladder of refusals rather than written as
  * a chain of `if`s, so each refusal sits beside the reason it returns and a
@@ -17,6 +14,7 @@
  */
 
 import * as v from "valibot";
+import { askProvider, type ProviderCall } from "#payment/provider-call.ts";
 import { malformedProviderRead } from "#payment/provider-failures.ts";
 import type {
   ProviderInvalidReason,
@@ -28,44 +26,43 @@ const MISSING: ProviderRead<never> = {
   status: "invalid",
 };
 
-/** What one provider read needs to know beyond the call itself. */
-type ProviderResourceRead<Account, Answer, Resource> = {
-  /** The account facts the call needs, or null when nothing is configured. */
-  account: Account | null;
-  /** Ask the provider. Unwrap any envelope here, so an answer that carries no
-   *  resource comes back as null. */
-  ask: (account: Account) => Promise<Answer | null | undefined>;
-  /** Judge the answer: the resource, or the one reason it is refused. */
-  judge: (answer: Answer, account: Account) => ProviderRead<Resource>;
-  /** The read meaning of a caught provider failure, or nothing when the error
-   *  is a bug of ours rather than the provider's. */
-  failure: (error: unknown) => ProviderRead<never> | undefined;
+const NOT_CONFIGURED: ProviderRead<never> = {
+  reason: "not_configured",
+  status: "unavailable",
 };
 
-/** Read one provider resource. Only the call is caught: a bug in the judging
- * step stays an internal error rather than becoming a provider answer. */
-export const readProviderResource = async <Account, Answer, Resource>({
+/** What one provider read needs to know beyond the call itself: it asks the
+ *  same way any provider call does, and unwraps any envelope in that step so an
+ *  answer carrying no resource comes back as null. A read then says only how it
+ *  judges the answer, and what a failed call proves — never a found resource. */
+type ProviderResourceRead<Account, Answer, Resource> = Pick<
+  ProviderCall<Account, Answer | null | undefined, ProviderRead<Resource>>,
+  "account" | "ask"
+> & {
+  failure: (error: unknown) => ProviderRead<never> | undefined;
+  judge: (answer: Answer, account: Account) => ProviderRead<Resource>;
+};
+
+/** Read one provider resource: the shared call shell, told what an unconfigured
+ * provider and an empty answer mean for a read. */
+export const readProviderResource = <Account, Answer, Resource>({
   account,
   ask,
   judge,
   failure,
 }: ProviderResourceRead<Account, Answer, Resource>): Promise<
   ProviderRead<Resource>
-> => {
-  if (account === null) {
-    return { reason: "not_configured", status: "unavailable" };
-  }
-  let answer: Answer | null | undefined;
-  try {
-    answer = await ask(account);
-  } catch (error) {
-    const read = failure(error);
-    if (read === undefined) throw error;
-    return read;
-  }
-  if (answer === null || answer === undefined) return MISSING;
-  return judge(answer, account);
-};
+> =>
+  askProvider({
+    account,
+    ask,
+    failure,
+    judge: (answer, account) =>
+      answer === null || answer === undefined
+        ? MISSING
+        : judge(answer, account),
+    unconfigured: NOT_CONFIGURED,
+  });
 
 /** One provider's reads, once its account and failure reading are bound. The
  *  call and the judging are the only two things one read differs by. */

--- a/src/shared/payment/provider-resource-read.ts
+++ b/src/shared/payment/provider-resource-read.ts
@@ -14,7 +14,7 @@
  */
 
 import * as v from "valibot";
-import { askProvider, type ProviderCall } from "#payment/provider-call.ts";
+import { askProvider } from "#payment/provider-call.ts";
 import { malformedProviderRead } from "#payment/provider-failures.ts";
 import type {
   ProviderInvalidReason,
@@ -31,39 +31,6 @@ const NOT_CONFIGURED: ProviderRead<never> = {
   status: "unavailable",
 };
 
-/** What one provider read needs to know beyond the call itself: it asks the
- *  same way any provider call does, and unwraps any envelope in that step so an
- *  answer carrying no resource comes back as null. A read then says only how it
- *  judges the answer, and what a failed call proves — never a found resource. */
-type ProviderResourceRead<Account, Answer, Resource> = Pick<
-  ProviderCall<Account, Answer | null | undefined, ProviderRead<Resource>>,
-  "account" | "ask"
-> & {
-  failure: (error: unknown) => ProviderRead<never> | undefined;
-  judge: (answer: Answer, account: Account) => ProviderRead<Resource>;
-};
-
-/** Read one provider resource: the shared call shell, told what an unconfigured
- * provider and an empty answer mean for a read. */
-export const readProviderResource = <Account, Answer, Resource>({
-  account,
-  ask,
-  judge,
-  failure,
-}: ProviderResourceRead<Account, Answer, Resource>): Promise<
-  ProviderRead<Resource>
-> =>
-  askProvider({
-    account,
-    ask,
-    failure,
-    judge: (answer, account) =>
-      answer === null || answer === undefined
-        ? MISSING
-        : judge(answer, account),
-    unconfigured: NOT_CONFIGURED,
-  });
-
 /** One provider's reads, once its account and failure reading are bound. The
  *  call and the judging are the only two things one read differs by. */
 export type ResourceReader<Account> = <Answer, Resource>(
@@ -72,14 +39,24 @@ export type ResourceReader<Account> = <Answer, Resource>(
 ) => Promise<ProviderRead<Resource>>;
 
 /** Bind one provider's way of resolving its account and of reading a failed
- * call, so no read has to repeat either. */
+ * call, so no read has to repeat either. A failed call proves a refusal, never
+ * a found resource, which is why its reader answers a `ProviderRead<never>`. */
 export const providerResourceReader =
   <Account>(
     account: () => Account | null | Promise<Account | null>,
     failure: (error: unknown) => ProviderRead<never> | undefined,
   ): ResourceReader<Account> =>
   async (ask, judge) =>
-    readProviderResource({ account: await account(), ask, failure, judge });
+    askProvider({
+      account: await account(),
+      ask,
+      failure,
+      judge: (answer, resolved) =>
+        answer === null || answer === undefined
+          ? MISSING
+          : judge(answer, resolved),
+      unconfigured: NOT_CONFIGURED,
+    });
 
 /** One rung of a refusal ladder: it names the reason the answer is refused, or
  *  null when the answer passes this rung. */

--- a/src/shared/payment/refund-attempt.ts
+++ b/src/shared/payment/refund-attempt.ts
@@ -68,6 +68,13 @@ const needsReread = (
   attempt: RefundAttemptResult,
 ): attempt is RereadableRefundAttempt => REREAD_AFTER_SEND[attempt.kind];
 
+/** The answer when a refund never left this process, because the provider it
+ *  belongs to is not set up at all. Every adapter returns this same one. */
+export const REFUND_NOT_SENT: Extract<
+  RefundAttemptResult,
+  { kind: "not_sent" }
+> = { kind: "not_sent", reason: "not_configured" };
+
 /** Name an uncertain send without repeating its tagged-result shape. */
 export const uncertainRefund = (
   reason: UncertainRefundAttempt["reason"],

--- a/src/shared/square-provider.ts
+++ b/src/shared/square-provider.ts
@@ -12,9 +12,13 @@
  * - Webhook setup is manual (user provides signature key from dashboard)
  */
 
+import {
+  mapProviderReader,
+  type ProviderRead,
+} from "#payment/provider-read.ts";
 import { refundWithOneReread } from "#payment/refund-attempt.ts";
 import { requireProviderRefundAuthorization } from "#payment/refund-provider-authorization.ts";
-import { chargeMoneyRead } from "#payment/resources.ts";
+import { type ChargeMoney, chargeMoneyRead } from "#payment/resources.ts";
 import { validatedPaymentSession } from "#payment/validated-session.ts";
 /* jscpd:ignore-start -- imports */
 import { logDebug } from "#shared/logger.ts";
@@ -231,6 +235,27 @@ const readOrderPayment = async (
   return { payment, paymentReference };
 };
 
+/** Read one Square payment as the shared charge-money shape. */
+const readSquareCharge = mapProviderReader(
+  // A lambda, not the member itself: resolving it per call keeps test stubs live.
+  (reference: string) => squareApi.readPayment(reference),
+  (payment: SquarePayment): ProviderRead<ChargeMoney> => {
+    if (payment.status !== "COMPLETED") {
+      return { reason: "unsupported_status", status: "invalid" };
+    }
+    const captured = payment.amountMoney;
+    const refunded = payment.refundedMoney;
+    if (captured && refunded && captured.currency !== refunded.currency) {
+      return { reason: "mismatched_money", status: "invalid" };
+    }
+    return chargeMoneyRead(
+      captured?.amount,
+      captured?.currency,
+      squareMoneyReturned(refunded, captured),
+    );
+  },
+);
+
 /** Square's checkout-session builder (see {@link makeCreateCheckoutSession}). */
 const createSquareCheckoutSession = makeCreateCheckoutSession(
   "square",
@@ -246,22 +271,7 @@ export const squarePaymentProvider: PaymentProvider = {
 
   createCheckoutSession: createSquareCheckoutSession,
 
-  async readCharge(
-    paymentReference: string,
-  ): ReturnType<PaymentProvider["readCharge"]> {
-    const read = await squareApi.readPayment(paymentReference);
-    if (read.status !== "found") return read;
-    if (read.resource.status !== "COMPLETED") {
-      return { reason: "unsupported_status", status: "invalid" };
-    }
-    const captured = read.resource.amountMoney;
-    const refunded = read.resource.refundedMoney;
-    if (captured && refunded && captured.currency !== refunded.currency) {
-      return { reason: "mismatched_money", status: "invalid" };
-    }
-    const returned = squareMoneyReturned(refunded, captured);
-    return chargeMoneyRead(captured?.amount, captured?.currency, returned);
-  },
+  readCharge: readSquareCharge,
 
   refundCharge: refundWithOneReread(
     (request) => {

--- a/src/shared/square/payment-outcomes.ts
+++ b/src/shared/square/payment-outcomes.ts
@@ -1,10 +1,12 @@
 /* jscpd:ignore-start */
+import { askProvider } from "#payment/provider-call.ts";
 import { withExactRefundMoney } from "#payment/provider-failures.ts";
 import type { ProviderRead } from "#payment/provider-read.ts";
 import { judgedBy, refuseUnless } from "#payment/provider-resource-read.ts";
-import type {
-  RefundAttemptResult,
-  RefundRequest,
+import {
+  REFUND_NOT_SENT,
+  type RefundAttemptResult,
+  type RefundRequest,
 } from "#payment/refund-attempt.ts";
 import type { AuthorizedRefundRequest } from "#payment/refund-provider-authorization.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
@@ -98,35 +100,39 @@ const refundResult = (
     },
   );
 
+/** Record every failed send, whether or not Square owns the failure. */
+const loggedSquareRefundFailure = (
+  error: unknown,
+): RefundAttemptResult | undefined => {
+  const failure = squareRefundFailure(error);
+  logError({
+    code: ErrorCode.SQUARE_REFUND,
+    detail: failure
+      ? `outcome=${failure.kind} reason=${failure.reason}`
+      : "outcome=thrown reason=internal_error",
+    error,
+  });
+  return failure;
+};
+
 /** Send the exact admitted charge and keep Square's evidence as a tagged
  * result. Unknown internal errors still propagate. */
 export const refundSquareCharge = async (
   getClient: GetSquarePaymentClient,
   request: AuthorizedRefundRequest<"square">,
-): Promise<RefundAttemptResult> => {
-  const client = await getClient();
-  if (!client) return { kind: "not_sent", reason: "not_configured" };
-  let answer: { refund: SquareRefund };
-  try {
-    answer = await client.refunds.refundPayment({
-      amountMoney: {
-        amount: BigInt(request.charge.captured.amount),
-        currency: request.charge.captured.currency,
-      },
-      idempotencyKey: request.authorization.idempotencyKey,
-      paymentId: request.paymentReference,
-    });
-  } catch (error) {
-    const failure = squareRefundFailure(error);
-    logError({
-      code: ErrorCode.SQUARE_REFUND,
-      detail: failure
-        ? `outcome=${failure.kind} reason=${failure.reason}`
-        : "outcome=thrown reason=internal_error",
-      error,
-    });
-    if (failure) return failure;
-    throw error;
-  }
-  return refundResult(answer.refund, request);
-};
+): Promise<RefundAttemptResult> =>
+  askProvider({
+    account: await getClient(),
+    ask: (client: SquarePaymentClient) =>
+      client.refunds.refundPayment({
+        amountMoney: {
+          amount: BigInt(request.charge.captured.amount),
+          currency: request.charge.captured.currency,
+        },
+        idempotencyKey: request.authorization.idempotencyKey,
+        paymentId: request.paymentReference,
+      }),
+    failure: loggedSquareRefundFailure,
+    judge: (answer) => refundResult(answer.refund, request),
+    unconfigured: REFUND_NOT_SENT,
+  });

--- a/src/shared/stripe.ts
+++ b/src/shared/stripe.ts
@@ -2,8 +2,8 @@
 
 import { settings } from "#db/settings.ts";
 import type { Money } from "#payment/money.ts";
+import { askProvider, type ProviderCall } from "#payment/provider-call.ts";
 import {
-  type ProviderFailure,
   providerFailureOf,
   requireProviderFailure,
   withExactRefundMoney,
@@ -11,10 +11,11 @@ import {
 import type { ProviderRead } from "#payment/provider-read.ts";
 import {
   judgedBy,
-  readProviderResource,
+  providerResourceReader,
   refuseUnless,
 } from "#payment/provider-resource-read.ts";
 import {
+  REFUND_NOT_SENT,
   type RefundAttemptResult,
   type RefundRequest,
   uncertainRefund,
@@ -128,37 +129,34 @@ export interface StripeApi {
   testStripeConnection: () => Promise<StripeConnectionTestResult>;
 }
 
-const withStripeClient = async <Result>(
-  notConfigured: Result,
-  useClient: (client: StripeClient) => Promise<Result>,
-  useError: (error: unknown, failure: ProviderFailure | undefined) => Result,
-): Promise<Result> => {
-  const client = await stripeClientRuntime.get();
-  if (client === null) return notConfigured;
-  try {
-    return await useClient(client);
-  } catch (error) {
-    return useError(error, providerFailureOf(error));
-  }
-};
+/** Read one Stripe resource on the configured client. */
+const readStripeResource = providerResourceReader(
+  () => stripeClientRuntime.get(),
+  (error) => providerFailureOf(error)?.read,
+);
 
-const readPaymentIntent = async (
+/** Ask Stripe one thing on the configured client, answering as the caller says
+ *  an unconfigured Stripe must be answered. */
+const askStripe = async <Answer, Result>(
+  call: Omit<ProviderCall<StripeClient, Answer, Result>, "account">,
+): Promise<Result> =>
+  askProvider({ ...call, account: await stripeClientRuntime.get() });
+
+const readPaymentIntent = (
   id: string,
 ): Promise<ProviderRead<StripeExpandedPaymentIntent>> =>
-  readProviderResource({
-    account: await stripeClientRuntime.get(),
-    ask: (client) =>
+  readStripeResource(
+    (client) =>
       client.paymentIntents.retrieveWithLatestCharge(id, {
         maxNetworkRetries: REFUND_NETWORK_RETRIES.stripe,
       }),
-    failure: (error) => providerFailureOf(error)?.read,
-    judge: judgedBy([
+    judgedBy([
       refuseUnless(
         "mismatched_id",
         (intent: StripeExpandedPaymentIntent) => intent.id === id,
       ),
     ]),
-  });
+  );
 
 type StripeRefundStatus = Exclude<StripeRefund["status"], null>;
 type StripeRefundAnswer = (
@@ -217,21 +215,20 @@ const stripeRefundResult = (
 const refundCharge = (
   request: AuthorizedRefundRequest<"stripe">,
 ): Promise<RefundAttemptResult> =>
-  withStripeClient<RefundAttemptResult>(
-    { kind: "not_sent", reason: "not_configured" },
-    async (client) => {
-      const refund = await client.refunds.create(
+  askStripe({
+    ask: (client) =>
+      client.refunds.create(
         {
           amount: request.charge.captured.amount,
           payment_intent: request.paymentReference,
         },
         request.authorization.idempotencyKey,
         { maxNetworkRetries: REFUND_NETWORK_RETRIES.stripe },
-      );
-      return stripeRefundResult(request, refund);
-    },
-    (error) => requireProviderFailure(error).refund,
-  );
+      ),
+    failure: (error) => requireProviderFailure(error).refund,
+    judge: (refund) => stripeRefundResult(request, refund),
+    unconfigured: REFUND_NOT_SENT,
+  });
 
 class StripeCheckoutReadError extends Error {
   constructor(reason: string) {
@@ -240,26 +237,31 @@ class StripeCheckoutReadError extends Error {
   }
 }
 
-const retrieveCheckoutSession = async (
+/** A checkout Stripe says is gone is a genuine absence; anything else stops
+ *  the read loudly, after one logged line naming what Stripe answered. */
+const checkoutReadFailure = (error: unknown): StripeCheckoutSession | null => {
+  const failure = providerFailureOf(error);
+  if (failure?.read.status === "missing") return null;
+  logError({
+    code: ErrorCode.STRIPE_SESSION,
+    detail: sanitizeStripeError(error),
+  });
+  throw new StripeCheckoutReadError(
+    failure === undefined
+      ? "unexpected_failure"
+      : `${failure.read.status}:${failure.read.reason}`,
+  );
+};
+
+const retrieveCheckoutSession = (
   id: string,
 ): Promise<StripeCheckoutSession | null> =>
-  withStripeClient<StripeCheckoutSession | null>(
-    null,
-    (client) => client.checkout.sessions.retrieve(id),
-    (error, failure) => {
-      if (failure?.read.status === "missing") return null;
-      logError({
-        code: ErrorCode.STRIPE_SESSION,
-        detail: sanitizeStripeError(error),
-      });
-      if (failure === undefined) {
-        throw new StripeCheckoutReadError("unexpected_failure");
-      }
-      throw new StripeCheckoutReadError(
-        `${failure.read.status}:${failure.read.reason}`,
-      );
-    },
-  );
+  askStripe({
+    ask: (client) => client.checkout.sessions.retrieve(id),
+    failure: checkoutReadFailure,
+    judge: (session) => session,
+    unconfigured: null,
+  });
 
 export const stripeApi: StripeApi = {
   cleanupOldWebhookEndpoints,

--- a/src/shared/sumup-observation.ts
+++ b/src/shared/sumup-observation.ts
@@ -17,19 +17,29 @@
  * captured charge to the refund path instead of stranding it.
  */
 
+/* jscpd:ignore-start -- imports */
 import * as v from "valibot";
 import { isCurrency } from "#payment/money.ts";
 import type {
   ProviderInvalidReason,
   ProviderRead,
 } from "#payment/provider-read.ts";
+import {
+  judgeThrough,
+  parsedBy,
+  type Rung,
+  refuseUnless,
+} from "#payment/provider-resource-read.ts";
 import { isResourceId } from "#payment/resource-id.ts";
 import { toMinorUnits } from "#shared/currency.ts";
+import { requireValue } from "#shared/required-value.ts";
 import {
   SumupWireTransactionSchema,
   sumupPaymentFields,
 } from "#shared/sumup/wire.ts";
 import { exceedsCurrencyPrecision } from "#shared/validation/money.ts";
+
+/* jscpd:ignore-end */
 
 /** SumUp's documented checkout lifecycle (pinned @sumup/sdk 0.1.6). */
 const SumupCheckoutStatusSchema = v.picklist([
@@ -85,19 +95,15 @@ const WireCheckoutSchema = v.object({
 });
 type WireCheckout = v.InferOutput<typeof WireCheckoutSchema>;
 
-const invalidRead = (reason: ProviderInvalidReason): ProviderRead<never> => ({
-  reason,
-  status: "invalid",
-});
-
-/** What checking a checkout's charges concluded: a refusal reason, or an
- *  acceptance saying whether the named charge vouched for the money. Money a
+/** What checking a checkout's charges concluded: the reason they are refused,
+ *  or null beside whether the named charge vouched for the money. Money a
  *  charge did not vouch for is carried as unreadable — the session boundary's
  *  refusal is what sends a captured charge to the refund path, while refusing
  *  the whole read would strand it once SumUp's retries run out. */
-type ChildVerdict =
-  | { failure: ProviderInvalidReason }
-  | { failure: null; moneyVouchedFor: boolean };
+type ChildVerdict = {
+  failure: ProviderInvalidReason | null;
+  moneyVouchedFor: boolean;
+};
 
 /** The named charge vouches for the checkout's money only when it states
  *  both fields itself and neither disputes the checkout's own record. */
@@ -111,7 +117,10 @@ const chargeVouchesForMoney = (
   (c.currency === undefined ||
     charge.currency.toUpperCase() === c.currency.toUpperCase());
 
-const UNRECORDED_CHILD: ChildVerdict = { failure: "unrecorded_child" };
+const UNRECORDED_CHILD: ChildVerdict = {
+  failure: "unrecorded_child",
+  moneyVouchedFor: false,
+};
 
 /** One lifecycle status's rule for the charges a checkout may carry. */
 type ChildRule = (
@@ -135,7 +144,7 @@ const pendingChildVerdict: ChildRule = (c, charge, extras) => {
  *  names, captured under our merchant. */
 const paidChildVerdict: ChildRule = (c, charge, extras) => {
   if (!isResourceId(c.transaction_id ?? "") || charge === undefined) {
-    return { failure: "missing_documented_resource" };
+    return { failure: "missing_documented_resource", moneyVouchedFor: false };
   }
   if (extras.length > 0) return UNRECORDED_CHILD;
   if (charge.id !== c.transaction_id) return UNRECORDED_CHILD;
@@ -156,14 +165,45 @@ const checkChildren = (c: WireCheckout): ChildVerdict => {
     : UNRECORDED_CHILD;
 };
 
+/** Our own checkout reference, or null when SumUp named none we minted. A
+ *  checkout we created always carries the reference we generated: the booking
+ *  is encrypted under it, so without one the row cannot be opened. */
+const ourReference = (c: WireCheckout): string | null =>
+  c.checkout_reference !== undefined && isResourceId(c.checkout_reference)
+    ? c.checkout_reference
+    : null;
+
+/** The lifecycle SumUp named, or null when it is one we cannot read. */
+const knownStatus = (c: WireCheckout): SumupCheckoutStatus | null => {
+  const status = v.safeParse(SumupCheckoutStatusSchema, c.status);
+  return status.success ? status.output : null;
+};
+
+/** One fetched checkout, read once: the wire body beside the three answers the
+ *  rungs judge it by and the accept step then uses. */
+type ReadCheckout = {
+  checkout: WireCheckout;
+  children: ChildVerdict;
+  reference: string | null;
+  status: SumupCheckoutStatus | null;
+};
+
+const readCheckout = (body: unknown): ReadCheckout | null => {
+  const checkout = parsedBy(WireCheckoutSchema)(body);
+  if (checkout === null) return null;
+  return {
+    checkout,
+    children: checkChildren(checkout),
+    reference: ourReference(checkout),
+    status: knownStatus(checkout),
+  };
+};
+
 /** Normalize the accepted wire checkout, reading its amount in the currency
  *  SumUp returned with it and carrying unreadable money through as null. */
 const toSumupCheckout = (
-  c: WireCheckout,
-  status: SumupCheckoutStatus,
-  reference: string,
+  { checkout: c, children, reference, status }: ReadCheckout,
   facts: SumupReadFacts,
-  moneyVouchedFor: boolean,
 ): SumupCheckout => {
   const amount = typeof c.amount === "number" ? c.amount : null;
   const currency =
@@ -180,53 +220,46 @@ const toSumupCheckout = (
   // did not vouch for is unreadable too: a booking must never be priced by a
   // record the captured charge itself does not confirm.
   const readable =
-    moneyVouchedFor &&
+    children.moneyVouchedFor &&
     amount !== null &&
     !exceedsCurrencyPrecision(amount, conversionCurrency);
   return {
     amountMinor: readable ? toMinorUnits(amount, conversionCurrency) : null,
     createdAt: c.date,
     currency,
-    reference,
-    status,
+    // The two rungs above accepted this checkout on exactly these answers.
+    reference: requireValue(reference, "Accepted a checkout of nobody's"),
+    status: requireValue(status, "Accepted a checkout with no lifecycle"),
     transactionId: c.transaction_id ?? "",
   };
 };
 
-/**
- * Check one fetched checkout body against the facts we hold independently,
- * in the order the facts bind: shape, reference, id, merchant, lifecycle,
- * then the charge the record names.
- */
+/** What SumUp must state about a checkout before we can read it, in the order
+ *  the facts bind: shape, reference, id, merchant, lifecycle, then the charge
+ *  the record names. */
+const CHECKOUT_RUNGS = (
+  facts: SumupReadFacts,
+): readonly Rung<ReadCheckout>[] => [
+  refuseUnless("malformed_response", (read) => read.reference !== null),
+  refuseUnless(
+    "mismatched_id",
+    (read) => read.checkout.id === facts.requestedId,
+  ),
+  refuseUnless(
+    "mismatched_account",
+    (read) => read.checkout.merchant_code === facts.merchantCode,
+  ),
+  refuseUnless("unsupported_status", (read) => read.status !== null),
+  (read) => read.children.failure,
+];
+
+/** Check one fetched checkout body against the facts we hold independently. */
 export const classifySumupCheckout = (
   body: unknown,
   facts: SumupReadFacts,
-): ProviderRead<SumupCheckout> => {
-  const parsed = v.safeParse(WireCheckoutSchema, body);
-  if (!parsed.success) return invalidRead("malformed_response");
-  const c = parsed.output;
-  const reference = c.checkout_reference;
-  // A checkout we created always carries the reference we generated; the
-  // booking is encrypted under it, so without one the row cannot be opened.
-  if (reference === undefined || !isResourceId(reference)) {
-    return invalidRead("malformed_response");
-  }
-  if (c.id !== facts.requestedId) return invalidRead("mismatched_id");
-  if (c.merchant_code !== facts.merchantCode) {
-    return invalidRead("mismatched_account");
-  }
-  const status = v.safeParse(SumupCheckoutStatusSchema, c.status);
-  if (!status.success) return invalidRead("unsupported_status");
-  const verdict = checkChildren(c);
-  if (verdict.failure !== null) return invalidRead(verdict.failure);
-  return {
-    resource: toSumupCheckout(
-      c,
-      status.output,
-      reference,
-      facts,
-      verdict.moneyVouchedFor,
-    ),
-    status: "found",
-  };
-};
+): ProviderRead<SumupCheckout> =>
+  judgeThrough({
+    accept: (read: ReadCheckout): SumupCheckout => toSumupCheckout(read, facts),
+    parse: readCheckout,
+    rungs: CHECKOUT_RUNGS(facts),
+  })(body);

--- a/src/shared/sumup-observation.ts
+++ b/src/shared/sumup-observation.ts
@@ -227,9 +227,15 @@ const toSumupCheckout = (
     amountMinor: readable ? toMinorUnits(amount, conversionCurrency) : null,
     createdAt: c.date,
     currency,
-    // The two rungs above accepted this checkout on exactly these answers.
-    reference: requireValue(reference, "Accepted a checkout of nobody's"),
-    status: requireValue(status, "Accepted a checkout with no lifecycle"),
+    // The ladder refuses a checkout that states neither, so both are here.
+    reference: requireValue(
+      reference,
+      "The ladder accepted a SumUp checkout with no reference of ours",
+    ),
+    status: requireValue(
+      status,
+      "The ladder accepted a SumUp checkout with no known lifecycle",
+    ),
     transactionId: c.transaction_id ?? "",
   };
 };

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -12,6 +12,7 @@
  * - No webhook endpoint to set up (return_url is set per checkout)
  */
 
+import * as v from "valibot";
 import { getSumupCheckout } from "#db/sumup-checkouts.ts";
 import {
   type RefundAttemptResult,
@@ -41,14 +42,27 @@ import {
 import { readSumupCharge, sumupRefundOutcome } from "#shared/sumup/money.ts";
 import { sumupApi } from "#shared/sumup.ts";
 
-/** Build the provider-agnostic event from the two fields SumUp posts. A
- *  callback naming neither is not one of ours: resolveWebhookSession refuses a
- *  blank id before it looks anything up, so the absence is carried through
- *  rather than guessed at. */
-const sumupWebhookEvent = (body: unknown): WebhookEvent => {
-  const posted = body as { event_type?: string; id?: string };
-  const id = posted.id ?? "";
-  return { data: { object: { id } }, id, type: posted.event_type ?? "" };
+/** SumUp posts an object carrying two fields. A body that is not an object
+ *  names no checkout at all, and this public door is unsigned, so anyone can
+ *  post one. */
+const SumupWebhookBodySchema = v.object({
+  event_type: v.optional(v.string()),
+  id: v.optional(v.string()),
+});
+
+/** Build the provider-agnostic event from the two fields SumUp posts, or
+ *  nothing when the body is not one of its callbacks. A callback naming
+ *  neither field is still read: resolveWebhookSession refuses a blank id
+ *  before it looks anything up, so that absence is carried through rather
+ *  than guessed at. */
+const sumupWebhookEvent = (body: unknown): WebhookEvent | null => {
+  // valibot reads a list as an object carrying none of the fields, and a
+  // SumUp callback is never a list.
+  if (Array.isArray(body)) return null;
+  const posted = v.safeParse(SumupWebhookBodySchema, body);
+  if (!posted.success) return null;
+  const id = posted.output.id ?? "";
+  return { data: { object: { id } }, id, type: posted.output.event_type ?? "" };
 };
 
 /** SumUp's checkout-session builder (see {@link makeCreateCheckoutSession}). */

--- a/src/shared/sumup-provider.ts
+++ b/src/shared/sumup-provider.ts
@@ -21,7 +21,11 @@ import {
   type AuthorizedRefundRequest,
   requireProviderRefundAuthorization,
 } from "#payment/refund-provider-authorization.ts";
-import { makeCreateCheckoutSession } from "#shared/payment-helpers.ts";
+import { ErrorCode } from "#shared/logger.ts";
+import {
+  makeCreateCheckoutSession,
+  parseWebhookPayload,
+} from "#shared/payment-helpers.ts";
 import type {
   PaymentProvider,
   RetrieveSessionResult,
@@ -36,6 +40,16 @@ import {
 } from "#shared/sumup/checkout-resolution.ts";
 import { readSumupCharge, sumupRefundOutcome } from "#shared/sumup/money.ts";
 import { sumupApi } from "#shared/sumup.ts";
+
+/** Build the provider-agnostic event from the two fields SumUp posts. A
+ *  callback naming neither is not one of ours: resolveWebhookSession refuses a
+ *  blank id before it looks anything up, so the absence is carried through
+ *  rather than guessed at. */
+const sumupWebhookEvent = (body: unknown): WebhookEvent => {
+  const posted = body as { event_type?: string; id?: string };
+  const id = posted.id ?? "";
+  return { data: { object: { id } }, id, type: posted.event_type ?? "" };
+};
 
 /** SumUp's checkout-session builder (see {@link makeCreateCheckoutSession}). */
 const createSumupCheckoutSession = makeCreateCheckoutSession(
@@ -124,24 +138,9 @@ export const sumupPaymentProvider: PaymentProvider = {
 
   verifyWebhookSignature(payload: string): Promise<WebhookVerifyResult> {
     // SumUp does not sign webhooks; authenticity is established in
-    // resolveWebhookSession. We only parse the tiny payload
-    // ({ event_type, id }) into the provider-agnostic event shape here.
-    try {
-      const parsed = JSON.parse(payload) as {
-        event_type?: string;
-        id?: string;
-      };
-      const id = parsed.id ?? "";
-      return Promise.resolve({
-        listing: {
-          data: { object: { id } },
-          id,
-          type: parsed.event_type ?? "",
-        },
-        valid: true,
-      });
-    } catch {
-      return Promise.resolve({ error: "Invalid JSON payload", valid: false });
-    }
+    // resolveWebhookSession. This door only reads the tiny payload.
+    return Promise.resolve(
+      parseWebhookPayload(payload, ErrorCode.SUMUP_WEBHOOK, sumupWebhookEvent),
+    );
   },
 };

--- a/src/shared/sumup.ts
+++ b/src/shared/sumup.ts
@@ -20,11 +20,13 @@
 import { settings } from "#db/settings.ts";
 import { setSumupCheckoutId, storeSumupCheckout } from "#db/sumup-checkouts.ts";
 import { closedCheckoutErrorFor } from "#payment/checkout-failure.ts";
+import { askProvider } from "#payment/provider-call.ts";
 import type { ProviderRead } from "#payment/provider-read.ts";
 import {
   providerResourceReader,
   type ResourceReader,
 } from "#payment/provider-resource-read.ts";
+import { REFUND_NOT_SENT } from "#payment/refund-attempt.ts";
 import { transportFactsOf } from "#payment/transport-error.ts";
 /* jscpd:ignore-start */
 import { priceCheckout } from "#shared/checkout-pricing.ts";
@@ -246,21 +248,16 @@ export const sumupApi: {
     ),
 
   /** Submit a full refund without overstating SumUp's empty success body. */
-  refundTransaction: async (
-    transactionId: string,
-  ): Promise<SumupRefundSubmission> => {
-    const account = configuredSumupAccount();
-    if (account === null) return { kind: "not_sent", reason: "not_configured" };
-    try {
-      await account.client.refundTransaction(
-        account.merchantCode,
-        transactionId,
-      );
-      return { kind: "sent" };
-    } catch (err) {
-      return sumupRefundFailure(err);
-    }
-  },
+  refundTransaction: (transactionId: string): Promise<SumupRefundSubmission> =>
+    askProvider({
+      account: configuredSumupAccount(),
+      ask: (account: SumupAccount) =>
+        account.client.refundTransaction(account.merchantCode, transactionId),
+      failure: sumupRefundFailure,
+      // An empty success body only proves the request was sent.
+      judge: (): SumupRefundSubmission => ({ kind: "sent" }),
+      unconfigured: REFUND_NOT_SENT,
+    }),
 
   /** Test connection: verify API key + merchant code + currency support. */
   testSumupConnection: async (): Promise<SumupConnectionTestResult> => {

--- a/src/shared/webhook-verification.ts
+++ b/src/shared/webhook-verification.ts
@@ -1,6 +1,6 @@
 import type { ErrorCodeType } from "#shared/logger.ts";
 import { parseWebhookPayload } from "#shared/payment-helpers.ts";
-import type { WebhookVerifyResult } from "#shared/payments.ts";
+import type { WebhookEvent, WebhookVerifyResult } from "#shared/payments.ts";
 
 /** Turn a signature check outcome into the standard verify result: a plain
  * failure when the signature did not match, or the parsed event when it did.
@@ -13,5 +13,6 @@ export const finishWebhookVerification = (
   errorCode: ErrorCodeType,
 ): WebhookVerifyResult =>
   matched
-    ? parseWebhookPayload(payload, errorCode)
+    ? // A provider that signs its webhooks posts the event itself.
+      parseWebhookPayload(payload, errorCode, (body) => body as WebhookEvent)
     : { error: "Signature verification failed", valid: false };

--- a/src/shared/webhook-verification.ts
+++ b/src/shared/webhook-verification.ts
@@ -2,6 +2,14 @@ import type { ErrorCodeType } from "#shared/logger.ts";
 import { parseWebhookPayload } from "#shared/payment-helpers.ts";
 import type { WebhookEvent, WebhookVerifyResult } from "#shared/payments.ts";
 
+/** A provider that signs its webhooks posts the event itself, so the body is
+ *  the event — as long as it is an object at all. Anything else carries no
+ *  fields to read, and every reader of a `WebhookEvent` reads fields off it. */
+const signedWebhookEvent = (body: unknown): WebhookEvent | null =>
+  typeof body === "object" && body !== null && !Array.isArray(body)
+    ? (body as WebhookEvent)
+    : null;
+
 /** Turn a signature check outcome into the standard verify result: a plain
  * failure when the signature did not match, or the parsed event when it did.
  * Each provider passes its own error code so a bad payload logs under the right
@@ -13,6 +21,5 @@ export const finishWebhookVerification = (
   errorCode: ErrorCodeType,
 ): WebhookVerifyResult =>
   matched
-    ? // A provider that signs its webhooks posts the event itself.
-      parseWebhookPayload(payload, errorCode, (body) => body as WebhookEvent)
+    ? parseWebhookPayload(payload, errorCode, signedWebhookEvent)
     : { error: "Signature verification failed", valid: false };

--- a/test/shared/logger/error-codes.test.ts
+++ b/test/shared/logger/error-codes.test.ts
@@ -50,6 +50,7 @@ describe("error codes", () => {
       STRIPE_SESSION: "E_STRIPE_SESSION",
       STRIPE_SIGNATURE: "E_STRIPE_SIGNATURE",
       STRIPE_WEBHOOK_SETUP: "E_STRIPE_WEBHOOK_SETUP",
+      SUMUP_WEBHOOK: "E_SUMUP_WEBHOOK",
       VALIDATION_CONTENT_TYPE: "E_VALIDATION_CONTENT_TYPE",
       VALIDATION_FORM: "E_VALIDATION_FORM",
       WEBHOOK_PRICE_SIGNATURE: "E_WEBHOOK_PRICE_SIGNATURE",
@@ -98,6 +99,7 @@ describe("error codes", () => {
       E_STRIPE_SESSION: "Stripe session retrieval failed",
       E_STRIPE_SIGNATURE: "Stripe signature verification failed",
       E_STRIPE_WEBHOOK_SETUP: "Stripe webhook setup failed",
+      E_SUMUP_WEBHOOK: "SumUp webhook could not be read",
       E_VALIDATION_CONTENT_TYPE: "Invalid content type",
       E_VALIDATION_FORM: "Form validation error",
       E_WEBHOOK_PRICE_SIGNATURE:

--- a/test/shared/payment-helpers/dispatch.test.ts
+++ b/test/shared/payment-helpers/dispatch.test.ts
@@ -232,9 +232,41 @@ describe("payment-helpers", () => {
     expect(build).toEqual(expect.objectContaining({ createdAt }));
   });
 
+  const readIdField = (body: unknown) => {
+    const posted = body as { id: string };
+    return { data: { object: { id: posted.id } }, id: posted.id, type: "x" };
+  };
+
   test("parseWebhookPayload returns the invalid JSON error", () => {
-    expect(parseWebhookPayload("not JSON", ErrorCode.PAYMENT_CHECKOUT)).toEqual(
-      { error: "Invalid JSON payload", valid: false },
-    );
+    expect(
+      parseWebhookPayload("not JSON", ErrorCode.PAYMENT_CHECKOUT, readIdField),
+    ).toEqual({ error: "Invalid JSON payload", valid: false });
+  });
+
+  test("parseWebhookPayload reads the body the way its provider says", () => {
+    expect(
+      parseWebhookPayload('{"id":"evt_1"}', ErrorCode.PAYMENT_CHECKOUT, () => ({
+        data: { object: { id: "shaped" } },
+        id: "shaped",
+        type: "shaped.type",
+      })),
+    ).toEqual({
+      listing: {
+        data: { object: { id: "shaped" } },
+        id: "shaped",
+        type: "shaped.type",
+      },
+      valid: true,
+    });
+  });
+
+  // A bug in the reading step is ours, not a payload the provider mangled, so
+  // it must not come back as the invalid-JSON refusal.
+  test("parseWebhookPayload lets a broken reading step throw", () => {
+    expect(() =>
+      parseWebhookPayload("{}", ErrorCode.PAYMENT_CHECKOUT, () => {
+        throw new Error("reading step is broken");
+      }),
+    ).toThrow("reading step is broken");
   });
 });

--- a/test/shared/payment-helpers/dispatch.test.ts
+++ b/test/shared/payment-helpers/dispatch.test.ts
@@ -243,19 +243,15 @@ describe("payment-helpers", () => {
     ).toEqual({ error: "Invalid JSON payload", valid: false });
   });
 
-  test("parseWebhookPayload reads the body the way its provider says", () => {
+  test("parseWebhookPayload hands the parsed body to its provider", () => {
     expect(
-      parseWebhookPayload('{"id":"evt_1"}', ErrorCode.PAYMENT_CHECKOUT, () => ({
-        data: { object: { id: "shaped" } },
-        id: "shaped",
-        type: "shaped.type",
-      })),
+      parseWebhookPayload(
+        '{"id":"evt_1"}',
+        ErrorCode.PAYMENT_CHECKOUT,
+        readIdField,
+      ),
     ).toEqual({
-      listing: {
-        data: { object: { id: "shaped" } },
-        id: "shaped",
-        type: "shaped.type",
-      },
+      listing: { data: { object: { id: "evt_1" } }, id: "evt_1", type: "x" },
       valid: true,
     });
   });
@@ -264,6 +260,18 @@ describe("payment-helpers", () => {
     expect(
       parseWebhookPayload("{}", ErrorCode.PAYMENT_CHECKOUT, () => null),
     ).toEqual({ error: "Invalid JSON payload", valid: false });
+  });
+
+  test("parseWebhookPayload records the body its provider could not read", () => {
+    const errorSpy = spy(console, "error");
+    try {
+      parseWebhookPayload("{}", ErrorCode.PAYMENT_CHECKOUT, () => null);
+      expect(errorSpy.calls[0]?.args[0]).toBe(
+        '[Error] E_PAYMENT_CHECKOUT detail="JSON payload is not an event"',
+      );
+    } finally {
+      errorSpy.restore();
+    }
   });
 
   // A bug in the reading step is ours, not a payload the provider mangled, so

--- a/test/shared/payment-helpers/dispatch.test.ts
+++ b/test/shared/payment-helpers/dispatch.test.ts
@@ -260,6 +260,12 @@ describe("payment-helpers", () => {
     });
   });
 
+  test("parseWebhookPayload refuses JSON its provider cannot read", () => {
+    expect(
+      parseWebhookPayload("{}", ErrorCode.PAYMENT_CHECKOUT, () => null),
+    ).toEqual({ error: "Invalid JSON payload", valid: false });
+  });
+
   // A bug in the reading step is ours, not a payload the provider mangled, so
   // it must not come back as the invalid-JSON refusal.
   test("parseWebhookPayload lets a broken reading step throw", () => {

--- a/test/shared/payment/provider-call.test.ts
+++ b/test/shared/payment/provider-call.test.ts
@@ -1,0 +1,101 @@
+import { assertRejects } from "@std/assert";
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { askProvider } from "#payment/provider-call.ts";
+
+type Account = { token: string };
+
+const account: Account = { token: "k" };
+
+const neverAsked = (): Promise<never> => {
+  throw new Error("The provider must not be asked");
+};
+
+const neverRead = (): never => {
+  throw new Error("The answer must not be read");
+};
+
+describe("provider call", () => {
+  test("does not ask an unconfigured provider anything", async () => {
+    expect(
+      await askProvider({
+        account: null,
+        ask: neverAsked,
+        failure: neverRead,
+        judge: neverRead,
+        unconfigured: "nothing is set up",
+      }),
+    ).toBe("nothing is set up");
+  });
+
+  test("hands the account to the call and to the reading", async () => {
+    expect(
+      await askProvider({
+        account,
+        ask: (given) => Promise.resolve(given.token.toUpperCase()),
+        failure: neverRead,
+        judge: (answer, given) => `${answer}:${given.token}`,
+        unconfigured: "unused",
+      }),
+    ).toBe("K:k");
+  });
+
+  test("gives a failed call the meaning its failure reader proves", async () => {
+    expect(
+      await askProvider({
+        account,
+        ask: () => Promise.reject(new Error("429")),
+        failure: (error) => `refused: ${(error as Error).message}`,
+        judge: neverRead,
+        unconfigured: "unused",
+      }),
+    ).toBe("refused: 429");
+  });
+
+  test("re-raises a failure the provider does not own", async () => {
+    const ours = new Error("a bug of ours");
+    await assertRejects(
+      () =>
+        askProvider({
+          account,
+          ask: () => Promise.reject(ours),
+          failure: () => undefined,
+          judge: neverRead,
+          unconfigured: "unused",
+        }),
+      Error,
+      "a bug of ours",
+    );
+  });
+
+  // The reading step runs outside the catch, so a bug there stays our error
+  // instead of being handed to the failure reader as a provider answer.
+  test("does not read a broken reading step as a provider failure", async () => {
+    await assertRejects(
+      () =>
+        askProvider({
+          account,
+          ask: () => Promise.resolve("answered"),
+          failure: () => "the failure reader must not see this",
+          judge: (): string => {
+            throw new Error("reading step is broken");
+          },
+          unconfigured: "unused",
+        }),
+      Error,
+      "reading step is broken",
+    );
+  });
+
+  test("keeps an answer of nothing, because only a read calls that missing", async () => {
+    expect(
+      await askProvider({
+        account,
+        ask: () => Promise.resolve(null),
+        failure: neverRead,
+        judge: (answer) => `answered ${answer}`,
+        unconfigured: "unused",
+      }),
+    ).toBe("answered null");
+  });
+});

--- a/test/shared/payment/provider-resource-read.test.ts
+++ b/test/shared/payment/provider-resource-read.test.ts
@@ -8,7 +8,6 @@ import {
   judgeThrough,
   parsedBy,
   providerResourceReader,
-  readProviderResource,
   refuseUnless,
   refuseUnlessAll,
 } from "#payment/provider-resource-read.ts";
@@ -30,49 +29,46 @@ const neverJudged = (): never => {
 };
 
 describe("provider resource read", () => {
+  /** A reader for an account this provider has, and a failure reading that
+   *  claims nothing, so each test overrides only what it is about. */
+  const readFrom = (
+    resolve: () => Account | null | Promise<Account | null>,
+    failure: (error: unknown) => ProviderRead<never> | undefined = neverJudged,
+  ) => providerResourceReader(resolve, failure);
+
   test("does not ask an unconfigured provider anything", async () => {
-    expect(
-      await readProviderResource({
-        account: null,
-        ask: neverAsked,
-        failure: neverJudged,
-        judge: neverJudged,
-      }),
-    ).toEqual({ reason: "not_configured", status: "unavailable" });
+    expect(await readFrom(() => null)(neverAsked, neverJudged)).toEqual({
+      reason: "not_configured",
+      status: "unavailable",
+    });
   });
 
   test("hands the account to the call and to the judging", async () => {
     expect(
-      await readProviderResource({
-        account,
-        ask: (given) => Promise.resolve(given.token),
-        failure: neverJudged,
-        judge: (answer, given) => found(`${answer}:${given.token}`),
-      }),
+      await readFrom(() => account)(
+        (given) => Promise.resolve(given.token),
+        (answer, given) => found(`${answer}:${given.token}`),
+      ),
     ).toEqual(found("k:k"));
   });
 
   test("reads an answer that carries nothing as a resource not sent", async () => {
     for (const nothing of [null, undefined]) {
       expect(
-        await readProviderResource({
-          account,
-          ask: () => Promise.resolve(nothing),
-          failure: neverJudged,
-          judge: neverJudged,
-        }),
+        await readFrom(() => account)(
+          () => Promise.resolve(nothing),
+          neverJudged,
+        ),
       ).toEqual({ reason: "missing_documented_resource", status: "invalid" });
     }
   });
 
   test("gives a failed call the meaning its failure reader proves", async () => {
     expect(
-      await readProviderResource({
-        account,
-        ask: () => Promise.reject(new Error("down")),
-        failure: () => ({ reason: "rate_limited", status: "unavailable" }),
-        judge: neverJudged,
-      }),
+      await readFrom(
+        () => account,
+        () => ({ reason: "rate_limited", status: "unavailable" }),
+      )(() => Promise.reject(new Error("down")), neverJudged),
     ).toEqual({ reason: "rate_limited", status: "unavailable" });
   });
 
@@ -80,12 +76,10 @@ describe("provider resource read", () => {
     const ours = new Error("a bug of ours");
     await assertRejects(
       () =>
-        readProviderResource({
-          account,
-          ask: () => Promise.reject(ours),
-          failure: () => undefined,
-          judge: neverJudged,
-        }),
+        readFrom(
+          () => account,
+          () => undefined,
+        )(() => Promise.reject(ours), neverJudged),
       Error,
       "a bug of ours",
     );
@@ -94,14 +88,15 @@ describe("provider resource read", () => {
   test("does not catch a bug in the judging step", async () => {
     await assertRejects(
       () =>
-        readProviderResource({
-          account,
-          ask: () => Promise.resolve("answer"),
-          failure: () => ({ status: "missing" }),
-          judge: () => {
+        readFrom(
+          () => account,
+          () => ({ status: "missing" }),
+        )(
+          () => Promise.resolve("answer"),
+          () => {
             throw new Error("judging bug");
           },
-        }),
+        ),
       Error,
       "judging bug",
     );

--- a/test/shared/sumup-observation.test.ts
+++ b/test/shared/sumup-observation.test.ts
@@ -255,6 +255,32 @@ describe("classifySumupCheckout", () => {
     });
   }
 
+  // The clauses above forgive a checkout that states less than its charge
+  // does, rather than reading silence as a dispute. Only the checkout's own
+  // record prices the booking, so what each absence costs differs.
+  test("reads the money when only the charge names the currency", () => {
+    const { currency: _, ...noCurrency } = wirePaid();
+    expect(classify(noCurrency)).toEqual({
+      resource: expect.objectContaining({
+        // Read in the site currency, because the checkout named none, and
+        // carried as null so the boundary can see that it named none.
+        amountMinor: 1000,
+        currency: null,
+      }),
+      status: "found",
+    });
+  });
+
+  test("cannot read the money when only the charge names the amount", () => {
+    const { amount: _, ...noAmount } = wirePaid();
+    expect(classify(noAmount)).toEqual({
+      // The charge vouches for the checkout, but a booking is priced by the
+      // checkout's own amount, and this one states none.
+      resource: expect.objectContaining({ amountMinor: null }),
+      status: "found",
+    });
+  });
+
   test("refuses a second successful charge on a pending checkout", () => {
     const second = { ...WIRE_TXN, id: "txn_2" };
     const read = classify(wirePending({ transactions: [WIRE_TXN, second] }));

--- a/test/shared/sumup-observation.test.ts
+++ b/test/shared/sumup-observation.test.ts
@@ -70,6 +70,9 @@ describe("classifySumupCheckout", () => {
     const read = classify(wirePending());
     expect(read).toEqual({
       resource: expect.objectContaining({
+        // A still-open checkout has taken nothing, but its own amount is what
+        // the buyer is being asked for, so it stays readable.
+        amountMinor: 1000,
         status: "PENDING",
         transactionId: "",
       }),
@@ -96,7 +99,12 @@ describe("classifySumupCheckout", () => {
       wirePending({ status: "FAILED", transactions: [failedTxn] }),
     );
     expect(read).toEqual({
-      resource: expect.objectContaining({ status: "FAILED" }),
+      // A dead checkout carries no captured charge to dispute its amount, so
+      // the amount it states stays readable.
+      resource: expect.objectContaining({
+        amountMinor: 1000,
+        status: "FAILED",
+      }),
       status: "found",
     });
   });

--- a/test/shared/sumup-observation.test.ts
+++ b/test/shared/sumup-observation.test.ts
@@ -49,7 +49,8 @@ const wirePending = (over: Record<string, unknown> = {}) => {
   return paidWithoutTxnId;
 };
 
-const classify = (body: unknown) => classifySumupCheckout(body, FACTS);
+const classify = (body: unknown, facts: SumupReadFacts = FACTS) =>
+  classifySumupCheckout(body, facts);
 
 describe("classifySumupCheckout", () => {
   test("reads a paid checkout into the normalized shape", () => {
@@ -268,11 +269,15 @@ describe("classifySumupCheckout", () => {
   // record prices the booking, so what each absence costs differs.
   test("reads the money when only the charge names the currency", () => {
     const { currency: _, ...noCurrency } = wirePaid();
-    expect(classify(noCurrency)).toEqual({
+    // A site currency that holds no minor units at all, so the amount proves
+    // which currency read it: 10 in yen, and 1000 had it read the pounds the
+    // charge names.
+    const inYen = { ...FACTS, siteCurrency: "JPY" };
+    expect(classify(noCurrency, inYen)).toEqual({
       resource: expect.objectContaining({
         // Read in the site currency, because the checkout named none, and
         // carried as null so the boundary can see that it named none.
-        amountMinor: 1000,
+        amountMinor: 10,
         currency: null,
       }),
       status: "found",

--- a/test/shared/sumup-provider.test.ts
+++ b/test/shared/sumup-provider.test.ts
@@ -274,16 +274,27 @@ describe("sumup-provider", () => {
       });
     });
 
-    // A falsy non-string id/type is not the missing-field marker: `?? ""`
-    // passes it through, while `|| ""` would replace it — the webhook then
-    // rejects the session either way (a falsy id), but the parsed shape pins
-    // the `??` behavior.
-    test("passes falsy non-string id and event_type through unchanged", async () => {
+    // A SumUp callback names its checkout with text. A body whose id is a
+    // number never named one, so the door refuses it rather than carrying a
+    // value the session lookup would only refuse later.
+    test("rejects an id and event_type that are not text", async () => {
       expect(await verify('{"event_type":false,"id":0}')).toEqual({
-        listing: { data: { object: { id: 0 } }, id: 0, type: false },
-        valid: true,
+        error: "Invalid JSON payload",
+        valid: false,
       });
     });
+
+    // A public unsigned door: anyone can post any JSON at all. None of these
+    // is an object carrying SumUp's two fields, and reading a field off one
+    // used to crash the request instead of refusing it.
+    for (const body of ["null", "123", '"text"', "true", "[]"]) {
+      test(`refuses a payload that is JSON but not a callback: ${body}`, async () => {
+        expect(await verify(body)).toEqual({
+          error: "Invalid JSON payload",
+          valid: false,
+        });
+      });
+    }
 
     test("rejects an unparseable payload", async () => {
       expect(await verify("{not json")).toEqual({

--- a/test/shared/sumup-provider.test.ts
+++ b/test/shared/sumup-provider.test.ts
@@ -274,19 +274,24 @@ describe("sumup-provider", () => {
       });
     });
 
-    // A SumUp callback names its checkout with text. A body whose id is a
-    // number never named one, so the door refuses it rather than carrying a
-    // value the session lookup would only refuse later.
-    test("rejects an id and event_type that are not text", async () => {
-      expect(await verify('{"event_type":false,"id":0}')).toEqual({
-        error: "Invalid JSON payload",
-        valid: false,
+    // A SumUp callback names its checkout with text. A body naming it with
+    // anything else never named one, so the door refuses it rather than
+    // carrying a value the session lookup would only refuse later. Each field
+    // is refused on its own, so neither rule can stand in for the other.
+    for (const [field, body] of [
+      ["id", '{"event_type":"CHECKOUT_STATUS_CHANGED","id":0}'],
+      ["event_type", '{"event_type":false,"id":"co_42"}'],
+    ] as const) {
+      test(`rejects a ${field} that is not text`, async () => {
+        expect(await verify(body)).toEqual({
+          error: "Invalid JSON payload",
+          valid: false,
+        });
       });
-    });
+    }
 
-    // A public unsigned door: anyone can post any JSON at all. None of these
-    // is an object carrying SumUp's two fields, and reading a field off one
-    // used to crash the request instead of refusing it.
+    // A public unsigned door: anyone can post any JSON at all, and none of
+    // these is an object carrying SumUp's two fields.
     for (const body of ["null", "123", '"text"', "true", "[]"]) {
       test(`refuses a payload that is JSON but not a callback: ${body}`, async () => {
         expect(await verify(body)).toEqual({

--- a/test/shared/webhook-verification.test.ts
+++ b/test/shared/webhook-verification.test.ts
@@ -35,6 +35,17 @@ describe("finishWebhookVerification", () => {
     });
   });
 
+  // Every reader of a WebhookEvent reads fields off it, so a body with no
+  // fields to read is refused at the door rather than at the first reader.
+  for (const body of ["null", "123", '"text"', "true", "[]"]) {
+    test(`refuses a signed payload that is JSON but not an event: ${body}`, () => {
+      expect(finish(true, body)).toEqual({
+        error: "Invalid JSON payload",
+        valid: false,
+      });
+    });
+  }
+
   test("refuses a signed payload that is not JSON", () => {
     expect(finish(true, "{not json")).toEqual({
       error: "Invalid JSON payload",

--- a/test/shared/webhook-verification.test.ts
+++ b/test/shared/webhook-verification.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { ErrorCode } from "#shared/logger.ts";
+import type { WebhookEvent } from "#shared/payments.ts";
+import { finishWebhookVerification } from "#shared/webhook-verification.ts";
+
+const PAYLOAD = '{"data":{"object":{"id":"evt_1"}},"id":"evt_1","type":"paid"}';
+
+const finish = (matched: boolean, payload: string) =>
+  finishWebhookVerification(matched, payload, ErrorCode.STRIPE_SIGNATURE);
+
+describe("finishWebhookVerification", () => {
+  test("refuses a payload whose signature did not match", () => {
+    expect(finish(false, PAYLOAD)).toEqual({
+      error: "Signature verification failed",
+      valid: false,
+    });
+  });
+
+  test("does not read the body of a payload it refused", () => {
+    expect(finish(false, "not JSON at all")).toEqual({
+      error: "Signature verification failed",
+      valid: false,
+    });
+  });
+
+  test("reads a signed body as the event itself", () => {
+    expect(finish(true, PAYLOAD)).toEqual({
+      listing: {
+        data: { object: { id: "evt_1" } },
+        id: "evt_1",
+        type: "paid",
+      } satisfies WebhookEvent,
+      valid: true,
+    });
+  });
+
+  test("refuses a signed payload that is not JSON", () => {
+    expect(finish(true, "{not json")).toEqual({
+      error: "Invalid JSON payload",
+      valid: false,
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Four call sites wrote out the same shapes beside the shared ones that already
existed. This change folds them in and deletes the shells they replace. It
completes the `TODO.md` entry "Fold the last hand-rolled provider judges onto
the shared ladders", which is deleted here.

### One shell for every provider call

`askProvider` in `src/shared/payment/provider-call.ts` holds the four steps a
provider read and a provider send always share:

1. make sure that the provider is configured at all;
2. ask it;
3. read what it answered;
4. give a failed call its meaning, or let an error that is a bug of ours keep
   travelling.

Only step 2 is caught, so a bug in the reading step stays an internal error
instead of coming back as a provider answer.

Five call sites now run inside it:

- Square's refund send (`src/shared/square/payment-outcomes.ts`)
- SumUp's refund send (`src/shared/sumup.ts`)
- Stripe's refund send and Stripe's checkout read (`src/shared/stripe.ts`)
- every provider read, through `providerResourceReader`

`withStripeClient` is gone. Stripe was also the one provider that did not use
the shared bound reader, so `readPaymentIntent` now goes through
`providerResourceReader` like Square and SumUp. After that, `readProviderResource`
had no production caller left, so it folded into `providerResourceReader` and
stopped being exported. There is now one way to read a provider resource.

All three providers wrote out the same answer for a provider that is not set up.
That answer is now `REFUND_NOT_SENT` in `src/shared/payment/refund-attempt.ts`.

### One ladder for SumUp's checkout read

`classifySumupCheckout` was six sequential `if` arms, plus a helper that
re-implemented "the first rule to name a reason wins". It is now a declared rung
ladder, the same shape as `readSumupTransaction` beside it. The refusals happen
in the same order as before: shape, reference, id, merchant, lifecycle, then the
charge the record names.

### One combinator for Square's charge read

`squarePaymentProvider.readCharge` wrote out the found-branch mapping that Stripe
and SumUp get from `mapProviderReader`. It now uses the combinator.

### One door for every webhook body

SumUp ran its own `JSON.parse` beside `parseWebhookPayload`, the door both
signing providers use, and wrote the same "Invalid JSON payload" refusal a second
time. SumUp now goes through the shared door.

The door takes each provider's own reading of the body, because a signed provider
posts the event itself while SumUp posts two fields we build one from. That
reading runs outside the catch, so a bug in it no longer reads as bad JSON.

## What this means for the people using the site

Nothing changes on any page. Refunds, checkouts, and webhooks answer exactly as
they did. One thing improves behind the scenes: a SumUp callback with an
unreadable body used to disappear without a word. It is now recorded under the
new `E_SUMUP_WEBHOOK` code, so an operator can see it in the activity log.

## What did not change

A SumUp callback that names no id still becomes a blank id rather than a refusal.
`resolveWebhookSession` refuses a blank id before it looks anything up, so the
absence is expected, and the tests that pin it still pass.

Square's `webhookPayment` still reads its body with bare throws. M6 owns that
door. `TODO.md` records it in the whole-checkout diagnosis entry, which now names
the function it means.

## Tests

- `test/shared/payment/provider-call.test.ts` is new. It pins the unconfigured
  answer, the account reaching both the call and the reading, a failed call
  getting its meaning, an error nobody owns keeping its journey, and a broken
  reading step staying an error.
- `test/shared/webhook-verification.test.ts` is new. That module had no test at
  its mirror path, so the mutation gate refused to run for it.
- The shared webhook door gained tests for its reading step, and for a broken one.
- `deno task cpd` reports no clones. Its three findings during this work were each
  a real merge, and each was taken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDt6HtGubnxeYo4VyJYJfQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer error reporting when SumUp webhook payloads cannot be read.
  - Improved webhook processing with provider-specific event validation and event formats.
  - Standardized handling of unavailable payment accounts and unsent refunds.

- **Bug Fixes**
  - Improved payment, refund, checkout, and resource-read handling across Square, Stripe, and SumUp.
  - Preserved meaningful provider errors while rejecting malformed webhook payloads.
  - Improved SumUp checkout validation for references, statuses, currencies, and charge amounts.

- **Tests**
  - Expanded coverage for webhook verification, provider failures, unavailable accounts, and refund outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->