### PR TITLE
Break the join route-template import cycle

### DIFF
--- a/src/features/join.ts
+++ b/src/features/join.ts
@@ -107,7 +107,9 @@ const joinRoute =
  * Handle GET /join/:code
  */
 const handleJoinGet = joinRoute((request, code, _user, username) =>
-  publicFormPage(request, (flash) => joinPage(code, username, flash.error)),
+  publicFormPage(request, (flash) =>
+    joinPage(code, username, joinForm.render(), flash.error),
+  ),
 );
 
 const setPasswordRoute = (code: string, user: User) =>

--- a/src/ui/templates/join.tsx
+++ b/src/ui/templates/join.tsx
@@ -11,8 +11,7 @@ import { AuthFormPage } from "#templates/setup.tsx";
 /* jscpd:ignore-end */
 
 /**
- * Join page - set password for invited user. The route renders the password
- * form and passes its HTML in, so this template imports nothing from it.
+ * Join page - set password for invited user
  */
 export const joinPage = (
   code: string,

--- a/src/ui/templates/join.tsx
+++ b/src/ui/templates/join.tsx
@@ -4,7 +4,6 @@
 
 /* jscpd:ignore-start */
 import { t } from "#i18n";
-import { joinForm } from "#routes/join.ts";
 import { Flash } from "#shared/forms/flash.tsx";
 import { SuccessCompletePage } from "#templates/components/success-complete-page.tsx";
 import { simplePublicPage } from "#templates/public/prose-page.tsx";
@@ -12,18 +11,20 @@ import { AuthFormPage } from "#templates/setup.tsx";
 /* jscpd:ignore-end */
 
 /**
- * Join page - set password for invited user
+ * Join page - set password for invited user. The route renders the password
+ * form and passes its HTML in, so this template imports nothing from it.
  */
 export const joinPage = (
   code: string,
   username: string,
+  formHtml: string,
   error?: string,
 ): string =>
   AuthFormPage({
     action: `/join/${code}`,
     children: [<button type="submit">{t("join.set_password.submit")}</button>],
     error,
-    formHtml: joinForm.render(),
+    formHtml,
     heading: t("join.set_password.welcome", { username }),
     intro: t("join.set_password.instructions"),
     title: t("join.set_password.title"),

--- a/test/ui/templates/join.test.ts
+++ b/test/ui/templates/join.test.ts
@@ -9,12 +9,18 @@ describe("join templates", () => {
   registerPublicTemplateHooks();
 
   test("renders the password form for the invited user", () => {
-    const html = joinPage("invite-code", "New <User>", "Try again");
+    const html = joinPage(
+      "invite-code",
+      "New <User>",
+      "<password-fields/>",
+      "Try again",
+    );
 
     expect(html).toContain("<title>Set your password</title>");
     expect(html).toContain("Welcome, New &lt;User&gt;");
     expect(html).toContain('action="/join/invite-code"');
     expect(html).toContain("Set your password to complete your account setup.");
+    expect(html).toContain("<password-fields/>");
     expect(html).toContain("Try again");
     expect(html).toContain(">Set password</button>");
   });


### PR DESCRIPTION
## What changed

The join page template imported the password form from the join route,
and the route imported the page templates back. One direction is gone:
the route renders `joinForm` and passes the HTML into `joinPage`, the
way every non-cycling route-template pair in the tree already works.
The template imports nothing from the route now.

This is one pair of five with the same shape (`site`, `seeds`,
`builder`, `attributes` remain), the first slice of the architecture
job #2168 measured and recorded.

## Measured

The cyclic groups in the local module graph of `deno info --json
src/serve-app.ts`, counting runtime (code) import edges only — type-only
imports are erased, so they load no module and cost no cold start:

- before this change: **8** groups — one blob of 73 modules
  (`shared/accounting` + `shared/db`), two triangles (the listing-page
  files #2168 touches, and the public reservations trio), five
  route-template pairs
- after: **7** groups; the join pair is gone

The counts in #2168's TODO entry (10 groups, one of 332) came from a
run that also counted type-only edges. Both are true for what they
measured; runtime edges are the number that matters for cold starts.

## Tests

The template test passes a form-HTML fixture and asserts it lands in
the page, so the template no longer needs the route for cover. The
route keeps owning the form, and `test/features/join.test.ts` still
covers its rendering there. `precommit` and `precommit:mutation`
green (61/61).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the password form on invite join pages.
  * Ensured password fields are displayed correctly when joining an invitation.
* **Tests**
  * Added coverage verifying that the password fields appear in the rendered join page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->