### PR TITLE
Give the page address one type again, so main type-checks

### DIFF
--- a/test/specs/support/browser.ts
+++ b/test/specs/support/browser.ts
@@ -190,16 +190,14 @@ export const openAdminPage: OpensAPage = opensPagesAs(adminBrowser);
  * open can ignore what comes back. */
 export type OpensOneFixedPage = (world: TicketsWorld) => Promise<TestBrowser>;
 
-/** Where a page lives: an address that never changes, or one worked out from
- * the story so far. */
-export type PageAddress = string | ((world: TicketsWorld) => string);
-
 /** The organiser opens one page of their own, named once. Every "the owner
  * looks at X" step is this with a different address, so the address is the
- * only thing each caller says. The window comes back for a caller that reads
- * it, and a step that only needs the page open can ignore it. */
+ * only thing each caller says. An address that never changes is given as it
+ * is; one worked out from the story so far is given as a `PageAddress`. The
+ * window comes back for a caller that reads it, and a step that only needs
+ * the page open can ignore it. */
 export const opensAdminPageAt =
-  (where: PageAddress): OpensOneFixedPage =>
+  (where: string | PageAddress<[]>): OpensOneFixedPage =>
   (world) =>
     openAdminPage(world, typeof where === "string" ? where : where(world));
 


### PR DESCRIPTION
## main does not type-check right now

`deno task typecheck` fails on `main` at `3cbc76c`:

```
TS2300 Duplicate identifier 'PageAddress'.   test/specs/support/browser.ts:66
TS2300 Duplicate identifier 'PageAddress'.   test/specs/support/browser.ts:195
TS2314 Generic type 'PageAddress' requires 1 type argument(s).
TS7006 Parameter 'world' implicitly has an 'any' type.
```

Two pull requests each added a `PageAddress` type to
`test/specs/support/browser.ts`, and both merged. Neither was wrong on its
own. Each was green against the `main` it was tested on, and the pair was
never type-checked together before landing.

- One added `PageAddress = string | ((world: TicketsWorld) => string)`, for an
  address a page opener names once.
- The other added the general form `PageAddress<Args>`: an address worked out
  from the world and from whatever the story's own words named.

## The change

The general type stays, because it covers the other. `opensAdminPageAt` now
takes `string | PageAddress<[]>`, so a caller can still give an address that
never changes as a plain string:

```typescript
export const opensAdminPageAt =
  (where: string | PageAddress<[]>): OpensOneFixedPage =>
  (world) =>
    openAdminPage(world, typeof where === "string" ? where : where(world));
```

No caller changes.

## Checks

`typecheck`, `lint:ci`, `cpd` (all five configs) and `specs` (344 scenarios)
all pass on this branch. Each was run on its own exit code, not by reading its
output.