### PR TITLE
Make one page address type out of the two that collided

### DIFF
--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -61,12 +61,19 @@ export const organiserSendsAndIsTold = async (
   keepWhatTheyWereTold(world, ORGANISER, browser.pageText);
 };
 
-/** Where one page lives, worked out from the world and from whatever the
- * story's own words named — a person, a thing for sale, or nothing at all. */
-export type PageAddress<Args extends unknown[]> = (
+/** Where one page lives: an address that never changes, or one worked out
+ * from the world and from whatever the story's own words named — a person, a
+ * thing for sale, or nothing at all. */
+export type PageAddress<Args extends unknown[] = []> =
+  | string
+  | ((world: TicketsWorld, ...args: Args) => string);
+
+/** The address itself, whichever of the two ways the caller named it. */
+const addressOf = <Args extends unknown[]>(
+  where: PageAddress<Args>,
   world: TicketsWorld,
   ...args: Args
-) => string;
+): string => (typeof where === "string" ? where : where(world, ...args));
 
 /** The organiser opens one of their own pages and keeps what it said, so the
  * Then steps read the same page the When opened. Curried on which page,
@@ -77,7 +84,7 @@ export const organiserReads = <Args extends unknown[]>(
   where: PageAddress<Args>,
 ): StoryJourney<Args, void> =>
   keepsAnswerAs(ORGANISER, (world, ...args) =>
-    adminPageHtmlAt(world, where(world, ...args)),
+    adminPageHtmlAt(world, addressOf(where, world, ...args)),
   );
 
 /** The organiser writes one message on a page and sends it, keeping what the
@@ -89,7 +96,7 @@ export const writesOneMessage =
     button: () => string | Promise<string>,
   ): StoryJourney<[string, ...Args], void> =>
   async (world, message, ...args) => {
-    const page = await openAdminPage(world, where(world, ...args));
+    const page = await openAdminPage(world, addressOf(where, world, ...args));
     await organiserSendsAndIsTold(world, page, { message }, await button());
   };
 
@@ -190,10 +197,6 @@ export const openAdminPage: OpensAPage = opensPagesAs(adminBrowser);
  * open can ignore what comes back. */
 export type OpensOneFixedPage = (world: TicketsWorld) => Promise<TestBrowser>;
 
-/** Where a page lives: an address that never changes, or one worked out from
- * the story so far. */
-export type PageAddress = string | ((world: TicketsWorld) => string);
-
 /** The organiser opens one page of their own, named once. Every "the owner
  * looks at X" step is this with a different address, so the address is the
  * only thing each caller says. The window comes back for a caller that reads
@@ -201,7 +204,7 @@ export type PageAddress = string | ((world: TicketsWorld) => string);
 export const opensAdminPageAt =
   (where: PageAddress): OpensOneFixedPage =>
   (world) =>
-    openAdminPage(world, typeof where === "string" ? where : where(world));
+    openAdminPage(world, addressOf(where, world));
 
 /** What one of the owner's own pages says right now. Opening and reading are
  * one step, so no caller can assert against a window it opened earlier. */


### PR DESCRIPTION
`deno check test` fails on main. `test/specs/support/browser.ts` declares `PageAddress` twice:

```
TS2300 [ERROR]: Duplicate identifier 'PageAddress'.
TS2314 [ERROR]: Generic type 'PageAddress' requires 1 type argument(s).
```

## How it got in

Two pull requests each added a type of that name: #2149 at line 66, and #2154 at line 195. Neither branch carried the other's copy, so each was green on its own, and the clash only existed once both had merged. Nothing compared them, because nothing had to until they met.

## The fix

The two types say almost the same thing. One is a function of the world and of whatever the story named. The other is a fixed string, or a function of the world alone. Their union, with no extra arguments as the default, covers every caller — see the diff for the declaration, which takes an `Args` parameter defaulting to the empty list.

`addressOf` resolves an address whichever way its caller wrote it, so the `typeof where === "string"` test lives in one place rather than at the one call site that happened to need it. The three callers in the file read the same as before.

## Checks

`lint:ci`, `typecheck`, `cpd`, `check:comments`, `check:imports` and `specs:check` pass. `deno task typecheck` reports no errors across `src test cli scripts`, which it could not do before this change. `specs/access/setting-a-site-up.feature`, which drives these helpers, passes with 5 scenarios and 29 steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKHXScPdaCmjiVZqPW5Ngs