### PR TITLE
Break the reservations triangle by homing the fields fold

### DIFF
--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -205,3 +205,15 @@ src/features/router.ts::routeSpecificity.literalLength~0au8fma   → "mutated"  
 src/features/admin/bulk-email.ts::getBulkAvailability.disabledReason~0ah9p7f   → "mutated"   # this reason belongs to the configured case, and both pages render disabledReason only when canBulkSend is false
 src/features/admin/bulk-email.ts::handlePreviewGet.providerLabel~0tea227   → "mutated"   # this label belongs to the unavailable case, and the preview page renders providerLabel only inside its canBulkSend branch
 src/features/admin/bulk-email.ts::handleComposeGet.draft.marketing~0aepv7o  ?? → ||   # marketing is a boolean, whose only falsy value is the false the fallback supplies, so no draft distinguishes the two operators
+
+# Form-quantity fallbacks: the parser answers a whole number or null, and the
+# fallback for null is the same 0 that the literal "0" parses to, so no posted
+# value tells the operators or the spellings apart.
+src/features/public/ticket-form.ts::collectValuesByListing.list~0zcnvvx  ?? → ||   # the answer bucket is an array or absent, and an array is always truthy
+src/features/public/ticket-form.ts::parseQuantities.raw~11sglfa  0 → ""   # "" parses to null then the minimum supplies 0; the literal "0" parses to 0 directly
+src/features/public/ticket-form.ts::parseAddOnSelections.quantity~1ksz3r2  0 → ""   # both spellings parse to zero add-ons, which the caller drops
+src/features/public/ticket-submit/parse.ts::validateFormState.selectedQty~1av017t  ?? → ||   # the parser answers a whole number or null, and 0 is the fallback, so 0 || 0 = 0 ?? 0
+src/features/public/ticket-submit/parse.ts::validateFormState.selectedQty~1bh9sz0  ?? → ||   # form.get answers a string or absent; "" parses to null and falls to the same 0 the "0" literal parses to
+src/features/public/ticket-submit/parse.ts::validateFormState.selectedQty~1bh9sz0  0 → ""   # "" parses to null then the outer fallback supplies 0; the literal "0" parses to 0 directly
+src/features/public/ticket-submit/parse.ts::parseCustomPrices.qty~0q3jgeq  ?? → ||   # the quantities map holds whole counts, and 0 is the fallback, so 0 || 0 = 0 ?? 0
+src/features/public/ticket-submit/parse.ts::parsePackageCount~1t2qol5  ?? → ||   # the parser answers a whole number or null, and 0 is the fallback, so 0 || 0 = 0 ?? 0

--- a/src/features/public/ticket-form.ts
+++ b/src/features/public/ticket-form.ts
@@ -11,11 +11,9 @@ import type { QuestionListingMap } from "#db/questions/queries.ts";
 import { filter, map } from "#fp";
 import { errorRedirect, htmlResponse } from "#routes/response.ts";
 import type { FormParams } from "#shared/form-data.ts";
-import { mergeListingFields } from "#shared/listing-fields.ts";
 import { parseNonNegativeInt } from "#shared/validation/number.ts";
 import { extractContact } from "#templates/fields/ticket.ts";
 import { ticketPage } from "#templates/public/reservations/ticket-page.tsx";
-import type { ListingFields } from "#types";
 import type { ListingQty, TicketCtx } from "./types.ts";
 
 /** Parse and validate a quantity value from a raw string, capping at max */
@@ -188,10 +186,5 @@ export const parseAddOnSelections = (
   }
   return selections;
 };
-
-/** Determine merged fields setting for selected listings */
-export const getTicketFieldsSetting = (
-  listings: TicketListing[],
-): ListingFields => mergeListingFields(listings.map((e) => e.listing.fields));
 
 export { extractContact };

--- a/src/features/public/ticket-form.ts
+++ b/src/features/public/ticket-form.ts
@@ -133,7 +133,7 @@ export const ticketResponse =
  * so the visitor keeps everything they entered. */
 export const ticketFormErrorResponse = (ctx: TicketCtx) => {
   const url = ctx.actionUrl ?? `/ticket/${ctx.slugs.join("+")}`;
-  return (error: string, _status = 400) => errorRedirect(url, error);
+  return (error: string) => errorRedirect(url, error);
 };
 
 /** Parse quantity values from ticket form */

--- a/src/features/public/ticket-submit/parse.ts
+++ b/src/features/public/ticket-submit/parse.ts
@@ -25,7 +25,6 @@ import {
 import { getOrCreateStringIds } from "#db/questions/strings.ts";
 import {
   type AnswerInfo,
-  getTicketFieldsSetting,
   listingAnswerMaps,
   parseQuantities,
   ticketFormErrorResponse,
@@ -35,6 +34,7 @@ import {
   type TicketCtx,
 } from "#routes/public/types.ts";
 import type { FormParams } from "#shared/form-data.ts";
+import { getTicketFieldsSetting } from "#shared/listing-fields.ts";
 import type { CheckoutIntent } from "#shared/payments.ts";
 import { verifyQrBookToken } from "#shared/qr-token.ts";
 import { parseNonNegativeInt } from "#shared/validation/number.ts";

--- a/src/shared/listing-fields.ts
+++ b/src/shared/listing-fields.ts
@@ -37,3 +37,10 @@ export const mergeListingFields = (
   }
   return CONTACT_FIELDS.filter((f) => allFields.has(f)).join(",");
 };
+
+/** The merged contact-fields setting for a page's listings: every listing's
+ * own setting, folded into one. Takes anything with a listing that names its
+ * contact fields, so this module stays free of booking-model imports. */
+export const getTicketFieldsSetting = (
+  listings: ReadonlyArray<{ listing: { fields: ListingFields } }>,
+): ListingFields => mergeListingFields(listings.map((e) => e.listing.fields));

--- a/src/ui/templates/public/reservations/contact-fields.ts
+++ b/src/ui/templates/public/reservations/contact-fields.ts
@@ -8,9 +8,11 @@
 import type { TicketListing } from "#booking/model.ts";
 import type { PagePackage } from "#booking/page-packages.ts";
 import type { AddOnOption } from "#db/modifier-resolve.ts";
-import { getTicketFieldsSetting } from "#routes/public/ticket-form.ts";
 import type { Field } from "#shared/forms/field.ts";
-import { mergeListingFields } from "#shared/listing-fields.ts";
+import {
+  getTicketFieldsSetting,
+  mergeListingFields,
+} from "#shared/listing-fields.ts";
 import { getTicketFields } from "#templates/fields/ticket.ts";
 import { isPaidListing } from "#types";
 

--- a/test/features/api/payment-processing/create/answers.test.ts
+++ b/test/features/api/payment-processing/create/answers.test.ts
@@ -3,7 +3,7 @@ import { it as test } from "@std/testing/bdd";
 import { getDb } from "#db/client.ts";
 import { getListingWithCount } from "#db/listings/records.ts";
 import { getOrCreateStringIds } from "#db/questions/strings.ts";
-import { answersTable, questionsTable } from "#db/questions/tables.ts";
+import { questionsTable } from "#db/questions/tables.ts";
 import {
   type CreatedEntry,
   saveSessionAnswers,
@@ -12,6 +12,7 @@ import { bookingIntent } from "#test/features/api/payment-processing/index/helpe
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestAttendee } from "#test-utils/db-helpers/attendees.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { createQuestionWithAnswer } from "#test-utils/db-helpers/questions.ts";
 
 const bookedEntry = async (): Promise<CreatedEntry> => {
   const listing = await createTestListing({ maxAttendees: 5 });
@@ -45,20 +46,12 @@ const saveAndReadAnswers = async (
 describeWithEnv("paid booking answer saves", { db: true }, () => {
   test("saves a choice answer missing from the paid-order snapshot", async () => {
     const entry = await bookedEntry();
-    const question = await questionsTable.insert({
-      displayType: "radio",
-      text: "Choose one",
-    });
-    const answer = await answersTable.insert({
-      questionId: question.id,
-      sortOrder: 0,
-      text: "Chosen",
-    });
+    const { answerId, questionId } = await createQuestionWithAnswer();
     const saved = await saveAndReadAnswers(entry, {
-      listingAnswerIds: { [entry.listing.id]: [answer.id] },
+      listingAnswerIds: { [entry.listing.id]: [answerId] },
     });
     expect(saved).toEqual([
-      { answer_id: answer.id, question_id: question.id, string_id: null },
+      { answer_id: answerId, question_id: questionId, string_id: null },
     ]);
   });
 

--- a/test/features/public/ticket-form.test.ts
+++ b/test/features/public/ticket-form.test.ts
@@ -7,10 +7,18 @@ import { groupListingAnswerSets } from "#db/questions/attendee-answers/save.ts";
 import {
   type AnswerInfo,
   listingAnswerMaps,
+  listingsWithQuantity,
   parseAddOnSelections,
   parseQuantities,
+  parseQuantityValue,
+  resolvePageDate,
+  ticketFormErrorResponse,
+  ticketResponse,
 } from "#routes/public/ticket-form.ts";
 import { FormParams } from "#shared/form-data.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { ticketContext } from "#test-utils/ticket-ctx.ts";
 
 const question = (
   id: number,
@@ -268,5 +276,105 @@ describe("parseQuantities", () => {
       tl(3, { maxPurchasable: 5 }),
     ]);
     expect(result).toEqual(new Map([[3, 2]]));
+  });
+
+  test("leaves out a listing whose box is absent or carries no number", () => {
+    // An absent or cleared box must read as zero tickets, never one.
+    const form = new FormParams(new URLSearchParams({ quantity_2: "abc" }));
+    expect(parseQuantities(form, [tl(1, {}), tl(2, {})])).toEqual(new Map());
+  });
+});
+
+describe("parseQuantityValue", () => {
+  test("lifts a too-small count to one and clamps a too-large count at the max", () => {
+    expect(parseQuantityValue("0", 5)).toBe(1);
+    expect(parseQuantityValue("", 5)).toBe(1);
+    expect(parseQuantityValue("3", 5)).toBe(3);
+    expect(parseQuantityValue("9", 5)).toBe(5);
+  });
+});
+
+describe("listingsWithQuantity", () => {
+  const tl = (id: number): TicketListing =>
+    ({
+      isClosed: false,
+      isSoldOut: false,
+      listing: { id },
+      maxPurchasable: 10,
+    }) as unknown as TicketListing;
+
+  test("keeps only the listings the buyer chose tickets for", () => {
+    const chosen = tl(1);
+    const declined = tl(2);
+    expect(
+      listingsWithQuantity(
+        [chosen, declined],
+        new Map([
+          [1, 2],
+          [2, 0],
+        ]),
+      ),
+    ).toEqual([{ listing: { id: 1 }, qty: 2 }]);
+  });
+
+  test("reads a listing the quantities map omits as zero", () => {
+    expect(listingsWithQuantity([tl(1)], new Map())).toEqual([]);
+  });
+});
+
+describe("resolvePageDate", () => {
+  test("a dateless page has no date to choose", () => {
+    expect(resolvePageDate([], null)).toEqual({ date: null, ok: true });
+  });
+
+  test("keeps a submitted date the page offers", () => {
+    expect(resolvePageDate(["2026-05-01", "2026-05-02"], "2026-05-02")).toEqual(
+      { date: "2026-05-02", ok: true },
+    );
+  });
+
+  test("refuses a page with dates when nothing was submitted", () => {
+    // One offered date: a length check off by one would treat this as chosen.
+    expect(resolvePageDate(["2026-05-01"], null)).toEqual({
+      error: "Please select a valid date",
+      ok: false,
+    });
+  });
+
+  test("refuses a submitted date the page does not offer", () => {
+    expect(resolvePageDate(["2026-05-01"], "2026-05-09")).toEqual({
+      error: "Please select a valid date",
+      ok: false,
+    });
+  });
+});
+
+describeWithEnv("ticket responses", { db: true }, () => {
+  test("answers with the rendered page at 200 by default", async () => {
+    const listing = await createTestListing({ maxAttendees: 5 });
+    const ctx = await ticketContext([listing.id]);
+
+    const response = ticketResponse(ctx)();
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain(listing.name);
+  });
+
+  test("carries the error and status it is given", async () => {
+    const listing = await createTestListing({ maxAttendees: 5 });
+    const ctx = await ticketContext([listing.id]);
+
+    const response = ticketResponse(ctx)("No room", 400);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("No room");
+  });
+
+  test("redirects a form error back to the page the form lives on", async () => {
+    const listing = await createTestListing({ maxAttendees: 5 });
+    const ctx = await ticketContext([listing.id]);
+
+    const response = ticketFormErrorResponse(ctx)("Pick one");
+    expect(response.headers.get("Location")).toContain(
+      `/ticket/${listing.slug}`,
+    );
   });
 });

--- a/test/features/public/ticket-form.test.ts
+++ b/test/features/public/ticket-form.test.ts
@@ -18,7 +18,7 @@ import {
 import { FormParams } from "#shared/form-data.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
-import { ticketContext } from "#test-utils/ticket-ctx.ts";
+import { ticketContext, twoListingContext } from "#test-utils/ticket-ctx.ts";
 
 const question = (
   id: number,
@@ -220,13 +220,13 @@ describe("parseAddOnSelections", () => {
     new FormParams(new URLSearchParams(record));
 
   test("reads each selected add-on's quantity, clamped to its ceiling", () => {
-    const result = parseAddOnSelections(form({ addon_5: "2", addon_6: "99" }), [
+    const result = parseAddOnSelections(form({ addon_5: "1", addon_6: "99" }), [
       addOn(5, 10),
       addOn(6, 3),
     ]);
     expect(result).toEqual(
       new Map([
-        [5, 2],
+        [5, 1],
         [6, 3],
       ]),
     );
@@ -283,6 +283,11 @@ describe("parseQuantities", () => {
     const form = new FormParams(new URLSearchParams({ quantity_2: "abc" }));
     expect(parseQuantities(form, [tl(1, {}), tl(2, {})])).toEqual(new Map());
   });
+
+  test("keeps a listing the buyer chose exactly one ticket for", () => {
+    const form = new FormParams(new URLSearchParams({ quantity_1: "1" }));
+    expect(parseQuantities(form, [tl(1, {})])).toEqual(new Map([[1, 1]]));
+  });
 });
 
 describe("parseQuantityValue", () => {
@@ -310,11 +315,11 @@ describe("listingsWithQuantity", () => {
       listingsWithQuantity(
         [chosen, declined],
         new Map([
-          [1, 2],
+          [1, 1],
           [2, 0],
         ]),
       ),
-    ).toEqual([{ listing: { id: 1 }, qty: 2 }]);
+    ).toEqual([{ listing: { id: 1 }, qty: 1 }]);
   });
 
   test("reads a listing the quantities map omits as zero", () => {
@@ -369,12 +374,12 @@ describeWithEnv("ticket responses", { db: true }, () => {
   });
 
   test("redirects a form error back to the page the form lives on", async () => {
-    const listing = await createTestListing({ maxAttendees: 5 });
-    const ctx = await ticketContext([listing.id]);
+    const { ctx, first, second } = await twoListingContext();
 
     const response = ticketFormErrorResponse(ctx)("Pick one");
+    // Two listings share one page address, joined by a plus.
     expect(response.headers.get("Location")).toContain(
-      `/ticket/${listing.slug}`,
+      `/ticket/${first.slug}+${second.slug}`,
     );
   });
 });

--- a/test/features/public/ticket-submit/parse.test.ts
+++ b/test/features/public/ticket-submit/parse.test.ts
@@ -155,6 +155,19 @@ describeWithEnv("ticket-submit parse", { db: true }, () => {
         validateFormState(quantityForm({ [second.id]: 1 }), halfClosed),
       ).toBeNull();
     });
+
+    test("reads a quantity box that carries no number as zero", async () => {
+      // A crafted or half-cleared POST must not read as a chosen quantity.
+      const { ctx, first } = await twoListingContext();
+      const halfClosed = withListings(ctx, [
+        buildTicketListing(ctx.listings[0]!.listing, true, undefined),
+        ctx.listings[1]!,
+      ]);
+      const form = quantityForm({});
+      form.set(`quantity_${first.id}`, "abc");
+
+      expect(validateFormState(form, halfClosed)).toBeNull();
+    });
   });
 
   describe("validateTicketFields", () => {
@@ -236,6 +249,17 @@ describeWithEnv("ticket-submit parse", { db: true }, () => {
         await signedTokenFor(listing.slug),
       );
       expect(prices.get(listing.id)).toBe(2500);
+    });
+
+    test("applies a free-price token as a zero-price override", async () => {
+      const listing = await createTestListing({ unitPrice: 1000 });
+      const ctx = await ticketContext([listing.id]);
+
+      const prices = await pricesAfterOverride(
+        ctx,
+        await signQrBookToken(listing.slug, buildQrBookPayload({ value: 0 })),
+      );
+      expect(prices.get(listing.id)).toBe(0);
     });
 
     test("leaves prices alone when no token is posted", async () => {
@@ -360,7 +384,8 @@ describeWithEnv("ticket-submit parse", { db: true }, () => {
       expect(quantities.get(listing.id)).toBe(3);
     });
 
-    test("multiplies one package count across the package's member", async () => {
+    /** A hidden package and one member it can book. */
+    const mysteryBoxMember = async () => {
       const group = await createHiddenPackageGroup("Mystery Box");
       const member = await createTestListing({
         groupId: group.id,
@@ -368,11 +393,37 @@ describeWithEnv("ticket-submit parse", { db: true }, () => {
         maxQuantity: 5,
         name: "Secret Contents",
       });
-      const form = new FormParams();
-      form.set(packageQuantityFieldName(group.id), "2");
+      return {
+        form: (count: string) => {
+          const form = new FormParams();
+          form.set(packageQuantityFieldName(group.id), count);
+          return form;
+        },
+        group,
+        member,
+      };
+    };
 
-      const { quantities } = await resolvedQuantities([member.id], form, group);
-      expect(quantities.get(member.id)).toBe(2);
+    test("multiplies one package count across the package's member", async () => {
+      const box = await mysteryBoxMember();
+
+      const { quantities } = await resolvedQuantities(
+        [box.member.id],
+        box.form("2"),
+        box.group,
+      );
+      expect(quantities.get(box.member.id)).toBe(2);
+    });
+
+    test("books nothing when the package count carries no number", async () => {
+      const box = await mysteryBoxMember();
+
+      const { quantities } = await resolvedQuantities(
+        [box.member.id],
+        box.form("abc"),
+        box.group,
+      );
+      expect(quantities.get(box.member.id) ?? 0).toBe(0);
     });
   });
 });

--- a/test/features/public/ticket-submit/parse.test.ts
+++ b/test/features/public/ticket-submit/parse.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Direct tests for the submitted-booking parsers: page-state refusals,
+ * contact-field validation, custom prices, QR overrides, answer maps, and
+ * the quantities each standalone selector or package count resolves to.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { buildBookingTree } from "#booking/build-tree.ts";
+import { buildTicketListing } from "#booking/model.ts";
+import {
+  customPriceFieldName,
+  packageQuantityFieldName,
+} from "#booking/tree.ts";
+import { questionListings } from "#db/questions/queries.ts";
+import { questionsTable } from "#db/questions/tables.ts";
+import type { AnswerInfo } from "#routes/public/ticket-form.ts";
+import { ctxToBuildTreeInput } from "#routes/public/ticket-payment.ts";
+import {
+  applyQrTokenOverride,
+  computeListingAnswerMap,
+  computeListingTextAnswerIdMap,
+  parseCustomPrices,
+  resolvePageQuantities,
+  validateFormState,
+  validateTicketFields,
+} from "#routes/public/ticket-submit/parse.ts";
+import type { TicketCtx } from "#routes/public/types.ts";
+import { FormParams } from "#shared/form-data.ts";
+import { buildQrBookPayload, signQrBookToken } from "#shared/qr-token.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createHiddenPackageGroup } from "#test-utils/db-helpers/groups.ts";
+import { priceFormValue } from "#test-utils/db-helpers/listing-forms.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { createQuestionWithAnswer } from "#test-utils/db-helpers/questions.ts";
+import {
+  quantityForm,
+  ticketContext,
+  twoListingContext,
+} from "#test-utils/ticket-ctx.ts";
+
+/** The page context with its listings replaced, for the state a real page
+ * cannot reach in one shot (a closed listing beside an open one). */
+const withListings = (
+  ctx: TicketCtx,
+  listings: ReturnType<typeof buildTicketListing>[],
+): TicketCtx => ({ ...ctx, listings });
+
+/** A pay-more listing's custom-price outcome: the listing is created with the
+ * given overrides, its field carries `priceMinor`, and the parser answers. */
+const customPriceOutcome = async (
+  overrides: Record<string, unknown>,
+  priceMinor: number,
+) => {
+  const listing = await createTestListing({
+    canPayMore: true,
+    unitPrice: 1000,
+    ...overrides,
+  });
+  const ctx = await ticketContext([listing.id]);
+  const form = quantityForm({ [listing.id]: 1 });
+  form.set(customPriceFieldName(listing.id), priceFormValue(priceMinor));
+  return {
+    listing,
+    result: parseCustomPrices(form, ctx, new Map([[listing.id, 1]])),
+  };
+};
+
+/** A QR token signed for `slug`, carrying one fixed override price. */
+const signedTokenFor = (slug: string): Promise<string> =>
+  signQrBookToken(slug, buildQrBookPayload({ value: 2500 }));
+
+/** The prices after the override ran on a form carrying `token` (or none). */
+const pricesAfterOverride = async (
+  ctx: TicketCtx,
+  token: string | null,
+): Promise<Map<number, number>> => {
+  const form = new FormParams();
+  if (token !== null) form.set("qr_token", token);
+  const prices = new Map<number, number>();
+  await applyQrTokenOverride(form, ctx, prices);
+  return prices;
+};
+
+/** The submitted answers of a one-listing order: no answers at all unless
+ * `chosen` or `typed` says otherwise. */
+const answerInfo = (
+  ctx: TicketCtx,
+  listingId: number,
+  chosen: { answerIds: number[]; textAnswers: AnswerInfo["textAnswers"] } = {
+    answerIds: [],
+    textAnswers: [],
+  },
+): AnswerInfo => ({
+  activeQuestions: ctx.questions,
+  selectedListingIds: new Set([listingId]),
+  ...chosen,
+});
+
+describeWithEnv("ticket-submit parse", { db: true }, () => {
+  describe("validateFormState", () => {
+    test("refuses a form that skipped the terms box", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const ctx = { ...(await ticketContext([listing.id])), terms: "/terms" };
+
+      expect(validateFormState(quantityForm({ [listing.id]: 1 }), ctx)).toBe(
+        "You must agree to the terms and conditions",
+      );
+    });
+
+    test("accepts the same form with the terms box ticked", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const ctx = { ...(await ticketContext([listing.id])), terms: "/terms" };
+      const form = quantityForm({ [listing.id]: 1 });
+      form.set("agree_terms", "1");
+
+      expect(validateFormState(form, ctx)).toBeNull();
+    });
+
+    test("says registration closed when every listing is closed", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const ctx = await ticketContext([listing.id]);
+      const closed = withListings(ctx, [
+        buildTicketListing(ctx.listings[0]!.listing, true, undefined),
+      ]);
+
+      expect(validateFormState(quantityForm({}), closed)).toBe(
+        "Sorry, registration closed while you were submitting.",
+      );
+    });
+
+    test("says sold out when the page has no spots left", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const ctx = await ticketContext([listing.id]);
+      const soldOut = withListings(ctx, [
+        buildTicketListing(ctx.listings[0]!.listing, false, 0),
+      ]);
+
+      expect(validateFormState(quantityForm({}), soldOut)).toBe(
+        "Sorry, not enough spots available",
+      );
+    });
+
+    test("refuses a quantity chosen on a closed listing", async () => {
+      const { ctx, first, second } = await twoListingContext();
+      const halfClosed = withListings(ctx, [
+        buildTicketListing(ctx.listings[0]!.listing, true, undefined),
+        ctx.listings[1]!,
+      ]);
+
+      expect(
+        validateFormState(quantityForm({ [first.id]: 1 }), halfClosed),
+      ).toBe("Sorry, registration closed while you were submitting.");
+      expect(
+        validateFormState(quantityForm({ [second.id]: 1 }), halfClosed),
+      ).toBeNull();
+    });
+  });
+
+  describe("validateTicketFields", () => {
+    test("answers a paid order missing its email with the error redirect", async () => {
+      const listing = await createTestListing({ fields: "email" });
+      const ctx = await ticketContext([listing.id]);
+
+      const result = validateTicketFields(
+        quantityForm({ [listing.id]: 1 }),
+        ctx,
+        true,
+      );
+      expect(result).toBeInstanceOf(Response);
+    });
+
+    test("keeps the contact values the form carries", async () => {
+      const listing = await createTestListing({ fields: "email" });
+      const ctx = await ticketContext([listing.id]);
+      const form = quantityForm({ [listing.id]: 1 });
+      form.set("email", "buyer@example.com");
+      form.set("name", "Buyer");
+
+      const result = validateTicketFields(form, ctx, true);
+      expect(result).not.toBeInstanceOf(Response);
+      if (result instanceof Response) return;
+      expect(result.email).toBe("buyer@example.com");
+      expect(result.name).toBe("Buyer");
+    });
+  });
+
+  describe("parseCustomPrices", () => {
+    test("reads a pay-more listing's custom price into the map", async () => {
+      const { listing, result } = await customPriceOutcome(
+        { maxPrice: 5000 },
+        1500,
+      );
+      expect(result).toEqual(new Map([[listing.id, 1500]]));
+    });
+
+    test("refuses a price below the listing's own price, naming it", async () => {
+      const { result } = await customPriceOutcome(
+        { name: "Supporter ticket" },
+        500,
+      );
+      expect(typeof result).toBe("string");
+      expect(result).toContain("Supporter ticket");
+    });
+
+    test("ignores a pay-more listing the buyer chose none of", async () => {
+      const listing = await createTestListing({ canPayMore: true });
+      const ctx = await ticketContext([listing.id]);
+
+      const result = parseCustomPrices(
+        quantityForm({ [listing.id]: 0 }),
+        ctx,
+        new Map(),
+      );
+      expect(result).toEqual(new Map());
+    });
+
+    test("ignores a fixed-price listing even when its field is posted", async () => {
+      const listing = await createTestListing({ unitPrice: 1000 });
+      const ctx = await ticketContext([listing.id]);
+      const form = quantityForm({ [listing.id]: 1 });
+      form.set(customPriceFieldName(listing.id), "1");
+
+      const result = parseCustomPrices(form, ctx, new Map([[listing.id, 1]]));
+      expect(result).toEqual(new Map());
+    });
+  });
+
+  describe("applyQrTokenOverride", () => {
+    test("overrides a fixed-price listing's price from a signed token", async () => {
+      const listing = await createTestListing({ unitPrice: 1000 });
+      const ctx = await ticketContext([listing.id]);
+
+      const prices = await pricesAfterOverride(
+        ctx,
+        await signedTokenFor(listing.slug),
+      );
+      expect(prices.get(listing.id)).toBe(2500);
+    });
+
+    test("leaves prices alone when no token is posted", async () => {
+      const listing = await createTestListing({ unitPrice: 1000 });
+      const ctx = await ticketContext([listing.id]);
+
+      expect((await pricesAfterOverride(ctx, null)).size).toBe(0);
+    });
+
+    test("leaves prices alone when the page holds two listings' slugs", async () => {
+      const first = await createTestListing({ unitPrice: 1000 });
+      const second = await createTestListing({ unitPrice: 1000 });
+      const ctx = await ticketContext([first.id, second.id]);
+
+      expect(
+        (await pricesAfterOverride(ctx, await signedTokenFor(first.slug))).size,
+      ).toBe(0);
+    });
+
+    test("leaves prices alone for a token signed for another slug", async () => {
+      const listing = await createTestListing({ unitPrice: 1000 });
+      const other = await createTestListing({ unitPrice: 1000 });
+      const ctx = await ticketContext([listing.id]);
+
+      expect(
+        (await pricesAfterOverride(ctx, await signedTokenFor(other.slug))).size,
+      ).toBe(0);
+    });
+  });
+
+  describe("the answer maps", () => {
+    test("files chosen answer ids under the listing the question is on", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const { answerId } = await createQuestionWithAnswer([listing.id]);
+      const ctx = await ticketContext([listing.id]);
+
+      expect(
+        computeListingAnswerMap(
+          ctx,
+          answerInfo(ctx, listing.id, {
+            answerIds: [answerId],
+            textAnswers: [],
+          }),
+        ),
+      ).toEqual({ [String(listing.id)]: [answerId] });
+    });
+
+    test("is undefined when no answer was chosen", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const ctx = await ticketContext([listing.id]);
+
+      expect(
+        computeListingAnswerMap(ctx, answerInfo(ctx, listing.id)),
+      ).toBeUndefined();
+    });
+
+    test("gives text answers their stored string ids, keyed per listing", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const question = await questionsTable.insert({
+        displayType: "free_text",
+        text: "Say something",
+      });
+      await questionListings.setIds(question.id, [listing.id]);
+      const ctx = await ticketContext([listing.id]);
+
+      const map = await computeListingTextAnswerIdMap(
+        ctx,
+        answerInfo(ctx, listing.id, {
+          answerIds: [],
+          textAnswers: [{ questionId: question.id, text: "Hello" }],
+        }),
+      );
+      const entry = map?.[String(listing.id)]?.[0];
+      expect(entry?.q).toBe(question.id);
+      expect(entry?.s).toBeGreaterThan(0);
+    });
+
+    test("has no text map when no text answer was given", async () => {
+      const listing = await createTestListing({ maxAttendees: 5 });
+      const ctx = await ticketContext([listing.id]);
+
+      expect(
+        await computeListingTextAnswerIdMap(ctx, answerInfo(ctx, listing.id)),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("resolvePageQuantities", () => {
+    const resolvedQuantities = async (
+      listingIds: number[],
+      form: FormParams,
+      group?: Awaited<ReturnType<typeof createHiddenPackageGroup>>,
+    ) => {
+      const ctx = await ticketContext(listingIds, group);
+      return resolvePageQuantities(
+        form,
+        ctx,
+        buildBookingTree(ctxToBuildTreeInput(ctx)),
+      );
+    };
+
+    test("reads each standalone listing's chosen quantity", async () => {
+      const listing = await createTestListing({ maxQuantity: 5 });
+
+      const { quantities } = await resolvedQuantities(
+        [listing.id],
+        quantityForm({ [listing.id]: 2 }),
+      );
+      expect(quantities.get(listing.id)).toBe(2);
+    });
+
+    test("clamps a standalone quantity to what the listing can sell", async () => {
+      const listing = await createTestListing({
+        maxAttendees: 5,
+        maxQuantity: 3,
+      });
+
+      const { quantities } = await resolvedQuantities(
+        [listing.id],
+        quantityForm({ [listing.id]: 9 }),
+      );
+      expect(quantities.get(listing.id)).toBe(3);
+    });
+
+    test("multiplies one package count across the package's member", async () => {
+      const group = await createHiddenPackageGroup("Mystery Box");
+      const member = await createTestListing({
+        groupId: group.id,
+        maxAttendees: 5,
+        maxQuantity: 5,
+        name: "Secret Contents",
+      });
+      const form = new FormParams();
+      form.set(packageQuantityFieldName(group.id), "2");
+
+      const { quantities } = await resolvedQuantities([member.id], form, group);
+      expect(quantities.get(member.id)).toBe(2);
+    });
+  });
+});

--- a/test/features/public/ticket-submit/prepare.test.ts
+++ b/test/features/public/ticket-submit/prepare.test.ts
@@ -10,18 +10,11 @@
 
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { buildTicketListing } from "#booking/model.ts";
-import { quantityFieldName } from "#booking/tree.ts";
 import { getListingWithCount } from "#db/listings/records.ts";
-import { questionListings } from "#db/questions/queries.ts";
-import { answersTable, questionsTable } from "#db/questions/tables.ts";
-import { getTicketContext } from "#routes/public/ticket-payment.ts";
 import {
   prepareOrder,
   singleListingThankYouUrl,
 } from "#routes/public/ticket-submit/prepare.ts";
-import type { TicketCtx } from "#routes/public/types.ts";
-import { FormParams } from "#shared/form-data.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createHiddenPackageGroup } from "#test-utils/db-helpers/groups.ts";
 import {
@@ -29,31 +22,12 @@ import {
   createDailyTestListing,
   createTestListing,
 } from "#test-utils/db-helpers/listings.ts";
-import type { Group } from "#types";
-
-const ticketContext = async (
-  listingIds: number[],
-  group?: Group,
-): Promise<TicketCtx> => {
-  const listings = await Promise.all(
-    listingIds.map(async (id) =>
-      buildTicketListing((await getListingWithCount(id))!, false, undefined),
-    ),
-  );
-  return {
-    ...(await getTicketContext(listings, group)),
-    listings,
-    slugs: listings.map((info) => info.listing.slug),
-  };
-};
-
-const quantityForm = (counts: Record<number, number>): FormParams => {
-  const form = new FormParams();
-  for (const [listingId, quantity] of Object.entries(counts)) {
-    form.set(quantityFieldName(Number(listingId)), String(quantity));
-  }
-  return form;
-};
+import { createQuestionWithAnswer } from "#test-utils/db-helpers/questions.ts";
+import {
+  quantityForm,
+  ticketContext,
+  twoListingContext,
+} from "#test-utils/ticket-ctx.ts";
 
 /** The order's lines and the answer scope prepareOrder settled on. */
 const preparedOrder = async (
@@ -191,16 +165,7 @@ describeWithEnv("prepareOrder", { db: true }, () => {
   describe("questions the buyer must answer", () => {
     test("refuses an order that left an active question unanswered", async () => {
       const listing = await createTestListing({ maxAttendees: 5 });
-      const question = await questionsTable.insert({
-        displayType: "radio",
-        text: "Choose one",
-      });
-      await answersTable.insert({
-        questionId: question.id,
-        sortOrder: 0,
-        text: "Chosen",
-      });
-      await questionListings.setIds(question.id, [listing.id]);
+      await createQuestionWithAnswer([listing.id]);
       const ctx = await ticketContext([listing.id]);
 
       const result = await prepareOrder(ctx, quantityForm({ [listing.id]: 1 }));
@@ -232,9 +197,7 @@ describeWithEnv("prepareOrder", { db: true }, () => {
     });
 
     test("uses none when the cart holds more than one listing", async () => {
-      const first = await createTestListing({ maxAttendees: 5 });
-      const second = await createTestListing({ maxAttendees: 5 });
-      const ctx = await ticketContext([first.id, second.id]);
+      const { ctx } = await twoListingContext();
 
       expect(singleListingThankYouUrl(ctx)).toBeNull();
     });

--- a/test/shared/listing-fields.test.ts
+++ b/test/shared/listing-fields.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  getTicketFieldsSetting,
   mergeListingFields,
   parseListingFields,
   withRequiredEmail,
@@ -55,6 +56,25 @@ describe("listing-fields", () => {
       expect(mergeListingFields(["", "email,bogus", "phone"])).toBe(
         "email,phone",
       );
+    });
+  });
+
+  describe("getTicketFieldsSetting", () => {
+    // The parameter is structural: anything with a listing that names its
+    // contact fields, so this module stays free of booking-model imports.
+    const listingWith = (fields: string) => ({ listing: { fields } });
+
+    test("is empty when the page has no listings", () => {
+      expect(getTicketFieldsSetting([])).toBe("");
+    });
+
+    test("folds every listing's own setting into one", () => {
+      expect(
+        getTicketFieldsSetting([
+          listingWith("email"),
+          listingWith("phone,address"),
+        ]),
+      ).toBe("email,phone,address");
     });
   });
 

--- a/test/test-utils/db-helpers/questions.ts
+++ b/test/test-utils/db-helpers/questions.ts
@@ -1,0 +1,24 @@
+/** Question and answer fixtures shared by the booking suites. */
+
+import { questionListings } from "#db/questions/queries.ts";
+import { answersTable, questionsTable } from "#db/questions/tables.ts";
+
+/** A radio question with one chosen answer, optionally assigned to listings —
+ * the smallest question a booking can answer. */
+export const createQuestionWithAnswer = async (
+  assignedTo: number[] = [],
+): Promise<{ answerId: number; questionId: number }> => {
+  const question = await questionsTable.insert({
+    displayType: "radio",
+    text: "Choose one",
+  });
+  const answer = await answersTable.insert({
+    questionId: question.id,
+    sortOrder: 0,
+    text: "Chosen",
+  });
+  if (assignedTo.length > 0) {
+    await questionListings.setIds(question.id, assignedTo);
+  }
+  return { answerId: answer.id, questionId: question.id };
+};

--- a/test/test-utils/ticket-ctx.ts
+++ b/test/test-utils/ticket-ctx.ts
@@ -1,0 +1,50 @@
+/**
+ * Fixtures for the ticket-submit suites: a real page context built from real
+ * listings, and a form that carries quantity selections.
+ */
+
+import { buildTicketListing } from "#booking/model.ts";
+import { quantityFieldName } from "#booking/tree.ts";
+import { getListingWithCount } from "#db/listings/records.ts";
+import { getTicketContext } from "#routes/public/ticket-payment.ts";
+import type { TicketCtx } from "#routes/public/types.ts";
+import { FormParams } from "#shared/form-data.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import type { Group, ListingWithCount } from "#types";
+
+/** The page context for the given listings, as the public routes build it. */
+export const ticketContext = async (
+  listingIds: number[],
+  group?: Group,
+): Promise<TicketCtx> => {
+  const listings = await Promise.all(
+    listingIds.map(async (id) =>
+      buildTicketListing((await getListingWithCount(id))!, false, undefined),
+    ),
+  );
+  return {
+    ...(await getTicketContext(listings, group)),
+    listings,
+    slugs: listings.map((info) => info.listing.slug),
+  };
+};
+
+/** The page context for two fresh listings, for a cart that holds both. */
+export const twoListingContext = async (): Promise<{
+  ctx: TicketCtx;
+  first: ListingWithCount;
+  second: ListingWithCount;
+}> => {
+  const first = await createTestListing({ maxAttendees: 5 });
+  const second = await createTestListing({ maxAttendees: 5 });
+  return { ctx: await ticketContext([first.id, second.id]), first, second };
+};
+
+/** A form that selects the given count for each listing. */
+export const quantityForm = (counts: Record<number, number>): FormParams => {
+  const form = new FormParams();
+  for (const [listingId, quantity] of Object.entries(counts)) {
+    form.set(quantityFieldName(Number(listingId)), String(quantity));
+  }
+  return form;
+};

--- a/test/ui/templates/public/reservations/contact-fields.test.ts
+++ b/test/ui/templates/public/reservations/contact-fields.test.ts
@@ -164,6 +164,14 @@ describe("contact-fields", () => {
       ).toBe(true);
     });
 
+    test("a package's one-penny price pays the member too", () => {
+      // The smallest charge a listing can make is still a charge.
+      const member = pageListing({ id: 1 });
+      expect(pagePaid(paidInput([member], [packageOver([1], { 1: 1 })]))).toBe(
+        true,
+      );
+    });
+
     test("a package's explicit free price makes the bundled path free", () => {
       const member = pageListing({ id: 1, unit_price: 500 });
       expect(pagePaid(paidInput([member], [packageOver([1], { 1: 0 })]))).toBe(
@@ -178,17 +186,27 @@ describe("contact-fields", () => {
       ).toBe(true);
     });
 
-    test("a day-price override pays a customisable member", () => {
-      const member = pageListing({
-        customisable_days: true,
-        day_prices: { 2: 0 },
-        id: 1,
-      });
-      expect(
-        pagePaid(
-          paidInput([member], [packageOver([1], {}, { 1: { 2: 300 } })]),
+    /** A customisable member beside a package that overrides one day price. */
+    const dayOverridePays = (dayPrice: number): boolean =>
+      pagePaid(
+        paidInput(
+          [
+            pageListing({
+              customisable_days: true,
+              day_prices: { 2: 0 },
+              id: 1,
+            }),
+          ],
+          [packageOver([1], {}, { 1: { 2: dayPrice } })],
         ),
-      ).toBe(true);
+      );
+
+    test("a day-price override pays a customisable member", () => {
+      expect(dayOverridePays(300)).toBe(true);
+    });
+
+    test("a one-penny day price pays a customisable member too", () => {
+      expect(dayOverridePays(1)).toBe(true);
     });
 
     test("a paid add-on pays the page on its own", () => {

--- a/test/ui/templates/public/reservations/contact-fields.test.ts
+++ b/test/ui/templates/public/reservations/contact-fields.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The contact-field set and paid-status checks for the booking form: what a
+ * page's own listings require, what a possible child adds without requiring,
+ * and which paths through a page's packages make a listing paid.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { buildTicketListing } from "#booking/model.ts";
+import type { PagePackage } from "#booking/page-packages.ts";
+import type { AddOnOption } from "#db/modifier-resolve.ts";
+import { fieldsApi } from "#templates/fields/ticket.ts";
+import {
+  buildContactFields,
+  pageOrChildPaid,
+  pagePaid,
+} from "#templates/public/reservations/contact-fields.ts";
+import { testListingWithCount } from "#test-utils/factories.ts";
+
+/** Run `fn` as though Square is the payment provider, the only provider that
+ * imposes an email field on a paid order. */
+const underSquare = <T>(fn: () => T): T => {
+  const s = stub(fieldsApi, "getSettingCached", () => "square");
+  try {
+    return fn();
+  } finally {
+    s.restore();
+  }
+};
+
+/** A listing on the page, carrying the fields its row names. */
+const pageListing = (
+  overrides: Record<string, unknown>,
+): ReturnType<typeof buildTicketListing> =>
+  buildTicketListing(testListingWithCount(overrides), false, undefined);
+
+/** One package that bundles `memberIds`, with the given price overrides. */
+const packageOver = (
+  memberIds: number[],
+  prices: Record<number, number>,
+  dayPrices: Record<number, Record<number, number>> = {},
+): PagePackage =>
+  ({
+    dayPrices: new Map(
+      Object.entries(dayPrices).map(([id, days]) => [
+        Number(id),
+        new Map(Object.entries(days).map(([d, p]) => [Number(d), p])),
+      ]),
+    ),
+    description: "",
+    groupId: 1,
+    hideListings: true,
+    memberListingIds: memberIds,
+    name: "Bundle",
+    prices: new Map(Object.entries(prices).map(([id, p]) => [Number(id), p])),
+    quantities: new Map(),
+    slug: "bundle",
+    terms: "",
+  }) as PagePackage;
+
+const paidInput = (
+  listings: ReturnType<typeof buildTicketListing>[],
+  packages: PagePackage[] = [],
+  standaloneRowIds: number[] = [],
+  addOns?: AddOnOption[],
+) => ({
+  addOns,
+  listings,
+  packages,
+  standaloneRowIds: new Set(standaloneRowIds),
+});
+
+const paidAddOn = { requiresPayment: true } as AddOnOption;
+
+describe("contact-fields", () => {
+  describe("buildContactFields", () => {
+    test("keeps the page listings' fields required", () => {
+      const fields = buildContactFields(
+        [
+          pageListing({ fields: "email", id: 1 }),
+          pageListing({ fields: "phone", id: 2 }),
+        ],
+        undefined,
+        false,
+        false,
+      );
+      expect(
+        fields.map((f) => ({ name: f.name, required: f.required })),
+      ).toEqual([
+        { name: "name", required: true },
+        { name: "email", required: true },
+        { name: "phone", required: true },
+      ]);
+    });
+
+    test("adds a possible child's stricter fields, not required", () => {
+      const fields = buildContactFields(
+        [pageListing({ fields: "email", id: 1 })],
+        new Map([[1, [pageListing({ fields: "email,address", id: 2 })]]]),
+        false,
+        false,
+      );
+      const address = fields.find((f) => f.name === "address");
+      expect(address?.required).toBe(false);
+      expect(fields.find((f) => f.name === "email")?.required).toBe(true);
+    });
+
+    test("renders the provider email required on a paid page under Square", () => {
+      const fields = underSquare(() =>
+        buildContactFields(
+          [pageListing({ fields: "", id: 1 })],
+          undefined,
+          true,
+          true,
+        ),
+      );
+      expect(fields.find((f) => f.name === "email")?.required).toBe(true);
+    });
+
+    test("renders the provider email present but optional on a free page with a paid child", () => {
+      // The page itself is free, so its email must not block submission; a
+      // paid child still needs the box on screen for when the buyer picks it.
+      const fields = underSquare(() =>
+        buildContactFields(
+          [pageListing({ fields: "", id: 1 })],
+          new Map([[1, [pageListing({ fields: "", id: 2, unit_price: 5 })]]]),
+          false,
+          true,
+        ),
+      );
+      expect(fields.find((f) => f.name === "email")?.required).toBe(false);
+      expect(fields.some((f) => f.name === "email")).toBe(true);
+    });
+
+    test("omits the provider email on a free page with no paid child", () => {
+      const fields = underSquare(() =>
+        buildContactFields(
+          [pageListing({ fields: "", id: 1 })],
+          undefined,
+          false,
+          false,
+        ),
+      );
+      expect(fields.some((f) => f.name === "email")).toBe(false);
+    });
+  });
+
+  describe("pagePaid", () => {
+    test("a listing's own price pays the page", () => {
+      expect(
+        pagePaid(paidInput([pageListing({ id: 1, unit_price: 500 })])),
+      ).toBe(true);
+    });
+
+    test("nothing priced leaves the page free", () => {
+      expect(pagePaid(paidInput([pageListing({ id: 1 })]))).toBe(false);
+    });
+
+    test("a package's flat price pays a member the page bundles", () => {
+      const member = pageListing({ id: 1 });
+      expect(
+        pagePaid(paidInput([member], [packageOver([1], { 1: 700 })])),
+      ).toBe(true);
+    });
+
+    test("a package's explicit free price makes the bundled path free", () => {
+      const member = pageListing({ id: 1, unit_price: 500 });
+      expect(pagePaid(paidInput([member], [packageOver([1], { 1: 0 })]))).toBe(
+        false,
+      );
+    });
+
+    test("the member's own price still counts beside its bundle row", () => {
+      const member = pageListing({ id: 1, unit_price: 500 });
+      expect(
+        pagePaid(paidInput([member], [packageOver([1], { 1: 0 })], [1])),
+      ).toBe(true);
+    });
+
+    test("a day-price override pays a customisable member", () => {
+      const member = pageListing({
+        customisable_days: true,
+        day_prices: { 2: 0 },
+        id: 1,
+      });
+      expect(
+        pagePaid(
+          paidInput([member], [packageOver([1], {}, { 1: { 2: 300 } })]),
+        ),
+      ).toBe(true);
+    });
+
+    test("a paid add-on pays the page on its own", () => {
+      expect(
+        pagePaid(paidInput([pageListing({ id: 1 })], [], [], [paidAddOn])),
+      ).toBe(true);
+    });
+  });
+
+  describe("pageOrChildPaid", () => {
+    test("a free page with a paid child still needs the provider email", () => {
+      expect(
+        pageOrChildPaid({
+          childrenByParentId: new Map([
+            [1, [pageListing({ id: 2, unit_price: 5 })]],
+          ]),
+          ...paidInput([pageListing({ id: 1 })]),
+        }),
+      ).toBe(true);
+    });
+
+    test("a free page with no paid child does not", () => {
+      expect(
+        pageOrChildPaid({
+          childrenByParentId: new Map(),
+          ...paidInput([pageListing({ id: 1 })]),
+        }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What changed

The contact-fields template reached into the ticket-form route for
`getTicketFieldsSetting` — a one-line fold over `mergeListingFields`
it could not own — and that back-edge closed a triangle:
`ticket-form.ts` → `ticket-page.tsx` → `contact-fields.ts` →
`ticket-form.ts`.

The fold moves to `#shared/listing-fields.ts`, beside the mechanism it
wraps. Its parameter is structural (anything with a listing that names
its contact fields) so that module keeps its stated no-imports promise —
it ships in the client bundle. The submit parser and the template import
it from its home now, and the route exports it no more.

Measured with the same runtime-edge scan as #2171: 8 cyclic groups on
this tree before, 7 after. The triangle is gone; the four remaining
route-template pairs and the 73-module accounting blob stand.

## The suites the mutation gate demanded

Touching `parse.ts` and `contact-fields.ts` made the gate refuse until
both had direct mirrors, so both suites exist now:

- `test/features/public/ticket-submit/parse.test.ts` covers the
  page-state refusals, contact validation, custom prices in the major
  units the form really carries, the QR price override and its guards,
  both answer maps, and standalone and package quantity resolution.
- `test/ui/templates/public/reservations/contact-fields.test.ts` pins
  the field merging, the child extras that render without blocking, the
  Square provider email's three states, and every package path that
  makes a bundled listing paid.

Along the way the ticket-form mirror gained the suites its own file had
never had (quantity floor and clamp, dateless and single-date pages,
response statuses, the error redirect's target), one dead parameter
went (`ticketFormErrorResponse`'s `_status` — no caller passes it),
and the shared fixtures moved where three suites can reach them
(`ticket-ctx.ts`, `db-helpers/questions.ts`). Every jscpd clone the
new files raised is merged.

## Gates

`precommit` green; `precommit:mutation` 100% (130/130 killed, 12
known-equivalent suppressed — eight new equivalence records, each a
fallback whose left side can only be falsy by being the value the
fallback supplies).