### PR TITLE
Stop a migration batch on either subrequest refusal, not one message

### DIFF
--- a/src/shared/db/migrations/runner.ts
+++ b/src/shared/db/migrations/runner.ts
@@ -10,6 +10,7 @@ import { retryWithBackoff } from "#shared/retry.ts";
 import {
   BUNNY_SUBREQUEST_LIMIT,
   getSubrequestRemaining,
+  SubrequestBudgetError,
   withSubrequestAllowance,
 } from "#shared/subrequest-budget.ts";
 import { loadMigrations } from "./context.ts";
@@ -34,13 +35,6 @@ import type { Migration } from "./types.ts";
  * window is turned away and re-runs the same over-budget batch.
  */
 const MIGRATION_BOOKKEEPING_RESERVE = 5;
-
-/** True when `error` is the "subrequest budget spent" signal countSubrequest
- *  raises at the reserve cap — the cue to stop the batch here rather than a
- *  migration defect. The cap always trips this budget guard before the wider
- *  round-trip limit, so that is the only message to match. */
-const isSubrequestBudgetError = (error: unknown): boolean =>
-  errorMessage(error).startsWith("Subrequest allowance exceeded");
 
 /** The migrations whose ids are not yet recorded as applied, in run order.
  *  Checks the ids first so the implementations only load when at least one
@@ -88,7 +82,7 @@ export const verifyMigrationWithRetry = (migration: Migration): Promise<void> =>
     (error, { attempt, willRetry }) => {
       // A spent subrequest budget is not a transient lag: retrying just burns
       // the reserve. Propagate so the batch stops and its progress is recorded.
-      if (isSubrequestBudgetError(error)) throw error;
+      if (error instanceof SubrequestBudgetError) throw error;
       if (!willRetry) return;
       logDebug(
         "Migration",
@@ -121,7 +115,7 @@ export const applyMigrationWithRetry = async (
     // Re-running up() to repair a lagged snapshot only helps a transient miss;
     // an over-budget request has no budget left for a second up(), so hand the
     // signal back to stop the batch instead.
-    if (isSubrequestBudgetError(error)) throw error;
+    if (error instanceof SubrequestBudgetError) throw error;
     logDebug(
       "Migration",
       `verify ${migration.id} still failing after retries, re-running up(): ${errorMessage(
@@ -148,8 +142,10 @@ const applyUntilBudgetSpent = async (
     } catch (error) {
       // Out of budget: stop here so the caller records what finished and the
       // next request continues. The half-applied migration is idempotent, so
-      // it re-runs cleanly from the top next time.
-      if (isSubrequestBudgetError(error)) return;
+      // it re-runs cleanly from the top next time. Either refusal lands here:
+      // a statement blocked at the cap, and a migration that opens a
+      // transaction whose rollback reserve no longer fits.
+      if (error instanceof SubrequestBudgetError) return;
       throw error;
     }
     completed.push(migration);

--- a/src/shared/subrequest-budget.ts
+++ b/src/shared/subrequest-budget.ts
@@ -1,3 +1,4 @@
+import { namedError } from "#shared/named-error.ts";
 import { createScope } from "#shared/request-scoped.ts";
 
 /** Bunny Edge Scripting stops an incoming request after this many subrequests. */
@@ -16,6 +17,18 @@ type BudgetState = {
   counts: Counts;
   limits: Counts & { total: number };
 };
+
+/**
+ * This request has no subrequests left for the work it was about to start.
+ *
+ * Both refusals below raise it: the call blocked at the cap, and the block of
+ * work refused up front because its reserved tail no longer fits. A caller that
+ * can stop and continue on a later request — the migration runner — tells the
+ * two apart from a real defect by this type, never by the message text.
+ */
+export class SubrequestBudgetError extends namedError(
+  "SubrequestBudgetError",
+) {}
 
 const budgetScope = createScope<BudgetState>();
 
@@ -65,7 +78,7 @@ export const withSubrequestReserve = <T>(
     reserve.external > remaining.external ||
     reserve.total > remaining.total
   ) {
-    throw new Error(
+    throw new SubrequestBudgetError(
       `Subrequest reserve unavailable: need ${reserve.database} database + ` +
         `${reserve.external} external calls (${reserve.total} total), but ` +
         `${remaining.database} database + ${remaining.external} external ` +
@@ -137,7 +150,7 @@ export const countSubrequest = (
     enforce &&
     (nextCounts[kind] > state.limits[kind] || usage.total > state.limits.total)
   ) {
-    throw new Error(
+    throw new SubrequestBudgetError(
       `Subrequest allowance exceeded: ${usage.database} database + ` +
         `${usage.external} external calls. Blocked ${kind} operation: ${operation}`,
     );

--- a/test/shared/db/migrations/runner-budget.test.ts
+++ b/test/shared/db/migrations/runner-budget.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { getDb } from "#db/client.ts";
+import { getDb, withTransaction } from "#db/client.ts";
 import { releaseMigrationLock } from "#db/migrations/lock.ts";
 import {
   applyMigrationWithRetry,
@@ -9,16 +9,30 @@ import {
 } from "#db/migrations/runner.ts";
 import type { Migration } from "#db/migrations/types.ts";
 import { runWithQueryLogContext } from "#db/query-log.ts";
-import { runWithSubrequestBudget } from "#shared/subrequest-budget.ts";
+import {
+  getSubrequestRemaining,
+  runWithSubrequestBudget,
+  SubrequestBudgetError,
+} from "#shared/subrequest-budget.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { takeMigrationLock } from "#test-utils/migrations.ts";
 import { withVirtualBackoff } from "#test-utils/virtual-time.ts";
 
 /** The error countSubrequest raises once the request's budget is spent. */
 const budgetError = (n: number): Error =>
-  new Error(
+  new SubrequestBudgetError(
     `Subrequest allowance exceeded: ${n} database + 0 external calls. Blocked database operation: batch`,
   );
+
+/** A migration with the given work as its up() and a verify() that passes. */
+const migrationOf = (id: string, up: () => Promise<unknown>): Migration => ({
+  description: id,
+  id,
+  up: async () => {
+    await up();
+  },
+  verify: () => Promise.resolve(),
+});
 
 describe("db > migrations > runner subrequest budget", () => {
   test("verify does not retry a spent budget — the reserve is not for retries", async () => {
@@ -64,6 +78,20 @@ describeWithEnv(
   "db > migrations > runner subrequest budget against a database",
   { db: true },
   () => {
+    /** Run a batch the way a request does: one subrequest budget, one query log. */
+    const runBatch = async (pending: Migration[]): Promise<Migration[]> => {
+      const lockToken = await takeMigrationLock();
+      try {
+        return await runWithSubrequestBudget(() =>
+          runWithQueryLogContext(() =>
+            runPendingMigrations(pending, lockToken),
+          ),
+        );
+      } finally {
+        await releaseMigrationLock(lockToken);
+      }
+    };
+
     test("inside a request, runs as many migrations as fit and returns the finished prefix", async () => {
       // Each migration spends several round-trips; the batch as a whole exceeds
       // the request's budget, so the run stops partway and leaves headroom for
@@ -71,30 +99,35 @@ describeWithEnv(
       const spend = async (): Promise<void> => {
         for (let i = 0; i < 12; i += 1) await getDb().execute("SELECT 1");
       };
-      const costly = (id: string): Migration => ({
-        description: id,
-        id,
-        up: spend,
-        verify: () => Promise.resolve(),
-      });
-      const pending = ["m1", "m2", "m3", "m4", "m5", "m6"].map(costly);
-      const lockToken = await takeMigrationLock();
-      try {
-        const completed = await runWithSubrequestBudget(() =>
-          runWithQueryLogContext(() =>
-            runPendingMigrations(pending, lockToken),
-          ),
-        );
-        // Some — but not all — ran: the budget stopped the batch.
-        expect(completed.length).toBeGreaterThan(0);
-        expect(completed.length).toBeLessThan(pending.length);
-        // The ones that ran are the leading prefix, in order.
-        expect(completed.map((migration) => migration.id)).toEqual(
-          pending.slice(0, completed.length).map((migration) => migration.id),
-        );
-      } finally {
-        await releaseMigrationLock(lockToken);
-      }
+      const pending = ["m1", "m2", "m3", "m4", "m5", "m6"].map((id) =>
+        migrationOf(id, spend),
+      );
+      const completed = await runBatch(pending);
+      // Some — but not all — ran: the budget stopped the batch.
+      expect(completed.length).toBeGreaterThan(0);
+      expect(completed.length).toBeLessThan(pending.length);
+      // The ones that ran are the leading prefix, in order.
+      expect(completed.map((migration) => migration.id)).toEqual(
+        pending.slice(0, completed.length).map((migration) => migration.id),
+      );
+    });
+
+    test("stops the batch when a migration cannot reserve its transaction rollback", async () => {
+      // A table rebuild opens an interactive transaction, which refuses to
+      // start without a spare round-trip to roll itself back with. That refusal
+      // means "no budget left", not "this migration is broken", so the batch
+      // must stop and keep the migration that already finished.
+      const spendTheAllowance = async (): Promise<void> => {
+        const calls = getSubrequestRemaining().database;
+        for (let i = 0; i < calls; i += 1) await getDb().execute("SELECT 1");
+      };
+      const completed = await runBatch([
+        migrationOf("spend", spendTheAllowance),
+        migrationOf("rebuild", () =>
+          withTransaction((tx) => tx.execute("SELECT 1")),
+        ),
+      ]);
+      expect(completed.map((migration) => migration.id)).toEqual(["spend"]);
     });
   },
 );

--- a/test/shared/db/migrations/runner.test.ts
+++ b/test/shared/db/migrations/runner.test.ts
@@ -137,14 +137,14 @@ describe("db > migrations > runner", () => {
       expect(upCalls).toBe(1);
     });
 
-    test("re-runs up() once when verify keeps failing, so a skipped index recovers", async () => {
-      // Reproduces the production failure: up()'s syncIndexes ran against a
-      // primary snapshot that lagged the table it had just created in the same
-      // up(), so it silently skipped the index. Retrying verify() ALONE would
-      // fail on every attempt because the index was never created; only re-running
-      // up() (which now sees the table) creates it — which is why the failure
-      // cleared on the next request. up() is re-run only after a full round of
-      // verify retries has failed.
+    /**
+     * The production failure: up()'s syncIndexes ran against a primary snapshot
+     * that lagged the table it had just created in the same up(), so it silently
+     * skipped the index. Retrying verify() ALONE would fail on every attempt
+     * because the index was never created; only re-running up() (which now sees
+     * the table) creates it. Reports how many times up() ran.
+     */
+    const repairsASkippedIndex = async (): Promise<number> => {
       let upCalls = 0;
       let indexCreated = false;
       await withVirtualBackoff(() =>
@@ -152,8 +152,6 @@ describe("db > migrations > runner", () => {
           fakeMigration({
             up: () => {
               upCalls++;
-              // First up() skips the index (lagging snapshot); the second sees the
-              // table and creates it.
               if (upCalls >= 2) indexCreated = true;
               return Promise.resolve();
             },
@@ -168,9 +166,27 @@ describe("db > migrations > runner", () => {
           }),
         ),
       );
-      // up() ran exactly twice — once initially, once to repair — never per retry.
-      expect(upCalls).toBe(2);
-      expect(indexCreated).toBe(true);
+      return upCalls;
+    };
+
+    test("re-runs up() once when verify keeps failing, so a skipped index recovers", async () => {
+      // Twice — once initially, once to repair — never once per retry. It
+      // resolving at all is what says the second up() created the index.
+      expect(await repairsASkippedIndex()).toBe(2);
+    });
+
+    test("says it is re-running up(), and what verify was still missing", async () => {
+      // Without this line the log shows a migration running, then nothing until
+      // it either passes or fails, with no sign that up() was tried again.
+      await repairsASkippedIndex();
+      const lines = debugMessages(debugSpy()).map(String);
+      expect(
+        lines.some(
+          (line) =>
+            line.includes("fake-apply-retry still failing after retries") &&
+            line.includes("missing index idx_system_notes_attendee_id"),
+        ),
+      ).toBe(true);
     });
 
     test("rethrows the original error after re-running up() once and still failing", async () => {

--- a/test/shared/db/migrations/runner/budget.test.ts
+++ b/test/shared/db/migrations/runner/budget.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { getDb, withTransaction } from "#db/client.ts";
 import { releaseMigrationLock } from "#db/migrations/lock.ts";
+import { recordMigrationBatch } from "#db/migrations/markers.ts";
 import {
   applyMigrationWithRetry,
   runPendingMigrations,
@@ -78,18 +79,28 @@ describeWithEnv(
   "db > migrations > runner subrequest budget against a database",
   { db: true },
   () => {
-    /** Run a batch the way a request does: one subrequest budget, one query log. */
-    const runBatch = async (pending: Migration[]): Promise<Migration[]> => {
+    /** Run `work` the way a request does: one subrequest budget, one query log,
+     *  with the migration lock held for it. */
+    const asOneRequest = async <T>(
+      work: (lockToken: string) => Promise<T>,
+    ): Promise<T> => {
       const lockToken = await takeMigrationLock();
       try {
         return await runWithSubrequestBudget(() =>
-          runWithQueryLogContext(() =>
-            runPendingMigrations(pending, lockToken),
-          ),
+          runWithQueryLogContext(() => work(lockToken)),
         );
       } finally {
         await releaseMigrationLock(lockToken);
       }
+    };
+
+    const runBatch = (pending: Migration[]): Promise<Migration[]> =>
+      asOneRequest((lockToken) => runPendingMigrations(pending, lockToken));
+
+    /** Spend the database calls this request still has, keeping `spare` back. */
+    const spendAllBut = async (spare: number): Promise<void> => {
+      const calls = getSubrequestRemaining().database - spare;
+      for (let i = 0; i < calls; i += 1) await getDb().execute("SELECT 1");
     };
 
     test("inside a request, runs as many migrations as fit and returns the finished prefix", async () => {
@@ -117,17 +128,40 @@ describeWithEnv(
       // start without a spare round-trip to roll itself back with. That refusal
       // means "no budget left", not "this migration is broken", so the batch
       // must stop and keep the migration that already finished.
-      const spendTheAllowance = async (): Promise<void> => {
-        const calls = getSubrequestRemaining().database;
-        for (let i = 0; i < calls; i += 1) await getDb().execute("SELECT 1");
-      };
       const completed = await runBatch([
-        migrationOf("spend", spendTheAllowance),
+        migrationOf("spend", () => spendAllBut(0)),
         migrationOf("rebuild", () =>
           withTransaction((tx) => tx.execute("SELECT 1")),
         ),
       ]);
       expect(completed.map((migration) => migration.id)).toEqual(["spend"]);
+    });
+
+    test("leaves the caller room to record the batch and release the lock", async () => {
+      // The held-back round-trips are the whole reason a stale database moves
+      // forward: a batch that spent every call could not write its markers, so
+      // the next request would replay the same work behind a held lock.
+      await asOneRequest(async (lockToken) => {
+        const completed = await runPendingMigrations(
+          [migrationOf("spend", () => spendAllBut(0))],
+          lockToken,
+        );
+        await recordMigrationBatch(completed, false, lockToken);
+      });
+    });
+
+    test("runs one migration on the last call the request has", async () => {
+      // With less left than the runner holds back, the batch still gets one
+      // round-trip, so a reload attempts the next migration instead of
+      // stalling on a database that can never finish updating.
+      const completed = await asOneRequest(async (lockToken) => {
+        await spendAllBut(1);
+        return await runPendingMigrations(
+          [migrationOf("one call", () => getDb().execute("SELECT 1"))],
+          lockToken,
+        );
+      });
+      expect(completed.map((migration) => migration.id)).toEqual(["one call"]);
     });
   },
 );

--- a/test/shared/subrequest-budget.test.ts
+++ b/test/shared/subrequest-budget.test.ts
@@ -11,6 +11,18 @@ import {
   withSubrequestReserve,
 } from "#shared/subrequest-budget.ts";
 
+/**
+ * Run `work` in a request that has spent every subrequest it had.
+ *
+ * The migration runner stops its batch and continues on the next request when
+ * the budget runs out, and reads the type rather than the message to tell that
+ * refusal from a real defect. Both refusals below are raised from this state.
+ */
+const withNothingLeft = (work: () => void): void =>
+  runWithSubrequestBudget(() =>
+    withSubrequestAllowance({ database: 0, external: 0, total: 0 }, work),
+  );
+
 describe("combined subrequest budget", () => {
   test("reports the full allowance outside a request scope", async () => {
     expect(getSubrequestRemaining()).toEqual({
@@ -157,27 +169,21 @@ describe("combined subrequest budget", () => {
     });
   });
 
-  test("raises one type for both refusals, so a caller can stop on either", async () => {
-    // The migration runner stops its batch and continues on the next request
-    // when the budget runs out. It reads the type, not the message, so a call
-    // blocked at the cap and a reserve that no longer fits both reach it.
-    await runWithSubrequestBudget(async () => {
-      await withSubrequestAllowance(
-        { database: 0, external: 0, total: 0 },
-        async () => {
-          expect(() => countSubrequest("database", "blocked call")).toThrow(
-            SubrequestBudgetError,
-          );
-          expect(() =>
-            withSubrequestReserve(
-              { database: 1, external: 0, total: 1 },
-              () => {
-                throw new Error("reserved work must not run");
-              },
-            ),
-          ).toThrow(SubrequestBudgetError);
-        },
+  test("a call blocked at the cap raises the type a caller stops on", () => {
+    withNothingLeft(() => {
+      expect(() => countSubrequest("database", "blocked call")).toThrow(
+        SubrequestBudgetError,
       );
+    });
+  });
+
+  test("a reserve that no longer fits raises the type a caller stops on", () => {
+    withNothingLeft(() => {
+      expect(() =>
+        withSubrequestReserve({ database: 1, external: 0, total: 1 }, () => {
+          throw new Error("reserved work must not run");
+        }),
+      ).toThrow(SubrequestBudgetError);
     });
   });
 

--- a/test/shared/subrequest-budget.test.ts
+++ b/test/shared/subrequest-budget.test.ts
@@ -18,6 +18,16 @@ import {
  * the budget runs out, and reads the type rather than the message to tell that
  * refusal from a real defect. Both refusals below are raised from this state.
  */
+/** The error `work` refused with. Fails the test when it does not refuse. */
+const refusalFrom = (work: () => void): Error => {
+  try {
+    work();
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error("the work was allowed to run, so nothing refused it");
+};
+
 const withNothingLeft = (work: () => void): void =>
   runWithSubrequestBudget(() =>
     withSubrequestAllowance({ database: 0, external: 0, total: 0 }, work),
@@ -184,6 +194,53 @@ describe("combined subrequest budget", () => {
           throw new Error("reserved work must not run");
         }),
       ).toThrow(SubrequestBudgetError);
+    });
+  });
+
+  test("names itself, so a log line says which refusal this was", () => {
+    // An unnamed refusal reads as a bare Error wherever it is reported.
+    withNothingLeft(() => {
+      expect(
+        refusalFrom(() => countSubrequest("database", "blocked call")).name,
+      ).toBe("SubrequestBudgetError");
+    });
+  });
+
+  test("refuses a reserve the database calls alone cannot cover", () => {
+    // Only the database dimension is short, so a guard that demanded every
+    // dimension be short would let this reserve through.
+    runWithSubrequestBudget(() => {
+      withSubrequestAllowance({ database: 0, external: 5, total: 5 }, () => {
+        expect(() =>
+          withSubrequestReserve({ database: 1, external: 0, total: 1 }, () => {
+            throw new Error("reserved work must not run");
+          }),
+        ).toThrow("Subrequest reserve unavailable");
+      });
+    });
+  });
+
+  test("refuses a reserve the external calls alone cannot cover", () => {
+    runWithSubrequestBudget(() => {
+      withSubrequestAllowance({ database: 5, external: 0, total: 5 }, () => {
+        expect(() =>
+          withSubrequestReserve({ database: 0, external: 1, total: 1 }, () => {
+            throw new Error("reserved work must not run");
+          }),
+        ).toThrow("Subrequest reserve unavailable");
+      });
+    });
+  });
+
+  test("hands the work what is left after the tail is taken out", () => {
+    runWithSubrequestBudget(() => {
+      withSubrequestReserve({ database: 1, external: 1, total: 2 }, () => {
+        expect(getSubrequestRemaining()).toEqual({
+          database: BUNNY_SUBREQUEST_LIMIT - 1,
+          external: BUNNY_SUBREQUEST_LIMIT - 1,
+          total: BUNNY_SUBREQUEST_LIMIT - 2,
+        });
+      });
     });
   });
 

--- a/test/shared/subrequest-budget.test.ts
+++ b/test/shared/subrequest-budget.test.ts
@@ -6,6 +6,7 @@ import {
   getSubrequestRemaining,
   getSubrequestUsage,
   runWithSubrequestBudget,
+  SubrequestBudgetError,
   withSubrequestAllowance,
   withSubrequestReserve,
 } from "#shared/subrequest-budget.ts";
@@ -153,6 +154,30 @@ describe("combined subrequest budget", () => {
         external: BUNNY_SUBREQUEST_LIMIT,
         total: 1,
       });
+    });
+  });
+
+  test("raises one type for both refusals, so a caller can stop on either", async () => {
+    // The migration runner stops its batch and continues on the next request
+    // when the budget runs out. It reads the type, not the message, so a call
+    // blocked at the cap and a reserve that no longer fits both reach it.
+    await runWithSubrequestBudget(async () => {
+      await withSubrequestAllowance(
+        { database: 0, external: 0, total: 0 },
+        async () => {
+          expect(() => countSubrequest("database", "blocked call")).toThrow(
+            SubrequestBudgetError,
+          );
+          expect(() =>
+            withSubrequestReserve(
+              { database: 1, external: 0, total: 1 },
+              () => {
+                throw new Error("reserved work must not run");
+              },
+            ),
+          ).toThrow(SubrequestBudgetError);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
## What went wrong

A site that ran a long list of migrations answered `GET /custom.css` with an
error, and logged this:

```
E_CDN_REQUEST detail="GET /custom.css: Subrequest reserve unavailable:
need 1 database + 0 external calls (1 total), but 0 database + 50 external
calls (0 total) remain"
```

A request on the edge can make 50 subrequests. A migration batch can need
more than that, so the runner caps its own batch below the limit and holds
back five round-trips for its bookkeeping. When the cap refuses a call, the
runner stops the batch, records the migrations that finished, and tells the
visitor the update continues on the next request.

The runner found that refusal by the start of its message, `Subrequest
allowance exceeded`. The budget raises a second refusal with a different
message, `Subrequest reserve unavailable`. That one comes from
`withSubrequestReserve`, which refuses a block of work up front when the
round-trips it must keep for its own cleanup no longer fit.

An interactive transaction keeps one round-trip to roll itself back with. So
a migration that rebuilds a table (`recreateTable`, which the log shows as
`2026-06-26_attendees_kind_not_null`) raises the second message the moment
the batch runs out. The runner read that second message as a migration
defect, not as a spent budget. The request failed, the visitor got the error
page instead of the "update in progress" page, and the operator got an alert
for a migration that was working correctly.

The database still moved forward, because the four migrations that finished
were recorded before the failure. The site healed itself over the next few
reloads. The cost was the wrong page and a false alert on each one.

## The change

The two refusals are now one type. `SubrequestBudgetError` lives beside the
budget in `src/shared/subrequest-budget.ts`, and both `countSubrequest` and
`withSubrequestReserve` raise it. The messages do not change, so a log line
reads the same as before.

`src/shared/db/migrations/runner.ts` reads the type instead of the message
text, at all three places that ask "is this a spent budget or a real
failure?". The message-matching helper is deleted, along with its comment,
which claimed that the allowance message was the only one to match.

## For people using the site

While a site updates its database, a page now says the update continues,
which is what it already said for every other way the batch can run out. The
error page and its alert are gone for this case.

## The test file that the mutation gate could not reach

`test/shared/db/migrations/runner-budget.test.ts` sat beside the mirror path
for `src/shared/db/migrations/runner.ts`, not below it. The gate pairs a
source only with tests at its own mirror path, so it never ran that file
against the runner. The file is now
`test/shared/db/migrations/runner/budget.test.ts`, where the gate reaches it.

That move showed four mutants in the runner that no test had ever been asked
to kill, and the budget module had six more. All ten are now tests, listed
below. None went into `scripts/mutation/equivalent-mutants/`, because each one
was killable. `deno task precommit:mutation` reports 100%.

## Tests

The regression test for the failure above spends the whole capped allowance
in one migration, then gives the next migration a real interactive
transaction to open. Before the change it fails with the exact message from
the log. After it, the batch stops and returns the migration that finished.

The other new tests, and the mutant each one closes:

- The work inside a reserve sees the remaining budget minus the tail, so each
  of the three subtractions stays a subtraction.
- A reserve is refused when the database calls alone cannot cover it, and
  again when the external calls alone cannot, so each dimension blocks by
  itself.
- Each refusal has a test of its own, and the refusal carries its own name,
  so a log line identifies it.
- The runner leaves the caller room to record the batch and release the lock,
  so the held-back round-trips stay held back.
- The runner still runs one migration on the last call a request has, so a
  stale database always moves forward.
- The runner says it is re-running `up()`, and what verify was still missing.

The skipped-index scenario in `runner.test.ts` is now one helper that two
tests share: one asserts the repair, the other asserts the line that reports
it.