### PR TITLE
Break the db tangle's spine by homing the reachability core

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -231,3 +231,4 @@ src/shared/db/attendees/create.ts::capacityFailure.listingIds.durationDays~04izj
 src/shared/db/sumup-recovery.ts::listUnansweredSumupMoney.counted~06tpdj3 The unanswered SumUp count returned no result→""   # unreachable: one ResultSet per batch statement
 src/shared/db/sumup-recovery.ts::listUnansweredSumupMoney.total~06i495w The unanswered SumUp count returned no row→""   # unreachable: COUNT(*) always returns one row
 src/shared/db/sumup-recovery.ts::listUnansweredSumupMoney.listed~1ympdrn The unanswered SumUp listing returned no result→""   # unreachable: one ResultSet per batch statement
+src/shared/db/listing-relationship-validation.ts::listingById.listingPrices~0p5a2j2  ?? → ||   # the day-price map holds record objects, and a record is always truthy even when empty

--- a/src/shared/db/listing-relationship-validation.ts
+++ b/src/shared/db/listing-relationship-validation.ts
@@ -1,7 +1,6 @@
 import { inPlaceholders, resultRows, type TxScope } from "#db/client.ts";
 import type { DayPriceRow } from "#db/listing-prices.ts";
 import { rawListingsTable } from "#db/listings/table.ts";
-import { scopeIsChildDeadEnd } from "#db/modifier-resolve.ts";
 import { modifiersTable } from "#db/modifiers.ts";
 import { unique } from "#fp";
 import {
@@ -9,6 +8,7 @@ import {
   type EdgeListing,
   edgeFieldError,
   type ParentChildEdge,
+  scopeIsChildDeadEnd,
 } from "#shared/listing-parents-rules.ts";
 import type { DayPrices } from "#types";
 

--- a/src/shared/db/modifier-resolve.ts
+++ b/src/shared/db/modifier-resolve.ts
@@ -23,6 +23,10 @@ import { requiredMapValue, unique } from "#fp";
 import { t } from "#i18n";
 import { itemsSubtotal } from "#shared/booking-fee.ts";
 import { formatCurrency, toMinorUnits } from "#shared/currency.ts";
+import {
+  scopeIsChildDeadEnd,
+  scopeReachesPage,
+} from "#shared/listing-parents-rules.ts";
 import type { CheckoutItem, ModifierSpec } from "#shared/payments.ts";
 import { type ModifierTrigger, normalizeCode } from "#shared/price-modifier.ts";
 import type { Modifier } from "#types";
@@ -195,37 +199,6 @@ const scopeCoversListing = (
   listingId: number,
 ): boolean =>
   scope === null || (Array.isArray(scope) && scope.includes(listingId));
-
-/** Whether a resolved listing scope is reachable from a page's listing ids:
- * a whole-order scope (null) always is; a listing set must share an id. Shared
- * by the add-on listing and the child-reachability hard block. */
-const scopeReachesPage = (
-  scope: number[] | null,
-  pageIds: Set<number>,
-): boolean => scope === null || scope.some((id) => pageIds.has(id));
-
-/**
- * The single reachability test shared by both child-scoped-add-on hard blocks,
- * so the edge save and the modifier save can never diverge.
- *
- * An opt-in add-on is a dead end exactly when its resolved scope is a listing
- * set that names a suppressed child yet reaches none of the pages that would
- * load it. A whole-order scope (`null`) is reachable everywhere.
- *
- * Callers define "reachable" from their own side, which is why the two id sets
- * are parameters rather than derived here.
- */
-export const scopeIsChildDeadEnd = (
-  scope: number[] | null,
-  suppressed: Set<number>,
-  reachable: Set<number>,
-): boolean => {
-  if (scope === null) return false;
-  return (
-    scope.some((id) => suppressed.has(id)) &&
-    !scopeReachesPage(scope, reachable)
-  );
-};
 
 /**
  * Total quantity each "answer"-triggered modifier is requested for, respecting

--- a/src/shared/listing-parents-rules.ts
+++ b/src/shared/listing-parents-rules.ts
@@ -122,3 +122,34 @@ const EDGE_ERROR_RULES: readonly EdgeReason[] = [
  * checked separately by the editor.
  */
 export const edgeFieldError: EdgeReason = firstReason(EDGE_ERROR_RULES);
+
+/** Whether a resolved listing scope is reachable from a page's listing ids:
+ * a whole-order scope (null) always is; a listing set must share an id. Shared
+ * by the add-on listing and the child-reachability hard block. */
+export const scopeReachesPage = (
+  scope: number[] | null,
+  pageIds: Set<number>,
+): boolean => scope === null || scope.some((id) => pageIds.has(id));
+
+/**
+ * The single reachability test shared by both child-scoped-add-on hard blocks,
+ * so the edge save and the modifier save can never diverge.
+ *
+ * An opt-in add-on is a dead end exactly when its resolved scope is a listing
+ * set that names a suppressed child yet reaches none of the pages that would
+ * load it. A whole-order scope (`null`) is reachable everywhere.
+ *
+ * Callers define "reachable" from their own side, which is why the two id sets
+ * are parameters rather than derived here.
+ */
+export const scopeIsChildDeadEnd = (
+  scope: number[] | null,
+  suppressed: Set<number>,
+  reachable: Set<number>,
+): boolean => {
+  if (scope === null) return false;
+  return (
+    scope.some((id) => suppressed.has(id)) &&
+    !scopeReachesPage(scope, reachable)
+  );
+};

--- a/test/shared/db/modifier-resolve/reachability.test.ts
+++ b/test/shared/db/modifier-resolve/reachability.test.ts
@@ -1,35 +1,13 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { reachablePageIds, scopeIsChildDeadEnd } from "#db/modifier-resolve.ts";
+import { reachablePageIds } from "#db/modifier-resolve.ts";
 
 /**
- * The two pure rules behind the child-only add-on block. An add-on dead-ends
- * when every page that offers it belongs to a child listing with no page of
- * its own. Both rules are plain data in, plain answer out, so they are tested
- * here rather than through a saved listing.
+ * The pure rule behind which listings still serve a booking page that can
+ * offer an add-on. Plain data in, plain answer out, so it is tested here
+ * rather than through a saved listing. (The dead-end test over scopes moved
+ * with it to `test/shared/listing-parents-rules.test.ts`.)
  */
-
-describe("scopeIsChildDeadEnd", () => {
-  test("a whole-order add-on is never a dead end", () => {
-    // A null scope means the add-on loads on every page, so no listing choice
-    // takes it away.
-    expect(scopeIsChildDeadEnd(null, new Set([5]), new Set())).toBe(false);
-  });
-
-  test("a scope that names no hidden child is never a dead end", () => {
-    // Listing 5 keeps its own page. The add-on stays reachable there, whatever
-    // the parent pages hold.
-    expect(scopeIsChildDeadEnd([5], new Set([9]), new Set())).toBe(false);
-  });
-
-  test("a scope of one hidden child with no page left is a dead end", () => {
-    expect(scopeIsChildDeadEnd([5], new Set([5]), new Set())).toBe(true);
-  });
-
-  test("one live page in the scope rescues the hidden child", () => {
-    expect(scopeIsChildDeadEnd([5, 6], new Set([5]), new Set([6]))).toBe(false);
-  });
-});
 
 describe("reachablePageIds", () => {
   test("keeps a listing that is live and is not a hidden child", () => {

--- a/test/shared/listing-parents-rules.test.ts
+++ b/test/shared/listing-parents-rules.test.ts
@@ -6,6 +6,8 @@ import {
   durationsCompatible,
   type EdgeListing,
   edgeFieldError,
+  scopeIsChildDeadEnd,
+  scopeReachesPage,
 } from "#shared/listing-parents-rules.ts";
 
 /** The i18n message a broken edge rule reports for the named listing — the
@@ -20,6 +22,39 @@ describe("childAddOnError", () => {
     expect(message).toContain("Face Paint");
     expect(message).toContain("Bouncy Castle");
     expect(message).not.toContain("children_err");
+  });
+});
+
+describe("scopeReachesPage", () => {
+  test("a whole-order scope reaches every page", () => {
+    expect(scopeReachesPage(null, new Set())).toBe(true);
+  });
+
+  test("a listing scope reaches a page that shares one of its ids", () => {
+    expect(scopeReachesPage([7, 8], new Set([8, 9]))).toBe(true);
+    expect(scopeReachesPage([7], new Set([8, 9]))).toBe(false);
+  });
+});
+
+describe("scopeIsChildDeadEnd", () => {
+  test("a whole-order add-on is never a dead end", () => {
+    // A null scope means the add-on loads on every page, so no listing choice
+    // takes it away.
+    expect(scopeIsChildDeadEnd(null, new Set([5]), new Set())).toBe(false);
+  });
+
+  test("a scope that names no hidden child is never a dead end", () => {
+    // Listing 5 keeps its own page. The add-on stays reachable there, whatever
+    // the parent pages hold.
+    expect(scopeIsChildDeadEnd([5], new Set([9]), new Set())).toBe(false);
+  });
+
+  test("a scope of one hidden child with no page left is a dead end", () => {
+    expect(scopeIsChildDeadEnd([5], new Set([5]), new Set())).toBe(true);
+  });
+
+  test("one live page in the scope rescues the hidden child", () => {
+    expect(scopeIsChildDeadEnd([5, 6], new Set([5]), new Set([6]))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## The measurement was wrong, in a good way

The cycle scan behind #2168's TODO entry counted every import `deno
info` reports — including dynamic ones. But a dynamic import evaluates
nothing at load: `logger.ts` imports the activity log exactly that way,
with a comment saying why ("a static import here would drag the
activity-log table into every page's graph"). Counting load-time edges
only — the edges that cost cold starts — the "73-module blob" does not
exist: the biggest group in the tree was **7**, all under `src/shared/db/`.

## What changed

Those 7 — groups, groups/membership, listing-parents, listing-prices,
listing-relationship-validation, listings/records, modifier-resolve —
turned on one spine: `listing-relationship-validation` reached into
`modifier-resolve` for `scopeIsChildDeadEnd`, whose own doc says it is
"the single reachability test shared by both child-scoped-add-on hard
blocks, so the edge save and the modifier save can never diverge".

A core two writers share belongs between them, not inside one. It and
its `scopeReachesPage` helper move to `#shared/listing-parents-rules.ts`
— the pure leaf both writers already lean on — and its tests move with
it. The spine is gone.

Measured after: the seven dissolve into the two loops that are genuinely
left, each with a named owner —

- `listings/records → listing-prices → listing-parents → records`: the
  listing write pipeline (a save syncs day prices and re-validates
  edges). Real coupling, not an accident.
- `groups ↔ groups/membership`: the group write machinery and its
  membership rules. The deepest cut left on the map.

…plus `validation` and `modifier-resolve` freed entirely. Largest
cyclic group in the tree is now a route-template triangle.

## Gates

`precommit` green; `precommit:mutation` 100% (211/211, 14 suppressed).
One new equivalence record: the day-price map fallback, whose values are
record objects and therefore always truthy.