### PR TITLE
Turn on Biome's project domain, and break the cycle it finds

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,9 @@
     "lineWidth": 80
   },
   "linter": {
+    "domains": {
+      "project": "all"
+    },
     "enabled": true,
     "rules": {
       "a11y": {
@@ -56,6 +59,8 @@
         "useWhile": "error"
       },
       "correctness": {
+        "noUndeclaredDependencies": "off",
+        "noUnresolvedImports": "off",
         "noUnusedFunctionParameters": "error",
         "noUnusedImports": "error",
         "noUnusedVariables": "error"

--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -7,6 +7,7 @@ src/features/admin/settings-connection-lines.ts::credentialLine.mode~1vqeabi  ??
 
 src/features/admin/entity-pages.ts::defineEntityPage.renderPage.ctx.baseUrl~0v3px31  ?? → ||   # opts.baseUrl is a string and the only falsy string is the empty fallback itself
 src/features/admin/entity-pages.ts::defineEntityPage.renderPage.ctx.query~1xs3bh3  ?? → ||   # opts.query is a URLSearchParams object when present, so it is always truthy
+src/features/admin/listing-page-data.ts::loadListingRosterPanel.childNames~049e0ek  ?? → ||   # listingsByKey holds only non-empty ListingWithCount[], so get() is an array or undefined and an array is always truthy
 src/features/admin/site-content-page.ts::defineSiteContentPage.tabs~0786g3u  ?? → ||   # extraTabs is an array when present, and arrays are always truthy
 src/ui/templates/admin/holidays.tsx::HolidayEditPanel.html~1nrsidb  ?? → ||   # values is a render-values object when present, so it is always truthy
 src/ui/client/admin/manual-checkin.ts::initManualCheckin.filterOptions.text~0hoqwoy  ?? → ||   # textContent is string|null; its only falsy string is the empty fallback itself

--- a/src/features/admin/listing-page-data.ts
+++ b/src/features/admin/listing-page-data.ts
@@ -1,13 +1,14 @@
 /**
- * Data loaders for the listing entity page's read-only tabs — Overview,
- * Attendees (roster), and Activity. Each gathers exactly what its own tab
- * renders: per-tab loading means the expensive decrypted-attendee fetch only
- * runs for the two tabs that show the roster, never for Edit / Questions / QR.
+ * Data loaders for the listing entity page. Most serve the read-only tabs —
+ * Overview, Attendees (roster), and Activity. Each one gathers exactly what
+ * its own tab renders, so the expensive decrypted-attendee fetch runs for the
+ * two tabs that show the roster and for no other.
  *
- * The panels themselves (ListingOverviewPanel / ListingRosterPanel) live in the
- * listings template; these loaders assemble their props from the DB. The
- * gathering mirrors the pre-migration detail handler (listings-view.ts) so the
- * tabs render the same data the single detail page used to.
+ * `getListingAndGroups` is the exception, because the edit form and the edit
+ * tab's panels both need it. It sits here rather than inside either of them.
+ *
+ * The panels themselves (ListingOverviewPanel / ListingRosterPanel) live in
+ * the listings template. These loaders assemble their props from the DB.
  */
 
 import { listingMoneyTotals } from "#accounting/listing-money-totals.ts";

--- a/src/features/admin/listing-page-data.ts
+++ b/src/features/admin/listing-page-data.ts
@@ -19,15 +19,23 @@ import {
 } from "#db/activity-log.ts";
 import { decryptAttendees } from "#db/attendees/pii.ts";
 import { getAttendeeNamesByIds } from "#db/attendees/queries.ts";
-import { getHiddenPackageMemberIds } from "#db/groups.ts";
+import {
+  getHiddenPackageMemberIds,
+  groups,
+  listingGroups,
+} from "#db/groups.ts";
 import { getListingOverviewStats } from "#db/listing-overview-stats.ts";
 import {
   anyNonStandaloneChild,
   hydrateListingLinks,
   listingChildren,
 } from "#db/listing-parents.ts";
-import { getListingAggregateRecalculation } from "#db/listings/aggregates.ts";
+import {
+  getListingAggregateRecalculation,
+  type ListingAggregateRecalculation,
+} from "#db/listings/aggregates.ts";
 import { getAttendeesByListingIds } from "#db/listings/attendees.ts";
+import { getStoredListingWithCount } from "#db/listings/records.ts";
 import {
   loadNotesForAttendees,
   loadNotesForListing,
@@ -53,6 +61,7 @@ import { ListingRosterPanel } from "#templates/admin/listings/roster.tsx";
 import type { TableQuestionData } from "#templates/attendee-table/types.ts";
 import {
   type Attendee,
+  type Group,
   isOwnerRole,
   isPaidListing,
   type ListingWithCount,
@@ -65,6 +74,33 @@ import {
   rosterListSetup,
 } from "./listings-view.ts";
 import { loadListingOr } from "./load-listing.ts";
+
+/** Listing + its groups + aggregate recalculation, loaded for the edit pages. */
+export const getListingAndGroups = async (
+  listingId: number,
+): Promise<{
+  aggregateRecalculation: ListingAggregateRecalculation;
+  groups: Group[];
+  listing: ListingWithCount;
+  selectedGroupIds: number[];
+} | null> => {
+  const [listing, allGroups, selectedGroupIds] = await Promise.all([
+    // The edit form reads the listing's *stored* values, not the resolved view,
+    // so editing an inheriting listing can't bake the current defaults into its
+    // row (and the editor webhook lock below preserves the real stored URL).
+    getStoredListingWithCount(listingId),
+    groups.cache.getAll(),
+    listingGroups.getIds(listingId),
+  ]);
+  return listing
+    ? {
+        aggregateRecalculation: await getListingAggregateRecalculation(listing),
+        groups: allGroups,
+        listing,
+        selectedGroupIds,
+      }
+    : null;
+};
 
 /**
  * The listing entity page's loaded row: the listing plus the derived flags any

--- a/src/features/admin/listing-page-data.ts
+++ b/src/features/admin/listing-page-data.ts
@@ -85,9 +85,9 @@ export const getListingAndGroups = async (
   selectedGroupIds: number[];
 } | null> => {
   const [listing, allGroups, selectedGroupIds] = await Promise.all([
-    // The edit form reads the listing's *stored* values, not the resolved view,
-    // so editing an inheriting listing can't bake the current defaults into its
-    // row (and the editor webhook lock below preserves the real stored URL).
+    // The edit form reads the listing's *stored* values, not the resolved
+    // view. An edit to an inheriting listing must not bake the current
+    // defaults into its row.
     getStoredListingWithCount(listingId),
     groups.cache.getAll(),
     listingGroups.getIds(listingId),

--- a/src/features/admin/listing-page-management-panels.ts
+++ b/src/features/admin/listing-page-management-panels.ts
@@ -13,9 +13,11 @@ import { ListingEditPanel } from "#templates/admin/listings/edit-panel.tsx";
 import { ListingQuestionsPanel } from "#templates/admin/questions.tsx";
 import type { ListingWithCount } from "#types";
 import { loadItemImagesPanel } from "./item-images.ts";
-import type { LoadedListing } from "./listing-page-data.ts";
+import {
+  getListingAndGroups,
+  type LoadedListing,
+} from "./listing-page-data.ts";
 import { EMPTY_QR_VALUES, loadQrFormContext } from "./listing-qr.ts";
-import { getListingAndGroups } from "./listings-edit.ts";
 import { loadListingParentsSection } from "./listings-parents.ts";
 
 /**

--- a/src/features/admin/listings-edit.ts
+++ b/src/features/admin/listings-edit.ts
@@ -15,8 +15,6 @@ import { anyHiddenPackageGroup, groups, listingGroups } from "#db/groups.ts";
 import { listingChildren } from "#db/listing-parents.ts";
 import {
   adjustListingIncome,
-  getListingAggregateRecalculation,
-  type ListingAggregateRecalculation,
   type ListingAggregateValues,
   listingAggregates,
 } from "#db/listings/aggregates.ts";
@@ -65,13 +63,13 @@ import {
 import { getListingAggregateFields } from "#templates/fields/aggregate.ts";
 import {
   type AdminSession,
-  type Group,
   isListingType,
   type Listing,
   type ListingWithCount,
 } from "#types";
 import { withEntityFromParam } from "./entity-handlers.ts";
 import { listingPage } from "./listing-page.ts";
+import { getListingAndGroups } from "./listing-page-data.ts";
 import { loadListingEditPanel } from "./listing-page-management-panels.ts";
 import {
   buildCreateListingResource,
@@ -300,33 +298,6 @@ export const handleCreateListing: TypedRouteHandler<"POST /admin/listing"> =
       childWarning,
     );
   });
-
-/** Listing + its groups + aggregate recalculation, loaded for the edit pages. */
-export const getListingAndGroups = async (
-  listingId: number,
-): Promise<{
-  aggregateRecalculation: ListingAggregateRecalculation;
-  groups: Group[];
-  listing: ListingWithCount;
-  selectedGroupIds: number[];
-} | null> => {
-  const [listing, allGroups, selectedGroupIds] = await Promise.all([
-    // The edit form reads the listing's *stored* values, not the resolved view,
-    // so editing an inheriting listing can't bake the current defaults into its
-    // row (and the editor webhook lock below preserves the real stored URL).
-    getStoredListingWithCount(listingId),
-    groups.cache.getAll(),
-    listingGroups.getIds(listingId),
-  ]);
-  return listing
-    ? {
-        aggregateRecalculation: await getListingAggregateRecalculation(listing),
-        groups: allGroups,
-        listing,
-        selectedGroupIds,
-      }
-    : null;
-};
 
 type ListingAndGroups = NonNullable<
   Awaited<ReturnType<typeof getListingAndGroups>>

--- a/src/features/admin/seeds.ts
+++ b/src/features/admin/seeds.ts
@@ -9,9 +9,13 @@ import { t } from "#i18n";
 import { OWNER_FORM, ownerPage, withAuth } from "#routes/auth.ts";
 import { redirect } from "#routes/response.ts";
 import { getFlash } from "#shared/flash-context.ts";
-import { createSeeds, SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+import {
+  createSeeds,
+  MAX_SEED_LISTINGS,
+  SEED_MAX_ATTENDEES,
+} from "#shared/seeds.ts";
 import { adminSeedsPage } from "#templates/admin/seeds.tsx";
-import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
+import { seedsForm } from "#templates/fields/seeds.ts";
 
 /* jscpd:ignore-end */
 

--- a/src/shared/seeds.ts
+++ b/src/shared/seeds.ts
@@ -34,6 +34,9 @@ import { generateUniqueSlug, type SlugWithIndex } from "#shared/slug.ts";
 /** Max attendees per seeded listing */
 export const SEED_MAX_ATTENDEES = 100_000;
 
+/** Max listings that can be created in a single seed operation */
+export const MAX_SEED_LISTINGS = 30;
+
 /** Pick a random ticket quantity (1-4) */
 const randomQuantity = (): number => 1 + Math.floor(Math.random() * 4);
 

--- a/src/ui/templates/fields/seeds.ts
+++ b/src/ui/templates/fields/seeds.ts
@@ -2,10 +2,7 @@
 
 import { t } from "#i18n";
 import { defineForm } from "#shared/forms/definition.ts";
-import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
-
-/** Max listings that can be created in a single seed operation */
-export const MAX_SEED_LISTINGS = 30;
+import { MAX_SEED_LISTINGS, SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
 
 export const seedsForm = defineForm({
   fields: [

--- a/test/features/admin/listing-page-management-panels.test.ts
+++ b/test/features/admin/listing-page-management-panels.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The listing admin page's management tabs: what each panel puts on screen, and
+ * which groups the edit form ticks after a rejected save.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { listingGroups } from "#db/groups.ts";
+import { listingQuestions } from "#db/questions/queries.ts";
+import type { PageCtx } from "#routes/admin/entity-pages.ts";
+import {
+  type LoadedListing,
+  loadListingForPage,
+} from "#routes/admin/listing-page-data.ts";
+import {
+  loadListingAttributesPanel,
+  loadListingEditPanel,
+  loadListingImagesPanel,
+  loadListingQrPanel,
+  loadListingQuestionsPanel,
+} from "#routes/admin/listing-page-management-panels.ts";
+import type { AuthSession } from "#routes/auth.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import {
+  assignTestAttributeOptions,
+  createTestAttributeWithOptions,
+} from "#test-utils/db-helpers/attributes.ts";
+import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { createQuestion } from "#test-utils/questions/helpers.ts";
+import { withTestSession } from "#test-utils/session.ts";
+
+const SESSION: AuthSession = {
+  adminLevel: "owner",
+  token: "t",
+  userId: 1,
+  wrappedDataKey: null,
+};
+
+const CTX: PageCtx = {
+  baseUrl: "https://example.test",
+  query: new URLSearchParams(),
+  returnUrl: "/admin/listings/1",
+  session: SESSION,
+  tabHref: (slug: string) => `/admin/listings/1/${slug}`,
+};
+
+const loaded = async (id: number): Promise<LoadedListing> => {
+  const listing = await loadListingForPage(id);
+  if (!listing) throw new Error(`no listing ${id}`);
+  return listing;
+};
+
+const checkboxId = (tag: string): number => {
+  const found = /value="(\d+)"/.exec(tag);
+  if (!found) throw new Error(`checkbox with no value: ${tag}`);
+  return Number(found[1]);
+};
+
+/** The ids ticked under one checkbox name, read back out of the markup. */
+const ticked =
+  (name: string) =>
+  (html: string): number[] =>
+    html
+      .split("<input")
+      .filter(
+        (tag) => tag.includes(`name="${name}"`) && tag.includes("checked"),
+      )
+      .map(checkboxId);
+
+const tickedGroups = ticked("group_ids");
+const tickedQuestions = ticked("question_ids");
+const tickedOptions = ticked("option_ids");
+
+const editHtml = async (
+  listingId: number,
+  error?: string,
+  selectedGroupIds?: number[],
+): Promise<string> =>
+  await withTestSession(async () =>
+    String(
+      await loadListingEditPanel(
+        await loaded(listingId),
+        CTX,
+        error,
+        selectedGroupIds,
+      ),
+    ),
+  );
+
+/** A listing that belongs to one group, beside a second group it is not in. */
+const listingInAGroup = async (): Promise<{
+  listingId: number;
+  memberOf: number;
+  otherGroup: number;
+}> => {
+  const listing = await createTestListing({ name: "Autumn Fair" });
+  const memberOf = await createTestGroup({ name: "Weekends" });
+  const otherGroup = await createTestGroup({ name: "Evenings" });
+  await listingGroups.setIds(listing.id, [memberOf.id]);
+  return {
+    listingId: listing.id,
+    memberOf: memberOf.id,
+    otherGroup: otherGroup.id,
+  };
+};
+
+describeWithEnv(
+  "the listing page's management tabs",
+  { db: true, storage: "local" },
+  () => {
+    describe("the edit tab", () => {
+      test("shows the listing's stored name", async () => {
+        const listing = await createTestListing({ name: "Autumn Fair" });
+        expect(await editHtml(listing.id)).toContain("Autumn Fair");
+      });
+
+      test("ticks the groups the listing is stored in", async () => {
+        const { listingId, memberOf } = await listingInAGroup();
+        expect(tickedGroups(await editHtml(listingId))).toEqual([memberOf]);
+      });
+
+      test("ticks the groups the operator submitted, not the stored ones", async () => {
+        const { listingId, otherGroup } = await listingInAGroup();
+        const html = await editHtml(listingId, "Nope", [otherGroup]);
+        expect(tickedGroups(html)).toEqual([otherGroup]);
+      });
+
+      test("ticks nothing when the operator cleared every group", async () => {
+        // An empty submission is a real choice. Falling back to the stored ids
+        // would put the listing back in the group it was just taken out of.
+        const { listingId } = await listingInAGroup();
+        expect(tickedGroups(await editHtml(listingId, "Nope", []))).toEqual([]);
+      });
+
+      test("shows the message when a save was rejected", async () => {
+        const listing = await createTestListing({});
+        expect(await editHtml(listing.id, "Slug is taken")).toContain(
+          "Slug is taken",
+        );
+      });
+
+      test("shows no message when the tab is opened normally", async () => {
+        const listing = await createTestListing({});
+        expect(await editHtml(listing.id)).not.toContain("Slug is taken");
+      });
+    });
+
+    describe("the images tab", () => {
+      test("comes back to the listing after an upload", async () => {
+        const listing = await createTestListing({});
+        const html = await withTestSession(async () =>
+          String(await loadListingImagesPanel(await loaded(listing.id))),
+        );
+        expect(html).toContain(`/admin/listing/${listing.id}`);
+      });
+    });
+
+    describe("the questions tab", () => {
+      /** One assigned question and one unassigned, as the tab renders them. */
+      const questionsHtml = async (): Promise<{
+        assigned: number;
+        html: string;
+        unassigned: number;
+      }> => {
+        const listing = await createTestListing({});
+        const assigned = await createQuestion("Any allergies?");
+        const unassigned = await createQuestion("Parking needed?");
+        await listingQuestions.setIds(listing.id, [assigned]);
+        const html = await withTestSession(async () =>
+          String(await loadListingQuestionsPanel(await loaded(listing.id))),
+        );
+        return { assigned, html, unassigned };
+      };
+
+      test("offers every question the site has", async () => {
+        const { html } = await questionsHtml();
+        expect(html).toContain("Any allergies?");
+        expect(html).toContain("Parking needed?");
+      });
+
+      test("ticks only the questions this listing uses", async () => {
+        const { assigned, html } = await questionsHtml();
+        expect(tickedQuestions(html)).toEqual([assigned]);
+      });
+    });
+
+    describe("the attributes tab", () => {
+      /** One chosen option and one not, as the tab renders them. */
+      const attributesHtml = async (): Promise<{
+        chosen: number;
+        html: string;
+      }> => {
+        const listing = await createTestListing({});
+        const attribute = await createTestAttributeWithOptions("Access", [
+          "Step free",
+          "Stairs only",
+        ]);
+        const stepFree = attribute.options[0];
+        if (!stepFree)
+          throw new Error("the attribute kept none of its options");
+        await assignTestAttributeOptions(listing.id, [stepFree]);
+        const html = await withTestSession(async () =>
+          String(await loadListingAttributesPanel(await loaded(listing.id))),
+        );
+        return { chosen: stepFree.id, html };
+      };
+
+      test("offers every option the attribute has", async () => {
+        const { html } = await attributesHtml();
+        expect(html).toContain("Step free");
+        expect(html).toContain("Stairs only");
+      });
+
+      test("ticks only the options this listing shows", async () => {
+        const { chosen, html } = await attributesHtml();
+        expect(tickedOptions(html)).toEqual([chosen]);
+      });
+    });
+
+    describe("the QR tab", () => {
+      test("offers the booking-QR form for the listing", async () => {
+        const listing = await createTestListing({ name: "Autumn Fair" });
+        const html = await withTestSession(async () =>
+          String(await loadListingQrPanel(await loaded(listing.id))),
+        );
+        expect(html).toContain(`/admin/listing/${listing.id}/qr`);
+      });
+    });
+  },
+);

--- a/test/features/admin/listings-recalculate.test.ts
+++ b/test/features/admin/listings-recalculate.test.ts
@@ -8,7 +8,7 @@ import {
 import { RECALCULATE_FIELD_NAME } from "#shared/recalculate-fields.ts";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { createListingWithDriftedTotals } from "#test-utils/db-helpers/listings.ts";
+import { createListingWithDriftedTotals } from "#test-utils/db-helpers/listing-totals.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
 import { getTestSession } from "#test-utils/session.ts";
 

--- a/test/features/admin/seeds.test.ts
+++ b/test/features/admin/seeds.test.ts
@@ -2,8 +2,8 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { getAllListings } from "#db/listings/records.ts";
 import { t } from "#i18n";
-import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
-import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
+import { MAX_SEED_LISTINGS, SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+import { seedsForm } from "#templates/fields/seeds.ts";
 import {
   expectFlashRedirect,
   expectHtmlContains,

--- a/test/shared/db/listings/aggregates.test.ts
+++ b/test/shared/db/listings/aggregates.test.ts
@@ -8,10 +8,8 @@ import {
 } from "#db/listings/aggregates.ts";
 import { getListingWithCount } from "#db/listings/records.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import {
-  createListingWithDriftedTotals,
-  createTestListing,
-} from "#test-utils/db-helpers/listings.ts";
+import { createListingWithDriftedTotals } from "#test-utils/db-helpers/listing-totals.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 
 const storedTotals = (listingId: number) =>
   queryOne<{ booked_quantity: number; tickets_count: number }>(

--- a/test/shared/db/migrations/runner.test.ts
+++ b/test/shared/db/migrations/runner.test.ts
@@ -184,6 +184,7 @@ describe("db > migrations > runner", () => {
         lines.some(
           (line) =>
             line.includes("fake-apply-retry still failing after retries") &&
+            line.includes("re-running up()") &&
             line.includes("missing index idx_system_notes_attendee_id"),
         ),
       ).toBe(true);

--- a/test/shared/seeds.test.ts
+++ b/test/shared/seeds.test.ts
@@ -15,16 +15,24 @@ import {
   DEMO_LISTING_NAMES,
   DEMO_NAMES,
 } from "#shared/demo/samples.ts";
-import { createSeeds, SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+import {
+  createSeeds,
+  MAX_SEED_LISTINGS,
+  SEED_MAX_ATTENDEES,
+} from "#shared/seeds.ts";
 import { getTestPrivateKey } from "#test-utils/crypto.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 
 describeWithEnv("seeds", { db: true }, () => {
-  // The seeds page clamps to this ceiling and offers it as the box's max, so
-  // both of its own tests read it from here and would follow it if it moved.
-  // Naming the number is what keeps it from moving unnoticed.
+  // The seeds page clamps to these two ceilings and offers each as its box's
+  // max, so the page's own tests read them from here and would follow them if
+  // they moved. Naming the numbers is what keeps them from moving unnoticed.
   test("the attendee ceiling the seeds page clamps to is a hundred thousand", () => {
     expect(SEED_MAX_ATTENDEES).toBe(100_000);
+  });
+
+  test("the listing ceiling the seeds page clamps to is thirty", () => {
+    expect(MAX_SEED_LISTINGS).toBe(30);
   });
 
   test("reports exactly what it created", async () => {

--- a/test/test-utils/db-helpers/listing-totals.ts
+++ b/test/test-utils/db-helpers/listing-totals.ts
@@ -1,0 +1,26 @@
+import { listingAggregates } from "#db/listings/aggregates.ts";
+import type { Listing } from "#types";
+import { createTestAttendee } from "./attendees.ts";
+import { createTestListing } from "./listings.ts";
+
+/**
+ * A listing with one booking, then its stored running totals pushed off that
+ * truth. The starting point for any test about drift: the booking makes the
+ * recounted totals 1 and 1, and `stored` is what the listing wrongly claims.
+ */
+export const createListingWithDriftedTotals = async (
+  stored: { booked_quantity: number; tickets_count: number } = {
+    booked_quantity: 9,
+    tickets_count: 5,
+  },
+): Promise<Listing> => {
+  const listing = await createTestListing({ maxAttendees: 100 });
+  await createTestAttendee(
+    listing.id,
+    listing.slug,
+    "Counted Person",
+    "counted@example.com",
+  );
+  await listingAggregates.update(listing.id, stored);
+  return listing;
+};

--- a/test/test-utils/db-helpers/listings.ts
+++ b/test/test-utils/db-helpers/listings.ts
@@ -25,32 +25,6 @@ const allDays: string[] = [
   "Sunday",
 ];
 
-/**
- * A listing with one booking, then its stored running totals pushed off that
- * truth. The starting point for any test about drift: the booking makes the
- * recounted totals 1 and 1, and `stored` is what the listing wrongly claims.
- */
-export const createListingWithDriftedTotals = async (
-  stored: { booked_quantity: number; tickets_count: number } = {
-    booked_quantity: 9,
-    tickets_count: 5,
-  },
-): Promise<Listing> => {
-  const listing = await createTestListing({ maxAttendees: 100 });
-  // Imported here rather than at the top, because the attendee helpers import
-  // this module.
-  const { createTestAttendee } = await import("./attendees.ts");
-  await createTestAttendee(
-    listing.id,
-    listing.slug,
-    "Counted Person",
-    "counted@example.com",
-  );
-  const { listingAggregates } = await import("#db/listings/aggregates.ts");
-  await listingAggregates.update(listing.id, stored);
-  return listing;
-};
-
 /** A minute-precision ISO timestamp one minute in the past — always already
  * closed. The reference `closesAt` value for "registration closed" tests. */
 export const pastCloseTime = (): string =>

--- a/test/test-utils/ticket-ctx.ts
+++ b/test/test-utils/ticket-ctx.ts
@@ -5,7 +5,7 @@
 
 import { buildTicketListing } from "#booking/model.ts";
 import { quantityFieldName } from "#booking/tree.ts";
-import { getListingWithCount } from "#db/listings/records.ts";
+import { requireListingWithCount } from "#db/listings/records.ts";
 import { getTicketContext } from "#routes/public/ticket-payment.ts";
 import type { TicketCtx } from "#routes/public/types.ts";
 import { FormParams } from "#shared/form-data.ts";
@@ -19,7 +19,7 @@ export const ticketContext = async (
 ): Promise<TicketCtx> => {
   const listings = await Promise.all(
     listingIds.map(async (id) =>
-      buildTicketListing((await getListingWithCount(id))!, false, undefined),
+      buildTicketListing(await requireListingWithCount(id), false, undefined),
     ),
   );
   return {

--- a/test/ui/templates/fields/seeds.test.ts
+++ b/test/ui/templates/fields/seeds.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
-import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
+import { MAX_SEED_LISTINGS, SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+import { seedsForm } from "#templates/fields/seeds.ts";
 import { inputNamed } from "#test-utils/assertions.ts";
 
 describe("seeds form", () => {

--- a/test/ui/templates/public/reservations/contact-fields.test.ts
+++ b/test/ui/templates/public/reservations/contact-fields.test.ts
@@ -57,7 +57,7 @@ const packageOver = (
     quantities: new Map(),
     slug: "bundle",
     terms: "",
-  }) as PagePackage;
+  }) satisfies PagePackage;
 
 const paidInput = (
   listings: ReturnType<typeof buildTicketListing>[],


### PR DESCRIPTION
Turns on Biome's `project` domain and fixes the one import cycle it can see.

## What this buys, and what it does not

The domain is worth turning on, but it sees much less of this repository than it first appears, and a reviewer should know that before merging.

Biome resolves imports against `node_modules` and a package manifest. This project uses `deno.json`'s import map with `jsr:` and `npm:` specifiers, so Biome cannot follow a `#` alias at all. With the domain on and nothing else changed, `noUnresolvedImports` and `noUndeclaredDependencies` between them report **30,517 errors** — one for very nearly every import in the tree. Both are off here for that reason.

That same blind spot limits what the rest of the domain can do:

- **`noImportCycles` only sees relative imports.** The logger ↔ ntfy cycle this branch first measured was broken at the fan-out (#2180). Two `#`-alias cycles remain that `deno task lint:ci` passes over, and `deno task cycles` now reports both: the `listing-parents` / `listing-prices` / `listings/records` triangle, and the `groups.ts` / `groups/membership.ts` pair. They are recorded as issue #2210, with each load-time edge spelled out.
- **`noFloatingPromises` sees a promise whose type is locally evident, and misses one that arrives through a `#` alias.** I checked with a probe file: an unawaited call to a locally declared `async` function is reported, an unawaited call to a function imported as `#shared/ntfy.ts` is not.

So this is a partial guard, not a complete one. It is still worth having — it catches what it catches for free, and it costs one config change — but it does not mean the repository is cycle-free.

## How far from cycle-free, measured

A review asked for a Deno-aware cycle check, so I measured the job rather than guess at it: a Tarjan run over the `deno info --json` graph reported **10 cyclic groups**, one of them 332 modules wide. That measurement drove its own follow-ups, which have since landed: the report exists as `deno task cycles` (#2178), and the cycle breaks that grew out of the same finding cut the count to **2 groups** — the same two named above, each load-time edge spelled out, so the next person starts from a number rather than a wall. The report gates once the count reaches zero; until then it stays advisory, the way `deno task unread-fields` reports.

## The cycle it did find

```
listings-edit.ts → listing-page.ts → listing-page-management-panels.ts → listings-edit.ts
```

`getListingAndGroups` is a data loader with two callers. It moves to `listing-page-data.ts`, which both ends of the cycle already import, and the triangle becomes a chain.

The cycle had left a mark worth removing: `renderListingEditError` passed the page as `() => listingPage` rather than naming it, which is the kind of lazy thunk a module-init cycle forces on you.

The move made two comments in the destination false, and both are fixed. Its header said the file held read-only tab loaders only, and named Edit among the tabs it never serves. A comment inside the loader sent a reader to an editor webhook lock "below", which stayed in `listings-edit.ts`.

## A test where the source lives

`src/features/admin/listing-page-management-panels.ts` had no test at the matching path under `test/`, so `deno task precommit:mutation` refused to run for this branch at all. `test/features/admin/listing-page-management-panels.test.ts` reads each tab's markup back: the edit form's ticked groups, the questions and attributes a listing has chosen against the ones it has not, the address the images tab returns to, and the QR form.

One case is the reason the rest exist. After a rejected save the form must tick the groups the operator submitted, and an empty submission must tick nothing — a fall back to the stored ids would put the listing back into the group it was just taken out of.

The gate now runs and reports 100%, with one suppression this branch records: a `?? → ||` in `listing-page-data.ts` where the map holds only non-empty arrays, so no input can tell the two operators apart.

## Review follow-ups

The Codex and CodeRabbit passes also asked for changes inside this diff:

- `MAX_SEED_LISTINGS` now lives beside `SEED_MAX_ATTENDEES` in `#shared/seeds.ts`, so the seeds route no longer imports a validation ceiling from a template module. Its mirror test pins the listing ceiling beside the attendee one — the move had left the constant's mutant without a pin to fail it, which the mutation gate caught.
- The migration retry test names the second `up()` attempt's own diagnostic (`re-running up()`), not only the final failure and the missing index.
- `ticketContext` uses `requireListingWithCount`, which throws the standard `Listing not found` error, instead of asserting a nullable read.
- The `packageOver` fixture satisfies `PagePackage` rather than asserting it, so a wrong field is a compile error.

Two asks were recorded as follow-ups instead: issue #2211 (split the six-area ticket-parser test into one file per area) and issue #2212 (split the three oversized shared modules `bunny-cdn`, `limits`, `storage`, with the old surfaces deleted rather than kept behind facades).

## Measured and rejected

- **Linting JSON.** 76 findings, nearly all Biome's `useSortedKeys` wanting to reorder the keys of 66 locale files and `deno.json`'s import map. Churn, no correctness gain.
- **Adding `deno lint` beside Biome.** 298 findings, 221 of them `require-await`, plus 24 `no-process-global` — which contradicts the documented Bunny `process.env` usage. It is a second linter with different opinions, not a stricter setting of this one.

## On the original question

`deno task lint:ci` is what CI's `checks` job runs and what `scripts/precommit/steps.ts:29` runs, so GitHub and precommit were already identical. `deno task lint` is equally strict — same `--error-on-warnings`, and `scripts/biome.ts` additionally promotes info-level diagnostics to hard failures, which Biome alone does not. The only difference is that `lint` writes fixes and `lint:ci` does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared seed configuration with a maximum of 30 listings per seed operation.
  * Improved admin listing edit-page data loading, including groups and aggregate information.

* **Bug Fixes**
  * Improved listing aggregate recalculation and update handling.
  * Refined admin management panel data and error scenarios.

* **Tests**
  * Added coverage for listing management panels, aggregate recalculation, seed limits, and migration recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

