### PR TITLE
Drop the property-testing library nothing imports

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -613,11 +613,12 @@ also exists: `scripts/test-quality-audit.ts`.
   behind a flag or with a tighter changed-set bound) only if the per-commit
   mutation cost comes down.
 
-- **Property-based tests (item 5).** `fast-check` is a dependency in `deno.json`
-  that no test imports any more, so it is dead weight until this lands. Add
-  properties for: slug generation, CSV round-trips (commas / quotes / CRLF),
-  date formatting across timezones, token parsers, and URL safety — or drop the
-  dependency.
+- **Property-based tests (item 5).** Add properties for: slug generation, CSV
+  round-trips (commas / quotes / CRLF), date formatting across timezones, token
+  parsers, and URL safety. Whoever takes this adds the property-testing library
+  back: `fast-check` sat in `deno.json` with no importer for long enough that it
+  was dropped, so the dependency arrives with its first real test rather than
+  ahead of it.
 - **Weak-assertion audit lifecycle (item 6).** The script exists but isn't wired
   into CI. Escalate it: informational → CI warning → review gate for touched
   files.

--- a/deno.json
+++ b/deno.json
@@ -94,7 +94,6 @@
     "#cli/": "./cli/",
     "#scripts/": "./scripts/",
     "@libsql/client": "npm:@libsql/client@^0.17.2",
-    "fast-check": "npm:fast-check@^3.23.0",
     "@formatjs/icu-messageformat-parser": "npm:@formatjs/icu-messageformat-parser@^2.11",
     "intl-messageformat": "npm:intl-messageformat@^10",
     "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",

--- a/deno.lock
+++ b/deno.lock
@@ -71,7 +71,6 @@
     "npm:auto-console-group@^1.3.0": "1.3.0",
     "npm:esbuild@0.28": "0.28.0",
     "npm:esbuild@0.28.0": "0.28.0",
-    "npm:fast-check@^3.23.0": "3.23.2",
     "npm:fflate@~0.8.2": "0.8.2",
     "npm:happy-dom@15": "15.11.7",
     "npm:happy-dom@20.0.11": "20.0.11",
@@ -1532,12 +1531,6 @@
     "estraverse@5.3.0": {
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
     },
-    "fast-check@3.23.2": {
-      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "dependencies": [
-        "pure-rand"
-      ]
-    },
     "fast-sha256@1.3.0": {
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
@@ -2076,9 +2069,6 @@
     "punycode.js@2.3.1": {
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
     },
-    "pure-rand@6.1.0": {
-      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
-    },
     "read-package-up@12.0.0": {
       "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
       "dependencies": [
@@ -2441,7 +2431,6 @@
       "npm:@sentry/deno@^10.60.0",
       "npm:auto-console-group@^1.3.0",
       "npm:esbuild@0.28",
-      "npm:fast-check@^3.23.0",
       "npm:fflate@~0.8.2",
       "npm:happy-dom@^15.11.7",
       "npm:intl-messageformat@10",


### PR DESCRIPTION
`fast-check` sat in the import map of `deno.json` with no importer. Nothing in
`src`, `test`, `scripts`, `cli`, or `e2e-payments` referenced it.

The library arrived for the property-based tests that item 5 of the
test-quality entry in `TODO.md` has asked for since `TEST_QUALITY_IMPROVEMENTS.md`
was retired. Those tests were never written. #2169 recorded the fact and left
the choice open: write the tests, or drop the dependency. This drops it.

## What changes

- `deno.json` loses the one import-map line.
- `deno.lock` loses `fast-check` and its one transitive dependency,
  `pure-rand`, plus the workspace reference. Nothing else in the lock moves.
- `TODO.md` keeps item 5 open, because the tests are still worth writing. Its
  wording changes, because it can no longer describe a dependency waiting in
  the config. It now says that whoever writes the first property test adds the
  library back with it, so the dependency arrives with a caller rather than
  ahead of one.

## Checks

`deno task precommit` passes in full, including the coverage suite.

Two checks matter more than usual for a dependency removal, and both pass:

- `deno install --frozen=true` — the lockfile agrees with the config, which is
  what the deploy action's `deno install` needs.
- `deno task typecheck` — it covers the test files, which is where a
  `fast-check` import would live if one existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNpaFtZMeH53Wk2bafgSne

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNpaFtZMeH53Wk2bafgSne)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated property-based testing plans with defined coverage areas.
  * Clarified that `fast-check` will be reintroduced with its first meaningful test.

* **Chores**
  * Removed the unused `fast-check` dependency mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->