### PR TITLE
Load the message catalog in every test runner, and say why a key did not resolve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1552,12 +1552,17 @@ deno task test:files test/shared/payments.test.ts specs/payments/capacity-after-
 #### Lower-level alternative
 
 For a pure unit test that imports neither the app nor Stripe, you can skip the
-harness and run `deno test` directly on the file (fastest, but it fails on a
-missing `src/ui/static/*.js` asset or an unstarted stripe-mock if the test does
-import them):
+harness and run `deno test` directly on the file. This is the fastest way. It
+fails on a missing `src/ui/static/*.js` asset, or on an unstarted stripe-mock,
+when the test imports them.
+
+Always keep `--preload ./test/test-utils/preload.ts`. The preload puts the
+complete message catalog in the isolate. The runner tasks do this for you.
+Without the preload, every `t()` call throws `Missing translation for key "…"`
+for copy that is already in the catalog.
 
 ```bash
-deno test --no-check --allow-all test/shared/dates.test.ts
+deno test --no-check --allow-all --preload ./test/test-utils/preload.ts test/shared/dates.test.ts
 ```
 
 To do this for a test that depends on stripe-mock (anything importing Stripe),
@@ -1566,7 +1571,7 @@ you, or run `.bin/stripe-mock -http-port 12111` manually) and set the env vars
 to the port you chose:
 
 ```bash
-STRIPE_MOCK_HOST=localhost STRIPE_MOCK_PORT=12111 deno test --no-check --allow-all test/scripts/stripe-mock/ports.test.ts
+STRIPE_MOCK_HOST=localhost STRIPE_MOCK_PORT=12111 deno test --no-check --allow-all --preload ./test/test-utils/preload.ts test/scripts/stripe-mock/ports.test.ts
 ```
 
 ## Environment Variables

--- a/deno.json
+++ b/deno.json
@@ -22,7 +22,7 @@
     "specs:evidence": "deno run --v8-flags=--expose-gc -A scripts/run-spec-evidence.ts",
     "specs:check": "deno run --allow-read scripts/check-specs.ts",
     "specs:files": "deno run --v8-flags=--expose-gc -A scripts/run-specs.ts",
-    "test:raw": "deno task build:static && deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi test/",
+    "test:raw": "deno task build:static && deno test --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --allow-sys --allow-ffi --preload ./test/test-utils/preload.ts test/",
     "lint": "deno fmt && deno run -A scripts/biome.ts check --write --error-on-warnings src test scripts cli e2e-payments",
     "lint:ci": "deno fmt --check && deno run -A scripts/biome.ts check --error-on-warnings src test scripts cli e2e-payments",
     "typecheck": "deno check src test cli scripts && deno check --config=e2e-payments/deno.json e2e-payments/src",

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -168,6 +168,13 @@ const resolveMessage = (locale: string, key: string): Resolved | null => {
   return resolved;
 };
 
+/** Names which of the two causes applies, so a reader does not search for copy
+ * that is already in the catalog. */
+const missingKeyReason = (owner: MessageGroup | undefined): string =>
+  owner === undefined
+    ? "No loaded message group holds the key. The key is wrong, or its group is not loaded."
+    : `Group "${owner}" holds the key, but this scope does not declare it.`;
+
 /**
  * Translate a key with optional ICU MessageFormat parameters.
  *
@@ -189,7 +196,8 @@ export const t = (key: string, values?: Record<string, unknown>): string => {
       : resolveMessage(locale, key);
   if (resolved === null) {
     throw new Error(
-      `Missing translation for key "${key}" (locale "${locale}")`,
+      `Missing translation for key "${key}" (locale "${locale}"). ` +
+        missingKeyReason(owner),
     );
   }
   // Plain copy is already its final text; only ICU messages need formatting.

--- a/test/shared/i18n/loading.test.ts
+++ b/test/shared/i18n/loading.test.ts
@@ -221,4 +221,23 @@ describe("lazy message groups", () => {
         expect(t("common.icu_apostrophe")).toBe("It's ready");
       },
     ));
+
+  test("names the group that holds a key this scope did not declare", () =>
+    withColdMessages(async () => {
+      await ensureMessageGroups(MESSAGE_GROUPS);
+
+      await withMessageGroups(["common"], () => {
+        expect(() => t("admin.dashboard.guide_link")).toThrow(
+          'Group "dashboard" holds the key, but this scope does not declare it.',
+        );
+      });
+    }));
+
+  test("says no group holds a key whose catalog never loaded", () =>
+    withColdMessages(() => {
+      expect(() => t("common.yes")).toThrow(
+        "No loaded message group holds the key. The key is wrong, or its group is not loaded.",
+      );
+      return Promise.resolve();
+    }));
 });


### PR DESCRIPTION
## The reported error

```
Missing translation for key "fields.listing.hidden_hint_group" (locale "en")
```

The copy is not missing. It sits in `src/locales/en/listings-table.json`, and
the app reads it. The full test suite, the Cucumber specs, and the edge bundle
all hold it.

## The cause

A test isolate gets the complete message catalog from
`--preload ./test/test-utils/preload.ts`. Only the runner scripts passed that
flag. A direct `deno test` run therefore held no catalog, and the first `t()`
call in the file threw.

`AGENTS.md` documented that direct command **without** the flag, under
"Lower-level alternative". It named only two caveats, a missing
`src/ui/static/*.js` asset and an unstarted stripe-mock. So the documented way
to run one test file could not work for any test that renders copy.

`test/ui/templates/fields/group.test.ts` is the file that produces the exact
message above. The first translation the group form asks for is the hint on the
group visibility checkbox:

```bash
deno test --no-check --allow-all test/ui/templates/fields/group.test.ts
# Missing translation for key "fields.listing.hidden_hint_group" (locale "en")
```

The message then sent the reader to search `src/locales/` for copy that was
already there.

## What changed

- **`AGENTS.md`** — both single-file commands keep
  `--preload ./test/test-utils/preload.ts`. The section says what the preload
  does, and what happens without it.
- **`deno.json`** — `deno task test:raw` passes the same flag. It ran the whole
  of `test/` without a catalog, so it had the same fault.
- **`src/shared/i18n.ts`** — `t()` names which of the two causes applies:
  - `Group "dashboard" holds the key, but this scope does not declare it.`
  - `No loaded message group holds the key. The key is wrong, or its group is not loaded.`
- **`test/shared/i18n/loading.test.ts`** — one regression test for each cause.

## What this means for the people who use the site

Nothing changes on any page. The copy, the routes, and the message groups are
the same. This is a fix to the developer tools and to a developer error
message.

## Checks

All of these ran on `7d65e7a` and passed.

- Both new tests fail against the old error text and pass with the new one.
- With the documented flag, `test/ui/templates/fields/group.test.ts` passes.
- `deno task precommit` passed. This covers lint, typecheck, cpd,
  `check:copy`, `check:comments`, `check:imports`, `check:equivalents`,
  `build:edge`, and `test:coverage`.
- `deno task precommit:mutation` passed for `src/shared/i18n.ts`. The score is
  100%, from 76 mutants: 75 killed, 0 survived, 1 suppressed as
  known-equivalent.
- `deno task specs` passed before the change, and the complete suite passed
  before the change too.

## The same message from a production site

The same text was also reported from a production site, on
`GET /admin/catalog/import`. That is a **different fault, and main already
fixes it**. This pull request does not change that path.

Before #1883, `src/features/admin/catalog-transfer/import.ts` imported
`generateUniqueGroupSlug` from `#routes/admin/groups.ts`. That module builds
the group create form in its body, and the first translation the form asks for
is `fields.listing.hidden_hint_group`. The catalog area declared only
`["catalog-transfer", "validation"]`, so `listings-table` never loaded, and the
area threw while it loaded.

- #1883 moved `generateUniqueGroupSlug` to `#shared/db/groups.ts`, so the import
  path no longer reaches the admin groups route module. It also added the
  cold-scope guard in `test/features/admin/catalog-transfer/routes.test.ts`.
- #1971 added `groups` and `listings-table` to the catalog area, for the
  refusal messages a rejected import renders.

I verified both ends. At `55f213b1`, the commit before #1883, loading the
catalog area under its declared scope throws a missing-translation error. On
main it loads with no error, and the scope reads
`["catalog-transfer", "groups", "listings-table", "validation"]`.

A site that still shows this error runs a build from before 2026-07-22, and an
upgrade fixes it.