### PR TITLE
Merge eleven near-copies that jscpd cannot see

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2776,3 +2776,43 @@ fixes nothing, and the work belongs in the ruleset.
 Until that changes, a red `checks` never blocks a merge, and main can break
 again the same way. Only a person who runs `deno task precommit` before the
 merge stops it.
+
+---
+
+## The renamed copies jscpd cannot see
+
+_Origin: the type-2 duplication pass (PR #2172). These are the sites that pass
+left behind, and the scan that finds them._
+
+jscpd compares exact runs of tokens, so two blocks that do the same work with
+different names, numbers, or field counts never match. A second scan finds them:
+replace every identifier and every literal with one symbol, hash a sliding
+window of the result, and report a window that repeats with more than one
+original spelling. Drop import statements and runs that are mostly string
+literals first, or data files and import blocks bury the real answers. At a
+45-token window over `src/` this reported about 40 sites, and reading them found
+eleven merges. The scan is not in the repository, because it needs a person to
+read every hit. Write it again from this paragraph.
+
+These hits were read and left. Each is a real merge, and none is urgent.
+
+- **One way for a test helper to post a form.** `submitNewAttendeeForm`
+  (`test/test-utils/attendee-form/helpers.ts`) and `postLogistics`
+  (`test/test-utils/logistics-tab.ts`) both open a session, take its CSRF token,
+  and post one form. `adminFormPost` in `test/test-utils/session.ts` is a third
+  spelling that also sends `settings_version` and returns the cookie and the
+  token beside the response. Decide whether every admin form post must carry
+  `settings_version`, then make one helper and migrate all three.
+- **The table columns the fold could not take.** 32 hand-rolled columns became
+  `translatedTableColumn` calls in #2172. Eleven more carry an extra property —
+  `class`, `cellAttrs`, an alignment — so they stayed object literals. They are
+  in `bulk-actions.tsx`, `built-sites/renewal-summary.tsx`,
+  `availability-checker.tsx`, `attendee-form/listing-editor.tsx`, and
+  `attendee-detail.tsx`. Widen the curry to take the extras, or give the common
+  ones their own named column builders.
+- **The form-definition trailer.** Every form in `src/ui/templates/fields/` ends
+  with the same two declarations: a type alias over
+  `FormDefinition<ReturnType<...>>`, then a `getXForm` that calls `defineForm`
+  with those fields. About eight forms repeat it. A curry takes it, but the type
+  alias is what `FormValues<XForm>` reads, so check every reader before changing
+  the shape.

--- a/scripts/check-imports/rules.ts
+++ b/scripts/check-imports/rules.ts
@@ -26,12 +26,24 @@ export interface ImportIssue {
 
 const isFolder = (alias: Alias): boolean => alias.name.endsWith("/");
 
+/**
+ * Read `text` on one side of an alias and write it out on the other. A folder
+ * alias keeps whatever followed the prefix; a plain alias only matches the
+ * whole thing. Reading a specifier and writing a spelling are this one
+ * translation, run in opposite directions.
+ */
+const across =
+  (from: keyof Alias, to: keyof Alias) =>
+  (alias: Alias, text: string): string | null => {
+    if (!isFolder(alias)) return text === alias[from] ? alias[to] : null;
+    if (!text.startsWith(alias[from])) return null;
+    return alias[to] + text.slice(alias[from].length);
+  };
+
 /** The file an alias points at, or null when the alias does not cover it. */
-const pathFor = (alias: Alias, specifier: string): string | null => {
-  if (!isFolder(alias)) return specifier === alias.name ? alias.target : null;
-  if (!specifier.startsWith(alias.name)) return null;
-  return alias.target + specifier.slice(alias.name.length);
-};
+const pathFor = across("name", "target");
+
+const nameFor = across("target", "name");
 
 /**
  * Whether an alias is one we ask people to write. A folder alias and a one-word
@@ -43,11 +55,26 @@ const isSpellable = (alias: Alias): boolean =>
   isFolder(alias) || !alias.name.includes("/");
 
 /** How an alias would spell `path`, or null when it cannot reach it. */
-const spellingFor = (alias: Alias, path: string): string | null => {
-  if (!isSpellable(alias)) return null;
-  if (!isFolder(alias)) return path === alias.target ? alias.name : null;
-  if (!path.startsWith(alias.target)) return null;
-  return alias.name + path.slice(alias.target.length);
+const spellingFor = (alias: Alias, path: string): string | null =>
+  isSpellable(alias) ? nameFor(alias, path) : null;
+
+/**
+ * The winning answer the alias table gives, or null when no alias reaches.
+ * `answerFrom` reads one alias, and `beats` says which of two answers wins.
+ * Both lookups below are this one walk over the table.
+ */
+const bestFromAliases = <T>(
+  aliases: Alias[],
+  answerFrom: (alias: Alias) => T | null,
+  beats: (answer: T, best: T) => boolean,
+): T | null => {
+  let best: T | null = null;
+  for (const alias of aliases) {
+    const answer = answerFrom(alias);
+    if (answer === null) continue;
+    if (best === null || beats(answer, best)) best = answer;
+  }
+  return best;
 };
 
 /**
@@ -58,14 +85,14 @@ export const resolveSpecifier = (
   aliases: Alias[],
   specifier: string,
 ): string | null => {
-  let best: { length: number; path: string } | null = null;
-  for (const alias of aliases) {
-    const path = pathFor(alias, specifier);
-    if (path === null) continue;
-    if (best === null || alias.name.length > best.length) {
-      best = { length: alias.name.length, path };
-    }
-  }
+  const best = bestFromAliases(
+    aliases,
+    (alias) => {
+      const path = pathFor(alias, specifier);
+      return path === null ? null : { length: alias.name.length, path };
+    },
+    (answer, best) => answer.length > best.length,
+  );
   return best === null ? null : best.path;
 };
 
@@ -73,20 +100,14 @@ export const resolveSpecifier = (
  * The one spelling we want for `path`: the shortest, then the alphabetically
  * first so two equally short aliases still give one answer.
  */
-export const bestSpelling = (aliases: Alias[], path: string): string | null => {
-  let best: string | null = null;
-  for (const alias of aliases) {
-    const spelling = spellingFor(alias, path);
-    if (spelling === null) continue;
-    if (
-      best === null ||
+export const bestSpelling = (aliases: Alias[], path: string): string | null =>
+  bestFromAliases(
+    aliases,
+    (alias) => spellingFor(alias, path),
+    (spelling, best) =>
       spelling.length < best.length ||
-      (spelling.length === best.length && spelling < best)
-    )
-      best = spelling;
-  }
-  return best;
-};
+      (spelling.length === best.length && spelling < best),
+  );
 
 /**
  * Every top-level import in `content`. A line that starts in column 0 is the

--- a/scripts/check-imports/rules.ts
+++ b/scripts/check-imports/rules.ts
@@ -33,7 +33,10 @@ const isFolder = (alias: Alias): boolean => alias.name.endsWith("/");
  * translation, run in opposite directions.
  */
 const across =
-  (from: keyof Alias, to: keyof Alias) =>
+  (
+    from: keyof Alias,
+    to: keyof Alias,
+  ): ((alias: Alias, text: string) => string | null) =>
   (alias: Alias, text: string): string | null => {
     if (!isFolder(alias)) return text === alias[from] ? alias[to] : null;
     if (!text.startsWith(alias[from])) return null;

--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -38,7 +38,7 @@ src/ui/templates/admin/backup.tsx::backupsTable.key~1353jpe  created → ""   # 
 src/ui/templates/admin/backup.tsx::backupsTable.key~1o7pzgq  timestamp → ""   # same as backup.tsx's created key — the backups table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
 src/ui/templates/admin/backup.tsx::backupsTable.key~1tpb30l  size → ""   # same as backup.tsx's created key — the backups table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
 src/ui/templates/admin/backup.tsx::backupsTable.key~120g5gv  actions → ""   # same as backup.tsx's created key — the backups table is rendered without columnKeys, hiddenKeys, or filters, so its column keys are never read
-src/ui/templates/admin/settings-statuses.tsx::statusColumns.key~0406nc7  flags → ""   # the statuses list renders these columns with only a reorder option, so it supplies no columnKeys, no hiddenKeys, and no filters, and statusColumns never reaches renderColumnReference, so no reader of a column key is in play
+src/ui/templates/admin/settings-statuses.tsx::statusColumns~1m0nc07  flags → ""   # the statuses list renders these columns with only a reorder option, so it supplies no columnKeys, no hiddenKeys, and no filters, and statusColumns never reaches renderColumnReference, so no reader of a column key is in play
 src/ui/templates/admin/settings-statuses.tsx::renderStatusFields.value~0evfpwz  ?? → ||   # status?.name is a string or undefined, and the only falsy string is the empty fallback itself
 src/ui/templates/admin/settings-statuses.tsx::renderStatusFields.value~053yv47  ?? → ||   # FormParams.get is a string or undefined, and the only falsy string is the empty fallback itself
 # attributes list (ui/templates/admin/attributes.tsx) — column keys nothing
@@ -47,11 +47,11 @@ src/ui/templates/admin/attributes.tsx::adminAttributesPage.columns.key~0vgsq6i  
 src/ui/templates/admin/attributes.tsx::adminAttributesPage.columns.key~0flrsnk  options → ""   # same as the attribute key above — the attributes list supplies only reorder, so no reader of a column key is in play
 # groups list, holidays table, logistics agents — three more tables whose
 # column keys nothing reads back.
-src/ui/templates/admin/groups/list.tsx::groupColumns.key~1qw07sv  name → ""   # adminGroupsPage renders these columns with a context and nothing else, so it supplies no columnKeys, no hiddenKeys, and no filters, and groupColumns never reaches renderColumnReference
-src/ui/templates/admin/groups/list.tsx::groupColumns.key~0xjgtx3  slug → ""   # same as the name key above — the groups list supplies only a context, so no reader of a column key is in play
+src/ui/templates/admin/groups/list.tsx::groupColumns~0ixy9zk  name → ""   # adminGroupsPage renders these columns with a context and nothing else, so it supplies no columnKeys, no hiddenKeys, and no filters, and groupColumns never reaches renderColumnReference
+src/ui/templates/admin/groups/list.tsx::groupColumns~1bp6sm8  slug → ""   # same as the name key above — the groups list supplies only a context, so no reader of a column key is in play
 src/ui/templates/admin/holidays.tsx::holidayColumns.key~1lbn6k9  start_date → ""   # HolidayTable renders these columns with a scroll class and nothing else, so no columnKeys, hiddenKeys, or filters read the key, and holidayColumns never reaches renderColumnReference
 src/ui/templates/admin/holidays.tsx::holidayColumns.key~0mip5xw  end_date → ""   # same as the start_date key above — the holidays table supplies only a scroll class
-src/ui/templates/admin/logistics.tsx::agentColumns.key~1qw07sv  name → ""   # AgentsSection renders these columns with no options at all, so nothing supplies a column-key reader, and agentColumns never reaches renderColumnReference
+src/ui/templates/admin/logistics.tsx::agentColumns~15k9yrk  name → ""   # AgentsSection renders these columns with no options at all, so nothing supplies a column-key reader, and agentColumns never reaches renderColumnReference
 src/ui/templates/admin/logistics.tsx::LogisticsAgentEditPanel.html~01ax7pa  ?? → ||   # values is a form-values object or undefined, and an object is always truthy, so || keeps exactly what ?? keeps
 
 # schema-atlas.tsx: formatTimeAgo returns a formatted string or null, never

--- a/src/features/admin/aggregate-recalculation.ts
+++ b/src/features/admin/aggregate-recalculation.ts
@@ -20,17 +20,16 @@ type AggregateParseResult<T> =
   | { input: T | null; ok: true }
   | { error: string; ok: false };
 
-export const parseEditableAggregateForm = <TValues, TInput>(
+export const parseEditableAggregateForm = <TValues>(
   form: FormParams,
   fields: Field[],
-  toInput: (values: TValues) => TInput,
-): AggregateParseResult<TInput> => {
+): AggregateParseResult<TValues> => {
   if (!fields.some((field) => form.has(field.name))) {
     return { input: null, ok: true };
   }
   const result: ValidationResult<TValues> = validateForm<TValues>(form, fields);
   return result.valid
-    ? { input: toInput(result.values), ok: true }
+    ? { input: result.values, ok: true }
     : errorResult(result.error);
 };
 

--- a/src/features/admin/listings-edit.ts
+++ b/src/features/admin/listings-edit.ts
@@ -18,7 +18,7 @@ import {
   getListingAggregateRecalculation,
   type ListingAggregateRecalculation,
   type ListingAggregateValues,
-  updateListingAggregateValues,
+  listingAggregates,
 } from "#db/listings/aggregates.ts";
 import {
   getListingWithCount,
@@ -429,7 +429,7 @@ const handleListingEditSuccess = async (
   id: number,
 ): Promise<Response> => {
   if (aggregateValues) {
-    await updateListingAggregateValues(id, aggregateValues);
+    await listingAggregates.update(id, aggregateValues);
   }
   const durationWarning = await reconcileDurationChange(
     row,

--- a/src/features/admin/listings-edit.ts
+++ b/src/features/admin/listings-edit.ts
@@ -76,7 +76,6 @@ import { loadListingEditPanel } from "./listing-page-management-panels.ts";
 import {
   buildCreateListingResource,
   buildUpdateListingResource,
-  extractListingAggregateValues,
   parseGroupIds,
 } from "./listings-form.ts";
 import { copyDuplicatedChildEdges } from "./listings-parents.ts";
@@ -459,10 +458,10 @@ const parseAggregatesForRole = (
   | { ok: false; error: string } =>
   session.adminLevel === "editor"
     ? { input: null, ok: true }
-    : parseEditableAggregateForm<
-        ListingAggregateValues,
-        ListingAggregateValues
-      >(form, getListingAggregateFields(), extractListingAggregateValues);
+    : parseEditableAggregateForm<ListingAggregateValues>(
+        form,
+        getListingAggregateFields(),
+      );
 
 /** Handle POST /admin/listing/:id/edit */
 export const handleAdminListingEditPost: TypedRouteHandler<

--- a/src/features/admin/listings-form.ts
+++ b/src/features/admin/listings-form.ts
@@ -16,7 +16,6 @@ import {
   syncListingPrices,
   writeListingDayCounts,
 } from "#db/listing-prices.ts";
-import type { ListingAggregateValues } from "#db/listings/aggregates.ts";
 import { listingsTable } from "#db/listings/records.ts";
 import { computeSlugIndex } from "#db/listings/table.ts";
 import { settings } from "#db/settings.ts";
@@ -211,13 +210,6 @@ const extractListingUpdateInput = async (
     slugIndex,
   };
 };
-
-export const extractListingAggregateValues = (
-  values: ListingAggregateValues,
-): ListingAggregateValues => ({
-  booked_quantity: values.booked_quantity,
-  tickets_count: values.tickets_count,
-});
 
 /** Persist the listing's group memberships AND its per-day-count prices in the
  * row write's transaction. extractCommonFields always sets groupIds (parseGroupIds

--- a/src/features/admin/listings-recalculate.ts
+++ b/src/features/admin/listings-recalculate.ts
@@ -9,7 +9,7 @@ import { logActivity } from "#db/activity-log.ts";
 import {
   getListingAggregateRecalculation,
   LISTING_AGGREGATE_FIELDS,
-  resetListingAggregateFields,
+  listingAggregates,
 } from "#db/listings/aggregates.ts";
 import { getListingWithCount } from "#db/listings/records.ts";
 /* jscpd:ignore-start */
@@ -36,7 +36,7 @@ const listingRecalculateHandlers = createRecalculateHandlers({
   log: (listing) =>
     logActivity(`Listing '${listing.name}' totals recalculated`, listing),
   render: renderListingRecalculatePage,
-  reset: resetListingAggregateFields,
+  reset: listingAggregates.reset,
   successMessage: t("listings_table.recalculate_success"),
   successPath: (listing) => `/admin/listing/${listing.id}/edit`,
   withEntity: (id: string | number | undefined) => (handler) =>

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -23,12 +23,11 @@ import {
   type ModifierAggregateValues,
   type ModifierInput,
   type ModifierRow,
+  modifierAggregates,
   modifierGroups,
   modifierListings,
   modifiersTable,
-  resetModifierAggregateFields,
   setModifierAnswers,
-  updateModifierAggregateValues,
 } from "#db/modifiers.ts";
 import { getAllQuestionsWithAnswers } from "#db/questions/queries.ts";
 import { once } from "#fp";
@@ -370,7 +369,7 @@ const handleEditPost: TypedRouteHandler<"POST /admin/modifiers/:id/edit"> = (
     const result = await getModifiersResource().update(id, form);
     if (result.ok) {
       if (aggregates.input) {
-        await updateModifierAggregateValues(id, aggregates.input);
+        await modifierAggregates.update(id, aggregates.input);
       }
       await logActivity(`Modifier '${result.row.name}' updated`);
       return redirect("/admin/modifiers", "Modifier updated", true);
@@ -411,7 +410,7 @@ const modifierRecalculateHandlers = createRecalculateHandlers({
   log: (modifier) =>
     logActivity(`Modifier '${modifier.name}' totals recalculated`),
   render: renderModifierRecalculatePage,
-  reset: resetModifierAggregateFields,
+  reset: modifierAggregates.reset,
   successMessage: t("modifiers.recalculate.success"),
   successPath: (modifier) => `/admin/modifiers/${modifier.id}/edit`,
   withEntity: withModifier,

--- a/src/features/admin/modifiers.ts
+++ b/src/features/admin/modifiers.ts
@@ -109,13 +109,6 @@ const extractModifierInput = async (
   };
 };
 
-const extractModifierAggregateValues = (
-  values: ModifierAggregateValues,
-): ModifierAggregateValues => ({
-  total_uses: values.total_uses,
-  usage_count: values.usage_count,
-});
-
 const resolveAddOnScope = (
   scope: ModifierScope | undefined,
   listingIds: number[],
@@ -359,10 +352,10 @@ const handleEditPost: TypedRouteHandler<"POST /admin/modifiers/:id/edit"> = (
   withAuth(request, AUTH_FORM, async (_session, form) => {
     const modifier = await getModifier(id);
     if (!modifier) return notFoundResponse();
-    const aggregates = parseEditableAggregateForm<
-      ModifierAggregateValues,
-      ModifierAggregateValues
-    >(form, getModifierAggregateFields(), extractModifierAggregateValues);
+    const aggregates = parseEditableAggregateForm<ModifierAggregateValues>(
+      form,
+      getModifierAggregateFields(),
+    );
     if (!aggregates.ok) {
       return modifierPage.renderEditError(id, _session, form, aggregates.error);
     }

--- a/src/features/admin/questions/answers.ts
+++ b/src/features/admin/questions/answers.ts
@@ -12,11 +12,10 @@ import type { Answer, QuestionWithAnswers } from "#db/question-types.ts";
 import {
   ANSWER_AGGREGATE_FIELDS,
   type AnswerAggregateValues,
+  answerAggregates,
   getAnswerAggregateRecalculation,
   getAnswerModifierId,
-  resetAnswerAggregateFields,
   setAnswerModifier,
-  updateAnswerAggregateValues,
 } from "#db/questions/aggregates.ts";
 import { deleteAnswer } from "#db/questions/delete.ts";
 import { findAnswerById } from "#db/questions/parsing.ts";
@@ -237,7 +236,7 @@ export const handleEditAnswerPost: ParamsRoute<AnswerRouteParams> =
       });
       await setAnswerModifier(answer.id, modifierId);
       if (aggregates.input) {
-        await updateAnswerAggregateValues(answer.id, aggregates.input);
+        await answerAggregates.update(answer.id, aggregates.input);
       }
       await logActivity(`Answer '${text}' updated in question ${question.id}`);
       return redirect(
@@ -290,7 +289,7 @@ export const handleAnswerRecalculatePost: ParamsRoute<AnswerRouteParams> =
           session,
           t("questions.recalculate.choose"),
         ),
-      reset: (selected) => resetAnswerAggregateFields(answer.id, selected),
+      reset: (selected) => answerAggregates.reset(answer.id, selected),
       successMessage: t("questions.recalculate.success"),
       successPath: editAnswerPath(params),
     }),

--- a/src/features/admin/questions/answers.ts
+++ b/src/features/admin/questions/answers.ts
@@ -194,13 +194,6 @@ export const handleEditAnswerGet: ParamsRoute<AnswerRouteParams> =
     );
   });
 
-/** Map the validated aggregate form values onto the stored aggregate columns. */
-const extractAnswerAggregateValues = (
-  values: AnswerAggregateValues,
-): AnswerAggregateValues => ({
-  times_selected: values.times_selected,
-});
-
 /** Handle POST /admin/questions/:id/answers/:answerId/edit (text + modifier) */
 export const handleEditAnswerPost: ParamsRoute<AnswerRouteParams> =
   createAuthedFormRoute<{ text: string }, AnswerRouteParams, AnswerContext>({
@@ -223,10 +216,10 @@ export const handleEditAnswerPost: ParamsRoute<AnswerRouteParams> =
       ) {
         return errorRedirect(editAnswerPath(params), "Invalid modifier");
       }
-      const aggregates = parseEditableAggregateForm<
-        AnswerAggregateValues,
-        AnswerAggregateValues
-      >(form, getAnswerAggregateFields(), extractAnswerAggregateValues);
+      const aggregates = parseEditableAggregateForm<AnswerAggregateValues>(
+        form,
+        getAnswerAggregateFields(),
+      );
       if (!aggregates.ok) {
         return errorRedirect(editAnswerPath(params), aggregates.error);
       }

--- a/src/features/admin/settings-wallets.ts
+++ b/src/features/admin/settings-wallets.ts
@@ -20,22 +20,19 @@ import {
 import { isValidAppleSigningPair } from "#shared/apple-wallet/cms.ts";
 import type { RequestRoute } from "#shared/response-steps.ts";
 
-/** One plain-text credential on a wallet form: the form field it comes from,
- * the error shown when the operator leaves it blank, and where it is stored. */
+/** One credential on a wallet form: the form field it comes from, the error
+ * shown when the operator leaves it blank, and where it is stored. */
 type WalletTextField = {
   missingKey: string;
   name: string;
   save: (value: string) => Promise<void>;
 };
 
-/** One uploaded secret on a wallet form: how to read it back, how to tell it is
- * the right kind of file, and what to say when it is missing or wrong. */
-type WalletSecretField = {
+/** One uploaded secret on a wallet form: a credential that also knows how to
+ * read its stored value back, and how to tell it is the right kind of file. */
+type WalletSecretField = WalletTextField & {
   invalidKey: string;
   looksValid: (value: string) => boolean | Promise<boolean>;
-  missingKey: string;
-  name: string;
-  save: (value: string) => Promise<void>;
   savedValue: () => string;
 };
 

--- a/src/features/admin/settings-wallets.ts
+++ b/src/features/admin/settings-wallets.ts
@@ -18,89 +18,48 @@ import {
   isValidCertificate,
 } from "#shared/apple-wallet/certificate.ts";
 import { isValidAppleSigningPair } from "#shared/apple-wallet/cms.ts";
+import type { RequestRoute } from "#shared/response-steps.ts";
 
-/**
- * Handle POST /admin/settings/apple-wallet - owner only
- */
-type AppleWalletFormData = {
-  passTypeId: string;
-  teamId: string;
-  cert: SecretFieldResult;
-  key: SecretFieldResult;
-  wwdr: SecretFieldResult;
+/** One plain-text credential on a wallet form: the form field it comes from,
+ * the error shown when the operator leaves it blank, and where it is stored. */
+type WalletTextField = {
+  missingKey: string;
+  name: string;
+  save: (value: string) => Promise<void>;
 };
 
-const isAllCleared = (d: AppleWalletFormData): boolean =>
-  !d.passTypeId &&
-  !d.teamId &&
-  d.cert.action === "cleared" &&
-  d.key.action === "cleared" &&
-  d.wwdr.action === "cleared";
+/** One uploaded secret on a wallet form: how to read it back, how to tell it is
+ * the right kind of file, and what to say when it is missing or wrong. */
+type WalletSecretField = {
+  invalidKey: string;
+  looksValid: (value: string) => boolean | Promise<boolean>;
+  missingKey: string;
+  name: string;
+  save: (value: string) => Promise<void>;
+  savedValue: () => string;
+};
 
-export const handleAppleWalletPost = settingsHandler<AppleWalletFormData>({
-  advanced: true,
-  extract: (form) => ({
-    cert: processSecretField(form, "apple_wallet_signing_cert"),
-    key: processSecretField(form, "apple_wallet_signing_key"),
-    passTypeId: form.getString("apple_wallet_pass_type_id"),
-    teamId: form.getString("apple_wallet_team_id"),
-    wwdr: processSecretField(form, "apple_wallet_wwdr_cert"),
-  }),
-  formId: "settings-apple-wallet",
-  log: (d) =>
-    isAllCleared(d)
-      ? t("success.apple_wallet_cleared")
-      : t("success.apple_wallet_updated"),
-  save: async (d) => {
-    if (isAllCleared(d)) {
-      await Promise.all([
-        settings.update.appleWallet.passTypeId(""),
-        settings.update.appleWallet.teamId(""),
-        settings.update.appleWallet.signingCert(""),
-        settings.update.appleWallet.signingKey(""),
-        settings.update.appleWallet.wwdrCert(""),
-      ]);
-      return;
-    }
-    await settings.update.appleWallet.passTypeId(d.passTypeId);
-    await settings.update.appleWallet.teamId(d.teamId);
-    await saveSecret(d.cert, settings.update.appleWallet.signingCert);
-    await saveSecret(d.key, settings.update.appleWallet.signingKey);
-    await saveSecret(d.wwdr, settings.update.appleWallet.wwdrCert);
-  },
-  validate: async (d) => {
-    if (isAllCleared(d)) return null;
-    if (!d.passTypeId) return t("error.apple_pass_type_id_required");
-    if (!d.teamId) return t("error.apple_team_id_required");
-    if (!settings.appleWallet.hasDbConfig) {
-      // No saved config to fall back on, so every secret must be uploaded now.
-      const missing = await firstAppleSecretProblem(d)((field, secret) =>
-        secret.action === "provided" ? null : t(field.missingKey),
-      );
-      if (missing) return missing;
-    }
-    const invalidSecret = await firstAppleSecretProblem(d)(
-      async (field, secret) =>
-        (await field.looksValid(
-          effectiveSecretValue(secret, field.savedValue()),
-        ))
-          ? null
-          : t(field.invalidKey),
-    );
-    if (invalidSecret) return invalidSecret;
-    const signingCert = effectiveSecretValue(
-      d.cert,
-      settings.appleWallet.signingCert,
-    );
-    const signingKey = effectiveSecretValue(
-      d.key,
-      settings.appleWallet.signingKey,
-    );
-    return (await isValidAppleSigningPair(signingCert, signingKey))
-      ? null
-      : t("error.apple_signing_pair_mismatch");
-  },
-});
+/** What one wallet's settings form is, said as data: its fields, its log lines,
+ * and whether it already has saved config to fall back on. */
+type WalletForm = {
+  clearedKey: string;
+  formId: string;
+  hasSavedConfig: () => boolean;
+  secrets: readonly WalletSecretField[];
+  texts: readonly WalletTextField[];
+  updatedKey: string;
+  /** A check no single field can make alone, run last. Apple's signing
+   * certificate and key must be a matching pair. */
+  pairCheck?: (
+    uploadedValue: (field: WalletSecretField) => string,
+  ) => Promise<string | null>;
+};
+
+/** One submitted wallet form, keyed by form field name. */
+type WalletValues = {
+  secrets: Record<string, SecretFieldResult>;
+  texts: Record<string, string>;
+};
 
 /** The uploaded secret, or the saved value when the masked field was kept. */
 const effectiveSecretValue = (
@@ -108,108 +67,191 @@ const effectiveSecretValue = (
   saved: string,
 ): string => (secret.action === "provided" ? secret.value : saved);
 
-/** One Apple Wallet secret upload, described as data: how to read it from the
- * form, where to load its saved value, and how to validate it. */
-type AppleSecretField = {
-  fromForm: (d: AppleWalletFormData) => SecretFieldResult;
-  invalidKey: string;
-  looksValid: (value: string) => boolean | Promise<boolean>;
-  missingKey: string;
-  savedValue: () => string;
-};
+/** True when the operator emptied every box, which means "turn this wallet
+ * off" rather than "save these details". */
+const isAllCleared = (wallet: WalletForm, values: WalletValues): boolean =>
+  wallet.texts.every((field) => !values.texts[field.name]) &&
+  wallet.secrets.every(
+    (field) => values.secrets[field.name]?.action === "cleared",
+  );
 
-/** The three secret uploads on the Apple Wallet form. */
-const APPLE_SECRET_FIELDS = [
-  {
-    fromForm: (d) => d.cert,
-    invalidKey: "error.apple_signing_cert_invalid",
-    looksValid: isValidAppleCertificate,
-    missingKey: "error.apple_signing_cert_required",
-    savedValue: () => settings.appleWallet.signingCert,
-  },
-  {
-    fromForm: (d) => d.key,
-    invalidKey: "error.apple_signing_key_invalid",
-    looksValid: isValidRsaPrivateKey,
-    missingKey: "error.apple_signing_key_required",
-    savedValue: () => settings.appleWallet.signingKey,
-  },
-  {
-    fromForm: (d) => d.wwdr,
-    invalidKey: "error.apple_wwdr_cert_invalid",
-    looksValid: isValidCertificate,
-    missingKey: "error.apple_wwdr_cert_required",
-    savedValue: () => settings.appleWallet.wwdrCert,
-  },
-] satisfies AppleSecretField[];
-
-/** First problem found across the Apple secret fields, checked in form order.
- * Null when every field passes — the expected outcome for a valid submit. */
-const firstAppleSecretProblem =
+/** First problem found across the wallet's secrets, checked in form order.
+ * Null when every secret passes — the expected outcome for a valid submit. */
+const firstSecretProblem =
+  (wallet: WalletForm, values: WalletValues) =>
   (
-    d: AppleWalletFormData,
-  ): ((
     problemWith: (
-      field: AppleSecretField,
+      field: WalletSecretField,
       secret: SecretFieldResult,
     ) => string | null | Promise<string | null>,
-  ) => Promise<string | null>) =>
-  (problemWith) =>
-    firstProblem((field: AppleSecretField) =>
-      problemWith(field, field.fromForm(d)),
-    )(APPLE_SECRET_FIELDS);
+  ): Promise<string | null> =>
+    firstProblem((field: WalletSecretField) =>
+      // A field the form always posts, so a missing entry is a wiring bug.
+      problemWith(field, values.secrets[field.name] as SecretFieldResult),
+    )(wallet.secrets);
+
+const validateWallet = async (
+  wallet: WalletForm,
+  values: WalletValues,
+): Promise<string | null> => {
+  if (isAllCleared(wallet, values)) return null;
+  const blankText = wallet.texts.find((field) => !values.texts[field.name]);
+  if (blankText) return t(blankText.missingKey);
+  const checkSecrets = firstSecretProblem(wallet, values);
+  if (!wallet.hasSavedConfig()) {
+    // No saved config to fall back on, so every secret must be uploaded now.
+    const missing = await checkSecrets((field, secret) =>
+      secret.action === "provided" ? null : t(field.missingKey),
+    );
+    if (missing) return missing;
+  }
+  const invalidSecret = await checkSecrets(async (field, secret) =>
+    (await field.looksValid(effectiveSecretValue(secret, field.savedValue())))
+      ? null
+      : t(field.invalidKey),
+  );
+  if (invalidSecret) return invalidSecret;
+  return wallet.pairCheck
+    ? wallet.pairCheck((field) =>
+        effectiveSecretValue(
+          values.secrets[field.name] as SecretFieldResult,
+          field.savedValue(),
+        ),
+      )
+    : null;
+};
+
+const saveWallet = async (
+  wallet: WalletForm,
+  values: WalletValues,
+): Promise<void> => {
+  if (isAllCleared(wallet, values)) {
+    await Promise.all(
+      [...wallet.texts, ...wallet.secrets].map((field) => field.save("")),
+    );
+    return;
+  }
+  for (const field of wallet.texts) {
+    await field.save(values.texts[field.name] as string);
+  }
+  for (const field of wallet.secrets) {
+    await saveSecret(
+      values.secrets[field.name] as SecretFieldResult,
+      field.save,
+    );
+  }
+};
+
+/** The owner-only POST that saves one wallet's settings. Both wallets are this
+ * one handler, told which fields they have. */
+const walletSettingsHandler = (wallet: WalletForm): RequestRoute =>
+  settingsHandler<WalletValues>({
+    advanced: true,
+    extract: (form) => ({
+      secrets: Object.fromEntries(
+        wallet.secrets.map((field) => [
+          field.name,
+          processSecretField(form, field.name),
+        ]),
+      ),
+      texts: Object.fromEntries(
+        wallet.texts.map((field) => [field.name, form.getString(field.name)]),
+      ),
+    }),
+    formId: wallet.formId,
+    log: (values) =>
+      t(isAllCleared(wallet, values) ? wallet.clearedKey : wallet.updatedKey),
+    save: (values) => saveWallet(wallet, values),
+    validate: (values) => validateWallet(wallet, values),
+  });
+
+/** The three secret uploads on the Apple Wallet form. The signing pair is named
+ * because the pair check needs to read both back. */
+const APPLE_SIGNING_CERT: WalletSecretField = {
+  invalidKey: "error.apple_signing_cert_invalid",
+  looksValid: isValidAppleCertificate,
+  missingKey: "error.apple_signing_cert_required",
+  name: "apple_wallet_signing_cert",
+  save: (value) => settings.update.appleWallet.signingCert(value),
+  savedValue: () => settings.appleWallet.signingCert,
+};
+
+const APPLE_SIGNING_KEY: WalletSecretField = {
+  invalidKey: "error.apple_signing_key_invalid",
+  looksValid: isValidRsaPrivateKey,
+  missingKey: "error.apple_signing_key_required",
+  name: "apple_wallet_signing_key",
+  save: (value) => settings.update.appleWallet.signingKey(value),
+  savedValue: () => settings.appleWallet.signingKey,
+};
+
+const APPLE_WWDR_CERT: WalletSecretField = {
+  invalidKey: "error.apple_wwdr_cert_invalid",
+  looksValid: isValidCertificate,
+  missingKey: "error.apple_wwdr_cert_required",
+  name: "apple_wallet_wwdr_cert",
+  save: (value) => settings.update.appleWallet.wwdrCert(value),
+  savedValue: () => settings.appleWallet.wwdrCert,
+};
+
+/**
+ * Handle POST /admin/settings/apple-wallet - owner only
+ */
+export const handleAppleWalletPost = walletSettingsHandler({
+  clearedKey: "success.apple_wallet_cleared",
+  formId: "settings-apple-wallet",
+  hasSavedConfig: () => settings.appleWallet.hasDbConfig,
+  pairCheck: async (uploadedValue) =>
+    (await isValidAppleSigningPair(
+      uploadedValue(APPLE_SIGNING_CERT),
+      uploadedValue(APPLE_SIGNING_KEY),
+    ))
+      ? null
+      : t("error.apple_signing_pair_mismatch"),
+  secrets: [APPLE_SIGNING_CERT, APPLE_SIGNING_KEY, APPLE_WWDR_CERT],
+  texts: [
+    {
+      missingKey: "error.apple_pass_type_id_required",
+      name: "apple_wallet_pass_type_id",
+      save: (value) => settings.update.appleWallet.passTypeId(value),
+    },
+    {
+      missingKey: "error.apple_team_id_required",
+      name: "apple_wallet_team_id",
+      save: (value) => settings.update.appleWallet.teamId(value),
+    },
+  ],
+  updatedKey: "success.apple_wallet_updated",
+});
 
 /**
  * Handle POST /admin/settings/google-wallet - owner only
  */
-type GoogleWalletFormData = {
-  issuerId: string;
-  email: string;
-  key: SecretFieldResult;
-};
-
-const isGoogleWalletCleared = (d: GoogleWalletFormData): boolean =>
-  !d.issuerId && !d.email && d.key.action === "cleared";
-
-export const handleGoogleWalletPost = settingsHandler<GoogleWalletFormData>({
-  advanced: true,
-  extract: (form) => ({
-    email: form.getString("google_wallet_service_account_email"),
-    issuerId: form.getString("google_wallet_issuer_id"),
-    key: processSecretField(form, "google_wallet_service_account_key"),
-  }),
+export const handleGoogleWalletPost = walletSettingsHandler({
+  clearedKey: "success.google_wallet_cleared",
   formId: "settings-google-wallet",
-  log: (d) =>
-    isGoogleWalletCleared(d)
-      ? t("success.google_wallet_cleared")
-      : t("success.google_wallet_updated"),
-  save: async (d) => {
-    if (isGoogleWalletCleared(d)) {
-      await Promise.all([
-        settings.update.googleWallet.issuerId(""),
-        settings.update.googleWallet.serviceAccountEmail(""),
-        settings.update.googleWallet.serviceAccountKey(""),
-      ]);
-      return;
-    }
-    await settings.update.googleWallet.issuerId(d.issuerId);
-    await settings.update.googleWallet.serviceAccountEmail(d.email);
-    await saveSecret(d.key, settings.update.googleWallet.serviceAccountKey);
-  },
-  validate: async (d) => {
-    if (isGoogleWalletCleared(d)) return null;
-    if (!d.issuerId) return t("error.google_issuer_id_required");
-    if (!d.email) return t("error.google_service_email_required");
-    if (!settings.googleWallet.hasDbConfig && d.key.action !== "provided") {
-      return t("error.google_service_key_required");
-    }
-    const key = effectiveSecretValue(
-      d.key,
-      settings.googleWallet.serviceAccountKey,
-    );
-    if (!(await isValidRsaPrivateKey(key))) {
-      return t("error.google_service_key_invalid");
-    }
-    return null;
-  },
+  hasSavedConfig: () => settings.googleWallet.hasDbConfig,
+  secrets: [
+    {
+      invalidKey: "error.google_service_key_invalid",
+      looksValid: isValidRsaPrivateKey,
+      missingKey: "error.google_service_key_required",
+      name: "google_wallet_service_account_key",
+      save: (value) => settings.update.googleWallet.serviceAccountKey(value),
+      savedValue: () => settings.googleWallet.serviceAccountKey,
+    },
+  ],
+  texts: [
+    {
+      missingKey: "error.google_issuer_id_required",
+      name: "google_wallet_issuer_id",
+      save: (value) => settings.update.googleWallet.issuerId(value),
+    },
+    {
+      missingKey: "error.google_service_email_required",
+      name: "google_wallet_service_account_email",
+      save: (value) => settings.update.googleWallet.serviceAccountEmail(value),
+    },
+  ],
+  updatedKey: "success.google_wallet_updated",
 });

--- a/src/shared/bunny-cdn.ts
+++ b/src/shared/bunny-cdn.ts
@@ -188,6 +188,13 @@ const loadFreeCertificate = async (
   return okOrError(response, "Load free certificate");
 };
 
+/** Report a failed Bunny call and hand the failure straight back — what every
+ * step below does when its call does not come back ok. */
+const reported = <T extends { error: string }>(failure: T): T => {
+  logError({ code: ErrorCode.CDN_REQUEST, detail: failure.error });
+  return failure;
+};
+
 /**
  * Validate a custom domain by adding it to the Bunny CDN pull zone
  * and enabling force SSL. Returns success or an error message.
@@ -197,8 +204,7 @@ const validateCustomDomainImpl = async (
 ): Promise<BunnyApiResult> => {
   const zoneResult = await bunnyCdnApi.findPullZoneId();
   if (!zoneResult.ok) {
-    logError({ code: ErrorCode.CDN_REQUEST, detail: zoneResult.error });
-    return zoneResult;
+    return reported(zoneResult);
   }
 
   const pullZoneId = zoneResult.id;
@@ -213,14 +219,12 @@ const validateCustomDomainImpl = async (
     !hostnameResult.ok &&
     hostnameResult.errorKey !== HOSTNAME_ALREADY_REGISTERED
   ) {
-    logError({ code: ErrorCode.CDN_REQUEST, detail: hostnameResult.error });
-    return hostnameResult;
+    return reported(hostnameResult);
   }
 
   const certResult = await loadFreeCertificate(hostname);
   if (!certResult.ok) {
-    logError({ code: ErrorCode.CDN_REQUEST, detail: certResult.error });
-    return certResult;
+    return reported(certResult);
   }
 
   const sslResult = await pullZonePost(
@@ -230,8 +234,7 @@ const validateCustomDomainImpl = async (
     "Set force SSL",
   );
   if (!sslResult.ok) {
-    logError({ code: ErrorCode.CDN_REQUEST, detail: sslResult.error });
-    return sslResult;
+    return reported(sslResult);
   }
 
   return { ok: true };
@@ -331,8 +334,7 @@ const registerBunnySubdomainImpl = async (
   // Resolve CDN hostname for CNAME target (stable .b-cdn.net, not custom domain)
   const cdnHostname = await bunnyCdnApi.getCdnHostname();
   if (!cdnHostname.ok) {
-    logError({ code: ErrorCode.CDN_REQUEST, detail: cdnHostname.error });
-    return cdnHostname;
+    return reported(cdnHostname);
   }
   const target = cdnHostname.hostname;
 

--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -22,11 +22,19 @@ const providers = new Set<CacheStatProvider>();
  * it, tests must call it so their entries never outlive the test). */
 export type Unregister = () => void;
 
+/** Build the "join this set, and here is how to leave it" register function a
+ * set of load-time registrations needs. Both registries below are one. */
+const registrar =
+  <T>(members: Set<T>) =>
+  (member: T): Unregister => {
+    members.add(member);
+    return () => {
+      members.delete(member);
+    };
+  };
+
 /** Register a cache stat provider (called at module load time) */
-export const registerCache = (provider: CacheStatProvider): Unregister => {
-  providers.add(provider);
-  return () => providers.delete(provider);
-};
+export const registerCache = registrar(providers);
 
 /** Collect stats from all registered caches */
 export const getAllCacheStats = (): CacheStat[] =>
@@ -73,10 +81,7 @@ const resetHooks = new Set<Invalidator>();
 /** Register an extra full-clear to run with a write cause when every cache is
  * reset. Only needed by caches without a table registration;
  * `resetAllCaches` already fires every table-registered invalidator. */
-export const registerCacheReset = (reset: Invalidator): Unregister => {
-  resetHooks.add(reset);
-  return () => resetHooks.delete(reset);
-};
+export const registerCacheReset = registrar(resetHooks);
 
 /**
  * Clear every registered cache: each table-registered invalidator once (a

--- a/src/shared/cache-registry.ts
+++ b/src/shared/cache-registry.ts
@@ -25,7 +25,7 @@ export type Unregister = () => void;
 /** Build the "join this set, and here is how to leave it" register function a
  * set of load-time registrations needs. Both registries below are one. */
 const registrar =
-  <T>(members: Set<T>) =>
+  <T>(members: Set<T>): ((member: T) => Unregister) =>
   (member: T): Unregister => {
     members.add(member);
     return () => {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -128,12 +128,19 @@ export const getEmbedHosts = async (): Promise<string[]> => {
   return parseEmbedHosts(raw);
 };
 
+/** True only when every named environment variable carries a value. Each
+ * "is this integration set up" answer below is one of these, so a new one
+ * names its variables rather than writing the check again. */
+const allEnvSet =
+  (...names: string[]) =>
+  (): boolean =>
+    names.every((name) => !!getEnv(name));
+
 /**
  * Check if Bunny CDN pull zone management is enabled
  * Requires both BUNNY_API_KEY and BUNNY_SCRIPT_ID to be set
  */
-export const isBunnyCdnEnabled = (): boolean =>
-  !!getEnv("BUNNY_API_KEY") && !!getEnv("BUNNY_SCRIPT_ID");
+export const isBunnyCdnEnabled = allEnvSet("BUNNY_API_KEY", "BUNNY_SCRIPT_ID");
 
 /**
  * Get the Bunny CDN API key from environment
@@ -144,11 +151,13 @@ export const getBunnyApiKey = (): string => requireEnv("BUNNY_API_KEY");
  * Check if Bunny DNS subdomain feature is enabled.
  * Requires BUNNY_API_KEY and BUNNY_DNS_ZONE_ID to be set.
  */
-export const isBunnyDnsEnabled = (): boolean =>
-  !!getEnv("BUNNY_API_KEY") && !!getEnv("BUNNY_DNS_ZONE_ID");
+export const isBunnyDnsEnabled = allEnvSet(
+  "BUNNY_API_KEY",
+  "BUNNY_DNS_ZONE_ID",
+);
 
 /** Check if the Bunny hosted database provider is enabled (requires BUNNY_API_KEY). */
-export const isBunnyDbEnabled = (): boolean => !!getEnv("BUNNY_API_KEY");
+export const isBunnyDbEnabled = allEnvSet("BUNNY_API_KEY");
 
 /** Check if this instance can build other sites. */
 export const isBuilderEnabled = (): boolean =>
@@ -193,8 +202,10 @@ export const getBotpoisonSecretKey = (): string =>
  * Requires both BOTPOISON_PUBLIC_KEY and BOTPOISON_SECRET_KEY to be set.
  * This gates the public contact form feature.
  */
-export const isBotpoisonEnabled = (): boolean =>
-  !!getBotpoisonPublicKey() && !!getBotpoisonSecretKey();
+export const isBotpoisonEnabled = allEnvSet(
+  "BOTPOISON_PUBLIC_KEY",
+  "BOTPOISON_SECRET_KEY",
+);
 
 /**
  * Whether the inter-instance site-credentials endpoint is enabled. Off unless
@@ -202,17 +213,17 @@ export const isBotpoisonEnabled = (): boolean =>
  * is a high-entropy shared secret the operator passes to the upgrade workflow at
  * trigger time (it is never stored in GitHub).
  */
-export const isInstanceApiEnabled = (): boolean =>
-  !!getEnv("MAIN_INSTANCE_KEY");
+export const isInstanceApiEnabled = allEnvSet("MAIN_INSTANCE_KEY");
 
 /** The shared secret authorizing the inter-instance site-credentials endpoint. */
 export const getMainInstanceKey = (): string => requireEnv("MAIN_INSTANCE_KEY");
 
 /** Check if Deno Deploy hosting has its token, organization ID, and domain slug. */
-export const isDenoDeployEnabled = (): boolean =>
-  !!getEnv("DENO_DEPLOY_TOKEN") &&
-  !!getEnv("DENO_DEPLOY_ORG_ID") &&
-  !!getEnv("DENO_DEPLOY_ORG_SLUG");
+export const isDenoDeployEnabled = allEnvSet(
+  "DENO_DEPLOY_TOKEN",
+  "DENO_DEPLOY_ORG_ID",
+  "DENO_DEPLOY_ORG_SLUG",
+);
 
 /** Get the Deno Deploy API token from environment. */
 export const getDenoDeployToken = (): string => requireEnv("DENO_DEPLOY_TOKEN");
@@ -230,10 +241,11 @@ export const getDefaultDbProvider = (): "bunny" | "turso" =>
   getEnv("DEFAULT_DB_HOST") === "turso" ? "turso" : "bunny";
 
 /** Whether Turso hosting has its API token, organization, and group set. */
-export const isTursoEnabled = (): boolean =>
-  !!getEnv("TURSO_API_TOKEN") &&
-  !!getEnv("TURSO_ORGANIZATION") &&
-  !!getEnv("TURSO_GROUP");
+export const isTursoEnabled = allEnvSet(
+  "TURSO_API_TOKEN",
+  "TURSO_ORGANIZATION",
+  "TURSO_GROUP",
+);
 
 /** Get the Turso API token from environment. */
 export const getTursoApiToken = (): string => requireEnv("TURSO_API_TOKEN");

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -132,7 +132,7 @@ export const getEmbedHosts = async (): Promise<string[]> => {
  * "is this integration set up" answer below is one of these, so a new one
  * names its variables rather than writing the check again. */
 const allEnvSet =
-  (...names: string[]) =>
+  (...names: string[]): (() => boolean) =>
   (): boolean =>
     names.every((name) => !!getEnv(name));
 

--- a/src/shared/db/common-schema.ts
+++ b/src/shared/db/common-schema.ts
@@ -1,4 +1,5 @@
 import type { BlindIndex, EnvKeyEncrypted } from "#crypto/sealed.ts";
+import { executeUpdate, resetAggregates } from "#db/client.ts";
 import {
   createKeyedCache,
   type KeyedCache,
@@ -53,6 +54,30 @@ export type AggregateRecalculation<F extends string> = Record<
   F,
   { current: number; recalculated: number }
 >;
+
+/** The two owner-facing repairs every trigger-maintained aggregate column set
+ * needs: write the numbers the operator typed, and rebuild chosen columns from
+ * the rows they count. */
+export type AggregateRepairs<F extends string> = {
+  reset: (entityId: number, fields: readonly F[]) => Promise<void>;
+  update: (entityId: number, values: AggregateValues<F>) => Promise<void>;
+};
+
+/**
+ * Both repairs for one table's aggregate columns, given the SQL that recounts
+ * each one. Every aggregate family declares its table and its per-column
+ * recount here rather than writing the same two wrappers again.
+ */
+export const aggregateRepairs = <F extends string>(
+  table: string,
+  resetSql: Record<F, string>,
+): AggregateRepairs<F> => ({
+  reset: (entityId, fields) =>
+    resetAggregates(table, entityId, fields, resetSql),
+  update: async (entityId, values) => {
+    await executeUpdate(table, { ...values }, { id: entityId });
+  },
+});
 
 type EncryptFn = (v: string) => Promise<EnvKeyEncrypted>;
 type DecryptFn = (v: EnvKeyEncrypted) => Promise<string>;

--- a/src/shared/db/listings/aggregates.ts
+++ b/src/shared/db/listings/aggregates.ts
@@ -1,12 +1,14 @@
 /** Listing aggregate inspection, correction, and rebuilding. */
 
 import { inOwnTx, ledgerTx } from "#accounting/ledger-tx.ts";
+/* jscpd:ignore-start */
 import { requireOne } from "#db/client.ts";
 import {
   type AggregateRecalculation,
   type AggregateValues,
   aggregateRepairs,
 } from "#db/common-schema.ts";
+/* jscpd:ignore-end */
 import {
   ticketCountPredicateFor,
   ticketCountSumExpr,

--- a/src/shared/db/listings/aggregates.ts
+++ b/src/shared/db/listings/aggregates.ts
@@ -1,10 +1,11 @@
 /** Listing aggregate inspection, correction, and rebuilding. */
 
 import { inOwnTx, ledgerTx } from "#accounting/ledger-tx.ts";
-import { execute, requireOne, resetAggregates } from "#db/client.ts";
-import type {
-  AggregateRecalculation,
-  AggregateValues,
+import { requireOne } from "#db/client.ts";
+import {
+  type AggregateRecalculation,
+  type AggregateValues,
+  aggregateRepairs,
 } from "#db/common-schema.ts";
 import {
   ticketCountPredicateFor,
@@ -48,36 +49,22 @@ export const getListingAggregateRecalculation = async (
   };
 };
 
-/** Manually set every editable listing aggregate. */
-export const updateListingAggregateValues = async (
-  listingId: number,
-  values: ListingAggregateValues,
-): Promise<void> => {
-  await execute(
-    "UPDATE listings AS listing SET booked_quantity = ?, tickets_count = ? WHERE listing.id = ?",
-    [values.booked_quantity, values.tickets_count, listingId],
-  );
-};
-
 /** Correct projected listing income to the requested amount. */
 export const adjustListingIncome = (
   listingId: number,
   targetIncome: number,
 ): Promise<void> => inOwnTx(ledgerTx.correct.income)(listingId, targetIncome);
 
-const aggregateResetSql: Record<ListingAggregateField, string> = {
-  booked_quantity:
-    "booked_quantity = COALESCE((SELECT SUM(listingAttendee.quantity) FROM listing_attendees AS listingAttendee WHERE listingAttendee.listing_id = ?), 0)",
-  tickets_count: `tickets_count = (SELECT COUNT(*) FROM listing_attendees AS listingAttendee WHERE listingAttendee.listing_id = ? AND ${ticketCountPredicateFor(
-    "listingAttendee.quantity",
-    "listingAttendee.attendee_id",
-  )})`,
-};
-
-/** Reset selected listing aggregate columns from booking rows. */
-export const resetListingAggregateFields = async (
-  listingId: number,
-  fields: ListingAggregateField[],
-): Promise<void> => {
-  await resetAggregates("listings", listingId, fields, aggregateResetSql);
-};
+/** Write the operator's typed listing aggregates, or rebuild chosen ones from
+ * the booking rows they count. */
+export const listingAggregates = aggregateRepairs<ListingAggregateField>(
+  "listings",
+  {
+    booked_quantity:
+      "booked_quantity = COALESCE((SELECT SUM(listingAttendee.quantity) FROM listing_attendees AS listingAttendee WHERE listingAttendee.listing_id = ?), 0)",
+    tickets_count: `tickets_count = (SELECT COUNT(*) FROM listing_attendees AS listingAttendee WHERE listingAttendee.listing_id = ? AND ${ticketCountPredicateFor(
+      "listingAttendee.quantity",
+      "listingAttendee.attendee_id",
+    )})`,
+  },
+);

--- a/src/shared/db/modifiers.ts
+++ b/src/shared/db/modifiers.ts
@@ -13,18 +13,17 @@ import { accountBalanceSubquery } from "#accounting/projection-sql.ts";
 import { decrypt, encrypt } from "#crypto/encryption.ts";
 import {
   executeBatch,
-  executeUpdate,
   inPlaceholders,
   queryAll,
   queryIdColumn,
   queryOne,
   requireOne,
-  resetAggregates,
   update,
 } from "#db/client.ts";
 import {
   type AggregateRecalculation,
   type AggregateValues,
+  aggregateRepairs,
   idAndEncryptedNameSchema,
 } from "#db/common-schema.ts";
 import { defineIdTable } from "#db/define-id-table.ts";
@@ -201,14 +200,6 @@ export const getModifierAggregateRecalculation = async (
   };
 };
 
-/** Manually set every editable modifier aggregate from the edit form. */
-export const updateModifierAggregateValues = async (
-  modifierId: number,
-  values: ModifierAggregateValues,
-): Promise<void> => {
-  await executeUpdate("modifiers", { ...values }, { id: modifierId });
-};
-
 /**
  * Correct a modifier's projected revenue to `targetRevenue` in its own write
  * transaction — the standalone form of `ledgerTx.correct.modifierRevenue` (see
@@ -220,20 +211,17 @@ export const updateModifierAggregateValues = async (
  */
 export const adjustModifierRevenue = inOwnTx(ledgerTx.correct.modifierRevenue);
 
-const aggregateResetSql: Record<ModifierAggregateField, string> = {
-  total_uses:
-    "total_uses = COALESCE((SELECT SUM(quantity) FROM modifier_usages WHERE modifier_id = ?), 0)",
-  usage_count:
-    "usage_count = (SELECT COUNT(*) FROM modifier_usages WHERE modifier_id = ?)",
-};
-
-/** Reset selected modifier aggregate columns from actual usage rows. */
-export const resetModifierAggregateFields = async (
-  modifierId: number,
-  fields: ModifierAggregateField[],
-): Promise<void> => {
-  await resetAggregates("modifiers", modifierId, fields, aggregateResetSql);
-};
+/** Write the operator's typed modifier aggregates, or rebuild chosen ones from
+ * the usage rows they count. */
+export const modifierAggregates = aggregateRepairs<ModifierAggregateField>(
+  "modifiers",
+  {
+    total_uses:
+      "total_uses = COALESCE((SELECT SUM(quantity) FROM modifier_usages WHERE modifier_id = ?), 0)",
+    usage_count:
+      "usage_count = (SELECT COUNT(*) FROM modifier_usages WHERE modifier_id = ?)",
+  },
+);
 
 /** The listings a "listings"-scoped modifier is charged on, keyed by modifier
  * id: `getIds` reads them (the admin scope editor), `setIds` replaces the set

--- a/src/shared/db/questions/aggregates.ts
+++ b/src/shared/db/questions/aggregates.ts
@@ -6,16 +6,11 @@
  * The `modifier_id` column links an answer to the price modifier it triggers.
  */
 
+import { execute, queryAll, queryOne, requireOne } from "#db/client.ts";
 import {
-  execute,
-  queryAll,
-  queryOne,
-  requireOne,
-  resetAggregates,
-} from "#db/client.ts";
-import type {
-  AggregateRecalculation,
-  AggregateValues,
+  type AggregateRecalculation,
+  type AggregateValues,
+  aggregateRepairs,
 } from "#db/common-schema.ts";
 import { map } from "#fp";
 
@@ -65,29 +60,15 @@ export const getAnswerAggregateRecalculation = async (
   };
 };
 
-/** Manually set an answer's editable aggregate from the edit form. */
-export const updateAnswerAggregateValues = async (
-  answerId: number,
-  values: AnswerAggregateValues,
-): Promise<void> => {
-  await execute("UPDATE answers SET times_selected = ? WHERE id = ?", [
-    values.times_selected,
-    answerId,
-  ]);
-};
-
-const answerAggregateResetSql: Record<AnswerAggregateField, string> = {
-  times_selected:
-    "times_selected = COALESCE((SELECT COUNT(*) FROM attendee_answers WHERE answer_id = ?), 0)",
-};
-
-/** Reset selected answer aggregate columns from the actual attendee_answers. */
-export const resetAnswerAggregateFields = async (
-  answerId: number,
-  fields: AnswerAggregateField[],
-): Promise<void> => {
-  await resetAggregates("answers", answerId, fields, answerAggregateResetSql);
-};
+/** Write the operator's typed selection total, or rebuild it from the actual
+ * attendee_answers rows. */
+export const answerAggregates = aggregateRepairs<AnswerAggregateField>(
+  "answers",
+  {
+    times_selected:
+      "times_selected = COALESCE((SELECT COUNT(*) FROM attendee_answers WHERE answer_id = ?), 0)",
+  },
+);
 
 /** Get the price-modifier id a single answer triggers, or null when it has
  * none. The modifier_id column isn't part of the decrypted Answer shape, so the

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -626,7 +626,7 @@ type Rung = readonly [size: number, suffix: string];
  * rounded to a whole number of them, and falls back to `baseSuffix` below the
  * smallest rung. Every human-readable size and duration below is one of these. */
 const laddered =
-  (rungs: readonly Rung[], baseSuffix: string) =>
+  (rungs: readonly Rung[], baseSuffix: string): ((value: number) => string) =>
   (value: number): string => {
     for (const [size, suffix] of rungs) {
       if (value >= size) return `${Math.round(value / size)}${suffix}`;

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -618,53 +618,63 @@ export const FORM_STASH_MAX_ENTRIES = limit(
 // Debug page display
 // ---------------------------------------------------------------------------
 
+/** One rung of a size ladder: how many base units it holds, and what to call
+ * it. Ladders are written biggest first. */
+type Rung = readonly [size: number, suffix: string];
+
+/** Build a formatter that names a number in the biggest rung it reaches,
+ * rounded to a whole number of them, and falls back to `baseSuffix` below the
+ * smallest rung. Every human-readable size and duration below is one of these. */
+const laddered =
+  (rungs: readonly Rung[], baseSuffix: string) =>
+  (value: number): string => {
+    for (const [size, suffix] of rungs) {
+      if (value >= size) return `${Math.round(value / size)}${suffix}`;
+    }
+    return `${value}${baseSuffix}`;
+  };
+
 /** Format bytes as a human-readable size string */
-export const formatBytes = (bytes: number): string => {
-  if (bytes >= 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))}MB`;
-  if (bytes >= 1024) return `${Math.round(bytes / 1024)}KB`;
-  return `${bytes}B`;
-};
+export const formatBytes = laddered(
+  [
+    [1024 * 1024, "MB"],
+    [1024, "KB"],
+  ],
+  "B",
+);
 
 /** Format milliseconds as a human-readable duration string */
-export const formatMs = (ms: number): string => {
-  if (ms >= 60 * 60 * 1000) {
-    const h = Math.round(ms / (60 * 60 * 1000));
-    return `${h}h`;
-  }
-  if (ms >= 60 * 1000) {
-    const m = Math.round(ms / (60 * 1000));
-    return `${m}min`;
-  }
-  if (ms >= 1000) {
-    const s = Math.round(ms / 1000);
-    return `${s}s`;
-  }
-  return `${ms}ms`;
-};
+export const formatMs = laddered(
+  [
+    [60 * 60 * 1000, "h"],
+    [60 * 1000, "min"],
+    [1000, "s"],
+  ],
+  "ms",
+);
 
 /** Format seconds as a human-readable duration string */
-export const formatSeconds = (seconds: number): string => {
-  if (seconds >= 86400) {
-    const d = Math.round(seconds / 86400);
-    return `${d}d`;
-  }
-  if (seconds >= 3600) {
-    const h = Math.round(seconds / 3600);
-    return `${h}h`;
-  }
-  if (seconds >= 60) {
-    const m = Math.round(seconds / 60);
-    return `${m}min`;
-  }
-  return `${seconds}s`;
+export const formatSeconds = laddered(
+  [
+    [24 * 60 * 60, "d"],
+    [60 * 60, "h"],
+    [60, "min"],
+  ],
+  "s",
+);
+
+/** The units that carry their own ladder. Every other unit is a plain count,
+ * so it reads as "<value> <unit>". */
+const UNIT_FORMATTERS: Record<string, (value: number) => string> = {
+  bytes: formatBytes,
+  ms: formatMs,
+  seconds: formatSeconds,
 };
 
 /** Format a limit value with its unit into a human-readable string */
 export const formatLimitValue = (value: number, unit: string): string => {
-  if (unit === "bytes") return formatBytes(value);
-  if (unit === "ms") return formatMs(value);
-  if (unit === "seconds") return formatSeconds(value);
-  return `${value} ${unit}`;
+  const format = UNIT_FORMATTERS[unit];
+  return format ? format(value) : `${value} ${unit}`;
 };
 
 /** The debug-page display list, derived from the limit declarations above. */

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -232,15 +232,6 @@ export const deleteListingAttachmentFile = async (
   }
 };
 
-/** Delete all attachment files for a list of listings */
-export const deleteAllListingAttachmentFiles = async (
-  listings: readonly ListingWithAttachmentStorage[],
-): Promise<void> => {
-  for (const listing of listings) {
-    await deleteListingAttachmentFile(listing, "database reset");
-  }
-};
-
 /** Delete the full-size image and thumbnail files for a first-class image. */
 export const deleteImageStorageFiles = async (
   image: ImageWithStorage,
@@ -277,14 +268,23 @@ export const deleteImageStorageFilesStrict = async (
   if (failure) throw failure;
 };
 
+/** Turn a "delete one record's files" function into the whole-table sweep the
+ * database reset runs. Both sweeps below are this one loop. */
+const deletesEveryFileFor =
+  <Record>(deleteOne: (record: Record, reason: string) => Promise<void>) =>
+  async (records: readonly Record[]): Promise<void> => {
+    for (const record of records) await deleteOne(record, "database reset");
+  };
+
+/** Delete all attachment files for a list of listings */
+export const deleteAllListingAttachmentFiles = deletesEveryFileFor(
+  deleteListingAttachmentFile,
+);
+
 /** Delete all first-class image files. */
-export const deleteAllImageStorageFiles = async (
-  images: readonly ImageWithStorage[],
-): Promise<void> => {
-  for (const image of images) {
-    await deleteImageStorageFiles(image, "database reset");
-  }
-};
+export const deleteAllImageStorageFiles = deletesEveryFileFor(
+  deleteImageStorageFiles,
+);
 
 /** Generate a random `.webp` filename. Every uploaded image is transcoded to
  * WebP, so stored image variants always carry the `.webp` extension. */

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -271,7 +271,9 @@ export const deleteImageStorageFilesStrict = async (
 /** Turn a "delete one record's files" function into the whole-table sweep the
  * database reset runs. Both sweeps below are this one loop. */
 const deletesEveryFileFor =
-  <Record>(deleteOne: (record: Record, reason: string) => Promise<void>) =>
+  <Record>(
+    deleteOne: (record: Record, reason: string) => Promise<void>,
+  ): ((records: readonly Record[]) => Promise<void>) =>
   async (records: readonly Record[]): Promise<void> => {
     for (const record of records) await deleteOne(record, "database reset");
   };

--- a/src/ui/templates/admin/api-keys.tsx
+++ b/src/ui/templates/admin/api-keys.tsx
@@ -21,7 +21,7 @@ import { sectionsRenderer } from "#templates/components/aggregate-sections.tsx";
 import { PageBlock } from "#templates/components/page-structure.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import type { AdminSession } from "#types";
 
 /* jscpd:ignore-end */
@@ -61,21 +61,11 @@ const ApiKeyLink = ({ apiKey }: { apiKey: ApiKeyDisplay }): JSX.Element => (
 );
 
 const apiKeyColumns: readonly TableColumn<ApiKeyDisplay>[] = [
-  {
-    cell: (apiKey) => <ApiKeyLink apiKey={apiKey} />,
-    header: translatedTableHeader("common.name"),
-    key: "name",
-  },
-  {
-    cell: createdCell,
-    header: translatedTableHeader("common.created"),
-    key: "created",
-  },
-  {
-    cell: lastUsedCell,
-    header: translatedTableHeader("api_keys.col.last_used"),
-    key: "last_used",
-  },
+  translatedTableColumn("name", "common.name", (apiKey) => (
+    <ApiKeyLink apiKey={apiKey} />
+  )),
+  translatedTableColumn("created", "common.created", createdCell),
+  translatedTableColumn("last_used", "api_keys.col.last_used", lastUsedCell),
 ];
 
 const apiKeyTable = defineTable(apiKeyColumns);

--- a/src/ui/templates/admin/attendee-detail.tsx
+++ b/src/ui/templates/admin/attendee-detail.tsx
@@ -26,7 +26,10 @@ import { HeaderRow } from "#templates/components/header-row.tsx";
 import { PageBlock } from "#templates/components/page-structure.tsx";
 import { renderTable } from "#templates/components/table.tsx";
 import { colClass } from "#templates/components/table-columns.ts";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import {
+  translatedTableColumn,
+  translatedTableHeader,
+} from "#templates/components/translated-table-column.ts";
 
 /** One key/value row of a detail table: a header cell plus a value cell. */
 const DetailTableRow = ({
@@ -93,59 +96,50 @@ const bookingColumns: readonly TableColumn<
   AttendeeBooking,
   BookingTableContext
 >[] = [
-  {
-    cell: (booking, context) => (
-      <>
-        <a href={`/admin/listing/${booking.listingId}`}>
-          {booking.listingName}
-        </a>
-        <InactiveNote active={booking.listingActive} leadingSpace />
-        {booking.parentListingId > 0 ? (
-          <div class="muted small">
-            {t("attendee_detail.addon_under", {
-              parent:
-                context.nameByListingId.get(booking.parentListingId) ??
-                `#${booking.parentListingId}`,
-            })}
-          </div>
-        ) : null}
-        {context.childNamesByParentId.has(booking.listingId) ? (
-          <div class="muted small">
-            {t("attendee_detail.includes_addon", {
-              children: context.childNamesByParentId
-                .get(booking.listingId)!
-                .join(", "),
-            })}
-          </div>
-        ) : null}
-      </>
-    ),
-    header: translatedTableHeader("terms.listing"),
-    key: "listing",
-  },
-  {
-    cell: (booking) =>
-      booking.startAt
-        ? formatDateRangeLabel(booking.startAt, booking.endAt)
-        : "—",
-    header: translatedTableHeader("common.date"),
-    key: "date",
-  },
+  translatedTableColumn("listing", "terms.listing", (booking, context) => (
+    <>
+      <a href={`/admin/listing/${booking.listingId}`}>{booking.listingName}</a>
+      <InactiveNote active={booking.listingActive} leadingSpace />
+      {booking.parentListingId > 0 ? (
+        <div class="muted small">
+          {t("attendee_detail.addon_under", {
+            parent:
+              context.nameByListingId.get(booking.parentListingId) ??
+              `#${booking.parentListingId}`,
+          })}
+        </div>
+      ) : null}
+      {context.childNamesByParentId.has(booking.listingId) ? (
+        <div class="muted small">
+          {t("attendee_detail.includes_addon", {
+            children: context.childNamesByParentId
+              .get(booking.listingId)!
+              .join(", "),
+          })}
+        </div>
+      ) : null}
+    </>
+  )),
+  translatedTableColumn("date", "common.date", (booking) =>
+    booking.startAt
+      ? formatDateRangeLabel(booking.startAt, booking.endAt)
+      : "—",
+  ),
   {
     cell: (booking) => booking.quantity,
     class: "quantity",
     header: translatedTableHeader("common.quantity"),
     key: "quantity",
   },
-  {
-    cell: (booking) =>
+  translatedTableColumn(
+    "status",
+    "common.status",
+    (booking) =>
       BookingStatusBadges({
         checkedIn: booking.checkedIn,
         refunded: booking.refunded,
       }) ?? "—",
-    header: translatedTableHeader("common.status"),
-    key: "status",
-  },
+  ),
 ];
 
 const bookingsTable = defineTable(bookingColumns);

--- a/src/ui/templates/admin/attendee-form/listing-editor.tsx
+++ b/src/ui/templates/admin/attendee-form/listing-editor.tsx
@@ -28,7 +28,10 @@ import type {
 } from "#templates/admin/attendee-form/types.ts";
 import { ErrorAlert } from "#templates/components/error.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import {
+  translatedTableColumn,
+  translatedTableHeader,
+} from "#templates/components/translated-table-column.ts";
 
 /* jscpd:ignore-end */
 
@@ -166,16 +169,8 @@ const listingColumns: readonly TableColumn<
   AttendeeFormLine,
   AttendeeFormTemplateData
 >[] = [
-  {
-    cell: listingNameCell,
-    header: translatedTableHeader("terms.listing"),
-    key: "listing",
-  },
-  {
-    cell: listingDatesCell,
-    header: translatedTableHeader("attendee_form.col_dates"),
-    key: "dates",
-  },
+  translatedTableColumn("listing", "terms.listing", listingNameCell),
+  translatedTableColumn("dates", "attendee_form.col_dates", listingDatesCell),
   {
     cell: listingQuantityCell,
     className: "attendee-line-qty",

--- a/src/ui/templates/admin/attributes.tsx
+++ b/src/ui/templates/admin/attributes.tsx
@@ -26,7 +26,7 @@ import {
 } from "#templates/components/reorder-list.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import type { AdminSession } from "#types";
 import {
   type ListingPanelProps,
@@ -52,16 +52,12 @@ const AttributeListingLink = ({
 );
 
 const attributeListingColumns: readonly TableColumn<AttributeListingRow>[] = [
-  {
-    cell: (listing) => <AttributeListingLink listing={listing} />,
-    header: translatedTableHeader("terms.listing"),
-    key: "listing",
-  },
-  {
-    cell: (listing) => listing.optionTexts.join(", "),
-    header: translatedTableHeader("attributes.options_column"),
-    key: "options",
-  },
+  translatedTableColumn("listing", "terms.listing", (listing) => (
+    <AttributeListingLink listing={listing} />
+  )),
+  translatedTableColumn("options", "attributes.options_column", (listing) =>
+    listing.optionTexts.join(", "),
+  ),
 ];
 
 const attributeListingsTable = defineTable(attributeListingColumns);

--- a/src/ui/templates/admin/availability-checker.tsx
+++ b/src/ui/templates/admin/availability-checker.tsx
@@ -19,7 +19,10 @@ import { SELECT_PREFIX, START_DATE_FIELD } from "#shared/order-select.ts";
 import type { TableColumn } from "#shared/tables/column.ts";
 import { defineTable } from "#shared/tables/definition.ts";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import {
+  translatedTableColumn,
+  translatedTableHeader,
+} from "#templates/components/translated-table-column.ts";
 import { OrderCartButtonBody } from "#templates/public/order-gallery.tsx";
 /* jscpd:ignore-end */
 
@@ -64,11 +67,9 @@ const availabilityColumns: readonly TableColumn<AvailabilityRow>[] = [
     ),
     key: "select",
   },
-  {
-    cell: (row) => <a href={`/admin/listing/${row.id}`}>{row.name}</a>,
-    header: translatedTableHeader("availability.listing"),
-    key: "listing",
-  },
+  translatedTableColumn("listing", "availability.listing", (row) => (
+    <a href={`/admin/listing/${row.id}`}>{row.name}</a>
+  )),
   {
     cell: (row) => `${row.remaining}/${row.total}`,
     cellAttrs: (row) => ({ class: row.remaining <= 0 ? "danger" : undefined }),

--- a/src/ui/templates/admin/built-sites/list-parts.tsx
+++ b/src/ui/templates/admin/built-sites/list-parts.tsx
@@ -10,7 +10,7 @@ import { WritableOnly } from "#templates/admin/writable-only.tsx";
 import { ActionButton, GuideFooter } from "#templates/components/actions.tsx";
 import { NewTabUrl } from "#templates/components/new-tab-link.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import type { ListingWithCount } from "#types";
 /* jscpd:ignore-end */
 
@@ -44,36 +44,27 @@ const builtSiteUrlCell = (site: BuiltSite): JSX.Element => (
 );
 
 const builtSiteColumns: readonly TableColumn<BuiltSite>[] = [
-  {
-    cell: builtSiteNameCell,
-    header: translatedTableHeader("common.name"),
-    key: "name",
-  },
-  {
-    cell: builtSiteUrlCell,
-    header: translatedTableHeader("built_sites.table_site_url"),
-    key: "site_url",
-  },
-  {
-    cell: (site) =>
-      site.assignedAttendeeId
-        ? t("built_sites.status_assigned", { id: site.assignedAttendeeId })
-        : site.assignable
-          ? t("built_sites.status_available")
-          : t("built_sites.status_not_assignable"),
-    header: translatedTableHeader("common.status"),
-    key: "status",
-  },
-  {
-    cell: (site) => site.updates,
-    header: translatedTableHeader("built_sites.table_updates"),
-    key: "updates",
-  },
-  {
-    cell: (site) => formatDeadlineLabel(site.readOnlyFrom),
-    header: translatedTableHeader("built_sites.table_read_only"),
-    key: "read_only",
-  },
+  translatedTableColumn("name", "common.name", builtSiteNameCell),
+  translatedTableColumn(
+    "site_url",
+    "built_sites.table_site_url",
+    builtSiteUrlCell,
+  ),
+  translatedTableColumn("status", "common.status", (site) =>
+    site.assignedAttendeeId
+      ? t("built_sites.status_assigned", { id: site.assignedAttendeeId })
+      : site.assignable
+        ? t("built_sites.status_available")
+        : t("built_sites.status_not_assignable"),
+  ),
+  translatedTableColumn(
+    "updates",
+    "built_sites.table_updates",
+    (site) => site.updates,
+  ),
+  translatedTableColumn("read_only", "built_sites.table_read_only", (site) =>
+    formatDeadlineLabel(site.readOnlyFrom),
+  ),
 ];
 
 const builtSitesTable = defineTable(builtSiteColumns);

--- a/src/ui/templates/admin/built-sites/renewal-summary.tsx
+++ b/src/ui/templates/admin/built-sites/renewal-summary.tsx
@@ -6,17 +6,18 @@ import type { TableColumn } from "#shared/tables/column.ts";
 import { defineTable } from "#shared/tables/definition.ts";
 import { ErrorNote } from "#templates/components/error.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import {
+  translatedTableColumn,
+  translatedTableHeader,
+} from "#templates/components/translated-table-column.ts";
 import type { ListingWithCount } from "#types";
 
 /* jscpd:ignore-end */
 
 const renewalTierColumns: readonly TableColumn<ListingWithCount>[] = [
-  {
-    cell: (tier) => <a href={`/admin/listing/${tier.id}`}>{tier.name}</a>,
-    header: translatedTableHeader("built_sites.tier_table_tier"),
-    key: "tier",
-  },
+  translatedTableColumn("tier", "built_sites.tier_table_tier", (tier) => (
+    <a href={`/admin/listing/${tier.id}`}>{tier.name}</a>
+  )),
   {
     cell: (tier) => tier.months_per_unit,
     class: "quantity",

--- a/src/ui/templates/admin/features.tsx
+++ b/src/ui/templates/admin/features.tsx
@@ -14,7 +14,7 @@ import { BackButton } from "#templates/components/actions.tsx";
 import { TitledArticle } from "#templates/components/page-structure.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import { YesNoRadios } from "#templates/components/yes-no-radios.tsx";
 import type { AdminSession, Theme } from "#types";
 
@@ -32,19 +32,12 @@ const featureRows = (enabledFeatures: EnabledFeatures): FeatureRow[] =>
   }));
 
 const featureColumns: TableColumn<FeatureRow>[] = [
-  {
-    cell: ({ feature }) => (
-      <a href={`/admin/features/${feature.slug}`}>{t(feature.labelKey)}</a>
-    ),
-    header: translatedTableHeader("features.column.feature"),
-    key: "feature",
-  },
-  {
-    cell: ({ enabled }) =>
-      t(enabled ? "features.status.enabled" : "features.status.disabled"),
-    header: translatedTableHeader("features.column.status"),
-    key: "status",
-  },
+  translatedTableColumn("feature", "features.column.feature", ({ feature }) => (
+    <a href={`/admin/features/${feature.slug}`}>{t(feature.labelKey)}</a>
+  )),
+  translatedTableColumn("status", "features.column.status", ({ enabled }) =>
+    t(enabled ? "features.status.enabled" : "features.status.disabled"),
+  ),
 ];
 
 const featureTable = defineTable(featureColumns);

--- a/src/ui/templates/admin/groups/list.tsx
+++ b/src/ui/templates/admin/groups/list.tsx
@@ -8,7 +8,7 @@ import { successListPage } from "#templates/admin/admin-page.tsx";
 import { GuideFooter } from "#templates/components/actions.tsx";
 import { itemsOrEmptyNote } from "#templates/components/reorder-list.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import type { AdminSession, Group } from "#types";
 
 /* jscpd:ignore-end */
@@ -19,16 +19,8 @@ const groupLink = (group: Group): JSX.Element => (
 
 const groupColumns: readonly TableColumn<Group, AdminSession["adminLevel"]>[] =
   [
-    {
-      cell: groupLink,
-      header: translatedTableHeader("common.name"),
-      key: "name",
-    },
-    {
-      cell: (group) => group.slug,
-      header: translatedTableHeader("common.slug"),
-      key: "slug",
-    },
+    translatedTableColumn("name", "common.name", groupLink),
+    translatedTableColumn("slug", "common.slug", (group) => group.slug),
   ];
 
 const groupsTable = defineTable(groupColumns);

--- a/src/ui/templates/admin/images.tsx
+++ b/src/ui/templates/admin/images.tsx
@@ -33,7 +33,7 @@ import {
 } from "#templates/components/linked-items.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import {
   type AdminSession,
   type Image,
@@ -126,26 +126,21 @@ const imageLinkedItemGroups = (
 };
 
 const imageColumns: readonly TableColumn<Image>[] = [
-  {
-    cell: (image) => thumbnail(image),
-    header: translatedTableHeader("images.column.thumbnail"),
-    key: "thumbnail",
-  },
-  {
-    cell: (image) =>
-      isReadOnly() ? (
-        image.name
-      ) : (
-        <a href={`/admin/images/${image.id}/edit`}>{image.name}</a>
-      ),
-    header: translatedTableHeader("common.name"),
-    key: "name",
-  },
-  {
-    cell: (image) => image.alt_text,
-    header: translatedTableHeader("images.field.alt_text"),
-    key: "alt_text",
-  },
+  translatedTableColumn("thumbnail", "images.column.thumbnail", (image) =>
+    thumbnail(image),
+  ),
+  translatedTableColumn("name", "common.name", (image) =>
+    isReadOnly() ? (
+      image.name
+    ) : (
+      <a href={`/admin/images/${image.id}/edit`}>{image.name}</a>
+    ),
+  ),
+  translatedTableColumn(
+    "alt_text",
+    "images.field.alt_text",
+    (image) => image.alt_text,
+  ),
 ];
 
 const imageTable = defineTable(imageColumns);

--- a/src/ui/templates/admin/listings/aggregates.tsx
+++ b/src/ui/templates/admin/listings/aggregates.tsx
@@ -13,8 +13,7 @@ import {
   ExpectedActualNotice,
   ExpectedActualTableRow,
 } from "#templates/admin/expected-actual.tsx";
-import type { RecalculateRow } from "#templates/admin/recalculate.tsx";
-import { buildRecalculateRows } from "#templates/admin/recalculate-rows.ts";
+import { recalculateRowsFor } from "#templates/admin/recalculate-rows.ts";
 import {
   bindRecalculatePage,
   recalculatePageRenderer,
@@ -35,27 +34,9 @@ export {
 export const nearCapacity = (listing: ListingWithCount): boolean =>
   capacityLevel(listing.attendee_count, listing.max_attendees).nearLimit;
 
-const listingAggregateFormatters: Record<
-  ListingAggregateField,
-  (value: number) => string
-> = {
-  booked_quantity: String,
-  tickets_count: String,
-};
-
-const formatListingAggregateValue = (
-  name: ListingAggregateField,
-  value: number,
-): string => listingAggregateFormatters[name](value);
-
-const listingRecalculateRows = (
-  snapshot: ListingAggregateRecalculation,
-): RecalculateRow[] =>
-  buildRecalculateRows(
-    getListingAggregateFields(),
-    formatListingAggregateValue,
-    snapshot,
-  );
+const listingRecalculateRows = recalculateRowsFor<ListingAggregateField>(
+  getListingAggregateFields,
+);
 
 /** The drift-notice copy plus the drifted running totals; the "fix it" link is
  * included only when a recalculate page is reachable. Shared by the inline

--- a/src/ui/templates/admin/logistics.tsx
+++ b/src/ui/templates/admin/logistics.tsx
@@ -35,7 +35,7 @@ import {
 import { TitledArticle } from "#templates/components/page-structure.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import { logisticsAgentForm } from "#templates/fields/listing.ts";
 import type { AdminLevel, LogisticsAgent } from "#types";
 
@@ -43,15 +43,11 @@ import type { AdminLevel, LogisticsAgent } from "#types";
 
 /** Single-column table of logistics agents (name linking to edit). */
 const agentColumns: TableColumn<LogisticsAgent>[] = [
-  {
-    cell: (agent) => (
-      <WritableLink href={adminPath("logisticsAgent", { id: agent.id })}>
-        {agent.name}
-      </WritableLink>
-    ),
-    header: translatedTableHeader("common.name"),
-    key: "name",
-  },
+  translatedTableColumn("name", "common.name", (agent) => (
+    <WritableLink href={adminPath("logisticsAgent", { id: agent.id })}>
+      {agent.name}
+    </WritableLink>
+  )),
 ];
 
 /** The logistics-agents list with inline add form (shown when logistics is on). */

--- a/src/ui/templates/admin/modifiers/aggregates.tsx
+++ b/src/ui/templates/admin/modifiers/aggregates.tsx
@@ -9,8 +9,7 @@ import type {
   ModifierAggregateRecalculation,
 } from "#db/modifiers.ts";
 import { t } from "#i18n";
-import type { RecalculateRow } from "#templates/admin/recalculate.tsx";
-import { buildRecalculateRows } from "#templates/admin/recalculate-rows.ts";
+import { recalculateRowsFor } from "#templates/admin/recalculate-rows.ts";
 import {
   bindRecalculatePage,
   type RunningTotalsConfig,
@@ -48,27 +47,9 @@ export const ModifierRunningTotalsSection = (
     config: modifierRunningTotalsConfig(props.modifier, props.values),
   });
 
-const modifierAggregateFormatters: Record<
-  ModifierAggregateField,
-  (value: number) => string
-> = {
-  total_uses: String,
-  usage_count: String,
-};
-
-const formatModifierAggregateValue = (
-  name: ModifierAggregateField,
-  value: number,
-): string => modifierAggregateFormatters[name](value);
-
-const modifierRecalculateRows = (
-  snapshot: ModifierAggregateRecalculation,
-): RecalculateRow[] =>
-  buildRecalculateRows(
-    getModifierAggregateFields(),
-    formatModifierAggregateValue,
-    snapshot,
-  );
+const modifierRecalculateRows = recalculateRowsFor<ModifierAggregateField>(
+  getModifierAggregateFields,
+);
 
 /** Renders the static config bits of the modifier recalculate page (action,
  *  labels, rows). The exported `adminModifierRecalculatePage` then binds the

--- a/src/ui/templates/admin/questions.tsx
+++ b/src/ui/templates/admin/questions.tsx
@@ -27,11 +27,8 @@ import {
   type ExpectedActualItem,
   ExpectedActualNotice,
 } from "#templates/admin/expected-actual.tsx";
-import {
-  adminRecalculatePage,
-  type RecalculateRow,
-} from "#templates/admin/recalculate.tsx";
-import { buildRecalculateRows } from "#templates/admin/recalculate-rows.ts";
+import { adminRecalculatePage } from "#templates/admin/recalculate.tsx";
+import { recalculateRowsFor } from "#templates/admin/recalculate-rows.ts";
 import { SubmitButton } from "#templates/components/actions.tsx";
 import {
   CheckboxForm,
@@ -314,14 +311,9 @@ const answerRecalculatePath = (questionId: number, answerId: number): string =>
 
 /** Build the recalculate table rows comparing the stored selection total with
  * the value rebuilt from attendee answers. */
-const answerRecalculateRows = (
-  snapshot: AnswerAggregateRecalculation,
-): RecalculateRow[] =>
-  buildRecalculateRows(
-    getAnswerAggregateFields(),
-    (_name: AnswerAggregateField, value) => String(value),
-    snapshot,
-  );
+const answerRecalculateRows = recalculateRowsFor<AnswerAggregateField>(
+  getAnswerAggregateFields,
+);
 
 /** Drifted answer aggregate columns as expected/actual items (expected = the
  * value rebuilt from attendee answers, actual = the stored running total). */

--- a/src/ui/templates/admin/recalculate-rows.ts
+++ b/src/ui/templates/admin/recalculate-rows.ts
@@ -10,7 +10,7 @@ type SnapshotValue = { current: number; recalculated: number };
 export const recalculateRowsFor =
   <Name extends string>(
     getFields: () => readonly { name: string; label: string }[],
-  ) =>
+  ): ((snapshot: Record<Name, SnapshotValue>) => RecalculateRow[]) =>
   (snapshot: Record<Name, SnapshotValue>): RecalculateRow[] =>
     getFields().map((field) => {
       const name = field.name as Name;

--- a/src/ui/templates/admin/recalculate-rows.ts
+++ b/src/ui/templates/admin/recalculate-rows.ts
@@ -4,29 +4,30 @@ import type { RecalculateRow } from "#templates/admin/recalculate.tsx";
  * and the `recalculated` count worked out fresh from the attendee records. */
 type SnapshotValue = { current: number; recalculated: number };
 
-/** Build the "stored vs recounted" rows for a recalculate page. For each
- * aggregate field it formats the stored value and the recounted value the same
- * way, so the listing and modifier recalculate pages build their rows once. */
-export const buildRecalculateRows = <Name extends string>(
-  fields: readonly { name: string; label: string }[],
-  formatValue: (name: Name, value: number) => string,
-  snapshot: Record<Name, SnapshotValue>,
-): RecalculateRow[] =>
-  fields.map((field) => {
-    const name = field.name as Name;
-    // The field list and the snapshot are paired module constants, so every
-    // field must have a snapshot value. If one is missing the pairing is wrong
-    // — fail loudly with the field name rather than crashing on `.current`.
-    const value = snapshot[name];
-    if (!value) {
-      throw new Error(
-        `Recalculate snapshot is missing the "${field.name}" field`,
-      );
-    }
-    return {
-      current: formatValue(name, value.current),
-      label: field.label,
-      name,
-      recalculated: formatValue(name, value.recalculated),
-    };
-  });
+/** Build a "stored vs recounted" row builder for one aggregate family, given
+ * the fields it can repair. Every recalculate page — listing, modifier,
+ * answer — is this one fold over its own field list. */
+export const recalculateRowsFor =
+  <Name extends string>(
+    getFields: () => readonly { name: string; label: string }[],
+  ) =>
+  (snapshot: Record<Name, SnapshotValue>): RecalculateRow[] =>
+    getFields().map((field) => {
+      const name = field.name as Name;
+      // The field list and the snapshot are paired module constants, so every
+      // field must have a snapshot value. If one is missing the pairing is
+      // wrong — fail loudly with the field name rather than crashing on
+      // `.current`.
+      const value = snapshot[name];
+      if (!value) {
+        throw new Error(
+          `Recalculate snapshot is missing the "${field.name}" field`,
+        );
+      }
+      return {
+        current: String(value.current),
+        label: field.label,
+        name,
+        recalculated: String(value.recalculated),
+      };
+    });

--- a/src/ui/templates/admin/sessions.tsx
+++ b/src/ui/templates/admin/sessions.tsx
@@ -12,33 +12,23 @@ import { successAdminPage } from "#templates/admin/admin-page.tsx";
 import { GuideFooter } from "#templates/components/actions.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import type { AdminSession, Session } from "#types";
 
 /* jscpd:ignore-end */
 
 const sessionColumns: readonly TableColumn<Session, string>[] = [
-  {
-    cell: (session) => `${session.token.slice(0, 8)}...`,
-    header: translatedTableHeader("sessions.col.token"),
-    key: "token",
-  },
-  {
-    cell: (session) =>
-      formatDatetimeShort(new Date(session.expires).toISOString()),
-    header: translatedTableHeader("sessions.col.expires"),
-    key: "expires",
-  },
-  {
-    cell: (session, currentToken) =>
-      session.token === currentToken ? (
-        <mark>{t("sessions.current")}</mark>
-      ) : (
-        ""
-      ),
-    header: translatedTableHeader("common.status"),
-    key: "status",
-  },
+  translatedTableColumn(
+    "token",
+    "sessions.col.token",
+    (session) => `${session.token.slice(0, 8)}...`,
+  ),
+  translatedTableColumn("expires", "sessions.col.expires", (session) =>
+    formatDatetimeShort(new Date(session.expires).toISOString()),
+  ),
+  translatedTableColumn("status", "common.status", (session, currentToken) =>
+    session.token === currentToken ? <mark>{t("sessions.current")}</mark> : "",
+  ),
 ];
 
 const sessionsTable = defineTable(sessionColumns);

--- a/src/ui/templates/admin/settings-statuses.tsx
+++ b/src/ui/templates/admin/settings-statuses.tsx
@@ -23,7 +23,10 @@ import { SettingsCheckbox } from "#templates/admin/settings/settings-checkbox.ts
 import { ActionButton, GuideFooter } from "#templates/components/actions.tsx";
 import { Badge } from "#templates/components/badge.tsx";
 import { ProseIntro } from "#templates/components/prose-heading.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import {
+  translatedTableColumn,
+  translatedTableHeader,
+} from "#templates/components/translated-table-column.ts";
 
 /* jscpd:ignore-end */
 
@@ -49,11 +52,9 @@ const statusColumns: TableColumn<AttendeeStatus>[] = [
     (s) => adminPath("status", { id: s.id }),
     (s) => s.name,
   ),
-  {
-    cell: (s) => statusBadges(s),
-    header: translatedTableHeader("statuses.flags_header"),
-    key: "flags",
-  },
+  translatedTableColumn("flags", "statuses.flags_header", (s) =>
+    statusBadges(s),
+  ),
 ];
 
 /** One named checkbox for a status flag. */

--- a/src/ui/templates/admin/site-pages.tsx
+++ b/src/ui/templates/admin/site-pages.tsx
@@ -25,7 +25,10 @@ import { SubmitButton } from "#templates/components/actions.tsx";
 import { InlineFormButton } from "#templates/components/inline-form-button.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import {
+  translatedTableColumn,
+  translatedTableHeader,
+} from "#templates/components/translated-table-column.ts";
 import type {
   AdminSession,
   SitePage,
@@ -109,11 +112,11 @@ const nestedPageColumns = pageColumns(nestedPage);
 
 const nestedPageTable = defineTable<NestedPageRow>([
   nestedPageColumns.name,
-  {
-    cell: ({ parentName }) => parentName,
-    header: translatedTableHeader("site.pages.parent_column"),
-    key: "parent",
-  },
+  translatedTableColumn(
+    "parent",
+    "site.pages.parent_column",
+    ({ parentName }) => parentName,
+  ),
   nestedPageColumns.actions,
 ]);
 

--- a/src/ui/templates/admin/sms.tsx
+++ b/src/ui/templates/admin/sms.tsx
@@ -14,7 +14,7 @@ import { GuideFooter } from "#templates/components/actions.tsx";
 import { SectionFieldset } from "#templates/components/aggregate-sections.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
-import { translatedTableHeader } from "#templates/components/translated-table-column.ts";
+import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
 import type { AdminSession, Attendee, ListingWithCount } from "#types";
 /* jscpd:ignore-end */
 
@@ -33,16 +33,14 @@ type SmsPageOptions = {
 };
 
 const historyColumns: readonly TableColumn<SmsHistoryItem>[] = [
-  {
-    cell: (item) => formatDatetimeShort(item.created),
-    header: translatedTableHeader("sms.contact.col_when"),
-    key: "when",
-  },
-  {
-    cell: (item) => item.message,
-    header: translatedTableHeader("sms.contact.col_message"),
-    key: "message",
-  },
+  translatedTableColumn("when", "sms.contact.col_when", (item) =>
+    formatDatetimeShort(item.created),
+  ),
+  translatedTableColumn(
+    "message",
+    "sms.contact.col_message",
+    (item) => item.message,
+  ),
 ];
 
 const smsHistoryTable = defineTable(historyColumns);

--- a/src/ui/templates/fields/admin.ts
+++ b/src/ui/templates/fields/admin.ts
@@ -299,33 +299,42 @@ const secretField = ({
   type,
 });
 
+/** One credential, named by the locale key its wording lives under: `<key>` is
+ * the label, `<key>_hint` the hint, and `<key>_placeholder` the placeholder
+ * when the catalog carries one. A credential with no example to show says so
+ * with `noPlaceholder`. */
+const credentialField = (
+  key: string,
+  name: string,
+  extra: { noPlaceholder?: true; type?: "text" } = {},
+): Field =>
+  secretField({
+    hint: t(`${key}_hint`),
+    label: t(key),
+    name,
+    ...(extra.noPlaceholder ? {} : { placeholder: t(`${key}_placeholder`) }),
+    ...(extra.type && { type: extra.type }),
+  });
+
 /**
  * Stripe key settings form field definitions (per-request builder)
  */
 export const getStripeKeyFields = (): Field[] => [
-  secretField({
-    hint: t("fields.stripe.secret_key_hint"),
-    label: t("fields.stripe.secret_key"),
-    name: PAYMENT_PROVIDERS.stripe.secretField,
-    placeholder: t("fields.stripe.secret_key_placeholder"),
-  }),
+  credentialField(
+    "fields.stripe.secret_key",
+    PAYMENT_PROVIDERS.stripe.secretField,
+  ),
 ];
 
 /**
  * Square access token and location form field definitions (per-request builder)
  */
 export const getSquareAccessTokenFields = (): Field[] => [
-  secretField({
-    hint: t("fields.square.access_token_hint"),
-    label: t("fields.square.access_token"),
-    name: PAYMENT_PROVIDERS.square.secretField,
-    placeholder: t("fields.square.access_token_placeholder"),
-  }),
-  secretField({
-    hint: t("fields.square.location_id_hint"),
-    label: t("fields.square.location_id"),
-    name: "square_location_id",
-    placeholder: t("fields.square.location_id_placeholder"),
+  credentialField(
+    "fields.square.access_token",
+    PAYMENT_PROVIDERS.square.secretField,
+  ),
+  credentialField("fields.square.location_id", "square_location_id", {
     type: "text",
   }),
 ];
@@ -334,10 +343,8 @@ export const getSquareAccessTokenFields = (): Field[] => [
  * Square webhook settings form field definitions (per-request builder)
  */
 export const getSquareWebhookFields = (): Field[] => [
-  secretField({
-    hint: t("fields.square.webhook_key_hint"),
-    label: t("fields.square.webhook_key"),
-    name: "square_webhook_signature_key",
+  credentialField("fields.square.webhook_key", "square_webhook_signature_key", {
+    noPlaceholder: true,
   }),
 ];
 
@@ -345,17 +352,8 @@ export const getSquareWebhookFields = (): Field[] => [
  * SumUp API key and merchant code form field definitions (per-request builder)
  */
 export const getSumupFields = (): Field[] => [
-  secretField({
-    hint: t("fields.sumup.api_key_hint"),
-    label: t("fields.sumup.api_key"),
-    name: PAYMENT_PROVIDERS.sumup.secretField,
-    placeholder: t("fields.sumup.api_key_placeholder"),
-  }),
-  secretField({
-    hint: t("fields.sumup.merchant_code_hint"),
-    label: t("fields.sumup.merchant_code"),
-    name: "sumup_merchant_code",
-    placeholder: t("fields.sumup.merchant_code_placeholder"),
+  credentialField("fields.sumup.api_key", PAYMENT_PROVIDERS.sumup.secretField),
+  credentialField("fields.sumup.merchant_code", "sumup_merchant_code", {
     type: "text",
   }),
 ];

--- a/test/features/admin/aggregate-recalculation.test.ts
+++ b/test/features/admin/aggregate-recalculation.test.ts
@@ -45,19 +45,28 @@ describe("parseEditableAggregateForm", () => {
       parseEditableAggregateForm(
         new FormParams({ other: "value" }),
         editableFields,
-        (values) => values,
       ),
     ).toEqual({ input: null, ok: true });
   });
 
   test("parses an aggregate when one of its fields was submitted", () => {
     expect(
-      parseEditableAggregateForm<{ name: string }, string>(
+      parseEditableAggregateForm<{ name: string }>(
         new FormParams({ name: "New name" }),
         editableFields,
-        (values) => values.name,
       ),
-    ).toEqual({ input: "New name", ok: true });
+    ).toEqual({ input: { name: "New name" }, ok: true });
+  });
+
+  // The declared fields decide the columns, so a stray form value can never
+  // reach a write.
+  test("keeps only the declared fields", () => {
+    expect(
+      parseEditableAggregateForm<{ name: string }>(
+        new FormParams({ name: "New name", other: "value" }),
+        editableFields,
+      ),
+    ).toEqual({ input: { name: "New name" }, ok: true });
   });
 });
 

--- a/test/features/admin/listings-form.test.ts
+++ b/test/features/admin/listings-form.test.ts
@@ -7,7 +7,6 @@ import { computeSlugIndex } from "#db/listings/table.ts";
 import {
   buildCreateListingResource,
   buildUpdateListingResource,
-  extractListingAggregateValues,
   parseGroupIds,
 } from "#routes/admin/listings-form.ts";
 import { VALID_DAY_NAMES } from "#shared/day-names.ts";
@@ -61,17 +60,6 @@ describeWithEnv("listings form", { db: true }, () => {
 
     test("is empty when no group is ticked", () => {
       expect(parseGroupIds(testFormParams({}))).toEqual([]);
-    });
-  });
-
-  describe("extractListingAggregateValues", () => {
-    test("keeps exactly the two aggregate columns", () => {
-      expect(
-        extractListingAggregateValues({
-          booked_quantity: 7,
-          tickets_count: 3,
-        }),
-      ).toEqual({ booked_quantity: 7, tickets_count: 3 });
     });
   });
 

--- a/test/features/admin/listings-recalculate.test.ts
+++ b/test/features/admin/listings-recalculate.test.ts
@@ -1,0 +1,147 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { listingAggregates } from "#db/listings/aggregates.ts";
+import { getListingWithCount } from "#db/listings/records.ts";
+import {
+  handleListingRecalculateGet,
+  handleListingRecalculatePost,
+} from "#routes/admin/listings-recalculate.ts";
+import { RECALCULATE_FIELD_NAME } from "#shared/recalculate-fields.ts";
+import { getAllActivityLog } from "#test-utils/activity-log.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestAttendee } from "#test-utils/db-helpers/attendees.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
+import { getTestSession } from "#test-utils/session.ts";
+
+/** A listing whose stored totals were pushed away from what its one booking
+ * says, so every test below starts from real drift to repair. */
+const listingWithDriftedTotals = async () => {
+  const listing = await createTestListing({ maxAttendees: 100 });
+  await createTestAttendee(
+    listing.id,
+    listing.slug,
+    "Counted Person",
+    "counted@example.com",
+  );
+  await listingAggregates.update(listing.id, {
+    booked_quantity: 9,
+    tickets_count: 5,
+  });
+  return listing;
+};
+
+const recalculatePath = (listingId: number): string =>
+  `/admin/listings/recalculate/${listingId}`;
+
+describeWithEnv("admin listing recalculate routes", { db: true }, () => {
+  describe("GET", () => {
+    test("shows the stored totals beside the recounted ones", async () => {
+      const listing = await listingWithDriftedTotals();
+      const { cookie } = await getTestSession();
+
+      const response = await handleListingRecalculateGet(
+        mockRequest(recalculatePath(listing.id), { headers: { cookie } }),
+        { listingId: listing.id },
+      );
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("Current");
+      expect(html).toContain("From attendee data");
+      // The stored 9 and the recounted 2 must both be on the page, or the
+      // operator cannot see what they are about to change.
+      await Deno.writeTextFile(
+        "/tmp/claude-0/-home-user-tickets/9375e6cc-caf5-549b-b40a-a36cbe28aaab/scratchpad/recalc.html",
+        html,
+      );
+    });
+
+    test("is a 404 for a listing id that does not exist", async () => {
+      const { cookie } = await getTestSession();
+      const response = await handleListingRecalculateGet(
+        mockRequest(recalculatePath(987654), { headers: { cookie } }),
+        { listingId: 987654 },
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("POST", () => {
+    test("resets the ticked total and leaves the others alone", async () => {
+      const listing = await listingWithDriftedTotals();
+      const { cookie, csrfToken } = await getTestSession();
+
+      const response = await handleListingRecalculatePost(
+        mockFormRequest(
+          recalculatePath(listing.id),
+          {
+            [RECALCULATE_FIELD_NAME]: "booked_quantity",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+        { listingId: listing.id },
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toMatch(
+        new RegExp(`^/admin/listing/${listing.id}/edit(\\?|$)`),
+      );
+      expect(response.headers.get("set-cookie")).toContain(
+        encodeURIComponent("Listing totals recalculated"),
+      );
+
+      const repaired = await getListingWithCount(listing.id);
+      expect(repaired?.attendee_count).toBe(1);
+      // tickets_count was not ticked, so it keeps the wrong stored value.
+      expect(repaired?.tickets_count).toBe(5);
+    });
+
+    test("names the listing in the activity log", async () => {
+      const listing = await listingWithDriftedTotals();
+      const { cookie, csrfToken } = await getTestSession();
+
+      await handleListingRecalculatePost(
+        mockFormRequest(
+          recalculatePath(listing.id),
+          {
+            [RECALCULATE_FIELD_NAME]: "booked_quantity",
+            csrf_token: csrfToken,
+          },
+          cookie,
+        ),
+        { listingId: listing.id },
+      );
+
+      const entries = await getAllActivityLog();
+      expect(entries.map((entry) => entry.message)).toContain(
+        `Listing '${listing.name}' totals recalculated`,
+      );
+    });
+
+    test("asks for a choice when no total is ticked, and changes nothing", async () => {
+      const listing = await listingWithDriftedTotals();
+      const { cookie, csrfToken } = await getTestSession();
+
+      const response = await handleListingRecalculatePost(
+        mockFormRequest(
+          recalculatePath(listing.id),
+          { csrf_token: csrfToken },
+          cookie,
+        ),
+        { listingId: listing.id },
+      );
+
+      // The page comes back as a client error, not a success, because the
+      // operator still has to choose.
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain(
+        "Choose at least one total to recalculate",
+      );
+      const untouched = await getListingWithCount(listing.id);
+      expect(untouched?.attendee_count).toBe(9);
+      expect(untouched?.tickets_count).toBe(5);
+    });
+  });
+});

--- a/test/features/admin/listings-recalculate.test.ts
+++ b/test/features/admin/listings-recalculate.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { listingAggregates } from "#db/listings/aggregates.ts";
 import { getListingWithCount } from "#db/listings/records.ts";
 import {
   handleListingRecalculateGet,
@@ -9,27 +8,9 @@ import {
 import { RECALCULATE_FIELD_NAME } from "#shared/recalculate-fields.ts";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { createTestAttendee } from "#test-utils/db-helpers/attendees.ts";
-import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { createListingWithDriftedTotals } from "#test-utils/db-helpers/listings.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
 import { getTestSession } from "#test-utils/session.ts";
-
-/** A listing whose stored totals were pushed away from what its one booking
- * says, so every test below starts from real drift to repair. */
-const listingWithDriftedTotals = async () => {
-  const listing = await createTestListing({ maxAttendees: 100 });
-  await createTestAttendee(
-    listing.id,
-    listing.slug,
-    "Counted Person",
-    "counted@example.com",
-  );
-  await listingAggregates.update(listing.id, {
-    booked_quantity: 9,
-    tickets_count: 5,
-  });
-  return listing;
-};
 
 const recalculatePath = (listingId: number): string =>
   `/admin/listings/recalculate/${listingId}`;
@@ -37,7 +18,7 @@ const recalculatePath = (listingId: number): string =>
 describeWithEnv("admin listing recalculate routes", { db: true }, () => {
   describe("GET", () => {
     test("shows the stored totals beside the recounted ones", async () => {
-      const listing = await listingWithDriftedTotals();
+      const listing = await createListingWithDriftedTotals();
       const { cookie } = await getTestSession();
 
       const response = await handleListingRecalculateGet(
@@ -69,7 +50,7 @@ describeWithEnv("admin listing recalculate routes", { db: true }, () => {
 
   describe("POST", () => {
     test("resets the ticked total and leaves the others alone", async () => {
-      const listing = await listingWithDriftedTotals();
+      const listing = await createListingWithDriftedTotals();
       const { cookie, csrfToken } = await getTestSession();
 
       const response = await handleListingRecalculatePost(
@@ -99,7 +80,7 @@ describeWithEnv("admin listing recalculate routes", { db: true }, () => {
     });
 
     test("names the listing in the activity log", async () => {
-      const listing = await listingWithDriftedTotals();
+      const listing = await createListingWithDriftedTotals();
       const { cookie, csrfToken } = await getTestSession();
 
       await handleListingRecalculatePost(
@@ -121,7 +102,7 @@ describeWithEnv("admin listing recalculate routes", { db: true }, () => {
     });
 
     test("asks for a choice when no total is ticked, and changes nothing", async () => {
-      const listing = await listingWithDriftedTotals();
+      const listing = await createListingWithDriftedTotals();
       const { cookie, csrfToken } = await getTestSession();
 
       const response = await handleListingRecalculatePost(

--- a/test/features/admin/listings-recalculate.test.ts
+++ b/test/features/admin/listings-recalculate.test.ts
@@ -30,12 +30,10 @@ describeWithEnv("admin listing recalculate routes", { db: true }, () => {
       const html = await response.text();
       expect(html).toContain("Current");
       expect(html).toContain("From attendee data");
-      // The stored 9 and the recounted 2 must both be on the page, or the
-      // operator cannot see what they are about to change.
-      await Deno.writeTextFile(
-        "/tmp/claude-0/-home-user-tickets/9375e6cc-caf5-549b-b40a-a36cbe28aaab/scratchpad/recalc.html",
-        html,
-      );
+      // Stored 9 and 5 beside the one booking's 1 and 1, or the operator
+      // cannot see what they are about to change.
+      expect(html).toContain("<td>9</td><td>1</td>");
+      expect(html).toContain("<td>5</td><td>1</td>");
     });
 
     test("is a 404 for a listing id that does not exist", async () => {

--- a/test/features/admin/modifiers/revenue-edit.test.ts
+++ b/test/features/admin/modifiers/revenue-edit.test.ts
@@ -4,8 +4,8 @@ import { stub } from "@std/testing/mock";
 import {
   getAllModifiers,
   getModifier,
+  modifierAggregates,
   modifiersTable,
-  updateModifierAggregateValues,
 } from "#db/modifiers.ts";
 import { handleRequest } from "#routes";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
@@ -258,7 +258,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
       await adminFormPost("/admin/modifiers", createData({ name: "Usage" }));
       const { id } = await lastModifier();
       await insertModifierUsage(id, 1, 2, 1000);
-      await updateModifierAggregateValues(id, {
+      await modifierAggregates.update(id, {
         total_uses: 9,
         usage_count: 5,
       });
@@ -280,7 +280,7 @@ describeWithEnv("server (admin modifiers)", { db: true }, () => {
       await adminFormPost("/admin/modifiers", createData({ name: "Reset" }));
       const { id } = await lastModifier();
       await insertModifierUsage(id, 1, 2, 1000);
-      await updateModifierAggregateValues(id, {
+      await modifierAggregates.update(id, {
         total_uses: 9,
         usage_count: 5,
       });

--- a/test/features/admin/questions/answers/edit.test.ts
+++ b/test/features/admin/questions/answers/edit.test.ts
@@ -305,10 +305,8 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       const listing = await createTestListing();
       await bookAnswer(listing.id, aId);
 
-      const { updateAnswerAggregateValues } = await import(
-        "#db/questions/aggregates.ts"
-      );
-      await updateAnswerAggregateValues(aId, { times_selected: 8 });
+      const { answerAggregates } = await import("#db/questions/aggregates.ts");
+      await answerAggregates.update(aId, { times_selected: 8 });
 
       const response = await adminGet(
         `/admin/questions/${qId}/answers/${aId}/recalculate`,
@@ -342,9 +340,10 @@ describeWithEnv("server (admin questions)", { db: true }, () => {
       const listing = await createTestListing();
       await bookAnswer(listing.id, aId);
 
-      const { updateAnswerAggregateValues, getAnswerSelectionTotals } =
-        await import("#db/questions/aggregates.ts");
-      await updateAnswerAggregateValues(aId, { times_selected: 99 });
+      const { answerAggregates, getAnswerSelectionTotals } = await import(
+        "#db/questions/aggregates.ts"
+      );
+      await answerAggregates.update(aId, { times_selected: 99 });
 
       const { response } = await adminFormPost(
         `/admin/questions/${qId}/answers/${aId}/recalculate`,

--- a/test/integration/db/attendees/create-attendee-atomic.test.ts
+++ b/test/integration/db/attendees/create-attendee-atomic.test.ts
@@ -5,7 +5,7 @@ import { decryptAttendees } from "#db/attendees/pii.ts";
 import { getAttendeeRaw, getAttendeesRaw } from "#db/attendees/queries.ts";
 import { dateToRange } from "#db/capacity.ts";
 import { getDb } from "#db/client.ts";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 import { getTestPrivateKey } from "#test-utils/crypto.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { expectNoAttendeesForListings } from "#test-utils/db-helpers/attendees.ts";
@@ -42,7 +42,7 @@ const expectCartRows = async (
 
 const setupBookedOutListing = async () => {
   const listing = await createTestListing({ maxAttendees: 1 });
-  await updateListingAggregateValues(listing.id, {
+  await listingAggregates.update(listing.id, {
     booked_quantity: 1,
     tickets_count: 0,
   });

--- a/test/integration/db/modifier-aggregates.test.ts
+++ b/test/integration/db/modifier-aggregates.test.ts
@@ -10,9 +10,8 @@ import {
   getModifier,
   getModifierAggregateRecalculation,
   MODIFIER_AGGREGATE_FIELDS,
+  modifierAggregates,
   modifiersTable,
-  resetModifierAggregateFields,
-  updateModifierAggregateValues,
 } from "#db/modifiers.ts";
 import { readModifierAggregates as aggregates } from "#test-utils/db/migration-test-helpers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -88,12 +87,12 @@ describeWithEnv(
       // here, not silently on the form.
       const m = await makeModifier();
       await insertModifierUsage(m.id, 1, 3, 1500);
-      await updateModifierAggregateValues(m.id, {
+      await modifierAggregates.update(m.id, {
         total_uses: 9,
         usage_count: 9,
       });
 
-      await resetModifierAggregateFields(m.id, [...MODIFIER_AGGREGATE_FIELDS]);
+      await modifierAggregates.reset(m.id, [...MODIFIER_AGGREGATE_FIELDS]);
 
       expect(await aggregates(m.id)).toEqual({
         total_uses: 3,
@@ -253,7 +252,7 @@ describeWithEnv(
       const m = await makeModifier();
       await insertModifierUsage(m.id, 1, 3, 1500);
 
-      await updateModifierAggregateValues(m.id, {
+      await modifierAggregates.update(m.id, {
         total_uses: 8,
         usage_count: 4,
       });
@@ -268,7 +267,7 @@ describeWithEnv(
       const m = await makeModifier();
       await insertModifierUsage(m.id, 1, 3, 1500);
       await insertModifierUsage(m.id, 2, 2, 1000);
-      await updateModifierAggregateValues(m.id, {
+      await modifierAggregates.update(m.id, {
         total_uses: 8,
         usage_count: 4,
       });
@@ -279,7 +278,7 @@ describeWithEnv(
         usage_count: { current: 4, recalculated: 2 },
       });
 
-      await resetModifierAggregateFields(m.id, ["total_uses"]);
+      await modifierAggregates.reset(m.id, ["total_uses"]);
 
       expect(await aggregates(m.id)).toEqual({
         total_uses: 5,

--- a/test/integration/server/groups/attendees.test.ts
+++ b/test/integration/server/groups/attendees.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 import { setDemoModeForTest } from "#shared/demo/mode.ts";
 import { expectHtmlResponse, expectStatus } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -63,7 +63,7 @@ describeWithEnv("server (admin groups) — attendee stats", { db: true }, () => 
         "actual-group@test.com",
         2,
       );
-      await updateListingAggregateValues(listing.id, {
+      await listingAggregates.update(listing.id, {
         booked_quantity: 9,
         tickets_count: 1,
       });

--- a/test/integration/server/listings/recalculate.test.ts
+++ b/test/integration/server/listings/recalculate.test.ts
@@ -1,7 +1,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 import { getListingWithCount } from "#db/listings/records.ts";
 import { handleRequest } from "#routes";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
@@ -49,7 +49,7 @@ describeWithEnv(
           "counted@example.com",
           2,
         );
-        await updateListingAggregateValues(listing.id, {
+        await listingAggregates.update(listing.id, {
           booked_quantity: 9,
           tickets_count: 5,
         });
@@ -89,7 +89,7 @@ describeWithEnv(
           gross: 9000,
           listingId: listing.id,
         });
-        await updateListingAggregateValues(listing.id, {
+        await listingAggregates.update(listing.id, {
           booked_quantity: 9,
           tickets_count: 5,
         });

--- a/test/integration/server/listings/show-basics.test.ts
+++ b/test/integration/server/listings/show-basics.test.ts
@@ -1,7 +1,7 @@
 // jscpd:ignore-start
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 import {
   assertAdminHtml,
   expectHtmlResponse,
@@ -141,7 +141,7 @@ describeWithEnv("server listings > show basics", { db: true }, () => {
         "actual@example.com",
         2,
       );
-      await updateListingAggregateValues(listing.id, {
+      await listingAggregates.update(listing.id, {
         booked_quantity: 9,
         tickets_count: 1,
       });

--- a/test/integration/servicing/aggregate-recompute-edge.test.ts
+++ b/test/integration/servicing/aggregate-recompute-edge.test.ts
@@ -15,7 +15,7 @@ import { it as test } from "@std/testing/bdd";
 import { getDb } from "#db/client.ts";
 import {
   getListingAggregateRecalculation,
-  resetListingAggregateFields,
+  listingAggregates,
 } from "#db/listings/aggregates.ts";
 import {
   getListingWithCount,
@@ -77,7 +77,7 @@ describeWithEnv(
     test("recomputing aggregates on a mixed-kind listing preserves the split", async () => {
       const listing = await setupListingLWithHoldAndAttendee();
       // Reset to zero then recompute from the live rows.
-      await resetListingAggregateFields(listing.id, [
+      await listingAggregates.reset(listing.id, [
         "booked_quantity",
         "tickets_count",
       ]);

--- a/test/integration/servicing/listing-aggregates.test.ts
+++ b/test/integration/servicing/listing-aggregates.test.ts
@@ -5,7 +5,7 @@
  * `booked_quantity` (that's what blocks capacity — §2) but NOT toward
  * `tickets_count` ("tickets sold" is a customer metric) and NOT toward `income`
  * (servicing is free). The trigger-maintained aggregates and the explicit
- * recompute (`getListingAggregateRecalculation` / `resetListingAggregateFields`)
+ * recompute (`getListingAggregateRecalculation` / `listingAggregates.reset`)
  * must agree on this split, so a recalc never re-introduces servicing into
  * tickets_count.
  *
@@ -23,7 +23,7 @@ import { accountBalance } from "#accounting/queries.ts";
 import { getDb } from "#db/client.ts";
 import {
   getListingAggregateRecalculation,
-  resetListingAggregateFields,
+  listingAggregates,
 } from "#db/listings/aggregates.ts";
 import {
   getListingWithCount,
@@ -76,7 +76,7 @@ describeWithEnv("servicing §10 — listing aggregates", { db: true }, () => {
     const listing = await createHoldAndInvalidate(3);
     const before = await getListingWithCount(listing.id);
     // Reset to zero then recompute from the live rows: the split must hold.
-    await resetListingAggregateFields(listing.id, [
+    await listingAggregates.reset(listing.id, [
       "booked_quantity",
       "tickets_count",
     ]);

--- a/test/shared/db/attendees/capacity/checks/batch.test.ts
+++ b/test/shared/db/attendees/capacity/checks/batch.test.ts
@@ -4,7 +4,7 @@ import {
   checkBatchAvailabilityImpl as checkBatchAvailability,
   checkLinesCapacity,
 } from "#db/attendees/capacity/checks.ts";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 import {
   enableQueryLog,
   getQueryLog,
@@ -246,7 +246,7 @@ describeWithEnv("db > attendees > checkBatchAvailability", { db: true }, () => {
       listingType: "standard",
       maxAttendees: 5,
     });
-    await updateListingAggregateValues(listing.id, {
+    await listingAggregates.update(listing.id, {
       booked_quantity: 5,
       tickets_count: 0,
     });

--- a/test/shared/db/attendees/capacity/remaining.test.ts
+++ b/test/shared/db/attendees/capacity/remaining.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { getListingRemainingForRange } from "#db/attendees/capacity/remaining.ts";
 import { getDb } from "#db/client.ts";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 /* jscpd:ignore-start -- imports */
 import { getListingWithCount } from "#db/listings/records.ts";
 import {
@@ -64,7 +64,7 @@ describeWithEnv(
 
     test("standard listing: remaining uses editable booked quantity", async () => {
       const listing = await createTestListing({ maxAttendees: 5 });
-      await updateListingAggregateValues(listing.id, {
+      await listingAggregates.update(listing.id, {
         booked_quantity: 4,
         tickets_count: 0,
       });

--- a/test/shared/db/common-schema.test.ts
+++ b/test/shared/db/common-schema.test.ts
@@ -1,0 +1,119 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { queryOne } from "#db/client.ts";
+import { aggregateRepairs, cachedEntityTable } from "#db/common-schema.ts";
+import type { Answer } from "#db/question-types.ts";
+import { answersTable } from "#db/questions/tables.ts";
+import {
+  getAllCacheStats,
+  invalidateCachesForTable,
+} from "#shared/cache-registry.ts";
+import {
+  addAnswer,
+  createQuestion,
+} from "#test/shared/db/questions/helpers.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+
+/** The answers table's own insert shape, which the module keeps private. */
+type AnswerRow = Parameters<typeof answersTable.insert>[0];
+
+type CachedRow = { id: number; key: string };
+
+const ROWS: CachedRow[] = [
+  { id: 1, key: "one" },
+  { id: 2, key: "two" },
+];
+
+/** A cache over the real answers table, named uniquely so the registry entry
+ * this leaves behind can never be mistaken for another test's. */
+const cacheNamed = (name: string, dependsOn: readonly string[] = []) =>
+  cachedEntityTable<Answer, AnswerRow, CachedRow>(
+    name,
+    answersTable,
+    {
+      fetchAll: () => Promise.resolve(ROWS),
+      idOf: (row) => row.id,
+      keyOf: (row) => row.key,
+      ttlMs: 60_000,
+    },
+    dependsOn,
+  );
+
+const statNamed = (name: string) =>
+  getAllCacheStats().find((stat) => stat.name === name);
+
+describe("cachedEntityTable", () => {
+  test("hands back the cache and the table it was given", async () => {
+    const entity = cacheNamed("common-schema-test-returned");
+    expect(entity.table).toBe(answersTable);
+    expect(await entity.cache.getAll()).toEqual(ROWS);
+  });
+
+  test("reports the cache's live size to the stats registry under its name", async () => {
+    const entity = cacheNamed("common-schema-test-stats");
+    expect(statNamed("common-schema-test-stats")?.entries).toBe(0);
+    await entity.cache.getAll();
+    expect(statNamed("common-schema-test-stats")?.entries).toBe(ROWS.length);
+  });
+
+  test("clears the cache when its own table is written", async () => {
+    const entity = cacheNamed("common-schema-test-own-table");
+    await entity.cache.getAll();
+    expect(entity.cache.size()).toBe(ROWS.length);
+    invalidateCachesForTable(answersTable.name);
+    expect(entity.cache.size()).toBe(0);
+  });
+
+  test("clears the cache when a table it depends on is written", async () => {
+    const entity = cacheNamed("common-schema-test-dependency", ["listings"]);
+    await entity.cache.getAll();
+    invalidateCachesForTable("listings");
+    expect(entity.cache.size()).toBe(0);
+  });
+});
+
+describeWithEnv("aggregateRepairs", { db: true }, () => {
+  const answerRepairs = aggregateRepairs<"times_selected">("answers", {
+    // Bind the id, then ignore it: this proves the factory passes the caller's
+    // own SQL through rather than knowing anything about answers.
+    times_selected: "times_selected = COALESCE((SELECT 33 WHERE ? > 0), 0)",
+  });
+
+  const storedTotal = async (answerId: number): Promise<number | undefined> =>
+    (
+      await queryOne<{ times_selected: number }>(
+        "SELECT times_selected FROM answers WHERE id = ?",
+        [answerId],
+      )
+    )?.times_selected;
+
+  const twoAnswers = async () => {
+    const question = await createQuestion("Size?");
+    return {
+      first: await addAnswer(question.id, 0, "S"),
+      second: await addAnswer(question.id, 1, "L"),
+    };
+  };
+
+  test("update writes the values, and only on the named row", async () => {
+    const { first, second } = await twoAnswers();
+    await answerRepairs.update(first.id, { times_selected: 12 });
+    expect(await storedTotal(first.id)).toBe(12);
+    expect(await storedTotal(second.id)).toBe(0);
+  });
+
+  test("reset runs the caller's SQL against the named row", async () => {
+    const { first, second } = await twoAnswers();
+    await answerRepairs.update(first.id, { times_selected: 12 });
+    await answerRepairs.reset(first.id, ["times_selected"]);
+    expect(await storedTotal(first.id)).toBe(33);
+    expect(await storedTotal(second.id)).toBe(0);
+  });
+
+  test("reset with no column named writes nothing", async () => {
+    const { first } = await twoAnswers();
+    await answerRepairs.update(first.id, { times_selected: 12 });
+    await answerRepairs.reset(first.id, []);
+    expect(await storedTotal(first.id)).toBe(12);
+  });
+});

--- a/test/shared/db/groups.test.ts
+++ b/test/shared/db/groups.test.ts
@@ -28,7 +28,7 @@ import {
   resetGroupListings,
   setGroupPackageMembers,
 } from "#db/groups.ts";
-import { updateListingAggregateValues } from "#db/listings/aggregates.ts";
+import { listingAggregates } from "#db/listings/aggregates.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
 import {
@@ -497,7 +497,7 @@ describeWithEnv("db > groups", { db: true, triggers: true }, () => {
         5,
         "manual-remaining",
       );
-      await updateListingAggregateValues(e1.id, {
+      await listingAggregates.update(e1.id, {
         booked_quantity: 4,
         tickets_count: 0,
       });

--- a/test/shared/db/listings/aggregates.test.ts
+++ b/test/shared/db/listings/aggregates.test.ts
@@ -19,15 +19,19 @@ const storedTotals = (listingId: number) =>
     [listingId],
   );
 
+/** The listing's row with its counts, refused loudly when it is not there —
+ * a listing the test just created must always come back. */
+const recalculationFor = async (listingId: number) => {
+  const listing = await getListingWithCount(listingId);
+  if (!listing) throw new Error(`No listing ${listingId} to recalculate`);
+  return getListingAggregateRecalculation(listing);
+};
+
 describeWithEnv("db > listing aggregates", { db: true }, () => {
   describe("getListingAggregateRecalculation", () => {
     test("pairs each stored total with the one rebuilt from bookings", async () => {
       const listing = await createListingWithDriftedTotals();
-      const withCount = await getListingWithCount(listing.id);
-      const recalculation = await getListingAggregateRecalculation(
-        // biome-ignore lint/style/noNonNullAssertion: the listing was just created
-        withCount!,
-      );
+      const recalculation = await recalculationFor(listing.id);
       expect(recalculation).toEqual({
         booked_quantity: { current: 9, recalculated: 1 },
         tickets_count: { current: 5, recalculated: 1 },
@@ -36,9 +40,7 @@ describeWithEnv("db > listing aggregates", { db: true }, () => {
 
     test("reads zero from a listing nobody booked", async () => {
       const listing = await createTestListing({ maxAttendees: 10 });
-      const withCount = await getListingWithCount(listing.id);
-      // biome-ignore lint/style/noNonNullAssertion: the listing was just created
-      const recalculation = await getListingAggregateRecalculation(withCount!);
+      const recalculation = await recalculationFor(listing.id);
       expect(recalculation.booked_quantity.recalculated).toBe(0);
       expect(recalculation.tickets_count.recalculated).toBe(0);
     });

--- a/test/shared/db/listings/aggregates.test.ts
+++ b/test/shared/db/listings/aggregates.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { queryOne } from "#db/client.ts";
+import {
+  adjustListingIncome,
+  getListingAggregateRecalculation,
+  listingAggregates,
+} from "#db/listings/aggregates.ts";
+import { getListingWithCount } from "#db/listings/records.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import {
+  createListingWithDriftedTotals,
+  createTestListing,
+} from "#test-utils/db-helpers/listings.ts";
+
+const storedTotals = (listingId: number) =>
+  queryOne<{ booked_quantity: number; tickets_count: number }>(
+    "SELECT booked_quantity, tickets_count FROM listings WHERE id = ?",
+    [listingId],
+  );
+
+describeWithEnv("db > listing aggregates", { db: true }, () => {
+  describe("getListingAggregateRecalculation", () => {
+    test("pairs each stored total with the one rebuilt from bookings", async () => {
+      const listing = await createListingWithDriftedTotals();
+      const withCount = await getListingWithCount(listing.id);
+      const recalculation = await getListingAggregateRecalculation(
+        // biome-ignore lint/style/noNonNullAssertion: the listing was just created
+        withCount!,
+      );
+      expect(recalculation).toEqual({
+        booked_quantity: { current: 9, recalculated: 1 },
+        tickets_count: { current: 5, recalculated: 1 },
+      });
+    });
+
+    test("reads zero from a listing nobody booked", async () => {
+      const listing = await createTestListing({ maxAttendees: 10 });
+      const withCount = await getListingWithCount(listing.id);
+      // biome-ignore lint/style/noNonNullAssertion: the listing was just created
+      const recalculation = await getListingAggregateRecalculation(withCount!);
+      expect(recalculation.booked_quantity.recalculated).toBe(0);
+      expect(recalculation.tickets_count.recalculated).toBe(0);
+    });
+  });
+
+  describe("listingAggregates.update", () => {
+    test("writes every editable total, and only for the named listing", async () => {
+      const listing = await createTestListing({ maxAttendees: 10 });
+      const other = await createTestListing({ maxAttendees: 10 });
+      await listingAggregates.update(listing.id, {
+        booked_quantity: 7,
+        tickets_count: 3,
+      });
+      expect(await storedTotals(listing.id)).toEqual({
+        booked_quantity: 7,
+        tickets_count: 3,
+      });
+      expect(await storedTotals(other.id)).toEqual({
+        booked_quantity: 0,
+        tickets_count: 0,
+      });
+    });
+  });
+
+  describe("listingAggregates.reset", () => {
+    test("rebuilds only the named column", async () => {
+      const listing = await createListingWithDriftedTotals();
+      await listingAggregates.reset(listing.id, ["booked_quantity"]);
+      expect(await storedTotals(listing.id)).toEqual({
+        booked_quantity: 1,
+        tickets_count: 5,
+      });
+    });
+
+    test("rebuilds every column when all are named", async () => {
+      const listing = await createListingWithDriftedTotals();
+      await listingAggregates.reset(listing.id, [
+        "booked_quantity",
+        "tickets_count",
+      ]);
+      expect(await storedTotals(listing.id)).toEqual({
+        booked_quantity: 1,
+        tickets_count: 1,
+      });
+    });
+
+    test("changes nothing when no column is named", async () => {
+      const listing = await createListingWithDriftedTotals();
+      await listingAggregates.reset(listing.id, []);
+      expect(await storedTotals(listing.id)).toEqual({
+        booked_quantity: 9,
+        tickets_count: 5,
+      });
+    });
+  });
+
+  describe("adjustListingIncome", () => {
+    test("moves projected income to the requested amount", async () => {
+      const listing = await createTestListing({ maxAttendees: 10 });
+      await adjustListingIncome(listing.id, 2500);
+      expect((await getListingWithCount(listing.id))?.income).toBe(2500);
+    });
+
+    test("is a no-op when the income already matches", async () => {
+      const listing = await createTestListing({ maxAttendees: 10 });
+      await adjustListingIncome(listing.id, 2500);
+      await adjustListingIncome(listing.id, 2500);
+      expect((await getListingWithCount(listing.id))?.income).toBe(2500);
+    });
+  });
+});

--- a/test/shared/db/migrations/schema/triggers/listing-aggregates.test.ts
+++ b/test/shared/db/migrations/schema/triggers/listing-aggregates.test.ts
@@ -6,8 +6,7 @@ import { getDb } from "#db/client.ts";
 import {
   adjustListingIncome,
   getListingAggregateRecalculation,
-  resetListingAggregateFields,
-  updateListingAggregateValues,
+  listingAggregates,
 } from "#db/listings/aggregates.ts";
 import {
   getListingWithCount,
@@ -190,7 +189,7 @@ describeWithEnv(
       expect(recalc.tickets_count).toEqual({ current: 1, recalculated: 1 });
       expect(recalc.booked_quantity).toEqual({ current: 3, recalculated: 3 });
 
-      await resetListingAggregateFields(listing.id, [
+      await listingAggregates.reset(listing.id, [
         "booked_quantity",
         "tickets_count",
       ]);
@@ -377,7 +376,7 @@ describeWithEnv(
       const listing = await createTestListing({ maxAttendees: 50 });
       await insertAttendee(listing.id, 1, 3);
 
-      await updateListingAggregateValues(listing.id, {
+      await listingAggregates.update(listing.id, {
         booked_quantity: 8,
         tickets_count: 4,
       });
@@ -392,7 +391,7 @@ describeWithEnv(
       const listing = await createTestListing({ maxAttendees: 50 });
       await insertAttendee(listing.id, 1, 3);
       await insertAttendee(listing.id, 2, 2);
-      await updateListingAggregateValues(listing.id, {
+      await listingAggregates.update(listing.id, {
         booked_quantity: 8,
         tickets_count: 4,
       });
@@ -403,7 +402,7 @@ describeWithEnv(
         tickets_count: { current: 4, recalculated: 2 },
       });
 
-      await resetListingAggregateFields(listing.id, ["booked_quantity"]);
+      await listingAggregates.reset(listing.id, ["booked_quantity"]);
 
       expect(await aggregates(listing.id)).toEqual({
         booked_quantity: 5,

--- a/test/shared/db/modifiers/table.test.ts
+++ b/test/shared/db/modifiers/table.test.ts
@@ -9,9 +9,8 @@ import {
   getModifierGroupListingIdsByModifierId,
   getModifierNamesByIds,
   MODIFIER_AGGREGATE_FIELDS,
+  modifierAggregates,
   modifiersTable,
-  resetModifierAggregateFields,
-  updateModifierAggregateValues,
 } from "#db/modifiers.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { insertModifier, insertModifierUsage } from "#test-utils/modifiers.ts";
@@ -93,7 +92,7 @@ describeWithEnv("db modifiers table", { db: true }, () => {
   describe("aggregates", () => {
     test("manual aggregate writes persist", async () => {
       const row = await insertModifier({ name: "Counted" });
-      await updateModifierAggregateValues(row.id, {
+      await modifierAggregates.update(row.id, {
         total_uses: 9,
         usage_count: 4,
       });
@@ -106,14 +105,12 @@ describeWithEnv("db modifiers table", { db: true }, () => {
       const row = await insertModifier({ name: "Recounted" });
       await insertModifierUsage(row.id, 1, 3, 150);
       await insertModifierUsage(row.id, 2, 2, 100);
-      await updateModifierAggregateValues(row.id, {
+      await modifierAggregates.update(row.id, {
         total_uses: 99,
         usage_count: 99,
       });
 
-      await resetModifierAggregateFields(row.id, [
-        ...MODIFIER_AGGREGATE_FIELDS,
-      ]);
+      await modifierAggregates.reset(row.id, [...MODIFIER_AGGREGATE_FIELDS]);
       const stored = await getModifier(row.id);
       expect(stored?.total_uses).toBe(5);
       expect(stored?.usage_count).toBe(2);

--- a/test/shared/db/questions/aggregates.test.ts
+++ b/test/shared/db/questions/aggregates.test.ts
@@ -1,0 +1,118 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { queryOne } from "#db/client.ts";
+import {
+  answerAggregates,
+  getAnswerAggregateRecalculation,
+  getAnswerModifierId,
+  getAnswerSelectionTotals,
+  setAnswerModifier,
+} from "#db/questions/aggregates.ts";
+import { saveAttendeeAnswers } from "#db/questions/attendee-answers/save.ts";
+import {
+  addAnswer,
+  createAttendee,
+  createQuestion,
+} from "#test/shared/db/questions/helpers.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+
+/** A question with two answers, the first picked once, then that answer's
+ * stored total pushed off the truth so every check starts from real drift. */
+const questionWithADriftedTotal = async () => {
+  const listing = await createTestListing();
+  const question = await createQuestion("Size?");
+  const small = await addAnswer(question.id, 0, "S");
+  const large = await addAnswer(question.id, 1, "L");
+  const attendee = await createAttendee(listing.id);
+  await saveAttendeeAnswers(
+    new Map([[attendee.id, { answerIds: [small.id], textAnswers: [] }]]),
+  );
+  await answerAggregates.update(small.id, { times_selected: 42 });
+  return { large, question, small };
+};
+
+const storedTotal = async (answerId: number): Promise<number | undefined> =>
+  (
+    await queryOne<{ times_selected: number }>(
+      "SELECT times_selected FROM answers WHERE id = ?",
+      [answerId],
+    )
+  )?.times_selected;
+
+describeWithEnv("db > answer aggregates", { db: true }, () => {
+  describe("getAnswerSelectionTotals", () => {
+    test("keys every answer of the question by its stored total", async () => {
+      const { question, small, large } = await questionWithADriftedTotal();
+      expect(await getAnswerSelectionTotals(question.id)).toEqual(
+        new Map([
+          [small.id, 42],
+          [large.id, 0],
+        ]),
+      );
+    });
+
+    test("is empty for a question with no answers", async () => {
+      const question = await createQuestion("Nothing?");
+      expect(await getAnswerSelectionTotals(question.id)).toEqual(new Map());
+    });
+  });
+
+  describe("getAnswerAggregateRecalculation", () => {
+    test("pairs the stored total with the one counted from attendees", async () => {
+      const { small } = await questionWithADriftedTotal();
+      expect(await getAnswerAggregateRecalculation(small.id)).toEqual({
+        times_selected: { current: 42, recalculated: 1 },
+      });
+    });
+
+    test("counts zero for an answer nobody picked", async () => {
+      const { large } = await questionWithADriftedTotal();
+      expect(await getAnswerAggregateRecalculation(large.id)).toEqual({
+        times_selected: { current: 0, recalculated: 0 },
+      });
+    });
+  });
+
+  describe("answerAggregates", () => {
+    test("update writes the total, and only for the named answer", async () => {
+      const { small, large } = await questionWithADriftedTotal();
+      await answerAggregates.update(large.id, { times_selected: 7 });
+      expect(await storedTotal(large.id)).toBe(7);
+      expect(await storedTotal(small.id)).toBe(42);
+    });
+
+    test("reset rebuilds the total from the attendee answers", async () => {
+      const { small } = await questionWithADriftedTotal();
+      await answerAggregates.reset(small.id, ["times_selected"]);
+      expect(await storedTotal(small.id)).toBe(1);
+    });
+
+    test("reset changes nothing when no column is named", async () => {
+      const { small } = await questionWithADriftedTotal();
+      await answerAggregates.reset(small.id, []);
+      expect(await storedTotal(small.id)).toBe(42);
+    });
+  });
+
+  describe("the modifier an answer triggers", () => {
+    test("is null until one is set", async () => {
+      const { small } = await questionWithADriftedTotal();
+      expect(await getAnswerModifierId(small.id)).toBeNull();
+    });
+
+    test("is read back after it is set, and cleared by null", async () => {
+      const { small } = await questionWithADriftedTotal();
+      await setAnswerModifier(small.id, 3);
+      expect(await getAnswerModifierId(small.id)).toBe(3);
+      await setAnswerModifier(small.id, null);
+      expect(await getAnswerModifierId(small.id)).toBeNull();
+    });
+
+    test("is set for the named answer alone", async () => {
+      const { small, large } = await questionWithADriftedTotal();
+      await setAnswerModifier(small.id, 3);
+      expect(await getAnswerModifierId(large.id)).toBeNull();
+    });
+  });
+});

--- a/test/shared/db/questions/queries/with-listings.test.ts
+++ b/test/shared/db/questions/queries/with-listings.test.ts
@@ -1,10 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  answerAggregates,
   getAnswerAggregateRecalculation,
   getAnswerSelectionTotals,
-  resetAnswerAggregateFields,
-  updateAnswerAggregateValues,
 } from "#db/questions/aggregates.ts";
 import { saveAttendeeAnswers } from "#db/questions/attendee-answers/save.ts";
 import {
@@ -125,7 +124,7 @@ describeWithEnv("custom questions", { db: true }, () => {
 
     test("getAnswerSelectionTotals returns the stored times_selected", async () => {
       const { a, q } = await seedAnswer();
-      await updateAnswerAggregateValues(a.id, { times_selected: 9 });
+      await answerAggregates.update(a.id, { times_selected: 9 });
       const totals = await getAnswerSelectionTotals(q.id);
       expect(totals.get(a.id)).toBe(9);
     });
@@ -141,18 +140,18 @@ describeWithEnv("custom questions", { db: true }, () => {
     test("getAnswerAggregateRecalculation flags drift from attendee answers", async () => {
       const { a } = await seedSelectedAnswer();
       // Force the stored total out of step with the one real selection.
-      await updateAnswerAggregateValues(a.id, { times_selected: 42 });
+      await answerAggregates.update(a.id, { times_selected: 42 });
 
       const recalc = await getAnswerAggregateRecalculation(a.id);
       expect(recalc.times_selected.current).toBe(42);
       expect(recalc.times_selected.recalculated).toBe(1);
     });
 
-    test("resetAnswerAggregateFields rebuilds the stored total", async () => {
+    test("answerAggregates.reset rebuilds the stored total", async () => {
       const { a } = await seedSelectedAnswer();
-      await updateAnswerAggregateValues(a.id, { times_selected: 42 });
+      await answerAggregates.update(a.id, { times_selected: 42 });
 
-      await resetAnswerAggregateFields(a.id, ["times_selected"]);
+      await answerAggregates.reset(a.id, ["times_selected"]);
 
       const recalc = await getAnswerAggregateRecalculation(a.id);
       expect(recalc.times_selected.current).toBe(1);

--- a/test/test-utils/db-helpers/listings.ts
+++ b/test/test-utils/db-helpers/listings.ts
@@ -25,6 +25,32 @@ const allDays: string[] = [
   "Sunday",
 ];
 
+/**
+ * A listing with one booking, then its stored running totals pushed off that
+ * truth. The starting point for any test about drift: the booking makes the
+ * recounted totals 1 and 1, and `stored` is what the listing wrongly claims.
+ */
+export const createListingWithDriftedTotals = async (
+  stored: { booked_quantity: number; tickets_count: number } = {
+    booked_quantity: 9,
+    tickets_count: 5,
+  },
+): Promise<Listing> => {
+  const listing = await createTestListing({ maxAttendees: 100 });
+  // Imported here rather than at the top, because the attendee helpers import
+  // this module.
+  const { createTestAttendee } = await import("./attendees.ts");
+  await createTestAttendee(
+    listing.id,
+    listing.slug,
+    "Counted Person",
+    "counted@example.com",
+  );
+  const { listingAggregates } = await import("#db/listings/aggregates.ts");
+  await listingAggregates.update(listing.id, stored);
+  return listing;
+};
+
 /** A minute-precision ISO timestamp one minute in the past — always already
  * closed. The reference `closesAt` value for "registration closed" tests. */
 export const pastCloseTime = (): string =>

--- a/test/ui/templates/admin/recalculate-rows.test.ts
+++ b/test/ui/templates/admin/recalculate-rows.test.ts
@@ -1,35 +1,41 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { buildRecalculateRows } from "#templates/admin/recalculate-rows.ts";
+import { recalculateRowsFor } from "#templates/admin/recalculate-rows.ts";
 
-describe("buildRecalculateRows", () => {
+describe("recalculateRowsFor", () => {
   const fields = [
     { label: "Booked", name: "booked" },
     { label: "Tickets", name: "tickets" },
   ];
-  const snapshot = {
-    booked: { current: 3, recalculated: 5 },
-    tickets: { current: 10, recalculated: 10 },
-  };
-  const format = (name: "booked" | "tickets", value: number): string =>
-    `${name}=${value}`;
+  const buildRows = recalculateRowsFor<"booked" | "tickets">(() => fields);
 
-  test("formats the stored and recounted value for each field", () => {
-    const rows = buildRecalculateRows(fields, format, snapshot);
+  test("shows the stored and recounted value for each field", () => {
+    const rows = buildRows({
+      booked: { current: 3, recalculated: 5 },
+      tickets: { current: 10, recalculated: 10 },
+    });
     expect(rows).toEqual([
+      { current: "3", label: "Booked", name: "booked", recalculated: "5" },
       {
-        current: "booked=3",
-        label: "Booked",
-        name: "booked",
-        recalculated: "booked=5",
-      },
-      {
-        current: "tickets=10",
+        current: "10",
         label: "Tickets",
         name: "tickets",
-        recalculated: "tickets=10",
+        recalculated: "10",
       },
     ]);
+  });
+
+  // The field labels come from t(), so they must be read per request rather
+  // than frozen when the module loads.
+  test("reads the field list again on every call", () => {
+    let label = "First";
+    const rows = recalculateRowsFor<"booked">(() => [
+      { label, name: "booked" },
+    ]);
+    const snapshot = { booked: { current: 1, recalculated: 2 } };
+    expect(rows(snapshot)[0]?.label).toBe("First");
+    label = "Second";
+    expect(rows(snapshot)[0]?.label).toBe("Second");
   });
 
   test("throws, naming the field, when the snapshot is missing one", () => {
@@ -37,7 +43,7 @@ describe("buildRecalculateRows", () => {
       "booked" | "tickets",
       { current: number; recalculated: number }
     >;
-    expect(() => buildRecalculateRows(fields, format, missing)).toThrow(
+    expect(() => buildRows(missing)).toThrow(
       'Recalculate snapshot is missing the "tickets" field',
     );
   });


### PR DESCRIPTION
## What this changes

`deno task cpd` compares exact runs of tokens. Two blocks that do the same
work with different names, different numbers, or a different count of fields
never match, so they pass the 0% gate untouched. This branch finds those
blocks with a second kind of scan and merges them.

The scan replaces every identifier and every literal with one symbol, then
looks for repeated shapes. It reports what jscpd calls a type-2 clone: the
same code, renamed. Eleven sites survived a read. Each one is now a single
mechanism. Two dead parameters came out with them.

## The merges

### One unit ladder, not three

`src/shared/limits.ts` held the same "step down until the number fits, round
it, add the suffix" loop three times, for bytes, for milliseconds, and for
seconds. Only the step sizes and the suffixes differed, so jscpd saw three
unrelated functions.

All three are now `laddered(rungs, baseSuffix)` with their own rungs.
`formatLimitValue` chose between them with an if-chain, which meant a new unit
could fall through in silence. It now reads a record.

### One way to repair an aggregate, not three

Listings, modifiers and answers each carry counter columns that database
triggers maintain and the owner can repair. Each of the three declared a
`reset` wrapper and an `update` wrapper. The wrappers differed only in the
table name and the recount SQL.

Two of the three `update` wrappers also wrote UPDATE SQL by hand that
`executeUpdate` already builds. All three now declare
`aggregateRepairs(table, resetSql)`, and callers say `listingAggregates.reset`
or `modifierAggregates.update`.

### One recalculate row builder, and a dead parameter removed

`buildRecalculateRows` took a `formatValue` argument so each family could
format its own numbers. All three callers answered it with `String`. Two of
them reached that answer through a per-column record whose every entry was
`String`, which is why the two looked different to jscpd.

The parameter and both records are gone. `recalculateRowsFor(getFields)` now
takes the snapshot. The field list is read on every call, because the labels
come from the message catalog and must follow a rename.

### One aggregate form parser, and a second dead parameter removed

`parseEditableAggregateForm` took a `toInput` argument so each family could
map its validated values onto its stored columns. All three families answered
it with a function that copies every field and changes nothing, which is why
no two of them matched. `validateForm` already returns one value per declared
field, so the mapping had nothing to do. The parameter and the three copies
are gone, and a test now pins that the declared fields decide the columns.

### One wallet settings handler, not two

The Apple Wallet form declared its three secret uploads as data and folded
over them. The Google Wallet form wrote the same clear, save and validate
logic by hand for its one secret. Different field counts and different names
meant no token run matched.

Both forms now declare a `WalletForm`: its text fields, its secret uploads,
its log lines, and whether saved config exists to fall back on. One handler
reads that declaration. Apple's extra rule, that the signing certificate and
the signing key must be a matching pair, is a named `pairCheck` on its own
declaration rather than a branch in shared code.

### One table-column call, not 32 object literals

`translatedTableColumn(key, headerKey, cell)` already existed, and 28 columns
used it. Another 32 across 15 files still wrote the object literal it builds.
jscpd could not see them, because each one names a different key and holds a
different cell body. All 32 now call it, and nine files no longer import
`translatedTableHeader` at all.

### One "is this integration set up" check, not six

Six `is<Integration>Enabled` answers in `config.ts` each asked whether every
one of a named set of environment variables carries a value. They matched no
token run, because they name different variables and count between one and
three of them. All six now read `allEnvSet("A", "B")`.

### One alias translation, and one walk over the table

`scripts/check-imports/rules.ts` read an alias forwards in `pathFor` and
backwards in `spellingFor`. The two were the same three lines with `name` and
`target` swapped. It also walked the alias table twice to pick a winner, once
by longest alias and once by shortest spelling.

The translation is now `across(from, to)`. The walk is `bestFromAliases`,
which takes the answer to read from one alias and the rule that says which of
two answers wins.

### One registrar, not two

`registerCache` and `registerCacheReset` both added a member to a set and
handed back the function that removes it. Both are now `registrar(set)`.

### One credential field, not six

Six payment-provider credential fields each read a label, a hint, and a
placeholder out of the message catalog under one key base. Different provider
names and one field with no placeholder meant no two matched. All six now
name their key base and let `credentialField` read the three.

### One whole-table file sweep, not two

`deleteAllListingAttachmentFiles` and `deleteAllImageStorageFiles` both walked
a list and called a per-record delete with the reason "database reset". Only
the record type and the delete differed. Both now come from
`deletesEveryFileFor(deleteOne)`.

### One "report this CDN failure" step, not five

Five steps in the Bunny CDN domain flows logged a failed call and returned the
same failure. Each named a different result variable, and one sat behind a
wider guard. All five now call `reported(failure)`.

## What the first merges surfaced

The duplication check went red after the first commit, which is what it is
for. Two more merges came out of it.

- The wallet form's text field and its secret field declared the same three
  members. The secret field now extends the text field.
- The listing and answer aggregate modules import the same three names from
  `#db/common-schema.ts`. An import block is the one sanctioned ignore, so it
  carries the tag rather than a fake difference.

The table-column fold also moved four recorded equivalent mutants: their
string sat inside a `key` property and now sits in a call argument, so their
anchors changed. Each still survives the lint and type-check gates, and the
reason recorded for each still holds, because it is about what the caller
supplies. Every entry carries its new anchor.

## What an operator sees

Nothing. Every merge keeps the same behaviour. The formatted sizes and
durations, the recalculate pages, the wallet settings forms, the admin tables,
the CDN domain flows, and the import check all give the same answers as
before.

## Testing

- `deno task lint`, `deno check src test`, `deno task cpd`, and
  `deno task check:equivalents` all pass.
- The affected suites pass: the limits tests, the listing, modifier and answer
  aggregate suites, the recalculate page routes, the Apple Wallet settings
  routes, the Bunny CDN domain suites, the storage deletion tests, the field
  contract tests, the i18n coverage test, and the import-rule tests.
- `test/ui/templates/admin/recalculate-rows.test.ts` is rewritten for the new
  shape. It adds a check that the field list is read again on every call,
  which is what keeps a renamed label correct.
- The test for the removed identity mapper is replaced by one that pins the
  behaviour that actually matters: a stray form value never reaches a write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMxkK2Zv9TAPDQQgNhpJ37