### PR TITLE
Scan the test helpers for duplication at 40 tokens, against src too

### DIFF
--- a/.jscpd.helpers.json
+++ b/.jscpd.helpers.json
@@ -1,0 +1,29 @@
+{
+  "threshold": 0,
+  "_comment": "The reusable test helpers under test/test-utils, scanned at 40 tokens rather than the 48 the rest of test/ gets, and scanned alongside src/ so a helper that reimplements production logic is flagged against the source it copied — a separate run could never see that. Like the Cucumber support helpers, these are production-shaped code — one named helper per thing a test does — so two helpers that nearly match are a merge to make. The *.test.ts files inside test/test-utils are tests of those helpers, not helpers, so they stay on the ordinary test/ scan: a test body repeats by design. src/ against itself is already held at 0% by .jscpd.json, so nothing new is reported there, and test/test-utils stays in the .jscpd.test.json scan too so its clones against test bodies are still caught. 40 is a ratchet position, not a floor: see docs/test-duplication.md for what each step down costs.",
+  "reporters": [
+    "console",
+    "json"
+  ],
+  "output": ".jscpd-report-helpers",
+  "ignore": [
+    "**/node_modules/**",
+    "**/fp.ts",
+    "**/db/migrations/2*.ts",
+    "**/db/migrations/schema/columns.ts",
+    "**/test-utils/**/*.test.ts"
+  ],
+  "format": [
+    "typescript",
+    "tsx"
+  ],
+  "absolute": false,
+  "gitignore": true,
+  "exitCode": 1,
+  "minLines": 1,
+  "minTokens": 40,
+  "path": [
+    "src",
+    "test/test-utils"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1278,6 +1278,31 @@ merge waiting to happen, and the whole point of this exercise. So:
   the same thing wearing two names. Keep pulling the thread until the merges are
   genuinely exhausted.
 
+### The four scans, and how hard each looks
+
+The 0% threshold is not the number that decides how hard jscpd looks.
+`minTokens` is: it sets the shortest run of tokens that counts as a clone, so a
+lower number is a tighter net. Four configs divide the tree, because helper code
+and test bodies deserve different nets.
+
+| Config                | Scans                            | minTokens |
+| --------------------- | -------------------------------- | --------- |
+| `.jscpd.json`         | `src`, `e2e-payments`, `scripts` | 19        |
+| `.jscpd.specs.json`   | `src` + `test/specs/support`     | 19        |
+| `.jscpd.helpers.json` | `src` + `test/test-utils`        | 40        |
+| `.jscpd.test.json`    | `test`                           | 48        |
+
+Both helper trees are scanned **alongside `src/`**, so a helper that
+reimplements production logic is flagged against the source it copied. A
+separate run could never see that pair. A test body is different: it repeats by
+design, and the shared mechanism is the test framework itself, so the whole of
+`test/` stays at the loose 48.
+
+**The helper number ratchets downward** — lower the one in
+`.jscpd.helpers.json`, bring the tree to it, repeat — the same way
+`check:comments` works. `docs/test-duplication.md` measures what each remaining
+step costs, and shows why 19 is already the floor for the Cucumber helpers.
+
 ## Database Queries
 
 Avoid `SELECT *`, and avoid loading more rows or columns than the caller needs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1277,6 +1277,33 @@ merge waiting to happen, and the whole point of this exercise. So:
   just wrote subsumes three more call sites, or that it and an older helper are
   the same thing wearing two names. Keep pulling the thread until the merges are
   genuinely exhausted.
+- **A curry almost always exists — "these two cannot be merged" is nearly always
+  wrong.** Two functions that differ only in a value, a path, a field name, a
+  message, or a callback are one function that has not been given its parameter
+  yet. Lift what differs into a factory's argument and let the returned function
+  take the data. This holds even when the two bodies look nothing alike at a
+  glance, because the shared part is often a _tail_ ("…and then keep what they
+  were told") or an _opening_ ("open this page, and then…"), and a curry takes
+  either. So treat every flagged pair as mergeable until you have actually
+  written the curry and found what the parameter would have to be. "This pair is
+  noise" is a conclusion you earn by trying, never a first reading — and if you
+  reach for that phrase about a whole band of results, you are almost certainly
+  looking at a factory nobody has written yet.
+
+  Before you write one, look for the factory that already exists. An
+  under-adopted curry reads exactly like unavoidable duplication: the pairs pile
+  up at the call sites that never adopted it, so the check looks like it is
+  flagging noise when it is really flagging the gap. The Cucumber page openers
+  are the reference. `opensAdminPageAt(path)` in `test/specs/support/browser.ts`
+  turns any "open this one fixed admin page" wrapper into a single line, and
+  four support files hand-rolled the wrapper anyway.
+- **The one honest exception is a shared _signature_ with nothing behind it.**
+  When two functions match only on their parameter list and return type, and
+  share no call at all, there is nothing to lift and a curry cannot help. Give
+  that signature a named type instead and let both sides declare it —
+  `ActOnOneThing` in `test/specs/support/world.ts` is the house example. Be
+  strict about which case you are in: if the two bodies call even one function
+  in common, you are in the curry case, not this one.
 
 ### The four scans, and how hard each looks
 
@@ -1298,10 +1325,10 @@ separate run could never see that pair. A test body is different: it repeats by
 design, and the shared mechanism is the test framework itself, so the whole of
 `test/` stays at the loose 48.
 
-**The helper number ratchets downward** — lower the one in
-`.jscpd.helpers.json`, bring the tree to it, repeat — the same way
-`check:comments` works. `docs/test-duplication.md` measures what each remaining
-step costs, and shows why 19 is already the floor for the Cucumber helpers.
+**Every helper number ratchets downward** — lower it, bring the tree to it,
+repeat — the same way `check:comments` works. `docs/test-duplication.md`
+measures what each remaining step costs. Read its counts as work to do, not as a
+floor: the counts fall as the curries land.
 
 ## Database Queries
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,45 @@
 # TODO — remaining follow-ups
 
+## Remove the alias exports in the test helpers
+
+_Origin: the test-helper duplication pass (`docs/test-duplication.md`). Found
+while reading the helper tree; too many call sites to fold into that change._
+
+Three helper names are second names for a call that already exists, which "No
+alias exports" in AGENTS.md forbids.
+
+- `errorLogged` and `debugLogged` in `test/test-utils/debug-log.ts` are both
+  `logLogged` with no change at all. Export `logLogged` and migrate the 52 call
+  sites across `test/`, then delete both aliases.
+- `getAdminLoginCsrfToken`, `getJoinCsrfToken`, `getSetupCsrfToken` and
+  `getTicketCsrfToken` in `test/test-utils/csrf.ts` are each `extractCsrfToken`
+  with no change. Callers must use `extractCsrfToken`.
+
+Neither is flagged by jscpd, because an alias is too short to reach any
+`minTokens` setting we can use. Both are found by reading.
+
+---
+
+## One way for a test helper to reach the app
+
+_Origin: the test-helper duplication pass (`docs/test-duplication.md`). The
+merges landed; this is the design question they left behind._
+
+`test/test-utils` reaches `handleRequest` two ways. 11 helper modules import it
+statically from `#routes`. The rest go through `sendToApp`, `awaitTestRequest`
+or `testPageHtml` in `mocks.ts`, which import `#routes` lazily so that loading
+the helper module never pulls the app graph in.
+
+Decide which is right and make every helper do it. The lazy seam costs one
+dynamic import for each call and keeps the graph out of an isolate that does not
+need it. The static import is plainer to read. Every test isolate evaluates the
+app graph anyway when it loads a helper that needs it, so measure the cold cost
+of an isolate that does not, before you choose. `test-browser.ts` caches
+`handleRequest` in a private field and is a third way; fold it into whichever
+wins.
+
+---
+
 ## Add a once-per-order option for answer-triggered modifiers
 
 _Origin: Codex review of PR #2150 (the delivery-area pricing guide entry). The

--- a/deno.json
+++ b/deno.json
@@ -26,7 +26,7 @@
     "lint": "deno fmt && deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts cli e2e-payments",
     "lint:ci": "deno fmt --check && deno run -A scripts/biome.ts check --error-on-warnings src test scripts cli e2e-payments",
     "typecheck": "deno check src test cli scripts && deno check --config=e2e-payments/deno.json e2e-payments/src",
-    "cpd": "deno run -A scripts/cpd.ts --config .jscpd.json && deno run -A scripts/cpd.ts --config .jscpd.test.json && deno run -A scripts/cpd.ts --config .jscpd.specs.json && deno run -A scripts/cpd.ts --config .jscpd.css.json src/ui/static/style.scss",
+    "cpd": "deno run -A scripts/cpd.ts --config .jscpd.json && deno run -A scripts/cpd.ts --config .jscpd.test.json && deno run -A scripts/cpd.ts --config .jscpd.specs.json && deno run -A scripts/cpd.ts --config .jscpd.helpers.json && deno run -A scripts/cpd.ts --config .jscpd.css.json src/ui/static/style.scss",
     "check:copy": "deno run --allow-read=src/locales scripts/check-copy.ts",
     "check:comments": "deno run --allow-read=src scripts/check-comments.ts",
     "check:imports": "deno run --allow-read=deno.json,src,test,scripts,cli scripts/check-imports.ts",

--- a/docs/test-duplication.md
+++ b/docs/test-duplication.md
@@ -5,9 +5,9 @@ setting we can choose, and records the decision taken and what is left to do.
 
 **Decided and shipped.** The reusable helpers under `test/test-utils` are
 scanned at **40 tokens**, alongside `src/`, by `.jscpd.helpers.json`. The
-Cucumber support helpers under `test/specs/support` stay at **19 tokens**, which
-the measurements below show is their floor. See [Where we are](#where-we-are)
-for the remaining steps.
+Cucumber support helpers under `test/specs/support` stay at **19 tokens** for
+now, and the work that lets them go lower is named below. See
+[Where we are](#where-we-are) for the remaining steps.
 
 All counts come from commit `ebc7c12` and from jscpd 5.0.12 with `minLines: 1`,
 the setting every config in this repository uses. A count is the number of clone
@@ -39,7 +39,7 @@ why the helper trees can be held tighter than the tree that contains them.
 
 ## What a helper tree costs at each setting
 
-### The Cucumber helpers stay at 19
+### The Cucumber helpers hold at 19 until the curries land
 
 `test/specs/support` reports no clones at 19 tokens. Below that the count rises
 steeply:
@@ -47,29 +47,62 @@ steeply:
 | minTokens | Clone pairs |
 | --------- | ----------- |
 | 19        | 0           |
-| 16        | 78          |
+| 16        | 75          |
 | 14        | 238         |
 | 12        | 444         |
 | 10        | 823         |
 
-The 78 pairs at 16 tokens are not merges. They are matches such as this one,
-between three separate helpers:
+**An earlier version of this document called the pairs at 16 tokens noise, and
+called 19 a floor. That was wrong.** The reasoning is recorded here so that it
+is not repeated. It rested on a sample of eight pairs, and on one argument: that
+a wrapper like this one is already a single call to the shared `openAdminPage`,
+so the merge exists.
 
 ```typescript
 const openKeysPage = (world: TicketsWorld): Promise<TestBrowser> =>
   openAdminPage(world, KEYS_PAGE);
-
-const openPrivacyPage = (world: TicketsWorld): Promise<TestBrowser> =>
-  openAdminPage(world, "/admin/privacy");
 ```
 
-Each one is already a single call to the shared `openAdminPage`. The merge
-exists. A tighter net here asks us to undo a correct factoring, which is the
-exact failure the policy warns against.
+The shared call is not what repeats. The wrapper shape repeats, and a curry
+takes it. `browser.ts` already holds that curry:
 
-A second, harder limit applies. `.jscpd.specs.json` scans `src/` alongside the
-support helpers, so a helper that reimplements production logic is flagged
-against the source it copied. `src/` is clean at 19 and cannot go below it:
+```typescript
+const openKeysPage = opensAdminPageAt(KEYS_PAGE);
+```
+
+A classification of all 78 pairs, rather than eight, gives this:
+
+| At 16 tokens, the two sides…               | Pairs |
+| ------------------------------------------ | ----- |
+| call a shared helper — a curry takes them  | 46    |
+| share only an assertion helper             | 5     |
+| match on the signature and the types alone | 27    |
+
+The 46 are merges. The 27 are the honest exception: two unrelated bodies behind
+the same `(world: TicketsWorld, name: string)` parameter list. A named type for
+that signature removes the repetition, and `ActOnOneThing` in
+`test/specs/support/world.ts` is that type already.
+
+### The factories exist, and the pairs mark who never adopted them
+
+Every family the 46 fall into has a factory in `test/specs/support/browser.ts`
+written for it. The pairs pile up at the call sites that hand-rolled the factory
+instead:
+
+| Factory                   | Files that use it | Sites that hand-roll it |
+| ------------------------- | ----------------- | ----------------------- |
+| `opensAdminPageAt`        | 2                 | 4, now 0                |
+| `withAdminPage`           | 1                 | about 21                |
+| `submitRenderedAdminForm` | 2                 | 9                       |
+
+This is why the band read as noise. An under-adopted curry looks exactly like
+unavoidable duplication, because the pairs cluster where the curry is absent.
+
+### The remaining limit is the config, not the helpers
+
+`.jscpd.specs.json` scans `src/` alongside the support helpers, so a helper that
+reimplements production logic is flagged against the source it copied. `src/` is
+clean at 19 and cannot go below it:
 
 | minTokens | Clone pairs in `src/` alone |
 | --------- | --------------------------- |
@@ -77,8 +110,10 @@ against the source it copied. `src/` is clean at 19 and cannot go below it:
 | 17        | 497                         |
 | 16        | 961                         |
 
-A lower number in that config drags `src/` down with it. **19 is the floor for
-the Cucumber helpers.**
+So the number in that config cannot come down. The support helpers need a
+second, support-only config to be held tighter, and that config can be added
+only after the curries below 19 are done. **19 is where the config sits, not
+where the helpers have to stay.**
 
 ### The other test helpers moved from 48 to 40
 
@@ -124,14 +159,18 @@ merges:
 | 40        | 0           | where the scan is set                      |
 | 36        | 17          | strong signal, mostly whole shared helpers |
 | 32        | 31          |                                            |
-| 28        | 67          | last band that is mostly real              |
-| 24        | 113         | noise starts                               |
+| 28        | 67          |                                            |
+| 24        | 113         |                                            |
 | 19        | 280         | parity with the Cucumber helpers           |
 
-Two things mark the noise floor near 24 tokens. Valibot schema fields match each
-other across unrelated schemas, which is the same coincidence that exempts
-`src/shared/db/migrations/schema/columns.ts` from `.jscpd.json`. One-line field
-builders match on their signature and nothing else.
+**These are counts, not verdicts.** A sample of the 24-token band showed valibot
+schema fields that match across unrelated schemas, which is the same coincidence
+that exempts `src/shared/db/migrations/schema/columns.ts` from `.jscpd.json`,
+and one-line field builders that match on a signature. That is a sample, and the
+Cucumber section above records what happens when a sample is read as a floor:
+the pairs there turned out to mark an under-adopted curry, not noise. Classify a
+band the way that section does, and try the curry, before calling any of it
+unavoidable.
 
 Each step down is a separate job. Take the number in `.jscpd.helpers.json` down,
 bring the tree to it, and repeat, the way the comment caps in
@@ -164,7 +203,14 @@ of 19,000 lines costs about one second.
 
 - **Done.** `test/test-utils` scanned at 40 tokens against `src/`. The
   production-schema reimplementation removed. 12 helper merges landed.
-- **Done.** `test/specs/support` confirmed at its floor of 19 tokens.
+- **Done.** `opensAdminPageAt` widened to hand back the window, and adopted by
+  the four support files that hand-rolled it. The pairs at 16 tokens went from
+  78 to 75.
+- **Next.** Adopt `withAdminPage` and `submitRenderedAdminForm` at the 30 sites
+  that hand-roll them, then work the smaller families. When `test/specs/support`
+  reports no pairs at 16 tokens, add a support-only config at 16 and keep
+  `.jscpd.specs.json` at 19 for the scan against `src/`.
 - **Next.** Take `.jscpd.helpers.json` to 36 tokens. 17 pairs, mostly whole
   helpers that duplicate a sibling.
-- **Then.** 32, then 28. Below 28 the pairs stop being merges.
+- **Then.** 32, 28, and below. Classify each band before you price it, and reach
+  for a curry before you call any pair unavoidable.

--- a/docs/test-duplication.md
+++ b/docs/test-duplication.md
@@ -1,0 +1,170 @@
+# Duplication limits for the test helpers: what each step down costs
+
+This measured how tightly jscpd can scan the two test helper trees, priced every
+setting we can choose, and records the decision taken and what is left to do.
+
+**Decided and shipped.** The reusable helpers under `test/test-utils` are
+scanned at **40 tokens**, alongside `src/`, by `.jscpd.helpers.json`. The
+Cucumber support helpers under `test/specs/support` stay at **19 tokens**, which
+the measurements below show is their floor. See [Where we are](#where-we-are)
+for the remaining steps.
+
+All counts come from commit `ebc7c12` and from jscpd 5.0.12 with `minLines: 1`,
+the setting every config in this repository uses. A count is the number of clone
+pairs the scan reports, not the number of places to edit: one merge usually
+clears several pairs.
+
+## The four scans, and why there are four
+
+The 0% threshold is not the number that decides how hard jscpd looks.
+`minTokens` is. It sets the shortest run of tokens that counts as a clone, so a
+lower number is a tighter net.
+
+| Config                | Scans                            | minTokens |
+| --------------------- | -------------------------------- | --------- |
+| `.jscpd.json`         | `src`, `e2e-payments`, `scripts` | 19        |
+| `.jscpd.specs.json`   | `src` + `test/specs/support`     | 19        |
+| `.jscpd.helpers.json` | `src` + `test/test-utils`        | 40        |
+| `.jscpd.test.json`    | `test`                           | 48        |
+
+Two trees hold reusable helpers. `test/specs/support` holds 76 files and 11,673
+lines behind the Cucumber steps. `test/test-utils` holds 160 helper files and
+19,164 lines, plus 32 files of tests for those helpers. Both are
+production-shaped code: one named helper for each thing a person, or a test,
+does. Two helpers that nearly match are a merge to make.
+
+A test body is different. It repeats by design, and the shared mechanism is the
+test framework itself. That is why the whole of `test/` sits at 48 tokens, and
+why the helper trees can be held tighter than the tree that contains them.
+
+## What a helper tree costs at each setting
+
+### The Cucumber helpers stay at 19
+
+`test/specs/support` reports no clones at 19 tokens. Below that the count rises
+steeply:
+
+| minTokens | Clone pairs |
+| --------- | ----------- |
+| 19        | 0           |
+| 16        | 78          |
+| 14        | 238         |
+| 12        | 444         |
+| 10        | 823         |
+
+The 78 pairs at 16 tokens are not merges. They are matches such as this one,
+between three separate helpers:
+
+```typescript
+const openKeysPage = (world: TicketsWorld): Promise<TestBrowser> =>
+  openAdminPage(world, KEYS_PAGE);
+
+const openPrivacyPage = (world: TicketsWorld): Promise<TestBrowser> =>
+  openAdminPage(world, "/admin/privacy");
+```
+
+Each one is already a single call to the shared `openAdminPage`. The merge
+exists. A tighter net here asks us to undo a correct factoring, which is the
+exact failure the policy warns against.
+
+A second, harder limit applies. `.jscpd.specs.json` scans `src/` alongside the
+support helpers, so a helper that reimplements production logic is flagged
+against the source it copied. `src/` is clean at 19 and cannot go below it:
+
+| minTokens | Clone pairs in `src/` alone |
+| --------- | --------------------------- |
+| 19        | 0                           |
+| 17        | 497                         |
+| 16        | 961                         |
+
+A lower number in that config drags `src/` down with it. **19 is the floor for
+the Cucumber helpers.**
+
+### The other test helpers moved from 48 to 40
+
+`test/test-utils` was scanned only at 48 tokens, and only against the rest of
+`test/`. These counts are for the helper files scanned together with `src/`,
+before any merge:
+
+| minTokens | Clone pairs |
+| --------- | ----------- |
+| 48        | 1           |
+| 44        | 4           |
+| 42        | 8           |
+| 40        | 13          |
+| 38        | 21          |
+| 36        | 35          |
+
+The single pair at 48 tokens was the find that made the scan worth adding.
+`test/test-utils/test-state.ts` held its own copy of `createTableSql` and
+`createIndexSql` from `src/shared/db/migrations/schema-sync.ts`. No config could
+see it, because no config scanned `test/test-utils` against `src/`. The golden
+test database was therefore built by a second copy of the production schema
+builder, and could drift from it. It now calls `fullSchemaCreateStatements()`.
+
+The 12 further pairs down to 40 tokens were real merges, and they landed. The
+largest was a scaffold that 13 helper modules each spelled out for themselves:
+
+```typescript
+const { handleRequest } = await import("#routes");
+const { mockFormRequest } = await import("#test-utils/mocks.ts");
+```
+
+`mocks.ts` already held `awaitTestRequest`, which does exactly this. It now also
+exports `sendToApp` and `testPageHtml`, and every helper module goes through one
+of the three.
+
+## What is left, and what each step costs
+
+These counts are for the helper files and `src/` at the commit above, after the
+merges:
+
+| minTokens | Clone pairs | Note                                       |
+| --------- | ----------- | ------------------------------------------ |
+| 40        | 0           | where the scan is set                      |
+| 36        | 17          | strong signal, mostly whole shared helpers |
+| 32        | 31          |                                            |
+| 28        | 67          | last band that is mostly real              |
+| 24        | 113         | noise starts                               |
+| 19        | 280         | parity with the Cucumber helpers           |
+
+Two things mark the noise floor near 24 tokens. Valibot schema fields match each
+other across unrelated schemas, which is the same coincidence that exempts
+`src/shared/db/migrations/schema/columns.ts` from `.jscpd.json`. One-line field
+builders match on their signature and nothing else.
+
+Each step down is a separate job. Take the number in `.jscpd.helpers.json` down,
+bring the tree to it, and repeat, the way the comment caps in
+`scripts/check-comments/run.ts` come down.
+
+## What was measured and rejected
+
+**A tighter scan for the whole of `test/`.** The tree is clean at 48 tokens and
+very expensive below it:
+
+| minTokens | Clone pairs in `test/` |
+| --------- | ---------------------- |
+| 48        | 0                      |
+| 44        | 291                    |
+| 40        | 873                    |
+| 36        | 1,749                  |
+| 32        | 3,385                  |
+
+The rise is test bodies, not helpers, so a lower number here buys little and
+costs a great deal. 48 stays.
+
+**A carve-out for `test/test-utils` in `.jscpd.test.json`.** The specs config
+takes `test/specs/support` out of the ordinary `test/` scan. That hides any
+clone between a support helper and a test body, and today the count of those is
+zero, so nothing is lost. `test/test-utils` is not carved out: it stays in both
+scans, so its clones against test bodies are still caught at 48. The second scan
+of 19,000 lines costs about one second.
+
+## Where we are
+
+- **Done.** `test/test-utils` scanned at 40 tokens against `src/`. The
+  production-schema reimplementation removed. 12 helper merges landed.
+- **Done.** `test/specs/support` confirmed at its floor of 19 tokens.
+- **Next.** Take `.jscpd.helpers.json` to 36 tokens. 17 pairs, mostly whole
+  helpers that duplicate a sibling.
+- **Then.** 32, then 28. Below 28 the pairs stop being merges.

--- a/test/specs/steps/inviting.ts
+++ b/test/specs/steps/inviting.ts
@@ -46,8 +46,8 @@ Given(
 
 When(
   "the owner looks at who may sign in",
-  function (this: TicketsWorld): Promise<void> {
-    return ownerOpensWhoMaySignIn(this);
+  async function (this: TicketsWorld): Promise<void> {
+    await ownerOpensWhoMaySignIn(this);
   },
 );
 

--- a/test/specs/steps/list-narrowing.ts
+++ b/test/specs/steps/list-narrowing.ts
@@ -17,8 +17,8 @@ import type { TicketsWorld } from "#test/specs/support/world.ts";
 
 When(
   "the organiser opens their list",
-  function (this: TicketsWorld): Promise<void> {
-    return organiserOpensList(this);
+  async function (this: TicketsWorld): Promise<void> {
+    await organiserOpensList(this);
   },
 );
 

--- a/test/specs/support/api-keys.ts
+++ b/test/specs/support/api-keys.ts
@@ -10,7 +10,7 @@ import { t } from "#i18n";
 import { handleRequest } from "#routes";
 import {
   findsTheWayInFrom,
-  openAdminPage,
+  opensAdminPageAt,
   opensListAtRow,
   type TakesOneThingDown,
   takesDownFromList,
@@ -40,8 +40,7 @@ const WHAT_THE_SITE_SELLS = "/api/admin/listings";
 /** The owner's own page listing the keys they have handed out, open in front
  * of them. Everything the owner does with a key starts here, the way it would
  * for a real person. */
-const openKeysPage = (world: TicketsWorld): Promise<TestBrowser> =>
-  openAdminPage(world, KEYS_PAGE);
+const openKeysPage = opensAdminPageAt(KEYS_PAGE);
 
 /** The owner opens their keys page, and it is theirs to read. */
 export const ownerOpensKeys = async (world: TicketsWorld): Promise<void> => {

--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -152,14 +152,18 @@ export const openAdminPage: OpensAPage = opensPagesAs(adminBrowser);
 /** Somebody opens one page whose address never changes. */
 export type OpensOneFixedPage = (world: TicketsWorld) => Promise<void>;
 
+/** Where a page lives: an address that never changes, or one worked out from
+ * the story so far. */
+export type PageAddress = string | ((world: TicketsWorld) => string);
+
 /** The organiser opens one page of their own, named once. Every "the owner
  * looks at X" step is this with a different address, so the address is the
- * only thing each caller says. */
+ * only thing each caller says. The window comes back for a caller that reads
+ * it, and a step that only needs the page open can ignore it. */
 export const opensAdminPageAt =
-  (path: string): OpensOneFixedPage =>
-  async (world) => {
-    await openAdminPage(world, path);
-  };
+  (where: PageAddress) =>
+  (world: TicketsWorld): Promise<TestBrowser> =>
+    openAdminPage(world, typeof where === "string" ? where : where(world));
 
 /** The organiser opens one of their own pages, and something is done with
  * the window they are looking at — the opening every organiser action on a

--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -149,8 +149,10 @@ export const opensPagesAs =
  * already. Every admin page a story reads starts here. */
 export const openAdminPage: OpensAPage = opensPagesAs(adminBrowser);
 
-/** Somebody opens one page whose address never changes. */
-export type OpensOneFixedPage = (world: TicketsWorld) => Promise<void>;
+/** Somebody opens one page whose address never changes, and is handed the
+ * window they are looking at it through. A caller that only needs the page
+ * open can ignore what comes back. */
+export type OpensOneFixedPage = (world: TicketsWorld) => Promise<TestBrowser>;
 
 /** Where a page lives: an address that never changes, or one worked out from
  * the story so far. */
@@ -161,8 +163,8 @@ export type PageAddress = string | ((world: TicketsWorld) => string);
  * only thing each caller says. The window comes back for a caller that reads
  * it, and a step that only needs the page open can ignore it. */
 export const opensAdminPageAt =
-  (where: PageAddress) =>
-  (world: TicketsWorld): Promise<TestBrowser> =>
+  (where: PageAddress): OpensOneFixedPage =>
+  (world) =>
     openAdminPage(world, typeof where === "string" ? where : where(world));
 
 /** The organiser opens one of their own pages, and something is done with

--- a/test/specs/support/buyer-questions.ts
+++ b/test/specs/support/buyer-questions.ts
@@ -12,6 +12,7 @@ import {
   ORGANISER,
   openAdminPage,
   openAsNewcomer,
+  opensAdminPageAt,
   takesDownFromOwnPage,
 } from "#test/specs/support/browser.ts";
 import { fillInAndSend } from "#test/specs/support/form-controls.ts";
@@ -171,8 +172,9 @@ export const answerInListDownload = async (
 };
 
 /** The question's own admin page, open. */
-const openQuestionPage = (world: TicketsWorld): Promise<TestBrowser> =>
-  openAdminPage(world, `/admin/questions/${askedQuestion(world).id}`);
+const openQuestionPage = opensAdminPageAt(
+  (world) => `/admin/questions/${askedQuestion(world).id}`,
+);
 
 /** Whether the question's own page offers a way to add answer choices. A
  * written question has none to offer, so its page must not either. */

--- a/test/specs/support/privacy.ts
+++ b/test/specs/support/privacy.ts
@@ -19,6 +19,7 @@ import { t } from "#i18n";
 // jscpd:ignore-start
 import {
   openAdminPage,
+  opensAdminPageAt,
   organiserSendsAndIsTold,
 } from "#test/specs/support/browser.ts";
 import {
@@ -70,8 +71,7 @@ const WHAT_ADA_TYPED: Record<WayOfKnowingSomebody, string> = {
 };
 
 /** The organiser's own Privacy page, open in their window. */
-const openPrivacyPage = (world: TicketsWorld): Promise<TestBrowser> =>
-  openAdminPage(world, "/admin/privacy");
+const openPrivacyPage = opensAdminPageAt("/admin/privacy");
 
 /** What the Privacy page says right now, read fresh — every rule here is about
  * what the organiser sees the next time they look. */

--- a/test/specs/support/statuses.ts
+++ b/test/specs/support/statuses.ts
@@ -14,7 +14,7 @@ import { t } from "#i18n";
 import {
   findsTheWayInFrom,
   ORGANISER,
-  openAdminPage,
+  opensAdminPageAt,
   opensListAtRow,
   type TakesOneThingDown,
   takesDownFromList,
@@ -32,7 +32,6 @@ import {
   type ReadAboutOneThing,
   type TicketsWorld,
 } from "#test/specs/support/world.ts";
-import type { TestBrowser } from "#test-utils/test-browser.ts";
 
 // jscpd:ignore-end
 
@@ -67,8 +66,7 @@ const theJob = (job: string): { badge: string; box: string } => {
 };
 
 /** The organiser's own list of states, open in front of them. */
-const openList = (world: TicketsWorld): Promise<TestBrowser> =>
-  openAdminPage(world, THE_LIST);
+const openList = opensAdminPageAt(THE_LIST);
 
 /** What the link into one state's own row looks like: the list's own address
  * with the state's number on the end. */

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -259,9 +259,8 @@ export const assertPublicHtml = async (
   path: string,
   ...substrings: string[]
 ): Promise<string> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest } = await import("#test-utils/mocks.ts");
-  const response = await handleRequest(mockRequest(path));
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  const response = await awaitTestRequest(path);
   return expectHtmlResponse(response, 200, ...substrings);
 };
 

--- a/test/test-utils/attendees/helpers.ts
+++ b/test/test-utils/attendees/helpers.ts
@@ -22,51 +22,53 @@ import { awaitTestRequest, mockFormRequest } from "#test-utils/mocks.ts";
 import { adminFormPost } from "#test-utils/session.ts";
 import type { Attendee, Listing } from "#types";
 
-/** A listing (100 spots by default) plus one attendee booked onto it ("John
- *  Doe" by default). The single most repeated setup across the attendee admin
- *  tests — pulled here so every delete/checkin/edit/resend test shares it. */
-export const setupListingAndAttendee = async (
-  opts: {
-    listing?: Parameters<typeof createTestListing>[0];
-    name?: string;
-    email?: string;
-  } = {},
-): Promise<{ listing: Listing; attendee: Attendee }> => {
-  const listing = await createTestListing({
-    maxAttendees: 100,
-    ...opts.listing,
-  });
-  const attendee = await createTestAttendee(
-    listing.id,
-    listing.slug,
-    opts.name ?? "John Doe",
-    opts.email ?? "john@example.com",
-  );
-  return { attendee, listing };
+type ListingAndPersonOpts = {
+  listing?: Parameters<typeof createTestListing>[0];
+  name?: string;
+  email?: string;
 };
+
+/** A listing (100 spots by default) plus "John Doe" booked onto it by
+ *  `book`. The single most repeated setup across the attendee admin tests —
+ *  pulled here so every delete/checkin/edit/resend test shares it. */
+const setupListingAndPerson =
+  <Booked>(
+    book: (listing: Listing, name: string, email: string) => Promise<Booked>,
+  ) =>
+  async (
+    opts: ListingAndPersonOpts = {},
+  ): Promise<Booked & { listing: Listing }> => {
+    const listing = await createTestListing({
+      maxAttendees: 100,
+      ...opts.listing,
+    });
+    const booked = await book(
+      listing,
+      opts.name ?? "John Doe",
+      opts.email ?? "john@example.com",
+    );
+    return { ...booked, listing };
+  };
+
+/** A listing plus one attendee booked onto it through the public route. */
+export const setupListingAndAttendee: (
+  opts?: ListingAndPersonOpts,
+) => Promise<{ attendee: Attendee; listing: Listing }> = setupListingAndPerson(
+  async (listing, name, email) => ({
+    attendee: await createTestAttendee(listing.id, listing.slug, name, email),
+  }),
+);
 
 /** Like `setupListingAndAttendee` but creates the attendee directly via
  *  the DB (`createTestAttendeeDirect`), returning its ticket token too. The
  *  merge-panel tests need the token (the public-route `createTestAttendee`
  *  leaves `ticket_token` unset), so they use this direct variant. */
-export const setupListingAndDirectAttendee = async (
-  opts: {
-    listing?: Parameters<typeof createTestListing>[0];
-    name?: string;
-    email?: string;
-  } = {},
-): Promise<{ listing: Listing; attendee: Attendee; token: string }> => {
-  const listing = await createTestListing({
-    maxAttendees: 100,
-    ...opts.listing,
-  });
-  const { attendee, token } = await createTestAttendeeDirect(
-    listing.id,
-    opts.name ?? "John Doe",
-    opts.email ?? "john@example.com",
+export const setupListingAndDirectAttendee: (
+  opts?: ListingAndPersonOpts,
+) => Promise<{ attendee: Attendee; listing: Listing; token: string }> =
+  setupListingAndPerson((listing, name, email) =>
+    createTestAttendeeDirect(listing.id, name, email),
   );
-  return { attendee, listing, token };
-};
 
 /** The first attendee from a `createTestAttendeeAtomic`-style result,
  *  throwing (loudly, like the tests it replaces) when booking failed. */

--- a/test/test-utils/crypto.ts
+++ b/test/test-utils/crypto.ts
@@ -66,24 +66,11 @@ export const getTestDataKey = async (): Promise<CryptoKey> => {
 
 export const getTestPrivateKey = async (): Promise<CryptoKey> => {
   const { decryptWithKey } = await import("#crypto/encryption.ts");
-  const { deriveKEKFromPassword, importPrivateKey, unwrapKey } = await import(
-    "#crypto/keys.ts"
-  );
-  const { getUserByUsername, verifyUserPassword } = await import(
-    "#db/users.ts"
-  );
+  const { importPrivateKey } = await import("#crypto/keys.ts");
   const { settings } = await import("#db/settings.ts");
-  const { TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD } = await import(
-    "#test-utils/internal.ts"
-  );
+  const { getOwnerDataKey } = await import("#test-utils/owner-key.ts");
 
-  const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-  if (!user?.wrapped_data_key) {
-    throw new Error("Test setup failed: no wrapped data key");
-  }
-  const ownerHash = (await verifyUserPassword(user, TEST_ADMIN_PASSWORD))!;
-  const kek = await deriveKEKFromPassword(TEST_ADMIN_PASSWORD, ownerHash);
-  const dataKey = await unwrapKey(user.wrapped_data_key, kek);
+  const dataKey = await getOwnerDataKey();
   const wrappedPrivateKey = settings.wrappedPrivateKey;
   if (!wrappedPrivateKey) {
     throw new Error("Test setup failed: no wrapped private key");

--- a/test/test-utils/csrf.ts
+++ b/test/test-utils/csrf.ts
@@ -87,10 +87,8 @@ export const getTicketCsrfToken = (html: string | null): string | null =>
 export const getPageWithCsrf = async (
   path: string,
 ): Promise<{ csrfToken: string; html: string }> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest } = await import("#test-utils/mocks.ts");
-  const response = await handleRequest(mockRequest(path));
-  const html = await response.text();
+  const { testPageHtml } = await import("#test-utils/mocks.ts");
+  const html = await testPageHtml(path);
   const csrfToken = extractCsrfToken(html);
   if (!csrfToken) throw new Error(`Failed to get CSRF token from ${path}`);
   return { csrfToken, html };
@@ -117,32 +115,31 @@ export const submitJoinForm = async (
   inviteCode: string,
   data: { password: string; password_confirm: string },
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest, mockRequest } = await import("#test-utils/mocks.ts");
-  const requireJoinCsrfTokenImport = await import("#test-utils/csrf.ts");
-  const joinGetResponse = await handleRequest(
-    mockRequest(`/join/${inviteCode}`),
+  const { awaitTestRequest, testPageHtml } = await import(
+    "#test-utils/mocks.ts"
   );
-  const joinHtml = await joinGetResponse.text();
-  const joinCsrf = requireJoinCsrfTokenImport.requireJoinCsrfToken(joinHtml);
-  return handleRequest(
-    mockFormRequest(`/join/${inviteCode}`, { ...data, csrf_token: joinCsrf }),
-  );
+  const joinPath = `/join/${inviteCode}`;
+  const joinCsrf = requireJoinCsrfToken(await testPageHtml(joinPath));
+  return awaitTestRequest(joinPath, {
+    data: { ...data, csrf_token: joinCsrf },
+  });
 };
 
+/** GET the booking page for `slug`, then POST its form back carrying the token
+ *  that page rendered. Single listings, joint pages, and packages all book
+ *  this way; only a single listing's page names a quantity field to line the
+ *  fields up with. */
 export const submitTicketForm = async (
   slug: string,
   data: Record<string, string>,
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest, mockTicketFormRequest } = await import(
+  const { mockTicketFormRequest, sendToApp, testPageHtml } = await import(
     "#test-utils/mocks.ts"
   );
-  const getResponse = await handleRequest(mockRequest(`/ticket/${slug}`));
-  const html = await getResponse.text();
+  const html = await testPageHtml(`/ticket/${slug}`);
   const csrfToken = await csrfTokenOrSignedFallback(html);
   const normalizedData = normalizeSingleListingFields(data, html);
-  return handleRequest(mockTicketFormRequest(slug, normalizedData, csrfToken));
+  return sendToApp(mockTicketFormRequest(slug, normalizedData, csrfToken));
 };
 
 /** POSTs a ticket form carrying no CSRF token at all and asserts the
@@ -152,9 +149,8 @@ export const expectMissingCsrfRejected = async (
   path: string,
   data: Record<string, string>,
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
-  const response = await handleRequest(mockFormRequest(path, data));
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  const response = await awaitTestRequest(path, { data });
   expect(response.status).toBe(302);
   expectFlash(
     response,
@@ -168,17 +164,13 @@ export const submitMultiTicketForm = async (
   slug: string,
   data: Record<string, string>,
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const path = `/ticket/${slug}`;
   const { csrfToken } = await getPageWithCsrf(path);
-  return handleRequest(
-    mockFormRequest(
-      path,
-      { ...data, csrf_token: csrfToken },
-      `csrf_token=${csrfToken}`,
-    ),
-  );
+  return awaitTestRequest(path, {
+    cookie: `csrf_token=${csrfToken}`,
+    data: { ...data, csrf_token: csrfToken },
+  });
 };
 
 /** Submits the joint ticket form as "John Doe", booking `quantity1` of

--- a/test/test-utils/db-contracts.test.ts
+++ b/test/test-utils/db-contracts.test.ts
@@ -115,7 +115,7 @@ describe("test-utils — db-backed & settings contracts", () => {
       resetDb();
       await createTestDb();
       await expect(getTestPrivateKey()).rejects.toThrow(
-        "Test setup failed: no wrapped data key",
+        "Test owner has no wrapped data key",
       );
 
       resetDb();
@@ -160,10 +160,10 @@ describe("test-utils — db-backed & settings contracts", () => {
       await createTestDb();
 
       await expect(createTestManagerSession()).rejects.toThrow(
-        "Admin user has no wrapped data key",
+        "Test owner has no wrapped data key",
       );
       await expect(createTestAgentSession()).rejects.toThrow(
-        "Admin user not set up",
+        "Test owner has no wrapped data key",
       );
     });
 

--- a/test/test-utils/db-helpers/attendees.ts
+++ b/test/test-utils/db-helpers/attendees.ts
@@ -58,19 +58,15 @@ export const createTestAttendee = async (
   quantity = 1,
   phone = "",
 ): Promise<Attendee> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest, mockTicketFormRequest } = await import(
+  const { mockTicketFormRequest, sendToApp, testPageHtml } = await import(
     "#test-utils/mocks.ts"
   );
   const { extractCsrfToken } = await import("#test-utils/csrf.ts");
 
-  const pageResponse = await handleRequest(
-    mockRequest(`/ticket/${listingSlug}`),
-  );
-  const pageHtml = await pageResponse.text();
+  const pageHtml = await testPageHtml(`/ticket/${listingSlug}`);
   const csrfToken = extractCsrfToken(pageHtml) ?? (await signCsrfToken());
 
-  const response = await handleRequest(
+  const response = await sendToApp(
     mockTicketFormRequest(
       listingSlug,
       { email, name, phone, [`quantity_${listingId}`]: String(quantity) },

--- a/test/test-utils/db-helpers/holidays.ts
+++ b/test/test-utils/db-helpers/holidays.ts
@@ -27,14 +27,19 @@ export const createTestHoliday = (
   );
 };
 
+/** The holiday as it is stored now. Editing and deleting both need it: the
+ * edit form re-sends the fields it does not change, and the delete form
+ * confirms by name. */
+const storedHoliday = async (holidayId: number): Promise<Holiday> => {
+  const { holidays } = await import("#db/holidays.ts");
+  return (await holidays.table.read.one({ id: holidayId })) as Holiday;
+};
+
 export const updateTestHoliday = async (
   holidayId: number,
   updates: Partial<HolidayInput>,
 ): Promise<Holiday> => {
-  const { holidays } = await import("#db/holidays.ts");
-  const existing = (await holidays.table.read.one({
-    id: holidayId,
-  })) as Holiday;
+  const existing = await storedHoliday(holidayId);
 
   return doAuthenticatedFormRequest(
     `/admin/holidays/${holidayId}/edit`,
@@ -43,19 +48,13 @@ export const updateTestHoliday = async (
       name: updates.name ?? existing.name,
       start_date: updates.startDate ?? existing.start_date,
     },
-    async () => {
-      const updated = await holidays.table.read.one({ id: holidayId });
-      return updated as Holiday;
-    },
+    () => storedHoliday(holidayId),
     "update holiday",
   );
 };
 
 export const deleteTestHoliday = async (holidayId: number): Promise<void> => {
-  const { holidays } = await import("#db/holidays.ts");
-  const existing = (await holidays.table.read.one({
-    id: holidayId,
-  })) as Holiday;
+  const existing = await storedHoliday(holidayId);
 
   return doAuthenticatedFormRequest(
     `/admin/holidays/${holidayId}/delete`,

--- a/test/test-utils/db-helpers/misc.ts
+++ b/test/test-utils/db-helpers/misc.ts
@@ -8,16 +8,12 @@ export const createTestInvite = async (
   adminLevel = "manager",
 ): Promise<{ inviteCode: string; cookie: string; csrfToken: string }> => {
   const { getTestSession } = await import("#test-utils/session.ts");
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const { cookie, csrfToken } = await getTestSession();
-  const inviteResponse = await handleRequest(
-    mockFormRequest(
-      "/admin/users",
-      { admin_level: adminLevel, csrf_token: csrfToken, username },
-      cookie,
-    ),
-  );
+  const inviteResponse = await awaitTestRequest("/admin/users", {
+    cookie,
+    data: { admin_level: adminLevel, csrf_token: csrfToken, username },
+  });
   const location = inviteResponse.headers.get("location") ?? "";
   const url = new URL(location, "http://localhost");
   const inviteLink = url.searchParams.get("invite") ?? "";
@@ -31,13 +27,12 @@ export const createTestInvite = async (
 };
 
 export const getEmbeddableTicketResponse = async (): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest } = await import("#test-utils/mocks.ts");
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const listing = await createTestListing({
     maxAttendees: 50,
     thankYouUrl: "https://example.com",
   });
-  return handleRequest(mockRequest(`/ticket/${listing.slug}`));
+  return awaitTestRequest(`/ticket/${listing.slug}`);
 };
 
 /** Assert that the admin password can be verified against the stored hash,

--- a/test/test-utils/db-helpers/request.ts
+++ b/test/test-utils/db-helpers/request.ts
@@ -10,9 +10,9 @@ async function doAuthenticatedRequest<T>(
   errorContext: string,
 ): Promise<T> {
   const { getTestSession } = await import("#test-utils/session.ts");
-  const { handleRequest } = await import("#routes");
+  const { sendToApp } = await import("#test-utils/mocks.ts");
   const session = await getTestSession();
-  const response = await handleRequest(
+  const response = await sendToApp(
     buildRequest(
       path,
       { ...formData, csrf_token: session.csrfToken },

--- a/test/test-utils/db.ts
+++ b/test/test-utils/db.ts
@@ -74,13 +74,8 @@ const cleanupUnlessKept = (
   };
 };
 
-const prepareTestClient = async (triggers = false): Promise<void> => {
-  if (getTestDbResource()) resetDb();
-  // Keep libsql's leaked file descriptors from exhausting the process limit
-  // under high `--parallel` worker counts (see reclaim-fds.ts).
-  maybeReclaimLeakedFds();
-  setupTestEncryptionKey();
-  settings.setup.clearCache();
+/** Drop every cached read a fresh database must not inherit. */
+const invalidateEntityCaches = (): void => {
   invalidateCachesForTable("sessions");
   invalidateUsersCache();
   invalidateListingsCache();
@@ -88,16 +83,22 @@ const prepareTestClient = async (triggers = false): Promise<void> => {
   groups.cache.invalidate();
   logisticsAgents.invalidate();
   attendeeStatuses.invalidate();
+};
 
-  // A temp file, not ":memory:": interactive transactions (withTransaction) open
-  // a second connection, and each ":memory:" connection is its own *separate*
-  // empty database — a transaction would see no schema. A file is shared across
-  // connections. `createTestDbClient` keeps the speed settings on it.
-  //
-  // Copy the golden DB (schema + default status, prebuilt by the harness for
-  // the whole run, else built once per isolate — see test-state.ts) rather
-  // than re-running the schema SQL on every test — a file copy is much cheaper
-  // than executing 100+ CREATE TABLE / INDEX / TRIGGER statements.
+/**
+ * Copy the golden database into a fresh temp file and open a client on it,
+ * with `DB_URL` pointed at the copy.
+ *
+ * A temp file, not ":memory:": interactive transactions (withTransaction) open
+ * a second connection, and each ":memory:" connection is its own *separate*
+ * empty database — a transaction would see no schema. A file is shared across
+ * connections. `createTestDbClient` keeps the speed settings on it.
+ *
+ * Copying the golden DB (schema + default status, prebuilt by the harness for
+ * the whole run, else built once per isolate — see test-state.ts) is much
+ * cheaper than executing 100+ CREATE TABLE / INDEX / TRIGGER statements.
+ */
+const openGoldenDbCopy = async (triggers: boolean): Promise<TestDbResource> => {
   const goldenPath = await getOrCreateGoldenDb();
   const path = await createTrackedTestDbFile(".db");
   await Deno.copyFile(goldenPath, path);
@@ -105,10 +106,22 @@ const prepareTestClient = async (triggers = false): Promise<void> => {
     DB_URL: `file:${path}`,
     DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: triggers ? undefined : "1",
   });
-  const client = await createTestDbClient(path);
-  setTestDbResource({ client, env, path });
+  return { client: await createTestDbClient(path), env, path };
+};
+
+const prepareTestClient = async (triggers = false): Promise<void> => {
+  if (getTestDbResource()) resetDb();
+  // Keep libsql's leaked file descriptors from exhausting the process limit
+  // under high `--parallel` worker counts (see reclaim-fds.ts).
+  maybeReclaimLeakedFds();
+  setupTestEncryptionKey();
+  settings.setup.clearCache();
+  invalidateEntityCaches();
+
+  const resource = await openGoldenDbCopy(triggers);
+  setTestDbResource(resource);
   using rollback = cleanupUnlessKept(resetDb);
-  setDb(client);
+  setDb(resource.client);
   rollback.keep();
 };
 
@@ -132,14 +145,7 @@ export const setupTransactionalTestDb = async (): Promise<
   // file-backed client per test and runs many `withTransaction` writes.
   maybeReclaimLeakedFds();
   setupTestEncryptionKey();
-  const goldenPath = await getOrCreateGoldenDb();
-  const path = await createTrackedTestDbFile(".db");
-  await Deno.copyFile(goldenPath, path);
-  const env = withEnv({
-    DB_URL: `file:${path}`,
-    DISABLE_AGGREGATE_TRIGGERS_FOR_TEST: "1",
-  });
-  const client = await createTestDbClient(path);
+  const { client, env, path } = await openGoldenDbCopy(false);
   setDb(client);
   return async () => {
     setDb(null);
@@ -194,13 +200,7 @@ export const resetDb = (): void => {
     setDb(null);
     settings.setup.clearCache();
     settings.invalidateCache();
-    invalidateUsersCache();
-    invalidateListingsCache();
-    holidays.invalidate();
-    groups.cache.invalidate();
-    logisticsAgents.invalidate();
-    attendeeStatuses.invalidate();
-    invalidateCachesForTable("sessions");
+    invalidateEntityCaches();
     setTestSession(null);
     setDemoModeForTest(false);
     resetEffectiveDomain();

--- a/test/test-utils/debug-log.ts
+++ b/test/test-utils/debug-log.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach } from "@std/testing/bdd";
-import { type Spy, spy } from "@std/testing/mock";
+import type { Spy } from "@std/testing/mock";
 import { map } from "#fp";
 import { setSuppressDebugLogs } from "#shared/log-settings.ts";
+import { useConsoleSpy } from "#test-utils/error-spy.ts";
 
 /** Return the first value from each captured debug call. */
 export const debugMessages = (debugSpy: Spy): unknown[] =>
@@ -9,29 +10,13 @@ export const debugMessages = (debugSpy: Spy): unknown[] =>
 
 /** Capture debug output for each test and restore global logging afterwards. */
 export const useDebugLogSpy = (): (() => Spy) => {
-  let debugSpy: Spy;
-  beforeEach(() => {
-    setSuppressDebugLogs(false);
-    debugSpy = spy(console, "debug");
-  });
-  afterEach(() => {
-    debugSpy.restore();
-    setSuppressDebugLogs(null);
-  });
-  return () => debugSpy;
+  beforeEach(() => setSuppressDebugLogs(false));
+  afterEach(() => setSuppressDebugLogs(null));
+  return useConsoleSpy("debug");
 };
 
 /** Capture console.error (where logError routes) per test. */
-export const useErrorLogSpy = (): (() => Spy) => {
-  let errorSpy: Spy;
-  beforeEach(() => {
-    errorSpy = spy(console, "error");
-  });
-  afterEach(() => {
-    errorSpy.restore();
-  });
-  return () => errorSpy;
-};
+export const useErrorLogSpy = (): (() => Spy) => useConsoleSpy("error");
 
 const logLogged = (logSpy: () => Spy, needle: string): boolean =>
   logSpy().calls.some((call) => String(call.args[0]).includes(needle));

--- a/test/test-utils/error-spy.ts
+++ b/test/test-utils/error-spy.ts
@@ -7,24 +7,31 @@ import { type Spy, spy } from "@std/testing/mock";
  * how a test proves an error path *logged*, not just returned a failure value
  * (a removed logError call is otherwise unobservable).
  */
+/** Spy on one console method for each test in the block, restoring it after.
+ * The single place a test suite takes console output over. */
+export const useConsoleSpy = (method: "debug" | "error"): (() => Spy) => {
+  let consoleSpy: Spy;
+  beforeEach(() => {
+    consoleSpy = spy(console, method);
+  });
+  afterEach(() => {
+    consoleSpy.restore();
+  });
+  return () => consoleSpy;
+};
+
 export const setupErrorSpy = (): {
   readonly calls: Spy["calls"];
   lastMessage: () => string | undefined;
   contains: (needle: string) => boolean;
 } => {
-  let errorSpy: Spy;
-  beforeEach(() => {
-    errorSpy = spy(console, "error");
-  });
-  afterEach(() => {
-    errorSpy.restore();
-  });
+  const errorSpy = useConsoleSpy("error");
   return {
     get calls() {
-      return errorSpy.calls;
+      return errorSpy().calls;
     },
     contains: (needle: string) =>
-      errorSpy.calls.some((call) => String(call.args[0]).includes(needle)),
-    lastMessage: () => errorSpy.calls.at(-1)?.args[0] as string | undefined,
+      errorSpy().calls.some((call) => String(call.args[0]).includes(needle)),
+    lastMessage: () => errorSpy().calls.at(-1)?.args[0] as string | undefined,
   };
 };

--- a/test/test-utils/internal.ts
+++ b/test/test-utils/internal.ts
@@ -1,4 +1,5 @@
 import { lazyRef } from "#fp";
+import type { TestFormValues } from "#test-utils/form-values.ts";
 
 /** The owner every test starts with. The username reads like a person's name,
  * because some stories leave a page behind that gets published: a screenshot
@@ -71,7 +72,7 @@ export const [getTestStoragePath, setTestStoragePath] = lazyRef<string | null>(
 
 export interface TestRequestOptions {
   cookie?: string;
-  data?: Record<string, string>;
+  data?: TestFormValues;
   method?: string;
 }
 

--- a/test/test-utils/listing-parents/helpers.ts
+++ b/test/test-utils/listing-parents/helpers.ts
@@ -162,8 +162,9 @@ export const postListingEdit = async (
     "#test-utils/db-helpers/listing-forms.ts"
   );
   const { getTestSession } = await import("#test-utils/session.ts");
-  const { handleRequest } = await import("#routes");
-  const { mockMultipartRequest } = await import("#test-utils/mocks.ts");
+  const { mockMultipartRequest, sendToApp } = await import(
+    "#test-utils/mocks.ts"
+  );
   const existing = (await getListingWithCount(listingId))!;
   const form = buildUpdateListingForm(updates, existing);
   // The edit form carries group membership as `group_ids` checkboxes. Translate
@@ -177,7 +178,7 @@ export const postListingEdit = async (
   const formWithGroups =
     groupIds.length > 0 ? { ...form, group_ids: String(groupIds[0]) } : form;
   const session = await getTestSession();
-  return handleRequest(
+  return sendToApp(
     mockMultipartRequest(
       `/admin/listing/${listingId}/edit`,
       { ...formWithGroups, csrf_token: session.csrfToken },

--- a/test/test-utils/mocks.ts
+++ b/test/test-utils/mocks.ts
@@ -38,14 +38,20 @@ export const mockRequestWithHost = (
 export const mockRequest = (path: string, options: RequestInit = {}): Request =>
   mockRequestWithHost(path, "localhost", options);
 
+/** A form-encoded request body, the one place test form values become a
+ *  urlencoded string. */
+const formBody = (data: TestFormValues): string => {
+  const params = new URLSearchParams();
+  appendTestFormValues(params, data);
+  return params.toString();
+};
+
 export const mockFormRequest = (
   path: string,
   data: TestFormValues = {},
   cookie?: string,
 ): Request => {
-  const params = new URLSearchParams();
-  appendTestFormValues(params, data);
-  const body = params.toString();
+  const body = formBody(data);
   const headers: HeadersInit = {
     "content-type": "application/x-www-form-urlencoded",
     host: "localhost",
@@ -358,7 +364,7 @@ export const testRequest = (
   if (data) {
     headers["content-type"] = "application/x-www-form-urlencoded";
     return new Request(`http://localhost${path}`, {
-      body: new URLSearchParams(data).toString(),
+      body: formBody(data),
       headers,
       method: method ?? "POST",
     });
@@ -370,16 +376,26 @@ export const testRequest = (
   });
 };
 
-export const awaitTestRequest = async (
+/** Send `request` to the app. The route graph is a dynamic import, so a helper
+ *  module that only builds requests never pulls it in. */
+export const sendToApp = async (request: Request): Promise<Response> => {
+  const { handleRequest } = await import("#routes");
+  return handleRequest(request);
+};
+
+export const awaitTestRequest = (
   path: string,
   tokenOrOptions?: string | TestRequestOptions | null,
-): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  if (typeof tokenOrOptions === "object" && tokenOrOptions !== null) {
-    return handleRequest(testRequest(path, null, tokenOrOptions));
-  }
-  return handleRequest(testRequest(path, tokenOrOptions));
-};
+): Promise<Response> =>
+  sendToApp(
+    typeof tokenOrOptions === "object" && tokenOrOptions !== null
+      ? testRequest(path, null, tokenOrOptions)
+      : testRequest(path, tokenOrOptions),
+  );
+
+/** GET `path` from the app and return its rendered HTML. */
+export const testPageHtml = async (path: string): Promise<string> =>
+  (await awaitTestRequest(path)).text();
 
 export const errorResponse =
   (status: number) =>

--- a/test/test-utils/owner-key.ts
+++ b/test/test-utils/owner-key.ts
@@ -1,0 +1,25 @@
+/**
+ * The test owner's data key, unwrapped from the owner's own password the way
+ * the login flow does it.
+ *
+ * Setup creates the owner at the v2 (password-bound) KEK scheme, so its KEK is
+ * salted with the owner's stored password hash. Every helper that wraps the
+ * key for a *new* user — a manager, an agent, a session — starts here.
+ */
+
+export const getOwnerDataKey = async (): Promise<CryptoKey> => {
+  const { deriveKEKFromPassword, unwrapKey } = await import("#crypto/keys.ts");
+  const { getUserByUsername, verifyUserPassword } = await import(
+    "#db/users.ts"
+  );
+  const { TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } = await import(
+    "#test-utils/internal.ts"
+  );
+  const owner = await getUserByUsername(TEST_ADMIN_USERNAME);
+  if (!owner?.wrapped_data_key) {
+    throw new Error("Test owner has no wrapped data key");
+  }
+  const ownerHash = (await verifyUserPassword(owner, TEST_ADMIN_PASSWORD))!;
+  const kek = await deriveKEKFromPassword(TEST_ADMIN_PASSWORD, ownerHash);
+  return unwrapKey(owner.wrapped_data_key, kek);
+};

--- a/test/test-utils/packages.ts
+++ b/test/test-utils/packages.ts
@@ -3,25 +3,17 @@
 import type { Group, ListingWithCount } from "#types";
 
 /**
- * Drive the public checkout submit for a package group: GET the package page
- * (seeding the CSRF token the POST needs), then POST the booking form fields.
- * Callers pass `package_quantity_<groupId>` plus any date/day-count/contact
- * fields.
+ * Drive the public checkout submit for a package group. Callers pass
+ * `package_quantity_<groupId>` plus any date/day-count/contact fields; a
+ * package page names no quantity field, so the shared submitter passes them
+ * through unchanged.
  */
 export const submitPackageBooking = async (
   slug: string,
   fields: Record<string, string>,
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest, mockTicketFormRequest } = await import(
-    "#test-utils/mocks.ts"
-  );
-  const { extractCsrfToken } = await import("#test-utils/csrf.ts");
-  const pageHtml = await (
-    await handleRequest(mockRequest(`/ticket/${slug}`))
-  ).text();
-  const csrf = extractCsrfToken(pageHtml)!;
-  return handleRequest(mockTicketFormRequest(slug, fields, csrf));
+  const { submitTicketForm } = await import("#test-utils/csrf.ts");
+  return submitTicketForm(slug, fields);
 };
 
 /** The package-building pieces both factories below load lazily, so importing

--- a/test/test-utils/parents.ts
+++ b/test/test-utils/parents.ts
@@ -31,9 +31,8 @@ import { enablePublicSite } from "./settings.ts";
 
 /** GET `/ticket/<slugs>` and return the raw Response. */
 export const ticketGet = async (slugs: string): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest } = await import("#test-utils/mocks.ts");
-  return handleRequest(mockRequest(`/ticket/${slugs}`));
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  return awaitTestRequest(`/ticket/${slugs}`);
 };
 
 /** GET the booking-page HTML for `slugs`. */
@@ -52,40 +51,33 @@ export const bookingPageToken = async (slugs: string): Promise<string> => {
   );
 };
 
-/** POST a booking to `/ticket/<slugs>` with the given fields (CSRF auto-added). */
-export const postBooking = async (
+/** POST `fields` under `<section>/<slugs>`, carrying the booking page's own
+ * CSRF token. Booking and quoting post the same form to two sections. */
+const postToBookingPath = async (
+  section: string,
   slugs: string,
   fields: Record<string, string>,
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const csrf = await bookingPageToken(slugs);
-  return handleRequest(
-    mockFormRequest(
-      `/ticket/${slugs}`,
-      { csrf_token: csrf, ...fields },
-      `csrf_token=${csrf}`,
-    ),
-  );
+  return awaitTestRequest(`/${section}/${slugs}`, {
+    cookie: `csrf_token=${csrf}`,
+    data: { csrf_token: csrf, ...fields },
+  });
 };
+
+/** POST a booking to `/ticket/<slugs>` with the given fields (CSRF auto-added). */
+export const postBooking = (
+  slugs: string,
+  fields: Record<string, string>,
+): Promise<Response> => postToBookingPath("ticket", slugs, fields);
 
 /** POST a `/calculate/<slugs>` quote, returning the rendered HTML fragment. */
 export const postCalculate = async (
   slugs: string,
   fields: Record<string, string>,
-): Promise<string> => {
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
-  const csrf = await bookingPageToken(slugs);
-  const res = await handleRequest(
-    mockFormRequest(
-      `/calculate/${slugs}`,
-      { csrf_token: csrf, ...fields },
-      `csrf_token=${csrf}`,
-    ),
-  );
-  return res.text();
-};
+): Promise<string> =>
+  (await postToBookingPath("calculate", slugs, fields)).text();
 
 /** POST a booking to `/ticket/<slug>` with the standard test contact
  *  (`email: "a@b.com"`, `name: "Ada"`) merged into `fields`. The shared default
@@ -175,10 +167,8 @@ export const makeCustomisableDailyParent = () =>
 
 /** GET a JSON API path and return the raw Response. */
 export const apiGet = async (path: string): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  return handleRequest(
-    new Request(`http://localhost${path}`, { headers: { host: "localhost" } }),
-  );
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  return awaitTestRequest(path);
 };
 
 /** GET `/api/listings` (the collection endpoint) and return the row whose slug
@@ -301,9 +291,8 @@ export const expectChildAvailability = (
  * shared fetch behind {@link publicBody} and {@link ticketPageStatus}. */
 const publicFetch = async (path: string): Promise<Response> => {
   await enablePublicSite();
-  const { handleRequest } = await import("#routes");
-  const { mockRequest } = await import("#test-utils/mocks.ts");
-  return handleRequest(mockRequest(path));
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  return awaitTestRequest(path);
 };
 
 /** Fetch a public page body with the public site enabled. Shared by the
@@ -413,22 +402,15 @@ export const postChildren = async (
   childIds: number[],
 ): Promise<Response> => {
   const { getTestSession } = await import("#test-utils/session.ts");
-  const { handleRequest } = await import("#routes");
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const { cookie, csrfToken } = await getTestSession();
-  const body = new URLSearchParams();
-  body.set("csrf_token", csrfToken);
-  for (const id of childIds) body.append("child_listing_ids", String(id));
-  return handleRequest(
-    new Request(`http://localhost/admin/listing/${listingId}/children`, {
-      body: body.toString(),
-      headers: {
-        "content-type": "application/x-www-form-urlencoded",
-        cookie,
-        host: "localhost",
-      },
-      method: "POST",
-    }),
-  );
+  return awaitTestRequest(`/admin/listing/${listingId}/children`, {
+    cookie,
+    data: {
+      child_listing_ids: childIds.map(String),
+      csrf_token: csrfToken,
+    },
+  });
 };
 
 /** GET an admin listing page (`/admin/listing/<id><suffix>`) as HTML. */
@@ -556,13 +538,7 @@ export const soldOutParentInGroup = async (
  */
 export const expectNoListingsCta = async (groupSlug: string): Promise<void> => {
   await enablePublicSite();
-  const { handleRequest } = await import("#routes");
-  const body = await (
-    await handleRequest(
-      new Request("http://localhost/listings", {
-        headers: { host: "localhost" },
-      }),
-    )
-  ).text();
+  const { testPageHtml } = await import("#test-utils/mocks.ts");
+  const body = await testPageHtml("/listings");
   expect(body).not.toContain(`href="/ticket/${groupSlug}"`);
 };

--- a/test/test-utils/servicing.ts
+++ b/test/test-utils/servicing.ts
@@ -319,12 +319,12 @@ export const adminPost = async (
   path: string,
   data: Record<string, string>,
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const { cookie, csrfToken } = await getTestSession();
-  return handleRequest(
-    mockFormRequest(path, { csrf_token: csrfToken, ...data }, cookie),
-  );
+  return awaitTestRequest(path, {
+    cookie,
+    data: { csrf_token: csrfToken, ...data },
+  });
 };
 
 // ─── Compound assertion helpers (curried where the shape is shared) ─────────

--- a/test/test-utils/session.ts
+++ b/test/test-utils/session.ts
@@ -1,4 +1,5 @@
-import type { Row } from "@libsql/client";
+import type { InValue } from "@libsql/client";
+import type { WrappedKey } from "#crypto/sealed.ts";
 import { generateSecureToken } from "#crypto/utils.ts";
 import { createApiKey } from "#db/api-keys.ts";
 import { getSession } from "#db/sessions.ts";
@@ -28,21 +29,18 @@ export const loginAsAdmin = async (
   cookie: string;
   csrfToken: string;
 }> => {
-  const { handleRequest } = await import("#routes");
-  const { mockRequest, mockAdminLoginRequest } = await import(
+  const { mockAdminLoginRequest, sendToApp, testPageHtml } = await import(
     "#test-utils/mocks.ts"
   );
   const { extractCsrfToken } = await import("#test-utils/csrf.ts");
 
-  const loginPageResponse = await handleRequest(mockRequest("/admin/"));
-  const loginHtml = await loginPageResponse.text();
-  const loginCsrfToken = extractCsrfToken(loginHtml);
+  const loginCsrfToken = extractCsrfToken(await testPageHtml("/admin/"));
 
   if (!loginCsrfToken) {
     throw new Error("Failed to get CSRF token for admin login");
   }
 
-  const loginResponse = await handleRequest(
+  const loginResponse = await sendToApp(
     await mockAdminLoginRequest({ password, username }, loginCsrfToken),
   );
   const cookie = loginResponse.headers
@@ -126,62 +124,58 @@ export const reloginAsAdmin = async (
   setTestSession(await loginAsAdmin(username, password));
 };
 
+/** Insert a user row and open a live session for it. The role helpers below
+ * differ only in the row they store and the key the session carries. */
+const createUserWithSession = async (
+  username: string,
+  row: Record<string, InValue>,
+  session: {
+    token: string;
+    csrfToken: string;
+    wrappedKey: WrappedKey | null;
+  },
+): Promise<number> => {
+  const { getDb, insert } = await import("#db/client.ts");
+  const { createSession } = await import("#db/sessions.ts");
+  const { getUserByUsername, invalidateUsersCache: invalidateUsers } =
+    await import("#db/users.ts");
+  await getDb().execute(insert("users", row));
+  invalidateUsers();
+  const userId = (await getUserByUsername(username))!.id;
+  await createSession(
+    session.token,
+    session.csrfToken,
+    Date.now() + 60_000,
+    session.wrappedKey,
+    userId,
+  );
+  return userId;
+};
+
 export const createTestManagerSession = async (
   token = "mgr-session",
   username = "testmanager",
 ): Promise<string> => {
   const { encrypt: enc } = await import("#crypto/encryption.ts");
   const { hmacHash } = await import("#crypto/hashing.ts");
-  const { deriveKEKFromPassword, unwrapKey, wrapKeyWithToken } = await import(
-    "#crypto/keys.ts"
-  );
-  const { getDb } = await import("#db/client.ts");
-  const { insert } = await import("#db/client.ts");
-  const { createSession } = await import("#db/sessions.ts");
-  const {
-    getUserByUsername,
-    invalidateUsersCache: invalidateUsers,
-    verifyUserPassword,
-  } = await import("#db/users.ts");
+  const { wrapKeyWithToken } = await import("#crypto/keys.ts");
+  const { getOwnerDataKey } = await import("#test-utils/owner-key.ts");
 
-  // The owner is created at the v2 (password-bound) KEK scheme by setup; its KEK
-  // is salted with the owner's stored password hash.
-  const user = await getUserByUsername(TEST_ADMIN_USERNAME);
-  if (!user?.wrapped_data_key) {
-    throw new Error("Admin user has no wrapped data key");
-  }
-  const ownerHash = (await verifyUserPassword(user, TEST_ADMIN_PASSWORD))!;
-  const kek = await deriveKEKFromPassword(TEST_ADMIN_PASSWORD, ownerHash);
-  const dataKey = await unwrapKey(user.wrapped_data_key, kek);
-
-  const managerIdx = await hmacHash(username);
-  const managerWrappedKey = await wrapKeyWithToken(
-    dataKey,
-    "user-key-placeholder",
-  );
-  await getDb().execute(
-    insert("users", {
+  const dataKey = await getOwnerDataKey();
+  await createUserWithSession(
+    username,
+    {
       admin_level: await enc("manager"),
       password_hash: "",
       username_hash: await enc(username),
-      username_index: managerIdx,
-      wrapped_data_key: managerWrappedKey,
-    }),
-  );
-  invalidateUsers();
-
-  const result = await getDb().execute(
-    "SELECT id FROM users ORDER BY id DESC LIMIT 1",
-  );
-  const userId = (result.rows[0] as Row).id as number;
-
-  const wrappedDataKey = await wrapKeyWithToken(dataKey, token);
-  await createSession(
-    token,
-    "mgr-csrf",
-    Date.now() + 60_000,
-    wrappedDataKey,
-    userId,
+      username_index: await hmacHash(username),
+      wrapped_data_key: await wrapKeyWithToken(dataKey, "user-key-placeholder"),
+    },
+    {
+      csrfToken: "mgr-csrf",
+      token,
+      wrappedKey: await wrapKeyWithToken(dataKey, token),
+    },
   );
 
   return `${getSessionCookieName()}=${token}`;
@@ -206,30 +200,12 @@ export const createTestAgentSession = async (
   const username = opts.username ?? "testagent";
   const { encrypt: enc } = await import("#crypto/encryption.ts");
   const { hashPassword, hmacHash } = await import("#crypto/hashing.ts");
-  const {
-    deriveKEK,
-    deriveKEKFromPassword,
-    unwrapKey,
-    wrapKey,
-    wrapKeyWithToken,
-  } = await import("#crypto/keys.ts");
-  const { getDb, insert } = await import("#db/client.ts");
-  const { createSession } = await import("#db/sessions.ts");
-  const {
-    getUserByUsername,
-    invalidateUsersCache: invalidateUsers,
-    verifyUserPassword,
-  } = await import("#db/users.ts");
-
-  // The owner is created at the v2 (password-bound) KEK scheme by setup; its KEK
-  // is salted with the owner's stored password hash.
-  const owner = await getUserByUsername(TEST_ADMIN_USERNAME);
-  if (!owner?.wrapped_data_key) throw new Error("Admin user not set up");
-  const ownerHash = (await verifyUserPassword(owner, TEST_ADMIN_PASSWORD))!;
-  const dataKey = await unwrapKey(
-    owner.wrapped_data_key,
-    await deriveKEKFromPassword(TEST_ADMIN_PASSWORD, ownerHash),
+  const { deriveKEK, wrapKey, wrapKeyWithToken } = await import(
+    "#crypto/keys.ts"
   );
+  const { getOwnerDataKey } = await import("#test-utils/owner-key.ts");
+
+  const dataKey = await getOwnerDataKey();
 
   // When given a password the agent is wrapped at the legacy v1 scheme with
   // kek_version defaulting to 1, so logging in as the agent exercises the
@@ -244,31 +220,27 @@ export const createTestAgentSession = async (
     userWrappedKey = await wrapKeyWithToken(dataKey, "user-key-placeholder");
   }
 
-  await getDb().execute(
-    insert("users", {
+  const userId = await createUserWithSession(
+    username,
+    {
       admin_level: await enc("agent"),
       password_hash: passwordHashEnc,
       username_hash: await enc(username),
       username_index: await hmacHash(username),
       wrapped_data_key: userWrappedKey,
-    }),
+    },
+    {
+      csrfToken: "agent-csrf",
+      token,
+      wrappedKey: await wrapKeyWithToken(dataKey, token),
+    },
   );
-  invalidateUsers();
-  const userId = (await getUserByUsername(username))!.id;
 
   if (opts.agentIds && opts.agentIds.length > 0) {
     const { userAgents } = await import("#db/user-agents.ts");
     await userAgents.setIds(userId, opts.agentIds);
   }
 
-  const wrappedDataKey = await wrapKeyWithToken(dataKey, token);
-  await createSession(
-    token,
-    "agent-csrf",
-    Date.now() + 60_000,
-    wrappedDataKey,
-    userId,
-  );
   return { cookie: `${getSessionCookieName()}=${token}`, userId };
 };
 
@@ -289,25 +261,19 @@ export const createTestEditorSession = async (
   const password = opts.password ?? "editorpass123";
   const { encrypt: enc } = await import("#crypto/encryption.ts");
   const { hashPassword, hmacHash } = await import("#crypto/hashing.ts");
-  const { getDb, insert } = await import("#db/client.ts");
-  const { createSession } = await import("#db/sessions.ts");
-  const { getUserByUsername, invalidateUsersCache: invalidateUsers } =
-    await import("#db/users.ts");
 
-  await getDb().execute(
-    insert("users", {
+  const userId = await createUserWithSession(
+    username,
+    {
       admin_level: await enc("editor"),
       kek_version: 2,
       password_hash: await enc(await hashPassword(password)),
       username_hash: await enc(username),
       username_index: await hmacHash(username),
       wrapped_data_key: null,
-    }),
+    },
+    { csrfToken: "editor-csrf", token, wrappedKey: null },
   );
-  invalidateUsers();
-  const userId = (await getUserByUsername(username))!.id;
-
-  await createSession(token, "editor-csrf", Date.now() + 60_000, null, userId);
   return { cookie: `${getSessionCookieName()}=${token}`, userId };
 };
 
@@ -340,28 +306,36 @@ export const getTestDataKeyForApiKey = async (): Promise<CryptoKey> => {
   return getTestDataKey();
 };
 
+/** A request to `path` carrying the headers that say who is asking, plus the
+ * host header the app needs. */
+const requestWithProof = (
+  proof: Record<string, string>,
+  path: string,
+  opts: RequestInit,
+): Request => {
+  const headers = new Headers(opts.headers);
+  for (const [name, value] of Object.entries(proof)) headers.set(name, value);
+  if (!headers.has("host")) headers.set("host", "localhost");
+  return new Request(`http://localhost${path}`, { ...opts, headers });
+};
+
 export const requestAsApiKey = (
   path: string,
   apiKey: string,
   opts: RequestInit = {},
-): Request => {
-  const headers = new Headers(opts.headers);
-  headers.set("authorization", `Bearer ${apiKey}`);
-  if (!headers.has("host")) headers.set("host", "localhost");
-  return new Request(`http://localhost${path}`, { ...opts, headers });
-};
+): Request =>
+  requestWithProof({ authorization: `Bearer ${apiKey}` }, path, opts);
 
 export const requestAsSession = (
   path: string,
   session: { cookie: string; csrfToken: string },
   opts: RequestInit = {},
-): Request => {
-  const headers = new Headers(opts.headers);
-  headers.set("cookie", session.cookie);
-  headers.set("x-csrf-token", session.csrfToken);
-  if (!headers.has("host")) headers.set("host", "localhost");
-  return new Request(`http://localhost${path}`, { ...opts, headers });
-};
+): Request =>
+  requestWithProof(
+    { cookie: session.cookie, "x-csrf-token": session.csrfToken },
+    path,
+    opts,
+  );
 
 export const apiRequest = async (
   path: string,
@@ -371,7 +345,7 @@ export const apiRequest = async (
     apiKey?: string;
   } = {},
 ): Promise<Response> => {
-  const { handleRequest } = await import("#routes");
+  const { sendToApp } = await import("#test-utils/mocks.ts");
   const apiKey = options.apiKey ?? (await createTestApiKeyToken());
   const method = options.method ?? "GET";
   const headers: HeadersInit =
@@ -381,7 +355,7 @@ export const apiRequest = async (
     headers,
     method,
   };
-  return handleRequest(requestAsApiKey(path, apiKey, init));
+  return sendToApp(requestAsApiKey(path, apiKey, init));
 };
 
 export const setupListingAndLogin = async (
@@ -406,19 +380,15 @@ export const adminFormPost = async (
   const { settings } = await import("#db/settings.ts");
   await settings.loadKeys([]);
   const { cookie, csrfToken } = await getTestSession();
-  const { handleRequest } = await import("#routes");
-  const { mockFormRequest } = await import("#test-utils/mocks.ts");
-  const response = await handleRequest(
-    mockFormRequest(
-      path,
-      {
-        csrf_token: csrfToken,
-        settings_version: String(settings.version),
-        ...data,
-      },
-      cookie,
-    ),
-  );
+  const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+  const response = await awaitTestRequest(path, {
+    cookie,
+    data: {
+      csrf_token: csrfToken,
+      settings_version: String(settings.version),
+      ...data,
+    },
+  });
   return { cookie, csrfToken, response };
 };
 
@@ -433,9 +403,10 @@ export const adminMultipartPost = async (
   },
 ): Promise<{ response: Response; cookie: string; csrfToken: string }> => {
   const { cookie, csrfToken } = await getTestSession();
-  const { handleRequest } = await import("#routes");
-  const { mockMultipartRequest } = await import("#test-utils/mocks.ts");
-  const response = await handleRequest(
+  const { mockMultipartRequest, sendToApp } = await import(
+    "#test-utils/mocks.ts"
+  );
+  const response = await sendToApp(
     mockMultipartRequest(
       path,
       { csrf_token: csrfToken, ...data },
@@ -492,38 +463,42 @@ export const setupAdminTest = async (
   return { attendee, cookie, csrfToken, listing };
 };
 
-export const adminAttendeeAction =
-  (action: string, scope: "listing" | "attendee" = "attendee") =>
-  (formData: Record<string, string> = {}) =>
+type AdminFixtureResult = AdminTestContext & { response: Response };
+
+/** Set up the standard admin fixture, send one request built from it, and
+ * hand back the fixture together with the response. */
+const onAdminFixture =
+  (send: (ctx: AdminTestContext) => Promise<Response>) =>
   async (
     listingOverrides: TestListingOverrides = {},
-  ): Promise<AdminTestContext & { response: Response }> => {
+  ): Promise<AdminFixtureResult> => {
     const ctx = await setupAdminTest(listingOverrides);
-    const { handleRequest } = await import("#routes");
-    const { mockFormRequest } = await import("#test-utils/mocks.ts");
-    const url =
-      scope === "listing"
-        ? `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/${action}`
-        : `/admin/attendees/${ctx.attendee.id}/${action}`;
-    const response = await handleRequest(
-      mockFormRequest(
-        url,
-        { csrf_token: ctx.csrfToken, ...formData },
-        ctx.cookie,
-      ),
-    );
-    return { ...ctx, response };
+    return { ...ctx, response: await send(ctx) };
   };
 
-export const adminListingPage =
-  (pathFn: (ctx: AdminTestContext) => string) =>
-  async (
-    listingOverrides: TestListingOverrides = {},
-  ): Promise<AdminTestContext & { response: Response }> => {
-    const ctx = await setupAdminTest(listingOverrides);
-    const { awaitTestRequest } = await import("#test-utils/mocks.ts");
-    const response = await awaitTestRequest(pathFn(ctx), {
-      cookie: ctx.cookie,
+export const adminAttendeeAction =
+  (action: string, scope: "listing" | "attendee" = "attendee") =>
+  (
+    formData: Record<string, string> = {},
+  ): ((
+    listingOverrides?: TestListingOverrides,
+  ) => Promise<AdminFixtureResult>) =>
+    onAdminFixture(async (ctx) => {
+      const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+      const url =
+        scope === "listing"
+          ? `/admin/listing/${ctx.listing.id}/attendee/${ctx.attendee.id}/${action}`
+          : `/admin/attendees/${ctx.attendee.id}/${action}`;
+      return awaitTestRequest(url, {
+        cookie: ctx.cookie,
+        data: { csrf_token: ctx.csrfToken, ...formData },
+      });
     });
-    return { ...ctx, response };
-  };
+
+export const adminListingPage = (
+  pathFn: (ctx: AdminTestContext) => string,
+): ((listingOverrides?: TestListingOverrides) => Promise<AdminFixtureResult>) =>
+  onAdminFixture(async (ctx) => {
+    const { awaitTestRequest } = await import("#test-utils/mocks.ts");
+    return awaitTestRequest(pathFn(ctx), { cookie: ctx.cookie });
+  });

--- a/test/test-utils/test-state.ts
+++ b/test/test-utils/test-state.ts
@@ -28,9 +28,9 @@ import {
   ensureDefaultAttendeeStatus,
 } from "#db/attendee-statuses.ts";
 import { getDb, insert, setDb } from "#db/client.ts";
-import { SCHEMA } from "#db/migrations/schema/index.ts";
 import { TRIGGERS } from "#db/migrations/schema/triggers.ts";
 import { SCHEMA_MIGRATIONS_TABLE } from "#db/migrations/schema/version.ts";
+import { fullSchemaCreateStatements } from "#db/migrations/schema-sync.ts";
 import { LATEST_UPDATE, SCHEMA_HASH } from "#db/migrations.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#db/settings.ts";
 import { lazyRef, once } from "#fp";
@@ -112,22 +112,6 @@ export const invalidateTestDbCache = (): void => {
   setSnapshotDisabled(true);
 };
 
-type SchemaEntry = (typeof SCHEMA)[number];
-type SchemaIndex = NonNullable<SchemaEntry[1]["indexes"]>[number];
-
-const createTableSql = ([name, table]: SchemaEntry): string =>
-  `CREATE TABLE IF NOT EXISTS ${name} (${table.columns
-    .map(([col, type]) => `${col} ${type}`)
-    .join(", ")})`;
-
-const createIndexSql = (tableName: string, idx: SchemaIndex): string => {
-  const unique = idx.unique ? "UNIQUE " : "";
-  const where = idx.where === undefined ? "" : ` WHERE ${idx.where}`;
-  return `CREATE ${unique}INDEX IF NOT EXISTS ${idx.name} ON ${tableName}(${idx.columns.join(
-    ", ",
-  )})${where}`;
-};
-
 const sqlString = (value: string): string => `'${value.replaceAll("'", "''")}'`;
 
 // Lazy (and cached): the migration modules are only needed to stamp a fresh
@@ -135,10 +119,7 @@ const sqlString = (value: string): string => `'${value.replaceAll("'", "''")}'`;
 const buildTestSchemaSql = once(async (): Promise<string> => {
   const migrations = await loadMigrations();
   return `${[
-    ...SCHEMA.map(createTableSql),
-    ...SCHEMA.flatMap(([name, table]) =>
-      (table.indexes ?? []).map((idx) => createIndexSql(name, idx)),
-    ),
+    ...fullSchemaCreateStatements(),
     ...TRIGGERS.map((trigger) => trigger.sql),
     `INSERT OR REPLACE INTO settings (key, value) VALUES ('latest_db_update', ${sqlString(
       LATEST_UPDATE,

--- a/test/test-utils/webhooks.ts
+++ b/test/test-utils/webhooks.ts
@@ -67,10 +67,10 @@ export const postWebhookAndAssert = async <T = Record<string, unknown>>(
   assertions?: (json: T) => void,
   signature = "sig_valid",
 ): Promise<T> => {
-  const { handleRequest } = await import("#routes");
+  const { sendToApp } = await import("#test-utils/mocks.ts");
   try {
     return await assertJson<T>(
-      handleRequest(mockWebhookRequest({}, { "stripe-signature": signature })),
+      sendToApp(mockWebhookRequest({}, { "stripe-signature": signature })),
       status,
       assertions,
     );
@@ -85,13 +85,11 @@ export const expectWebhookRejected = async (
   event: Parameters<typeof stubWebhookVerify>[0],
   message: string,
 ): Promise<void> => {
-  const { handleRequest } = await import("#routes");
+  const { sendToApp } = await import("#test-utils/mocks.ts");
   const verify = await stubWebhookVerify(event);
   try {
     await expect(
-      handleRequest(
-        mockWebhookRequest({}, { "stripe-signature": "sig_valid" }),
-      ),
+      sendToApp(mockWebhookRequest({}, { "stripe-signature": "sig_valid" })),
     ).rejects.toThrow(message);
   } finally {
     verify.restore();
@@ -168,6 +166,15 @@ export const expectRefundedWithNote = async (
   expect((await getNoteRows("attendee", [attendeeId])).length).toBe(1);
 };
 
+/** The listing's one and only attendee, asserted to be alone. Every webhook
+ * aftermath check below starts from it. */
+const onlyAttendee = async (listingId: number): Promise<Attendee> => {
+  const { getAttendeesRaw } = await import("#db/attendees/queries.ts");
+  const attendees = await getAttendeesRaw(listingId);
+  expect(attendees.length).toBe(1);
+  return attendees[0]!;
+};
+
 /**
  * Assert the standard "kept and refunded" aftermath: the order survives as a
  * single quantity-0 placeholder attendee on `listingId` (never dropped), the
@@ -179,11 +186,9 @@ export const expectKeptAsQuantityZeroAndRefunded = async (
   sessionId: string,
   mockRefund: { calls: unknown[] },
 ): Promise<void> => {
-  const { getAttendeesRaw } = await import("#db/attendees/queries.ts");
-  const attendees = await getAttendeesRaw(listingId);
-  expect(attendees.length).toBe(1);
-  expect(attendees[0]!.quantity).toBe(0);
-  await expectRefundedWithNote(attendees[0]!.id, mockRefund);
+  const attendee = await onlyAttendee(listingId);
+  expect(attendee.quantity).toBe(0);
+  await expectRefundedWithNote(attendee.id, mockRefund);
   await expectSessionFailed(sessionId);
 };
 
@@ -199,14 +204,11 @@ export const expectMergedMultiListingAttendee = async (
   listing1Id: number,
   listing2Id: number,
 ): Promise<{ id: number }> => {
-  const { getAttendeesRaw } = await import("#db/attendees/queries.ts");
-  const attendees1 = await getAttendeesRaw(listing1Id);
-  const attendees2 = await getAttendeesRaw(listing2Id);
-  expect(attendees1.length).toBe(1);
-  expect(attendees2.length).toBe(1);
-  expect(attendees1[0]!.id).toBe(attendees2[0]!.id);
-  expect(attendees1[0]!.quantity).toBe(0);
-  return attendees1[0]!;
+  const first = await onlyAttendee(listing1Id);
+  const second = await onlyAttendee(listing2Id);
+  expect(first.id).toBe(second.id);
+  expect(first.quantity).toBe(0);
+  return first;
 };
 
 /**
@@ -216,20 +218,21 @@ export const expectMergedMultiListingAttendee = async (
  * the "received" check out of `expectWebhookIgnored`/`expectWebhookPending`
  * so the two differ only in that one assertion.
  */
-const expectWebhookAcknowledged = async (
-  event: Parameters<typeof stubWebhookVerify>[0],
-  assertOutcome: (json: Record<string, unknown>) => void,
-  extraCleanup?: () => void,
-): Promise<void> => {
-  await stubAndPostWebhook(
-    event,
-    (json) => {
-      expect(json.received).toBe(true);
-      assertOutcome(json);
-    },
-    extraCleanup,
-  );
-};
+const expectWebhookAcknowledged =
+  (assertOutcome: (json: Record<string, unknown>) => void) =>
+  async (
+    event: Parameters<typeof stubWebhookVerify>[0],
+    extraCleanup?: () => void,
+  ): Promise<void> => {
+    await stubAndPostWebhook(
+      event,
+      (json) => {
+        expect(json.received).toBe(true);
+        assertOutcome(json);
+      },
+      extraCleanup,
+    );
+  };
 
 /**
  * The third canonical webhook outcome alongside "processed" and "kept and
@@ -237,15 +240,9 @@ const expectWebhookAcknowledged = async (
  * established. It is acknowledged without processing or refunding. A valid
  * proof whose booking will not parse is a different, retryable outcome.
  */
-export const expectWebhookIgnored = (
-  event: Parameters<typeof stubWebhookVerify>[0],
-  extraCleanup?: () => void,
-): Promise<void> =>
-  expectWebhookAcknowledged(
-    event,
-    (json) => expect(json.processed).toBeUndefined(),
-    extraCleanup,
-  );
+export const expectWebhookIgnored = expectWebhookAcknowledged((json) =>
+  expect(json.processed).toBeUndefined(),
+);
 
 /** Assert a listing has exactly one attendee recorded with the given
  *  `price_paid` — the tail check for a processed webhook whose test cares
@@ -255,10 +252,8 @@ export const expectAttendeeWithPricePaid = async (
   listingId: number,
   pricePaid: number,
 ): Promise<void> => {
-  const { getAttendeesRaw } = await import("#db/attendees/queries.ts");
-  const attendees = await getAttendeesRaw(listingId);
-  expect(attendees.length).toBe(1);
-  expect((attendees[0] as unknown as Record<string, unknown>).price_paid).toBe(
+  const attendee = await onlyAttendee(listingId);
+  expect((attendee as unknown as Record<string, unknown>).price_paid).toBe(
     pricePaid,
   );
 };
@@ -269,11 +264,9 @@ export const expectAttendeeWithPricePaid = async (
 export const expectAttendeeCreatedWithPiiBlob = async (
   listingId: number,
 ): Promise<Attendee> => {
-  const { getAttendeesRaw } = await import("#db/attendees/queries.ts");
-  const attendees = await getAttendeesRaw(listingId);
-  expect(attendees.length).toBe(1);
-  expect(attendees[0]?.pii_blob).not.toBe("");
-  return attendees[0]!;
+  const attendee = await onlyAttendee(listingId);
+  expect(attendee.pii_blob).not.toBe("");
+  return attendee;
 };
 
 /**
@@ -282,12 +275,6 @@ export const expectAttendeeCreatedWithPiiBlob = async (
  * status), so the webhook acknowledges it as a pending retry rather than
  * processing, refunding, or dropping it.
  */
-export const expectWebhookPending = (
-  event: Parameters<typeof stubWebhookVerify>[0],
-  extraCleanup?: () => void,
-): Promise<void> =>
-  expectWebhookAcknowledged(
-    event,
-    (json) => expect(json.status).toBe("pending"),
-    extraCleanup,
-  );
+export const expectWebhookPending = expectWebhookAcknowledged((json) =>
+  expect(json.status).toBe("pending"),
+);


### PR DESCRIPTION
## What this changes

`deno task cpd` now runs a fourth scan. `.jscpd.helpers.json` reads `src` and
`test/test-utils` together, and it counts a clone from 40 tokens instead of the
48 the rest of `test/` gets.

The question behind the change was how tight each test helper tree can be.
`docs/test-duplication.md` records the measurements and prices every remaining
step. Two answers came out of it.

## The Cucumber helpers are already at their floor

`test/specs/support` reports no clones at 19 tokens. At 16 it reports 78, and
they are not merges. A typical pair is two helpers that each make one call to
the shared `openAdminPage`. The merge exists, and a tighter net asks us to undo
it.

A second limit applies from outside. The same config scans `src/`, so a helper
that reimplements production logic is flagged against the source it copied.
`src/` is clean at 19 and reports 497 pairs at 17, so the number cannot come
down without dragging `src/` with it. **19 stays.**

## The other test helpers moved from 48 to 40

`test/test-utils` holds 160 helper files and 19,164 lines. It was the only
helper tree left at 48 tokens, the loose setting meant for test bodies, and the
only one never scanned against `src/`.

That second gap hid a real problem. `test/test-utils/test-state.ts` held its own
copy of `createTableSql` and `createIndexSql` from
`src/shared/db/migrations/schema-sync.ts`. No scan could see the pair, because
no scan read the two trees together. The golden database that every DB test
starts from was therefore built by a second copy of the production schema
builder, and could drift from it. `test-state.ts` now calls
`fullSchemaCreateStatements()`, so one builder makes both.

Twelve more merges brought the tree to 40:

- **One way to reach the app.** 13 helper modules each opened their own
  `await import("#routes")`. `mocks.ts` already had `awaitTestRequest` for this;
  it now also exports `sendToApp` and `testPageHtml`, and every helper goes
  through one of the three. `mockFormRequest` and `testRequest` also built the
  form body two ways; they now share one builder, so a helper can pass a field
  with several values through either.
- **One unwrap of the owner's data key.** The new `test/test-utils/owner-key.ts`
  holds it. `crypto.ts` and both session helpers called it out in full before.
- **`session.ts`**: one `createUserWithSession` behind the manager, agent and
  editor helpers; one request builder behind `requestAsApiKey` and
  `requestAsSession`; one admin fixture behind `adminAttendeeAction` and
  `adminListingPage`.
- **`db.ts`**: one golden-database copy, and one cache invalidation.
- **`webhooks.ts`**: one "the listing's only attendee" read behind four checks.
- **`error-spy.ts`**: one console spy, used by the debug and the error spies.
- Also merged: `attendees/helpers.ts`, `db-helpers/holidays.ts`, `packages.ts`,
  `parents.ts`, `csrf.ts`.

The `*.test.ts` files inside `test/test-utils` are tests of those helpers, not
helpers, so they stay on the ordinary `test/` scan. A test body repeats by
design.

## One test changed with the code

`db-contracts.test.ts` pinned three separate failure messages, one for each of
the three copies of the owner-key unwrap. The contract it holds is that the
crypto, manager and agent helpers all fail loudly when the setup owner key is
missing. That still holds, and the wording is now one wording, so the test names
the message the shared helper throws.

## What is left

40 is a ratchet position, not a floor. `docs/test-duplication.md` prices the
next steps: 36 costs 17 pairs, 32 costs 31, 28 costs 67. Below 28 the pairs stop
being merges, because valibot schema fields and one-line field builders start to
match each other.

The document also records what was measured and rejected. A tighter scan of all
of `test/` costs 291 pairs at 44 and 873 at 40, and the rise is test bodies, so
48 stays.

`TODO.md` picks up two findings from the same read that did not belong in this
change: the alias exports in `debug-log.ts` and `csrf.ts`, and the two ways a
helper reaches `handleRequest`.

## Checks

CI is green on this head: `merge-check`, `checks` and `test` all pass, and the
branch merges cleanly. Locally, `deno task cpd` (all five configs), `typecheck`,
`lint:ci`, `check:imports`, `check:comments` and `check:copy` all pass.
`precommit:mutation` reports nothing to do, because this branch changes no
`src/` file.