### PR TITLE
Correct comments the language pass broke, and record the merge-queue gap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ name: Test
 # queue out.
 #
 # The queue does NOT gate on these two checks. GitHub waits for the checks a
-# ruleset marks REQUIRED, and `checks` and `test` are not in that list for
-# `main`, so a red run here never blocks a merge. Runs 33021228000, 33022892823
-# and 33024444803 each failed `checks` in the queue and merged anyway. See
-# TODO.md, "The merge queue does not gate on `checks` or `test`".
+# ruleset marks REQUIRED. `checks` and `test` are not in that list for `main`,
+# so a red run here never blocks a merge. Runs 33021228000, 33022892823 and
+# 33024444803 each failed `checks` in the queue and merged anyway. See TODO.md,
+# "The merge queue does not gate on `checks` or `test`".
 on:
   push:
     branches-ignore: [main, "gh-readonly-queue/**"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,15 @@ name: Test
 
 # A merge queue builds its branch by pushing it, so `push` and `merge_group`
 # both fire on one queue branch and the suite runs twice on the same commit.
-# The queue waits for every check on the ref, so the second run only adds cost
-# and one more chance for a stalled runner to time the queue out. `merge_group`
-# still reports both check names there, which is what the queue gates on.
+# `merge_group` reports both check names on the queue ref, so the `push` run
+# there only adds cost and one more chance for a stalled runner to time the
+# queue out.
+#
+# The queue does NOT gate on these two checks. GitHub waits for the checks a
+# ruleset marks REQUIRED, and `checks` and `test` are not in that list for
+# `main`, so a red run here never blocks a merge. Runs 33021228000, 33022892823
+# and 33024444803 each failed `checks` in the queue and merged anyway. See
+# TODO.md, "The merge queue does not gate on `checks` or `test`".
 on:
   push:
     branches-ignore: [main, "gh-readonly-queue/**"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 # A merge queue builds its branch by pushing it, so `push` and `merge_group`
 # both fire on one queue branch and the suite runs twice on the same commit.
-# `merge_group` reports both check names on the queue ref, so the `push` run
-# there only adds cost and one more chance for a stalled runner to time the
-# queue out.
+# `merge_group` reports both check names on the queue ref. The `push` run there
+# only adds cost, and one more chance for a stalled runner to time the queue
+# out.
 #
 # The queue does NOT gate on these two checks. GitHub waits for the checks a
 # ruleset marks REQUIRED. `checks` and `test` are not in that list for `main`,

--- a/TODO.md
+++ b/TODO.md
@@ -3013,7 +3013,7 @@ and must be judged on its own.
 ## The merge queue does not gate on `checks` or `test`
 
 _Origin: #2158 merged with `checks` red, and so did the two merges before it. I
-found this while I traced why main stopped linting._
+found this while I traced why lint failed on main._
 
 `test.yml` runs on `merge_group`, so the queue does run the `checks` job, and
 that job runs `deno task lint:ci` before its other checks. The queue runs it,

--- a/TODO.md
+++ b/TODO.md
@@ -3007,3 +3007,38 @@ Do them together. Deletion of the fourteen entries is the proof that it works.
 Do not start with the deletion. Removal of the blind spot can unmask a genuinely
 dead export that a phantom same-file match was hiding, which is separate work
 and must be judged on its own.
+
+---
+
+## The merge queue does not gate on `checks` or `test`
+
+_Origin: #2158 merged with `checks` red, and so did the two merges before it.
+Found while tracing why main stopped linting._
+
+`test.yml` runs on `merge_group`, so the queue does run the `checks` job, and
+that job's first step is `deno task lint:ci`. The queue runs it, reads the
+failure, and merges anyway. Three consecutive merges did this:
+
+| Queue run     | PR    | `checks`        |
+| ------------- | ----- | --------------- |
+| `33021228000` | #2157 | failure, merged |
+| `33022892823` | #2155 | failure, merged |
+| `33024444803` | #2158 | failure, merged |
+
+The run before those, for #2156, passed. #2157 is the merge that put the
+duplicate `PageAddress` declaration on main, so the first ignored failure is
+also the one that broke main.
+
+GitHub waits for the checks a ruleset marks REQUIRED, not for every check on the
+ref. `checks` and `test` are not in that list for `main`, so both are advisory
+in the queue. The comment at the top of `test.yml` used to state the opposite,
+and that belief is why nothing looked.
+
+The fix is a repository setting, not a file here: Settings, then Rules, then the
+ruleset for `main`, then add `checks` and `test` to the merge queue's required
+status checks. No settings-as-code file exists in this repository, so nobody can
+make this change through a pull request.
+
+Until that changes, a red `checks` never blocks a merge, and main can break
+again the same way. `deno task precommit` before merge is the only thing that
+catches it, and it depends on a person running it.

--- a/TODO.md
+++ b/TODO.md
@@ -3012,12 +3012,12 @@ and must be judged on its own.
 
 ## The merge queue does not gate on `checks` or `test`
 
-_Origin: #2158 merged with `checks` red, and so did the two merges before it.
-Found while tracing why main stopped linting._
+_Origin: #2158 merged with `checks` red, and so did the two merges before it. I
+found this while I traced why main stopped linting._
 
 `test.yml` runs on `merge_group`, so the queue does run the `checks` job, and
-that job's first step is `deno task lint:ci`. The queue runs it, reads the
-failure, and merges anyway. Three consecutive merges did this:
+that job runs `deno task lint:ci` before its other checks. The queue runs it,
+reads the failure, and merges anyway. Three consecutive merges did this:
 
 | Queue run     | PR    | `checks`        |
 | ------------- | ----- | --------------- |
@@ -3034,11 +3034,15 @@ ref. `checks` and `test` are not in that list for `main`, so both are advisory
 in the queue. The comment at the top of `test.yml` used to state the opposite,
 and that belief is why nothing looked.
 
-The fix is a repository setting, not a file here: Settings, then Rules, then the
-ruleset for `main`, then add `checks` and `test` to the merge queue's required
-status checks. No settings-as-code file exists in this repository, so nobody can
-make this change through a pull request.
+The fix is a repository setting, not a file here. Open Settings, then Rules.
+Edit the ruleset for `main`. Add `checks` and `test` to the merge queue's
+required status checks. No settings-as-code file exists in this repository, so
+no pull request can make this change.
+
+Note what the gap is NOT. The failure is already detected: the `checks` job
+runs, fails, and reports. Nothing acts on that report. A new detector therefore
+fixes nothing, and the work belongs in the ruleset.
 
 Until that changes, a red `checks` never blocks a merge, and main can break
-again the same way. `deno task precommit` before merge is the only thing that
-catches it, and it depends on a person running it.
+again the same way. Only a person who runs `deno task precommit` before the
+merge stops it.

--- a/src/features/admin/listings-parents.ts
+++ b/src/features/admin/listings-parents.ts
@@ -114,7 +114,8 @@ type ChildOnlyAddOnResolver = (
 
 /**
  * Reject a parent→children edge set the inherited-date booking model or the v1
- * add-on scoping cannot honour. Nesting is one edge deep.
+ * add-on scoping cannot honour. A parent and its child have one edge, and
+ * neither takes another.
  *
  * An **empty** child set is always allowed. It clears the listing's edges, so a
  * listing that is itself a child can still save its blank children form, and a

--- a/src/features/admin/listings-parents.ts
+++ b/src/features/admin/listings-parents.ts
@@ -114,7 +114,7 @@ type ChildOnlyAddOnResolver = (
 
 /**
  * Reject a parent→children edge set the inherited-date booking model or the v1
- * add-on scoping cannot honour. A parent and its child are one level only.
+ * add-on scoping cannot honour. Nesting is one edge deep.
  *
  * An **empty** child set is always allowed. It clears the listing's edges, so a
  * listing that is itself a child can still save its blank children form, and a

--- a/src/features/admin/listings-parents.ts
+++ b/src/features/admin/listings-parents.ts
@@ -114,8 +114,8 @@ type ChildOnlyAddOnResolver = (
 
 /**
  * Reject a parent→children edge set the inherited-date booking model or the v1
- * add-on scoping cannot honour. A parent and its child have one edge, and
- * neither takes another.
+ * add-on scoping cannot honour. A parent must not itself be a child, and a
+ * child must not itself be a parent.
  *
  * An **empty** child set is always allowed. It clears the listing's edges, so a
  * listing that is itself a child can still save its blank children form, and a

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -279,9 +279,9 @@ const submitTicket = ticketFormRoute(
 );
 
 /**
- * A quote strips the PII that a buyer's visit count needs, so it runs at zero
- * visits. A returning buyer's `min_visits` modifiers are therefore absent. The
- * submit path reprices with the real count before it charges.
+ * A quote strips the PII needed to look up a buyer's visit count, so it runs at
+ * zero visits. A returning buyer's `min_visits` modifiers are therefore absent.
+ * The submit path reprices with the real count before it charges.
  *
  * With no payment provider the booking is taken without charging, but a paid
  * order still owes its full value, so the quote surfaces the amount owed and

--- a/src/shared/crypto/sealed.ts
+++ b/src/shared/crypto/sealed.ts
@@ -1,7 +1,7 @@
 /**
  * A sealed string is an ordinary string whose TYPE names which helper made it.
- * A function that receives plaintext, or a value sealed under the wrong scheme,
- * is then a compile error instead of unreadable data at rest.
+ * A call that hands a function plaintext, or a value sealed under the wrong
+ * scheme, is then a compile error instead of unreadable data at rest.
  *
  * Only the crypto helpers produce sealed values, so never build one with a cast
  * in application code. The one sanctioned cast is `col.encrypted`'s read

--- a/src/shared/db/attendees/queries.ts
+++ b/src/shared/db/attendees/queries.ts
@@ -174,10 +174,10 @@ const trimAttendeePage = (rows: Attendee[]): AttendeesPage => {
  * `listingIds` decides WHICH attendees match, and the returned rows still cover
  * all of a matched attendee's listings.
  *
- * An order by id works because AUTOINCREMENT rises with the registration date
- * but stays unique, which keeps each page deterministic and index-backed. One
- * extra attendee is read to report `hasNext` without a second count query. PII
- * stays encrypted, so decrypt with decryptAttendees first.
+ * An order by id works because AUTOINCREMENT ids are unique and increasing, so
+ * paging is deterministic. One extra attendee is read to report `hasNext`
+ * without a second count query. PII stays encrypted, so decrypt with
+ * decryptAttendees first.
  */
 export const getAttendeesPage = async ({
   listingIds,

--- a/src/shared/db/attendees/queries.ts
+++ b/src/shared/db/attendees/queries.ts
@@ -174,8 +174,8 @@ const trimAttendeePage = (rows: Attendee[]): AttendeesPage => {
  * `listingIds` decides WHICH attendees match, and the returned rows still cover
  * all of a matched attendee's listings.
  *
- * An order by id works because AUTOINCREMENT ids are unique and increasing, so
- * paging is deterministic. One extra attendee is read to report `hasNext`
+ * An order by id works because AUTOINCREMENT ids are unique and always rise.
+ * Each page is therefore deterministic. One extra attendee reports `hasNext`
  * without a second count query. PII stays encrypted, so decrypt with
  * decryptAttendees first.
  */

--- a/src/shared/ledger/validate.ts
+++ b/src/shared/ledger/validate.ts
@@ -60,8 +60,9 @@ const transferChecks: readonly TransferCheck[] = [
  * Returns every reason it was rejected, so a caller sees all the problems at
  * once rather than only the first.
  *
- * The amount must be a SAFE integer, so a sum of balances as JS numbers cannot
- * lose pennies. An account part must not carry the reserved key separator.
+ * Each amount must be a SAFE integer, so no single amount loses pennies as a JS
+ * number. Nothing bounds their sum, which {@link allBalances} accumulates as a
+ * plain number. An account part must not carry the reserved key separator.
  *
  * Currency is not a ledger concern: a site has one, fixed at setup, so every
  * transfer shares it.

--- a/src/shared/listing-templates.ts
+++ b/src/shared/listing-templates.ts
@@ -7,7 +7,8 @@
  *   purchaseable purchase_only (the "No check-in" flag)
  *   logistics    uses_logistics
  *
- * A listing that matches no named template is "Custom": full form, nothing hid.
+ * A listing that matches no named template is "Custom": full form, no fields
+ * hidden.
  */
 
 import type { Listing } from "#types";

--- a/src/shared/package-membership.ts
+++ b/src/shared/package-membership.ts
@@ -5,9 +5,9 @@
  * A package sets a fixed price per member and sells the whole bundle, so:
  *  - a pay-what-you-want listing has no fixed member price to charge.
  *  - a child listing is only ever sold alongside its parent.
- *  - on a HIDDEN package, a member that gates its own children shows a child
- *    selector that names the very listings the package hides. A VISIBLE package
- *    renders that selector fine.
+ *  - on a HIDDEN package, a member that gates its own children needs a child
+ *    selector, and that selector names the very listings the package hides. A
+ *    VISIBLE package renders that selector fine.
  */
 /* jscpd:ignore-start */
 import { t } from "#i18n";

--- a/src/shared/payment/row-machine-spec.ts
+++ b/src/shared/payment/row-machine-spec.ts
@@ -2,11 +2,11 @@
  * outcome on a row that ended clean. A cell missing from
  * {@link EXPECTED_MOVES} must refuse.
  *
- * Two production truths are kept as-is rather than smoothed over. A retire of a
- * review the row does not hold, and a record of books that were never behind,
- * are silent no-ops that STILL release the claim. A terminal outcome can also
- * replace an earlier one, the conservative-then-final write, so
- * `settled × write_outcome` is a declared self-move rather than a refusal.
+ * Two production truths are kept as-is rather than smoothed over. When the
+ * machine retires a review the row does not hold, or records books that were
+ * never behind, the move is a silent no-op that STILL releases the claim. A
+ * terminal outcome can also replace an earlier one, the conservative-then-final
+ * write, so `settled × write_outcome` is a declared self-move, not a refusal.
  *
  * A review acknowledgement belongs to the payment-review machine. */
 

--- a/src/shared/payment/row-machine-spec.ts
+++ b/src/shared/payment/row-machine-spec.ts
@@ -2,10 +2,10 @@
  * outcome on a row that ended clean. A cell missing from
  * {@link EXPECTED_MOVES} must refuse.
  *
- * Two production truths are kept as-is rather than smoothed over. When the
- * machine retires a review the row does not hold, or settles `books:
- * "recorded"` on a row carrying no `unrecorded` marker, the move is a silent
- * no-op that STILL releases the claim. A terminal outcome can also replace an
+ * Two production truths are kept as-is rather than smoothed over. The machine
+ * can retire a review the row does not hold. It can settle `books: "recorded"`
+ * on a row that carries no `unrecorded` marker. Each move is a silent no-op,
+ * and each STILL releases the claim. A terminal outcome can also replace an
  * earlier one, the conservative-then-final write, so `settled × write_outcome`
  * is a declared self-move, not a refusal.
  *

--- a/src/shared/payment/row-machine-spec.ts
+++ b/src/shared/payment/row-machine-spec.ts
@@ -3,10 +3,11 @@
  * {@link EXPECTED_MOVES} must refuse.
  *
  * Two production truths are kept as-is rather than smoothed over. When the
- * machine retires a review the row does not hold, or records books that were
- * never behind, the move is a silent no-op that STILL releases the claim. A
- * terminal outcome can also replace an earlier one, the conservative-then-final
- * write, so `settled × write_outcome` is a declared self-move, not a refusal.
+ * machine retires a review the row does not hold, or settles `books:
+ * "recorded"` on a row carrying no `unrecorded` marker, the move is a silent
+ * no-op that STILL releases the claim. A terminal outcome can also replace an
+ * earlier one, the conservative-then-final write, so `settled × write_outcome`
+ * is a declared self-move, not a refusal.
  *
  * A review acknowledgement belongs to the payment-review machine. */
 

--- a/src/shared/payment/sumup-recovery-machine-spec.ts
+++ b/src/shared/payment/sumup-recovery-machine-spec.ts
@@ -2,7 +2,7 @@
  * against, so a single lost callback is the whole of the notice we get. This
  * machine replaces that notice. Every staged checkout is asked about until
  * SumUp answers definitively. A row that can still hold unaccounted money is
- * never deleted, and never left with nothing to act on it.
+ * never deleted, and always stays in a state something can act on.
  *
  * The table below IS the production lookup, not a description of one. A cell it
  * leaves out is a declared refusal, and the mirror sweep proves it throws. */

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -277,8 +277,8 @@ export interface PaymentProvider {
    * stays provider-agnostic.
    *
    * @returns the session. `"skip"` acknowledges an event without processing it.
-   *          `"retry"` means the provider could not be read, or contradicted
-   *          our facts, so redelivery must try again. A rejection means the
+   *          `"retry"` means the read failed, or the provider contradicted our
+   *          facts, so redelivery must try again. A rejection means the
    *          provider reported a paid charge the boundary cannot read. `null`
    *          means the event is provably not ours.
    */

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -277,8 +277,8 @@ export interface PaymentProvider {
    * stays provider-agnostic.
    *
    * @returns the session. `"skip"` acknowledges an event without processing it.
-   *          `"retry"` means the provider went unread, or contradicted our
-   *          facts, so redelivery must try again. A rejection means the
+   *          `"retry"` means the provider could not be read, or contradicted
+   *          our facts, so redelivery must try again. A rejection means the
    *          provider reported a paid charge the boundary cannot read. `null`
    *          means the event is provably not ours.
    */

--- a/src/shared/payments.ts
+++ b/src/shared/payments.ts
@@ -277,10 +277,11 @@ export interface PaymentProvider {
    * stays provider-agnostic.
    *
    * @returns the session. `"skip"` acknowledges an event without processing it.
-   *          `"retry"` means the read failed, or the provider contradicted our
-   *          facts, so redelivery must try again. A rejection means the
-   *          provider reported a paid charge the boundary cannot read. `null`
-   *          means the event is provably not ours.
+   *          `"retry"` means the boundary refused before any read, the read
+   *          failed, or the provider contradicted our facts. Redelivery must
+   *          try again. A rejection means the provider reported a paid charge
+   *          the boundary cannot read. `null` means the event is provably not
+   *          ours.
    */
   resolveWebhookSession(listing: WebhookEvent): Promise<WebhookSessionResult>;
 

--- a/test/scripts/test-workflow.test.ts
+++ b/test/scripts/test-workflow.test.ts
@@ -18,17 +18,18 @@ const triggers = (workflow: string): string => {
 describe("Test workflow triggers", () => {
   test("does not run the suite twice on a merge queue branch", async () => {
     // A queue branch arrives as a push, so without this the suite runs once
-    // for `push` and again for `merge_group`. The queue waits for both, and a
-    // stalled duplicate once timed the queue out an hour after the real run
-    // had passed.
+    // for `push` and again for `merge_group`. A stalled duplicate once timed
+    // the queue out an hour after the real run had passed.
     expect(triggers(await readWorkflow())).toContain(
       'branches-ignore: [main, "gh-readonly-queue/**"]',
     );
   });
 
-  test("still reports on a merge queue branch, which the queue gates on", async () => {
-    // The pair matters: ignoring queue branches without this leaves the queue
-    // waiting for checks that never arrive, which is worse than the duplicate.
+  test("still reports on a merge queue branch", async () => {
+    // `checks` and `test` are not required checks on `main`, so the queue does
+    // not wait for them today. See TODO.md. Once they are required, a queue
+    // branch with no `merge_group` run reports nothing, and the queue waits for
+    // a check that never arrives.
     expect(triggers(await readWorkflow())).toContain("merge_group:");
   });
 


### PR DESCRIPTION
Comment text only. Three separate corrections, and the reason for the first one is the interesting part.

## Seven comments that the language pass made wrong

#2163 removed "-ing" verb forms from about fifty comment sentences to satisfy the ASD-STE100 rules in `AGENTS.md`. Seven of those rewrites changed what the sentence says. Both reviews caught them, and all seven are real.

| File | What it now claims | What is true |
| --- | --- | --- |
| `package-membership.ts` | a member that gates its own children **shows** a child selector | the code REFUSES that configuration |
| `crypto/sealed.ts` | the **function** is a compile error | the **call** is |
| `listings-parents.ts` | a parent and its child are **one level** | they are two, and nesting is one **edge** deep |
| `payments.ts` | the provider **went unread** | it **could not be read** |
| `ticket-submit.ts` | the **visit count** needs PII | the **lookup** does |
| `row-machine-spec.ts` | "a record of books" | reads as physical books, not `books: "unrecorded"` |
| `listing-templates.ts` | "nothing hid" | `hid` is the simple past |

`package-membership.ts` is the one that matters. The original said such a member **would show** a selector naming the listings a hidden package conceals. That is a counterfactual explaining why the rule exists: `gates_children_hidden` blocks the combination, and the locale copy says the selector "would reveal". Turning it into "shows" claimed the forbidden case renders. It keeps a counterfactual now, because the sentence is *about* a case that cannot happen and no phrasing without one is both true and short.

**Where the word rule and accuracy pull apart, accuracy wins.** That is the lesson of the parent PR arriving a second time: there, prose compressed to fit a line cap produced run-on sentences; here, prose reshaped to drop an "-ing" produced false statements. Both times the rule was applied to the sentence without re-reading the code beneath it.

## Two comments that claimed more than the code guarantees

Both predate the language pass, which only reworded them. A review's static analysis found both.

`db/attendees/queries.ts` said an order by id is safe because `AUTOINCREMENT` rises with the registration date, and that paging is index-backed. Neither is enforced. `created` comes from `nowIso()`, and a restore writes stored `created` values, so id order need not match registration order. The listing-filter branch groups, so it can need a temporary B-tree.

The fix deletes the claim rather than caveating it. The first attempt added both exceptions as prose, and `deno task check:comments` rejected the comment at 13 lines against the 12-line cap #2158 set. The comment now says only that ids are unique and increasing, which is what makes paging deterministic and is the whole of what a caller needs.

`ledger/validate.ts` said a SAFE integer amount means a sum of balances cannot lose pennies. Each amount is validated alone, and `allBalances` accumulates them into a plain `number`, so nothing bounds the total. Not a practical risk at minor-unit scale, but the comment stated a guarantee the code does not make.

## The merge queue does not gate on its own checks

The comment at the top of `.github/workflows/test.yml` said the queue waits for every check on the ref. It does not. GitHub waits for the checks a ruleset marks REQUIRED, and neither `checks` nor `test` is in that list for `main`.

That belief is why nothing looked. Three queue runs failed the `checks` job and merged anyway:

| Queue run | PR |
| --- | --- |
| `33021228000` | #2157 |
| `33022892823` | #2155 |
| `33024444803` | #2158 |

The first of those is the merge that put the duplicate `PageAddress` declaration on main, so the first ignored failure is also the one that broke main. #2158 then merged with `checks` red for the same reason, and #2163 existed to undo it.

The comment now states what is true, and `TODO.md` carries the finding. **The fix itself is a repository setting that no pull request can make**: Settings → Rules → the ruleset for `main` → add `checks` and `test` to the merge queue's required status checks. Until that changes, a red `checks` never blocks a merge.

## What an operator sees

Nothing. No route, template, message, or database column changed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145Xf9xPQFoQSM2nqPptbH7

---
_Generated by [Claude Code](https://claude.ai/code/session_0145Xf9xPQFoQSM2nqPptbH7)_