### PR TITLE
Break the four admin form cycles, and land the cycle report as a tool

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -33,6 +33,7 @@
     "precommit": "deno run -A scripts/precommit.ts",
     "precommit:mutation": "deno run -A scripts/precommit-mutation.ts",
     "find-unused-src": "deno run --allow-read scripts/find-unused-src.ts",
+    "cycles": "deno run -A scripts/cycles.ts",
     "line-counts": "deno run --allow-read=src,test scripts/line-counts.ts",
     "diff-code-lines": "deno run --allow-env=PATH --allow-run=git scripts/diff-code-lines.ts",
     "unit-tests-report": "deno run --allow-read=src,test,deno.json scripts/unit-tests-report.ts",

--- a/scripts/cycles.ts
+++ b/scripts/cycles.ts
@@ -1,8 +1,7 @@
 /**
  * The import-cycle report for the production module graph. A report, not a
- * gate: the tree carries known groups, so `deno task cycles` prints the
- * number to work down rather than failing on it. Run it with
- * `deno task cycles`.
+ * gate: the tree carries known groups, so this prints the number to work
+ * down rather than failing on it.
  */
 
 import { runCycleReport } from "./cycles/run.ts";

--- a/scripts/cycles.ts
+++ b/scripts/cycles.ts
@@ -1,0 +1,10 @@
+/**
+ * The import-cycle report for the production module graph. A report, not a
+ * gate: the tree carries known groups, so `deno task cycles` prints the
+ * number to work down rather than failing on it. Run it with
+ * `deno task cycles`.
+ */
+
+import { runCycleReport } from "./cycles/run.ts";
+
+console.log(await runCycleReport());

--- a/scripts/cycles/graph.ts
+++ b/scripts/cycles/graph.ts
@@ -4,7 +4,7 @@
  * screen. Data in, data out — the `deno info` read lives in run.ts.
  */
 
-import { relative } from "@std/path";
+import { fromFileUrl, relative } from "@std/path";
 import {
   type ModuleGraph,
   staticCodeSpecifiers,
@@ -24,7 +24,9 @@ export const loadTimeEdges = (
   const edges = new Map<string, Set<string>>();
   const localUnderRoot = (specifier: string): string | null => {
     if (!specifier.startsWith("file://")) return null;
-    const path = relative(root, specifier.replace("file://", ""));
+    // fromFileUrl decodes the URL: a repo path with a space arrives as
+    // %20, and the undecoded form reads as outside the root.
+    const path = relative(root, fromFileUrl(specifier));
     return path.startsWith("..") || path.startsWith("/") ? null : path;
   };
   for (const module of graph.modules) {

--- a/scripts/cycles/graph.ts
+++ b/scripts/cycles/graph.ts
@@ -5,6 +5,7 @@
  */
 
 import { fromFileUrl, relative, SEPARATOR } from "@std/path";
+import { requiredMapValue } from "#fp";
 import {
   type ModuleGraph,
   runtimeReachableSpecifiers,
@@ -126,12 +127,18 @@ export const cyclicGroups = (edges: Map<string, Set<string>>): string[][] => {
   const importsOf = nodes.map((node) =>
     [...(edges.get(node) ?? [])]
       .filter((target) => index.has(target))
-      .map((target) => index.get(target)!),
+      .map((target) =>
+        requiredMapValue(
+          index,
+          target,
+          `Module index has no entry for ${target}`,
+        ),
+      ),
   );
   const importersOf = nodes.map(() => [] as number[]);
-  importsOf.forEach((targets, from) => {
+  for (const [from, targets] of importsOf.entries()) {
     for (const to of targets) importersOf[to]!.push(from);
-  });
+  }
   return groupsFromFinishOrder(finishOrderOf(nodes, importsOf), importersOf)
     .filter((group) => group.length > 1)
     .map((group) => group.map((node) => nodes[node]!).sort())

--- a/scripts/cycles/graph.ts
+++ b/scripts/cycles/graph.ts
@@ -1,0 +1,147 @@
+/**
+ * The pure core of the import-cycle report: which modules a graph's
+ * load-time edges hold in mutual reachability, and how to say that on
+ * screen. Data in, data out — the `deno info` read lives in run.ts.
+ */
+
+import { relative } from "@std/path";
+import {
+  type ModuleGraph,
+  staticCodeSpecifiers,
+} from "#scripts/module-graph.ts";
+
+/**
+ * The load-time import edges of a graph: which local files under `root`
+ * evaluate which others. Keyed and valued by paths relative to `root`.
+ * Type-only imports evaluate nothing and dynamic imports are deferred to
+ * first use, so neither is an edge — a cycle through either costs no cold
+ * start and no load order.
+ */
+export const loadTimeEdges = (
+  graph: ModuleGraph,
+  root: string,
+): Map<string, Set<string>> => {
+  const edges = new Map<string, Set<string>>();
+  const localUnderRoot = (specifier: string): string | null => {
+    if (!specifier.startsWith("file://")) return null;
+    const path = relative(root, specifier.replace("file://", ""));
+    return path.startsWith("..") || path.startsWith("/") ? null : path;
+  };
+  for (const module of graph.modules) {
+    const from = localUnderRoot(module.specifier);
+    if (from === null) continue;
+    for (const toSpecifier of staticCodeSpecifiers(module.dependencies ?? [])) {
+      const to = localUnderRoot(toSpecifier);
+      if (to === null || to === from) continue;
+      const targets = edges.get(from) ?? new Set<string>();
+      targets.add(to);
+      edges.set(from, targets);
+    }
+  }
+  return edges;
+};
+
+/** The modules of a graph in the order their imports finish loading: a
+ * depth-first walk that records each module after everything it imports.
+ * Iterative, so a deep graph cannot overflow the stack. */
+const finishOrderOf = (nodes: string[], adjacency: number[][]): number[] => {
+  const seen = new Array<boolean>(nodes.length).fill(false);
+  const finished: number[] = [];
+  for (let start = 0; start < nodes.length; start++) {
+    if (seen[start]) continue;
+    seen[start] = true;
+    const stack: [number, number][] = [[start, 0]];
+    while (stack.length > 0) {
+      const [node, next] = stack[stack.length - 1]!;
+      if (next < adjacency[node]!.length) {
+        stack[stack.length - 1]![1] = next + 1;
+        const target = adjacency[node]![next]!;
+        if (!seen[target]) {
+          seen[target] = true;
+          stack.push([target, 0]);
+        }
+      } else {
+        stack.pop();
+        finished.push(node);
+      }
+    }
+  }
+  return finished;
+};
+
+/** The groups of mutually-loading modules, walked off the finish order in
+ * reverse: each unvisited module there starts one group. */
+const groupsFromFinishOrder = (
+  finished: number[],
+  transpose: number[][],
+): number[][] => {
+  const assigned = new Array<boolean>(finished.length).fill(false);
+  const groups: number[][] = [];
+  for (let i = finished.length - 1; i >= 0; i--) {
+    const start = finished[i]!;
+    if (assigned[start]) continue;
+    const group: number[] = [];
+    assigned[start] = true;
+    const work = [start];
+    while (work.length > 0) {
+      const node = work.pop()!;
+      group.push(node);
+      for (const source of transpose[node]!) {
+        if (!assigned[source]) {
+          assigned[source] = true;
+          work.push(source);
+        }
+      }
+    }
+    groups.push(group);
+  }
+  return groups;
+};
+
+/**
+ * The groups of modules that can each load the other: strongly connected
+ * components of more than one module, largest first, each member list
+ * sorted. A group is a load-order tangle — any module in it pulls in every
+ * other — and the count to work down is the group's size.
+ */
+export const cyclicGroups = (edges: Map<string, Set<string>>): string[][] => {
+  const nodes = [
+    ...new Set([
+      ...edges.keys(),
+      ...[...edges.values()].flatMap((targets) => [...targets]),
+    ]),
+  ];
+  const index = new Map(nodes.map((node, i) => [node, i]));
+  const adjacency = nodes.map((node) =>
+    [...(edges.get(node) ?? [])]
+      .filter((target) => index.has(target))
+      .map((target) => index.get(target)!),
+  );
+  const transpose = nodes.map(() => [] as number[]);
+  adjacency.forEach((targets, from) => {
+    for (const to of targets) transpose[to]!.push(from);
+  });
+  return groupsFromFinishOrder(finishOrderOf(nodes, adjacency), transpose)
+    .filter((group) => group.length > 1)
+    .map((group) => group.map((node) => nodes[node]!).sort())
+    .sort((a, b) => b.length - a.length);
+};
+
+/** The on-screen report: what was measured, and every group it found. */
+export const formatCycleReport = (
+  edges: Map<string, Set<string>>,
+  groups: string[][],
+): string => {
+  const lines = [
+    `modules with load-time imports: ${edges.size}`,
+    `cyclic groups: ${groups.length}`,
+    "",
+    "Load-time edges only: type-only imports evaluate nothing and dynamic",
+    "imports are deferred, so neither creates a load-order cycle.",
+  ];
+  for (const group of groups) {
+    lines.push("", `== group of ${group.length} ==`);
+    for (const member of group) lines.push(`  ${member}`);
+  }
+  return lines.join("\n");
+};

--- a/scripts/cycles/graph.ts
+++ b/scripts/cycles/graph.ts
@@ -9,7 +9,7 @@ import { requiredMapValue } from "#fp";
 import {
   type ModuleGraph,
   runtimeReachableSpecifiers,
-  staticCodeSpecifiers,
+  staticImportsBySpecifier,
 } from "#scripts/module-graph.ts";
 
 /**
@@ -19,13 +19,14 @@ import {
  * first use, so neither is an edge — a cycle through either costs no cold
  * start and no load order. Modules only a type import can reach are skipped
  * entirely: they never evaluate, so their inner cycles are not load-order
- * tangles.
+ * tangles. A module importing itself stays an edge: it is a tangle of one.
  */
 export const loadTimeEdges = (
   graph: ModuleGraph,
   root: string,
 ): Map<string, Set<string>> => {
   const reachable = runtimeReachableSpecifiers(graph);
+  const staticImports = staticImportsBySpecifier(graph);
   const edges = new Map<string, Set<string>>();
   const localUnderRoot = (specifier: string): string | null => {
     if (!specifier.startsWith("file://") || !reachable.has(specifier)) {
@@ -39,12 +40,12 @@ export const loadTimeEdges = (
     const escapesRoot = path === ".." || path.startsWith(`..${SEPARATOR}`);
     return escapesRoot ? null : path;
   };
-  for (const module of graph.modules) {
-    const from = localUnderRoot(module.specifier);
+  for (const [specifier, imports] of staticImports) {
+    const from = localUnderRoot(specifier);
     if (from === null) continue;
-    for (const toSpecifier of staticCodeSpecifiers(module.dependencies ?? [])) {
+    for (const toSpecifier of imports) {
       const to = localUnderRoot(toSpecifier);
-      if (to === null || to === from) continue;
+      if (to === null) continue;
       const targets = edges.get(from) ?? new Set<string>();
       targets.add(to);
       edges.set(from, targets);
@@ -111,10 +112,10 @@ const groupsFromFinishOrder = (
 };
 
 /**
- * The groups of modules that can each load the other — more than one module,
- * largest first, each member list sorted. A group is a load-order tangle:
- * any module in it pulls in every other, and the count to work down is the
- * group's size.
+ * The groups of modules that can each load the other — two or more modules,
+ * or one module that imports itself — largest first, each member list
+ * sorted. A group is a load-order tangle: any module in it pulls in every
+ * other, and the count to work down is the group's size.
  */
 export const cyclicGroups = (edges: Map<string, Set<string>>): string[][] => {
   const nodes = [
@@ -139,8 +140,10 @@ export const cyclicGroups = (edges: Map<string, Set<string>>): string[][] => {
   for (const [from, targets] of importsOf.entries()) {
     for (const to of targets) importersOf[to]!.push(from);
   }
+  const isTangle = (group: number[]): boolean =>
+    group.length > 1 || importsOf[group[0]!]!.includes(group[0]!);
   return groupsFromFinishOrder(finishOrderOf(nodes, importsOf), importersOf)
-    .filter((group) => group.length > 1)
+    .filter(isTangle)
     .map((group) => group.map((node) => nodes[node]!).sort())
     .sort((a, b) => b.length - a.length);
 };

--- a/scripts/cycles/graph.ts
+++ b/scripts/cycles/graph.ts
@@ -46,7 +46,7 @@ export const loadTimeEdges = (
 /** The modules of a graph in the order their imports finish loading: a
  * depth-first walk that records each module after everything it imports.
  * Iterative, so a deep graph cannot overflow the stack. */
-const finishOrderOf = (nodes: string[], adjacency: number[][]): number[] => {
+const finishOrderOf = (nodes: string[], importsOf: number[][]): number[] => {
   const seen = new Array<boolean>(nodes.length).fill(false);
   const finished: number[] = [];
   for (let start = 0; start < nodes.length; start++) {
@@ -55,9 +55,9 @@ const finishOrderOf = (nodes: string[], adjacency: number[][]): number[] => {
     const stack: [number, number][] = [[start, 0]];
     while (stack.length > 0) {
       const [node, next] = stack[stack.length - 1]!;
-      if (next < adjacency[node]!.length) {
+      if (next < importsOf[node]!.length) {
         stack[stack.length - 1]![1] = next + 1;
-        const target = adjacency[node]![next]!;
+        const target = importsOf[node]![next]!;
         if (!seen[target]) {
           seen[target] = true;
           stack.push([target, 0]);
@@ -75,7 +75,7 @@ const finishOrderOf = (nodes: string[], adjacency: number[][]): number[] => {
  * reverse: each unvisited module there starts one group. */
 const groupsFromFinishOrder = (
   finished: number[],
-  transpose: number[][],
+  importersOf: number[][],
 ): number[][] => {
   const assigned = new Array<boolean>(finished.length).fill(false);
   const groups: number[][] = [];
@@ -88,7 +88,7 @@ const groupsFromFinishOrder = (
     while (work.length > 0) {
       const node = work.pop()!;
       group.push(node);
-      for (const source of transpose[node]!) {
+      for (const source of importersOf[node]!) {
         if (!assigned[source]) {
           assigned[source] = true;
           work.push(source);
@@ -101,10 +101,10 @@ const groupsFromFinishOrder = (
 };
 
 /**
- * The groups of modules that can each load the other: strongly connected
- * components of more than one module, largest first, each member list
- * sorted. A group is a load-order tangle — any module in it pulls in every
- * other — and the count to work down is the group's size.
+ * The groups of modules that can each load the other — more than one module,
+ * largest first, each member list sorted. A group is a load-order tangle:
+ * any module in it pulls in every other, and the count to work down is the
+ * group's size.
  */
 export const cyclicGroups = (edges: Map<string, Set<string>>): string[][] => {
   const nodes = [
@@ -114,16 +114,16 @@ export const cyclicGroups = (edges: Map<string, Set<string>>): string[][] => {
     ]),
   ];
   const index = new Map(nodes.map((node, i) => [node, i]));
-  const adjacency = nodes.map((node) =>
+  const importsOf = nodes.map((node) =>
     [...(edges.get(node) ?? [])]
       .filter((target) => index.has(target))
       .map((target) => index.get(target)!),
   );
-  const transpose = nodes.map(() => [] as number[]);
-  adjacency.forEach((targets, from) => {
-    for (const to of targets) transpose[to]!.push(from);
+  const importersOf = nodes.map(() => [] as number[]);
+  importsOf.forEach((targets, from) => {
+    for (const to of targets) importersOf[to]!.push(from);
   });
-  return groupsFromFinishOrder(finishOrderOf(nodes, adjacency), transpose)
+  return groupsFromFinishOrder(finishOrderOf(nodes, importsOf), importersOf)
     .filter((group) => group.length > 1)
     .map((group) => group.map((node) => nodes[node]!).sort())
     .sort((a, b) => b.length - a.length);

--- a/scripts/cycles/graph.ts
+++ b/scripts/cycles/graph.ts
@@ -4,30 +4,39 @@
  * screen. Data in, data out — the `deno info` read lives in run.ts.
  */
 
-import { fromFileUrl, relative } from "@std/path";
+import { fromFileUrl, relative, SEPARATOR } from "@std/path";
 import {
   type ModuleGraph,
+  runtimeReachableSpecifiers,
   staticCodeSpecifiers,
 } from "#scripts/module-graph.ts";
 
 /**
- * The load-time import edges of a graph: which local files under `root`
+ * The load-time import edges of a graph: which modules reachable at runtime
  * evaluate which others. Keyed and valued by paths relative to `root`.
  * Type-only imports evaluate nothing and dynamic imports are deferred to
  * first use, so neither is an edge — a cycle through either costs no cold
- * start and no load order.
+ * start and no load order. Modules only a type import can reach are skipped
+ * entirely: they never evaluate, so their inner cycles are not load-order
+ * tangles.
  */
 export const loadTimeEdges = (
   graph: ModuleGraph,
   root: string,
 ): Map<string, Set<string>> => {
+  const reachable = runtimeReachableSpecifiers(graph);
   const edges = new Map<string, Set<string>>();
   const localUnderRoot = (specifier: string): string | null => {
-    if (!specifier.startsWith("file://")) return null;
+    if (!specifier.startsWith("file://") || !reachable.has(specifier)) {
+      return null;
+    }
     // fromFileUrl decodes the URL: a repo path with a space arrives as
     // %20, and the undecoded form reads as outside the root.
     const path = relative(root, fromFileUrl(specifier));
-    return path.startsWith("..") || path.startsWith("/") ? null : path;
+    // A leading ".." must be the parent escape itself — a name such as
+    // ..generated stays a module under the root.
+    const escapesRoot = path === ".." || path.startsWith(`..${SEPARATOR}`);
+    return escapesRoot ? null : path;
   };
   for (const module of graph.modules) {
     const from = localUnderRoot(module.specifier);

--- a/scripts/cycles/run.ts
+++ b/scripts/cycles/run.ts
@@ -11,7 +11,7 @@ const ROOT_MODULE = "src/serve-app.ts";
 
 /** Reads the module graph for `entry` from `cwd` — injectable so tests run
  * the report over fixtures without a `deno info` subprocess. */
-export type GraphReader = (entry: string, cwd: string) => Promise<ModuleGraph>;
+type GraphReader = (entry: string, cwd: string) => Promise<ModuleGraph>;
 
 /** The full import-cycle report for the production entry point's graph. */
 export const runCycleReport = async (

--- a/scripts/cycles/run.ts
+++ b/scripts/cycles/run.ts
@@ -1,0 +1,18 @@
+/**
+ * IO shell for the cycle report: reads the real module graph and returns the
+ * report text. Kept thin so the graph logic stays testable.
+ */
+
+import { resolve } from "@std/path";
+import { readModuleGraph } from "#scripts/module-graph.ts";
+import { cyclicGroups, formatCycleReport, loadTimeEdges } from "./graph.ts";
+
+const ROOT_MODULE = "src/serve-app.ts";
+
+/** The full import-cycle report for the production entry point's graph. */
+export const runCycleReport = async (): Promise<string> => {
+  const repoRoot = resolve(import.meta.dirname!, "../..");
+  const graph = await readModuleGraph(ROOT_MODULE, repoRoot);
+  const edges = loadTimeEdges(graph, repoRoot);
+  return formatCycleReport(edges, cyclicGroups(edges));
+};

--- a/scripts/cycles/run.ts
+++ b/scripts/cycles/run.ts
@@ -4,15 +4,21 @@
  */
 
 import { resolve } from "@std/path";
-import { readModuleGraph } from "#scripts/module-graph.ts";
+import { type ModuleGraph, readModuleGraph } from "#scripts/module-graph.ts";
 import { cyclicGroups, formatCycleReport, loadTimeEdges } from "./graph.ts";
 
 const ROOT_MODULE = "src/serve-app.ts";
 
+/** Reads the module graph for `entry` from `cwd` — injectable so tests run
+ * the report over fixtures without a `deno info` subprocess. */
+export type GraphReader = (entry: string, cwd: string) => Promise<ModuleGraph>;
+
 /** The full import-cycle report for the production entry point's graph. */
-export const runCycleReport = async (): Promise<string> => {
+export const runCycleReport = async (
+  readGraph: GraphReader = readModuleGraph,
+): Promise<string> => {
   const repoRoot = resolve(import.meta.dirname!, "../..");
-  const graph = await readModuleGraph(ROOT_MODULE, repoRoot);
+  const graph = await readGraph(ROOT_MODULE, repoRoot);
   const edges = loadTimeEdges(graph, repoRoot);
   return formatCycleReport(edges, cyclicGroups(edges));
 };

--- a/scripts/module-graph.ts
+++ b/scripts/module-graph.ts
@@ -1,17 +1,18 @@
 /**
- * Reading the local module graph with `deno info --json`. Shared by every
+ * Read the local module graph with `deno info --json`. Shared by every
  * tool that needs to know what imports what: the mutation state graph and
  * the import-cycle report.
  *
  * The two distinctions that matter to every reader:
- * - a dependency with no `code` specifier is type-only, and types never
- *   evaluate, so they belong to no runtime graph;
+ * - a dependency with no `code` specifier is type-only. Types never
+ *   evaluate, so they belong to no runtime graph.
  * - a dependency marked `isDynamic` is deferred to first use, so it costs
  *   no cold start and creates no load-order cycle.
  */
 
 import { fromFileUrl } from "@std/path";
 import * as v from "valibot";
+import { requiredMapValue } from "#fp";
 import { runCommand } from "#scripts/precommit/git.ts";
 
 // `deno info --json` emits a richer per-module object; only the fields used
@@ -55,7 +56,7 @@ const ModuleGraphSchema = v.object({
 export type ModuleGraph = v.InferOutput<typeof ModuleGraphSchema>;
 type Dependency = v.InferOutput<typeof DependencySchema>;
 
-/** Run `deno info --json` for `entry` from `cwd`, failing loudly on errors. */
+/** Run `deno info --json` for `entry` from `cwd`. Fail loudly on errors. */
 export const readModuleGraph = async (
   entry: string,
   cwd: string,
@@ -126,7 +127,11 @@ const reachableModules = (
       continue;
     }
     seen.add(specifier);
-    const module = bySpecifier.get(specifier)!;
+    const module = requiredMapValue(
+      bySpecifier,
+      specifier,
+      `Module list lost the entry for ${specifier}`,
+    );
     const runtimeImports = codeSpecifiers(module.dependencies, followDynamic);
     for (const resolved of runtimeImports) {
       if (!seen.has(resolved)) queue.push(resolved);

--- a/scripts/module-graph.ts
+++ b/scripts/module-graph.ts
@@ -44,8 +44,8 @@ const ModuleGraphSchema = v.object({
 });
 
 export type ModuleGraph = v.InferOutput<typeof ModuleGraphSchema>;
-export type Dependency = v.InferOutput<typeof DependencySchema>;
-export type GraphModule = ModuleGraph["modules"][number];
+type Dependency = v.InferOutput<typeof DependencySchema>;
+type GraphModule = ModuleGraph["modules"][number];
 
 /** Run `deno info --json` for `entry` from `cwd`, failing loudly on errors. */
 export const readModuleGraph = async (
@@ -127,10 +127,10 @@ export const reachableSpecifiers = (
 };
 
 /**
- * A module's runtime edges, dynamic imports included — the walk for
- * questions about what can ever evaluate.
+ * A module's runtime edges, dynamic imports included — the relation behind
+ * the runtime-reachability walk.
  */
-export const runtimeEdgesOf = (module: GraphModule): readonly string[] =>
+const runtimeEdgesOf = (module: GraphModule): readonly string[] =>
   codeSpecifiers(module.dependencies ?? [], true);
 
 /** A module's static edges only — the walk the cold-start question uses. */

--- a/scripts/module-graph.ts
+++ b/scripts/module-graph.ts
@@ -1,0 +1,94 @@
+/**
+ * Reading the local module graph with `deno info --json`. Shared by every
+ * tool that needs to know what imports what: the mutation state graph and
+ * the import-cycle report.
+ *
+ * The two distinctions that matter to every reader:
+ * - a dependency with no `code` specifier is type-only, and types never
+ *   evaluate, so they belong to no runtime graph;
+ * - a dependency marked `isDynamic` is deferred to first use, so it costs
+ *   no cold start and creates no load-order cycle.
+ */
+
+import { fromFileUrl } from "@std/path";
+import * as v from "valibot";
+import { runCommand } from "#scripts/precommit/git.ts";
+
+// `deno info --json` emits a richer per-module object; only the fields used
+// here are declared, the rest is ignored by valibot's strip behaviour.
+export const DependencySchema = v.object({
+  // The resolved specifier of the runtime (code) dependency. Absent for
+  // type-only imports — those never evaluate, so they are not part of any
+  // graph we walk.
+  code: v.optional(v.object({ specifier: v.string() })),
+  // Present and `true` only when the dependency is a dynamic `import(...)`.
+  // Static imports omit the key entirely.
+  isDynamic: v.optional(v.boolean()),
+  // The specifier as written in the source (`"#routes/auth.ts"`, `"./x.ts"`).
+  specifier: v.string(),
+});
+
+export const ModuleGraphSchema = v.object({
+  modules: v.array(
+    v.object({
+      dependencies: v.optional(v.array(DependencySchema)),
+      error: v.optional(v.string()),
+      specifier: v.string(),
+    }),
+  ),
+  // `deno info --json` always emits `roots` for a local entry; requiring it
+  // means a future Deno that drops the field fails loudly here instead of
+  // silently producing an empty graph that would let a cold-start regression
+  // pass trivially.
+  roots: v.array(v.string()),
+});
+
+export type ModuleGraph = v.InferOutput<typeof ModuleGraphSchema>;
+export type Dependency = v.InferOutput<typeof DependencySchema>;
+
+/** Run `deno info --json` for `entry` from `cwd`, failing loudly on errors. */
+export const readModuleGraph = async (
+  entry: string,
+  cwd: string,
+): Promise<ModuleGraph> => {
+  const result = await runCommand([Deno.execPath(), "info", "--json", entry], {
+    cwd,
+  });
+  if (!result.success) {
+    throw new Error(
+      `deno info --json ${entry} failed (exit ${result.code}): ${result.stderr.trim()}`,
+    );
+  }
+  const graph = v.parse(ModuleGraphSchema, JSON.parse(result.stdout));
+  // `deno info` exits 0 even when a module fails to resolve, reporting the
+  // failure per module instead. A module that failed to resolve has an
+  // unwalked dependency tree, so treating it as absent would silently
+  // under-count the graph — fail loudly instead.
+  for (const module of graph.modules) {
+    if (module.error !== undefined) {
+      throw new Error(`deno info --json ${entry}: ${module.error}`);
+    }
+  }
+  return graph;
+};
+
+/** Keep only file:// specifiers, converted to absolute paths. */
+export const localFiles = (specifiers: Iterable<string>): Set<string> =>
+  new Set(
+    [...specifiers]
+      .filter((specifier) => specifier.startsWith("file://"))
+      .map((specifier) => fromFileUrl(specifier)),
+  );
+
+/**
+ * Resolved specifiers of the **static** runtime deps of one module. Drops
+ * type-only imports (they never evaluate) and dynamic `import(...)` (it is
+ * deferred).
+ */
+export const staticCodeSpecifiers = (
+  deps: readonly Dependency[],
+): readonly string[] =>
+  deps
+    .filter((dep) => !dep.isDynamic)
+    .map((dep) => dep.code?.specifier)
+    .filter((specifier): specifier is string => !!specifier);

--- a/scripts/module-graph.ts
+++ b/scripts/module-graph.ts
@@ -28,14 +28,23 @@ const DependencySchema = v.object({
   specifier: v.string(),
 });
 
+// One module entry, normalised as it parses: a module with no dependencies
+// gets an empty list right at the boundary, so every reader downstream
+// trusts the list instead of coalescing an undefined away.
+const ModuleSchema = v.pipe(
+  v.object({
+    dependencies: v.optional(v.array(DependencySchema)),
+    error: v.optional(v.string()),
+    specifier: v.string(),
+  }),
+  v.transform((module) => ({
+    ...module,
+    dependencies: module.dependencies ?? [],
+  })),
+);
+
 const ModuleGraphSchema = v.object({
-  modules: v.array(
-    v.object({
-      dependencies: v.optional(v.array(DependencySchema)),
-      error: v.optional(v.string()),
-      specifier: v.string(),
-    }),
-  ),
+  modules: v.array(ModuleSchema),
   // `deno info --json` always emits `roots` for a local entry; requiring it
   // means a future Deno that drops the field fails loudly here instead of
   // silently producing an empty graph that would let a cold-start regression
@@ -45,7 +54,6 @@ const ModuleGraphSchema = v.object({
 
 export type ModuleGraph = v.InferOutput<typeof ModuleGraphSchema>;
 type Dependency = v.InferOutput<typeof DependencySchema>;
-type GraphModule = ModuleGraph["modules"][number];
 
 /** Run `deno info --json` for `entry` from `cwd`, failing loudly on errors. */
 export const readModuleGraph = async (
@@ -86,9 +94,8 @@ export const localFiles = (specifiers: Iterable<string>): Set<string> =>
  * type-only imports (they never evaluate) and dynamic `import(...)` (it is
  * deferred).
  */
-export const staticCodeSpecifiers = (
-  deps: readonly Dependency[],
-): readonly string[] => codeSpecifiers(deps, false);
+const staticCodeSpecifiers = (deps: readonly Dependency[]): readonly string[] =>
+  codeSpecifiers(deps, false);
 
 /** Resolved runtime (code) deps of one module, dynamic ones included when
  * `includeDynamic` says so — a deferred module still evaluates on first use. */
@@ -101,11 +108,11 @@ const codeSpecifiers = (
     .map((dep) => dep.code?.specifier)
     .filter((specifier): specifier is string => !!specifier);
 
-/** Breadth-first walk from `graph.roots` over the edges `edgesOf` names.
- * Shared by every reachability question over a module graph. */
-export const reachableSpecifiers = (
+/** Breadth-first walk from `graph.roots` over each module's runtime (code)
+ * deps — dynamic ones followed only when `followDynamic` says so. */
+const reachableModules = (
   graph: ModuleGraph,
-  edgesOf: (module: GraphModule) => readonly string[],
+  followDynamic: boolean,
 ): Set<string> => {
   const bySpecifier = new Map(
     graph.modules.map((module) => [module.specifier, module]),
@@ -119,7 +126,9 @@ export const reachableSpecifiers = (
       continue;
     }
     seen.add(specifier);
-    for (const resolved of edgesOf(bySpecifier.get(specifier)!)) {
+    const module = bySpecifier.get(specifier)!;
+    const runtimeImports = codeSpecifiers(module.dependencies, followDynamic);
+    for (const resolved of runtimeImports) {
       if (!seen.has(resolved)) queue.push(resolved);
     }
   }
@@ -127,15 +136,21 @@ export const reachableSpecifiers = (
 };
 
 /**
- * A module's runtime edges, dynamic imports included — the relation behind
- * the runtime-reachability walk.
+ * The static import targets of every module in the graph, keyed by the
+ * module's own specifier. Dynamic and type-only imports are absent: a
+ * deferred import decides no load order here, and a type import names no
+ * runtime target at all.
  */
-const runtimeEdgesOf = (module: GraphModule): readonly string[] =>
-  codeSpecifiers(module.dependencies ?? [], true);
-
-/** A module's static edges only — the walk the cold-start question uses. */
-export const staticEdgesOf = (module: GraphModule): readonly string[] =>
-  staticCodeSpecifiers(module.dependencies ?? []);
+export const staticImportsBySpecifier = (
+  graph: ModuleGraph,
+): Map<string, readonly string[]> => {
+  const bySpecifier = new Map<string, readonly string[]>();
+  for (const module of graph.modules) {
+    const staticImports = staticCodeSpecifiers(module.dependencies);
+    bySpecifier.set(module.specifier, staticImports);
+  }
+  return bySpecifier;
+};
 
 /**
  * The modules the entry can reach at runtime: static imports plus dynamic
@@ -144,4 +159,9 @@ export const staticEdgesOf = (module: GraphModule): readonly string[] =>
  * cycles inside that subtree cost no load order and no cold start.
  */
 export const runtimeReachableSpecifiers = (graph: ModuleGraph): Set<string> =>
-  reachableSpecifiers(graph, runtimeEdgesOf);
+  reachableModules(graph, true);
+
+/** The modules the entry reaches through static imports alone — the set a
+ * cold-start regression cares about, before any deferred import fires. */
+export const staticReachableSpecifiers = (graph: ModuleGraph): Set<string> =>
+  reachableModules(graph, false);

--- a/scripts/module-graph.ts
+++ b/scripts/module-graph.ts
@@ -16,7 +16,7 @@ import { runCommand } from "#scripts/precommit/git.ts";
 
 // `deno info --json` emits a richer per-module object; only the fields used
 // here are declared, the rest is ignored by valibot's strip behaviour.
-export const DependencySchema = v.object({
+const DependencySchema = v.object({
   // The resolved specifier of the runtime (code) dependency. Absent for
   // type-only imports — those never evaluate, so they are not part of any
   // graph we walk.
@@ -28,7 +28,7 @@ export const DependencySchema = v.object({
   specifier: v.string(),
 });
 
-export const ModuleGraphSchema = v.object({
+const ModuleGraphSchema = v.object({
   modules: v.array(
     v.object({
       dependencies: v.optional(v.array(DependencySchema)),
@@ -45,6 +45,7 @@ export const ModuleGraphSchema = v.object({
 
 export type ModuleGraph = v.InferOutput<typeof ModuleGraphSchema>;
 export type Dependency = v.InferOutput<typeof DependencySchema>;
+export type GraphModule = ModuleGraph["modules"][number];
 
 /** Run `deno info --json` for `entry` from `cwd`, failing loudly on errors. */
 export const readModuleGraph = async (
@@ -87,8 +88,60 @@ export const localFiles = (specifiers: Iterable<string>): Set<string> =>
  */
 export const staticCodeSpecifiers = (
   deps: readonly Dependency[],
+): readonly string[] => codeSpecifiers(deps, false);
+
+/** Resolved runtime (code) deps of one module, dynamic ones included when
+ * `includeDynamic` says so — a deferred module still evaluates on first use. */
+const codeSpecifiers = (
+  deps: readonly Dependency[],
+  includeDynamic: boolean,
 ): readonly string[] =>
   deps
-    .filter((dep) => !dep.isDynamic)
+    .filter((dep) => includeDynamic || !dep.isDynamic)
     .map((dep) => dep.code?.specifier)
     .filter((specifier): specifier is string => !!specifier);
+
+/** Breadth-first walk from `graph.roots` over the edges `edgesOf` names.
+ * Shared by every reachability question over a module graph. */
+export const reachableSpecifiers = (
+  graph: ModuleGraph,
+  edgesOf: (module: GraphModule) => readonly string[],
+): Set<string> => {
+  const bySpecifier = new Map(
+    graph.modules.map((module) => [module.specifier, module]),
+  );
+  const seen = new Set<string>();
+  const queue = [...graph.roots];
+
+  while (queue.length > 0) {
+    const specifier = queue.shift();
+    if (!specifier || seen.has(specifier) || !bySpecifier.has(specifier)) {
+      continue;
+    }
+    seen.add(specifier);
+    for (const resolved of edgesOf(bySpecifier.get(specifier)!)) {
+      if (!seen.has(resolved)) queue.push(resolved);
+    }
+  }
+  return seen;
+};
+
+/**
+ * A module's runtime edges, dynamic imports included — the walk for
+ * questions about what can ever evaluate.
+ */
+export const runtimeEdgesOf = (module: GraphModule): readonly string[] =>
+  codeSpecifiers(module.dependencies ?? [], true);
+
+/** A module's static edges only — the walk the cold-start question uses. */
+export const staticEdgesOf = (module: GraphModule): readonly string[] =>
+  staticCodeSpecifiers(module.dependencies ?? []);
+
+/**
+ * The modules the entry can reach at runtime: static imports plus dynamic
+ * ones, because a deferred module still evaluates on first use. Type-only
+ * imports reach nothing — a module only they can reach never evaluates, so
+ * cycles inside that subtree cost no load order and no cold start.
+ */
+export const runtimeReachableSpecifiers = (graph: ModuleGraph): Set<string> =>
+  reachableSpecifiers(graph, runtimeEdgesOf);

--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -57,3 +57,9 @@ src/ui/templates/admin/logistics.tsx::LogisticsAgentEditPanel.html~01ax7pa  ?? �
 # schema-atlas.tsx: formatTimeAgo returns a formatted string or null, never
 # "", so ?? and || pick the same side for every input.
 src/ui/templates/admin/schema-atlas.tsx::UnansweredMoneySection~15crpim ??→||   # formatTimeAgo → string|null, never ""
+
+# builder.tsx: the built-sites table renders every column with no columnKeys
+# or hiddenKeys passed, so a column's key reaches no rendered output.
+src/ui/templates/admin/builder.tsx::builtSitesTable~0ytajae name→""   # renderTable(builtSitesTable, sites) filters by key only when columnKeys/hiddenKeys are passed, and this page passes neither
+src/ui/templates/admin/builder.tsx::builtSitesTable~1mp2mcy url→""   # same: the key reaches no rendered output on this page
+src/ui/templates/admin/builder.tsx::builtSitesTable~0w4j3rw built→""   # same: the key reaches no rendered output on this page

--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -63,3 +63,7 @@ src/ui/templates/admin/schema-atlas.tsx::UnansweredMoneySection~15crpim ??→|| 
 src/ui/templates/admin/builder.tsx::builtSitesTable~0ytajae name→""   # renderTable(builtSitesTable, sites) filters by key only when columnKeys/hiddenKeys are passed, and this page passes neither
 src/ui/templates/admin/builder.tsx::builtSitesTable~1mp2mcy url→""   # same: the key reaches no rendered output on this page
 src/ui/templates/admin/builder.tsx::builtSitesTable~0w4j3rw built→""   # same: the key reaches no rendered output on this page
+
+# seeds.tsx: the page passes no nav route, and no nav section owns the empty
+# string, so any non-route value renders the same unhighlighted nav.
+src/ui/templates/admin/seeds.tsx::adminSeedsPage~0quyacc  →"mutated"   # the page passes no nav route, and no section owns the empty string, so any non-route value renders the same unhighlighted nav

--- a/scripts/mutation/state-graph.ts
+++ b/scripts/mutation/state-graph.ts
@@ -13,75 +13,15 @@
  * mirrors the per-mutant client-bundle rebuild owned by the static asset build.
  */
 
-import { fromFileUrl } from "@std/path";
-import * as v from "valibot";
-import { runCommand } from "#scripts/precommit/git.ts";
+import {
+  localFiles,
+  type ModuleGraph,
+  readModuleGraph,
+  staticCodeSpecifiers,
+} from "#scripts/module-graph.ts";
 
 /** The module whose import graph produces the prebuilt test state. */
 export const STATE_BUILDER_ROOT = "test/test-utils/test-state.ts";
-
-// `deno info --json` emits a richer per-module object; only the fields used
-// here are declared, the rest is ignored by valibot's strip behaviour.
-const DependencySchema = v.object({
-  // The resolved specifier of the runtime (code) dependency. Absent for
-  // type-only imports — those never evaluate, so they are not part of any
-  // graph we walk.
-  code: v.optional(v.object({ specifier: v.string() })),
-  // Present and `true` only when the dependency is a dynamic `import(...)`.
-  // Static imports omit the key entirely.
-  isDynamic: v.optional(v.boolean()),
-  // The specifier as written in the source (`"#routes/auth.ts"`, `"./x.ts"`).
-  specifier: v.string(),
-});
-
-const ModuleGraphSchema = v.object({
-  modules: v.array(
-    v.object({
-      dependencies: v.optional(v.array(DependencySchema)),
-      error: v.optional(v.string()),
-      specifier: v.string(),
-    }),
-  ),
-  // `deno info --json` always emits `roots` for a local entry; requiring it
-  // means a future Deno that drops the field fails loudly here instead of
-  // silently producing an empty graph that would let a cold-start regression
-  // pass trivially.
-  roots: v.array(v.string()),
-});
-
-/** Run `deno info --json` for `entry` from `cwd`, failing loudly on errors. */
-const readModuleGraph = async (
-  entry: string,
-  cwd: string,
-): Promise<v.InferOutput<typeof ModuleGraphSchema>> => {
-  const result = await runCommand([Deno.execPath(), "info", "--json", entry], {
-    cwd,
-  });
-  if (!result.success) {
-    throw new Error(
-      `deno info --json ${entry} failed (exit ${result.code}): ${result.stderr.trim()}`,
-    );
-  }
-  const graph = v.parse(ModuleGraphSchema, JSON.parse(result.stdout));
-  // `deno info` exits 0 even when a module fails to resolve, reporting the
-  // failure per module instead. A module that failed to resolve has an
-  // unwalked dependency tree, so treating it as absent would silently
-  // under-count the graph — fail loudly instead.
-  for (const module of graph.modules) {
-    if (module.error !== undefined) {
-      throw new Error(`deno info --json ${entry}: ${module.error}`);
-    }
-  }
-  return graph;
-};
-
-/** Keep only file:// specifiers, converted to absolute paths. */
-const localFiles = (specifiers: Iterable<string>): Set<string> =>
-  new Set(
-    [...specifiers]
-      .filter((specifier) => specifier.startsWith("file://"))
-      .map((specifier) => fromFileUrl(specifier)),
-  );
 
 /** Collect local files from a module graph rooted at `entry`, run from `cwd`. */
 type GraphFiles = (entry: string, cwd: string) => Promise<Set<string>>;
@@ -92,9 +32,7 @@ type GraphFiles = (entry: string, cwd: string) => Promise<Set<string>>;
  * shared by every caller; only which specifiers count differs.
  */
 const graphFilesFrom =
-  (
-    derive: (graph: v.InferOutput<typeof ModuleGraphSchema>) => Set<string>,
-  ): GraphFiles =>
+  (derive: (graph: ModuleGraph) => Set<string>): GraphFiles =>
   async (entry, cwd) =>
     localFiles(derive(await readModuleGraph(entry, cwd)));
 
@@ -108,23 +46,8 @@ export const collectModuleGraphFiles: GraphFiles = graphFilesFrom(
   (graph) => new Set(graph.modules.map((module) => module.specifier)),
 );
 
-/**
- * Resolved specifiers of the **static** runtime deps of one module. Drops
- * type-only imports (they never evaluate) and dynamic `import(...)` (it is
- * deferred). This is the one relation the cold-start walk cares about.
- */
-const staticCodeSpecifiers = (
-  deps: readonly v.InferOutput<typeof DependencySchema>[],
-): readonly string[] =>
-  deps
-    .filter((dep) => !dep.isDynamic)
-    .map((dep) => dep.code?.specifier)
-    .filter((specifier): specifier is string => !!specifier);
-
 /** Breadth-first walk of the static-import graph from `graph.roots`. */
-const walkStatic = (
-  graph: v.InferOutput<typeof ModuleGraphSchema>,
-): Set<string> => {
+const walkStatic = (graph: ModuleGraph): Set<string> => {
   const bySpecifier = new Map(
     graph.modules.map((module) => [module.specifier, module]),
   );

--- a/scripts/mutation/state-graph.ts
+++ b/scripts/mutation/state-graph.ts
@@ -16,9 +16,8 @@
 import {
   localFiles,
   type ModuleGraph,
-  reachableSpecifiers,
   readModuleGraph,
-  staticEdgesOf,
+  staticReachableSpecifiers,
 } from "#scripts/module-graph.ts";
 
 /** The module whose import graph produces the prebuilt test state. */
@@ -49,7 +48,7 @@ export const collectModuleGraphFiles: GraphFiles = graphFilesFrom(
 
 /** Breadth-first walk of the static-import graph from `graph.roots`. */
 const walkStatic = (graph: ModuleGraph): Set<string> =>
-  reachableSpecifiers(graph, staticEdgesOf);
+  staticReachableSpecifiers(graph);
 
 /**
  * Absolute paths of every local file reachable from `entry` through **static**

--- a/scripts/mutation/state-graph.ts
+++ b/scripts/mutation/state-graph.ts
@@ -16,8 +16,9 @@
 import {
   localFiles,
   type ModuleGraph,
+  reachableSpecifiers,
   readModuleGraph,
-  staticCodeSpecifiers,
+  staticEdgesOf,
 } from "#scripts/module-graph.ts";
 
 /** The module whose import graph produces the prebuilt test state. */
@@ -47,26 +48,8 @@ export const collectModuleGraphFiles: GraphFiles = graphFilesFrom(
 );
 
 /** Breadth-first walk of the static-import graph from `graph.roots`. */
-const walkStatic = (graph: ModuleGraph): Set<string> => {
-  const bySpecifier = new Map(
-    graph.modules.map((module) => [module.specifier, module]),
-  );
-  const seen = new Set<string>();
-  const queue = [...graph.roots];
-
-  while (queue.length > 0) {
-    const specifier = queue.shift();
-    if (!specifier || seen.has(specifier) || !bySpecifier.has(specifier)) {
-      continue;
-    }
-    seen.add(specifier);
-    const deps = bySpecifier.get(specifier)?.dependencies ?? [];
-    for (const resolved of staticCodeSpecifiers(deps)) {
-      if (!seen.has(resolved)) queue.push(resolved);
-    }
-  }
-  return seen;
-};
+const walkStatic = (graph: ModuleGraph): Set<string> =>
+  reachableSpecifiers(graph, staticEdgesOf);
 
 /**
  * Absolute paths of every local file reachable from `entry` through **static**

--- a/src/features/admin/attributes.ts
+++ b/src/features/admin/attributes.ts
@@ -53,7 +53,6 @@ import {
   createOrderedCollectionHandlers,
 } from "#shared/app-forms.ts";
 import { getFlash } from "#shared/flash-context.ts";
-import { defineTextForm } from "#shared/forms/definition.ts";
 import {
   adminAttributeDeletePage,
   adminAttributeOptionDeletePage,
@@ -63,24 +62,16 @@ import {
   attributeNameFlat,
 } from "#templates/admin/attributes.tsx";
 import {
+  attributeNameForm,
+  attributeOptionForm,
+} from "#templates/fields/attribute.ts";
+import {
   attributeListingRows,
   optionListingCounts,
 } from "./attribute-page-data.ts";
 import { createListingChoicePost } from "./listing-choice-post.ts";
 
 /* jscpd:ignore-end */
-
-export const attributeNameForm = defineTextForm(
-  "Attribute name",
-  "name",
-  "e.g. Difficulty",
-);
-
-export const attributeOptionForm = defineTextForm(
-  "Option text",
-  "text",
-  "e.g. Beginner",
-);
 
 const handleAttributesGet = ownerPage(async (session) => {
   const flash = getFlash();

--- a/src/features/admin/builder.ts
+++ b/src/features/admin/builder.ts
@@ -13,7 +13,6 @@ import {
   insertBuiltSite,
 } from "#db/built-sites.ts";
 import { settings } from "#db/settings.ts";
-import { t } from "#i18n";
 /* jscpd:ignore-start */
 import { OWNER_FORM, ownerPage } from "#routes/auth.ts";
 import { errorRedirect, notFoundResponse, redirect } from "#routes/response.ts";
@@ -26,16 +25,11 @@ import {
   isDenoDeployEnabled,
   isTursoEnabled,
 } from "#shared/config.ts";
-import { defineForm } from "#shared/forms/definition.ts";
 import {
   adminBuilderPage,
   type BuiltSiteDisplay,
 } from "#templates/admin/builder.tsx";
-import {
-  builtSiteBox,
-  denoDeployOption,
-  providerChoices,
-} from "#templates/fields/admin.ts";
+import { builderForm } from "#templates/fields/builder.ts";
 
 const BUILDER_PATH = "/admin/builder";
 
@@ -67,39 +61,6 @@ const handleBuilderGet = (request: Request): Promise<Response> =>
   isBuilderEnabled()
     ? renderBuilderPage(request)
     : Promise.resolve(notFoundResponse());
-
-export const builderForm = defineForm({
-  fields: [
-    {
-      ...builtSiteBox("site_name", "name", "text" as const),
-      maxlength: 64,
-      minlength: 1,
-      required: true,
-    },
-    ...providerChoices({
-      db: [
-        {
-          label: t("fields.built_site.provider.bunny_db_auto"),
-          value: "bunny",
-        },
-        { label: t("fields.built_site.provider.turso_auto"), value: "turso" },
-        { label: t("fields.built_site.provider.manual_db"), value: "manual" },
-      ],
-      hosting: [
-        { label: t("fields.built_site.provider.bunny_edge"), value: "bunny" },
-        denoDeployOption(),
-      ],
-    }),
-    {
-      ...builtSiteBox("db_url", "db_url", "url" as const),
-      hint: t("fields.built_site.auto_provision_hint"),
-    },
-    {
-      ...builtSiteBox("db_token", "db_token", "password" as const),
-      hint: t("fields.built_site.auto_provision_hint"),
-    },
-  ] as const,
-});
 
 /** Return an error message when a DB provider isn't configured, else null. */
 const dbProviderConfigError = (

--- a/src/features/admin/seeds.ts
+++ b/src/features/admin/seeds.ts
@@ -9,38 +9,11 @@ import { t } from "#i18n";
 import { OWNER_FORM, ownerPage, withAuth } from "#routes/auth.ts";
 import { redirect } from "#routes/response.ts";
 import { getFlash } from "#shared/flash-context.ts";
-import { defineForm } from "#shared/forms/definition.ts";
 import { createSeeds, SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
 import { adminSeedsPage } from "#templates/admin/seeds.tsx";
+import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
+
 /* jscpd:ignore-end */
-
-/** Max listings that can be created in a single seed operation */
-export const MAX_SEED_LISTINGS = 30;
-
-export const seedsForm = defineForm({
-  fields: [
-    {
-      defaultValue: "5",
-      id: "listing_count",
-      label: "Number of listings",
-      max: MAX_SEED_LISTINGS,
-      min: 1,
-      name: "listing_count",
-      required: true,
-      type: "number",
-    },
-    {
-      defaultValue: "10",
-      id: "attendees_per_listing",
-      label: "Attendees per listing",
-      max: SEED_MAX_ATTENDEES,
-      min: 0,
-      name: "attendees_per_listing",
-      required: true,
-      type: "number",
-    },
-  ] as const,
-});
 
 /** Handle GET /admin/seeds (show seed form) */
 const handleSeedsGet: TypedRouteHandler<"GET /admin/seeds"> = ownerPage(

--- a/src/features/admin/site.ts
+++ b/src/features/admin/site.ts
@@ -8,7 +8,6 @@ import { defineRoutes } from "#routes/router.ts";
 import { getAllListings } from "#db/listings/records.ts";
 import { MAX_WEBSITE_TITLE_LENGTH } from "#db/settings/constants.ts";
 import { settings } from "#db/settings.ts";
-import { t } from "#i18n";
 import {
   settingsHandler,
   settingsToggle,
@@ -20,7 +19,6 @@ import {
   SITE_CONTACT_DEMO_FIELDS,
   SITE_HOME_DEMO_FIELDS,
 } from "#shared/demo/overrides.ts";
-import { defineForm } from "#shared/forms/definition.ts";
 import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
 import { isPublicListing } from "#shared/listing-visibility.ts";
 import type { RequestRoute } from "#shared/response-steps.ts";
@@ -29,44 +27,6 @@ import {
   adminSiteHomePage,
   adminSiteOrderPage,
 } from "#templates/admin/site.tsx";
-import { formattingHint } from "#templates/components/formatting-hint.ts";
-
-/** A markdown text box for one site page, worded by the catalog keys under
- * `prefix` (`_label`, `_hint`, `_placeholder`). */
-const siteTextarea = <Name extends string>(field: Name, prefix: string) =>
-  ({
-    hintHtml: `${t(`${prefix}_hint`, { max: `${MAX_TEXTAREA_LENGTH}` })} ${formattingHint()}`,
-    id: field,
-    label: t(`${prefix}_label`),
-    markdown: true,
-    maxlength: MAX_TEXTAREA_LENGTH,
-    name: field,
-    placeholder: t(`${prefix}_placeholder`),
-    type: "textarea" as const,
-  }) as const;
-
-export const siteHomeForm = defineForm({
-  fields: [
-    {
-      autocomplete: "off" as const,
-      hint: t("site.home.title_hint", { max: `${MAX_WEBSITE_TITLE_LENGTH}` }),
-      id: "website_title",
-      label: t("site.home.title_label"),
-      maxlength: MAX_WEBSITE_TITLE_LENGTH,
-      name: "website_title",
-      type: "text" as const,
-    },
-    siteTextarea("homepage_text", "site.home.text"),
-  ] as const,
-});
-
-export const siteContactForm = defineForm({
-  fields: [siteTextarea("contact_page_text", "site.contact.text")] as const,
-});
-
-export const siteOrderForm = defineForm({
-  fields: [siteTextarea("order_intro_text", "site.order.text")] as const,
-});
 
 /** Count active, visible listings — every one appears on the order page. */
 const countOrderListings = async (): Promise<number> => {

--- a/src/locales/en/seed-data.json
+++ b/src/locales/en/seed-data.json
@@ -4,5 +4,7 @@
   "admin.seeds.intro": "Fill the empty site with example listings and attendees. Useful for testing and trying things out.",
   "admin.seeds.submit": "Create example data",
   "admin.seeds.back": "Back to dashboard",
-  "admin.seeds.created": "Created {listings, plural, one {# listing} other {# listings}} with {attendees, plural, one {# attendee} other {# attendees}}."
+  "admin.seeds.created": "Created {listings, plural, one {# listing} other {# listings}} with {attendees, plural, one {# attendee} other {# attendees}}.",
+  "admin.seeds.listing_count_label": "Number of listings",
+  "admin.seeds.attendees_label": "Attendees per listing"
 }

--- a/src/ui/templates/admin/attributes.tsx
+++ b/src/ui/templates/admin/attributes.tsx
@@ -4,10 +4,6 @@ import type { AttributeOption, AttributeWithOptions } from "#db/attributes.ts";
 import { t } from "#i18n";
 import { Raw } from "#jsx/jsx-runtime.ts";
 import type { AttributeListingRow } from "#routes/admin/attribute-page-data.ts";
-import {
-  attributeNameForm,
-  attributeOptionForm,
-} from "#routes/admin/attributes.ts";
 import { adminPath, adminPattern } from "#shared/admin-surface.ts";
 import type { TableColumn } from "#shared/tables/column.ts";
 import { defineTable } from "#shared/tables/definition.ts";
@@ -27,6 +23,10 @@ import {
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
 import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
+import {
+  attributeNameForm,
+  attributeOptionForm,
+} from "#templates/fields/attribute.ts";
 import type { AdminSession } from "#types";
 import {
   type ListingPanelProps,

--- a/src/ui/templates/admin/builder.tsx
+++ b/src/ui/templates/admin/builder.tsx
@@ -4,7 +4,6 @@
 
 import { t } from "#i18n";
 import { Raw } from "#jsx/jsx-runtime.ts";
-import { builderForm } from "#routes/admin/builder.ts";
 import { getDefaultDbProvider } from "#shared/config.ts";
 import { defineTable } from "#shared/tables/definition.ts";
 import { flashDataPage } from "#templates/admin/admin-page.tsx";
@@ -15,6 +14,7 @@ import { ProseSection } from "#templates/components/prose-section.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
 import { renderTable } from "#templates/components/table.tsx";
 import { translatedTableColumn } from "#templates/components/translated-table-column.ts";
+import { builderForm } from "#templates/fields/builder.ts";
 /* jscpd:ignore-end */
 
 export type BuiltSiteDisplay = {

--- a/src/ui/templates/admin/seeds.tsx
+++ b/src/ui/templates/admin/seeds.tsx
@@ -5,11 +5,11 @@
 /* jscpd:ignore-start */
 import { t } from "#i18n";
 import { Raw } from "#jsx/jsx-runtime.ts";
-import { seedsForm } from "#routes/admin/seeds.ts";
 import { flashFormPage } from "#templates/admin/admin-page.tsx";
 import { BackButton } from "#templates/components/actions.tsx";
 import { ProseHeading } from "#templates/components/prose-heading.tsx";
 import { SaveForm } from "#templates/components/save-form.tsx";
+import { seedsForm } from "#templates/fields/seeds.ts";
 /* jscpd:ignore-end */
 
 /** Seed data admin page */

--- a/src/ui/templates/admin/site.tsx
+++ b/src/ui/templates/admin/site.tsx
@@ -4,11 +4,6 @@
 
 import { t } from "#i18n";
 import type { Child } from "#jsx/jsx-runtime.ts";
-import {
-  siteContactForm,
-  siteHomeForm,
-  siteOrderForm,
-} from "#routes/admin/site.ts";
 import { flashOptsPage } from "#templates/admin/admin-page.tsx";
 import { GuideFooter } from "#templates/components/actions.tsx";
 import { ErrorNote } from "#templates/components/error.tsx";
@@ -16,6 +11,11 @@ import {
   renderedFieldsSaveForm,
   SaveForm,
 } from "#templates/components/save-form.tsx";
+import {
+  siteContactForm,
+  siteHomeForm,
+  siteOrderForm,
+} from "#templates/fields/site.ts";
 import type { AdminLevel, AdminSession } from "#types";
 
 /** The public-site guide footer shared by the home, contact and order editors

--- a/src/ui/templates/fields/attribute.ts
+++ b/src/ui/templates/fields/attribute.ts
@@ -1,8 +1,4 @@
-/**
- * The attribute editor forms. They live beside the other admin field
- * definitions, so the page template and the saving route share one
- * definition without either importing the other.
- */
+/** Attribute editor form fields (name and option text). */
 
 import { defineTextForm } from "#shared/forms/definition.ts";
 

--- a/src/ui/templates/fields/attribute.ts
+++ b/src/ui/templates/fields/attribute.ts
@@ -1,0 +1,19 @@
+/**
+ * The attribute editor forms. They live beside the other admin field
+ * definitions, so the page template and the saving route share one
+ * definition without either importing the other.
+ */
+
+import { defineTextForm } from "#shared/forms/definition.ts";
+
+export const attributeNameForm = defineTextForm(
+  "Attribute name",
+  "name",
+  "e.g. Difficulty",
+);
+
+export const attributeOptionForm = defineTextForm(
+  "Option text",
+  "text",
+  "e.g. Beginner",
+);

--- a/src/ui/templates/fields/builder.ts
+++ b/src/ui/templates/fields/builder.ts
@@ -1,8 +1,4 @@
-/**
- * The site builder form. It lives beside the other admin field definitions,
- * so the page template and the building route share one definition without
- * either importing the other.
- */
+/** Site builder form fields. */
 
 import { t } from "#i18n";
 import { defineForm } from "#shared/forms/definition.ts";

--- a/src/ui/templates/fields/builder.ts
+++ b/src/ui/templates/fields/builder.ts
@@ -1,0 +1,46 @@
+/**
+ * The site builder form. It lives beside the other admin field definitions,
+ * so the page template and the building route share one definition without
+ * either importing the other.
+ */
+
+import { t } from "#i18n";
+import { defineForm } from "#shared/forms/definition.ts";
+import {
+  builtSiteBox,
+  denoDeployOption,
+  providerChoices,
+} from "#templates/fields/admin.ts";
+
+export const builderForm = defineForm({
+  fields: [
+    {
+      ...builtSiteBox("site_name", "name", "text" as const),
+      maxlength: 64,
+      minlength: 1,
+      required: true,
+    },
+    ...providerChoices({
+      db: [
+        {
+          label: t("fields.built_site.provider.bunny_db_auto"),
+          value: "bunny",
+        },
+        { label: t("fields.built_site.provider.turso_auto"), value: "turso" },
+        { label: t("fields.built_site.provider.manual_db"), value: "manual" },
+      ],
+      hosting: [
+        { label: t("fields.built_site.provider.bunny_edge"), value: "bunny" },
+        denoDeployOption(),
+      ],
+    }),
+    {
+      ...builtSiteBox("db_url", "db_url", "url" as const),
+      hint: t("fields.built_site.auto_provision_hint"),
+    },
+    {
+      ...builtSiteBox("db_token", "db_token", "password" as const),
+      hint: t("fields.built_site.auto_provision_hint"),
+    },
+  ] as const,
+});

--- a/src/ui/templates/fields/seeds.ts
+++ b/src/ui/templates/fields/seeds.ts
@@ -1,0 +1,37 @@
+/**
+ * The demo-data seeds form. It lives beside the other admin field
+ * definitions, so the page template and the seeding route share one
+ * definition without either importing the other.
+ */
+
+import { t } from "#i18n";
+import { defineForm } from "#shared/forms/definition.ts";
+import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+
+/** Max listings that can be created in a single seed operation */
+export const MAX_SEED_LISTINGS = 30;
+
+export const seedsForm = defineForm({
+  fields: [
+    {
+      defaultValue: "5",
+      id: "listing_count",
+      label: t("admin.seeds.listing_count_label"),
+      max: MAX_SEED_LISTINGS,
+      min: 1,
+      name: "listing_count",
+      required: true,
+      type: "number",
+    },
+    {
+      defaultValue: "10",
+      id: "attendees_per_listing",
+      label: t("admin.seeds.attendees_label"),
+      max: SEED_MAX_ATTENDEES,
+      min: 0,
+      name: "attendees_per_listing",
+      required: true,
+      type: "number",
+    },
+  ] as const,
+});

--- a/src/ui/templates/fields/seeds.ts
+++ b/src/ui/templates/fields/seeds.ts
@@ -1,8 +1,4 @@
-/**
- * The demo-data seeds form. It lives beside the other admin field
- * definitions, so the page template and the seeding route share one
- * definition without either importing the other.
- */
+/** Demo-data seeds form fields. */
 
 import { t } from "#i18n";
 import { defineForm } from "#shared/forms/definition.ts";

--- a/src/ui/templates/fields/site.ts
+++ b/src/ui/templates/fields/site.ts
@@ -1,8 +1,4 @@
-/**
- * The site page editor's forms. They live here, beside the other admin field
- * definitions, so the page templates and the saving route share one
- * definition without either importing the other.
- */
+/** Site page editor form fields (home, contact, order intro). */
 
 import { MAX_WEBSITE_TITLE_LENGTH } from "#db/settings/constants.ts";
 import { t } from "#i18n";

--- a/src/ui/templates/fields/site.ts
+++ b/src/ui/templates/fields/site.ts
@@ -1,0 +1,48 @@
+/**
+ * The site page editor's forms. They live here, beside the other admin field
+ * definitions, so the page templates and the saving route share one
+ * definition without either importing the other.
+ */
+
+import { MAX_WEBSITE_TITLE_LENGTH } from "#db/settings/constants.ts";
+import { t } from "#i18n";
+import { defineForm } from "#shared/forms/definition.ts";
+import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
+import { formattingHint } from "#templates/components/formatting-hint.ts";
+
+/** A markdown text box for one site page, worded by the catalog keys under
+ * `prefix` (`_label`, `_hint`, `_placeholder`). */
+const siteTextarea = <Name extends string>(field: Name, prefix: string) =>
+  ({
+    hintHtml: `${t(`${prefix}_hint`, { max: `${MAX_TEXTAREA_LENGTH}` })} ${formattingHint()}`,
+    id: field,
+    label: t(`${prefix}_label`),
+    markdown: true,
+    maxlength: MAX_TEXTAREA_LENGTH,
+    name: field,
+    placeholder: t(`${prefix}_placeholder`),
+    type: "textarea" as const,
+  }) as const;
+
+export const siteHomeForm = defineForm({
+  fields: [
+    {
+      autocomplete: "off" as const,
+      hint: t("site.home.title_hint", { max: `${MAX_WEBSITE_TITLE_LENGTH}` }),
+      id: "website_title",
+      label: t("site.home.title_label"),
+      maxlength: MAX_WEBSITE_TITLE_LENGTH,
+      name: "website_title",
+      type: "text" as const,
+    },
+    siteTextarea("homepage_text", "site.home.text"),
+  ] as const,
+});
+
+export const siteContactForm = defineForm({
+  fields: [siteTextarea("contact_page_text", "site.contact.text")] as const,
+});
+
+export const siteOrderForm = defineForm({
+  fields: [siteTextarea("order_intro_text", "site.order.text")] as const,
+});

--- a/test/features/admin/attributes/crud.test.ts
+++ b/test/features/admin/attributes/crud.test.ts
@@ -50,6 +50,13 @@ describeWithEnv("server (admin attribute CRUD)", { db: true }, () => {
     });
   });
 
+  describe("GET /admin/attributes", () => {
+    test("serves the attributes collection page", async () => {
+      const response = await adminGet("/admin/attributes");
+      expect(response.status).toBe(200);
+    });
+  });
+
   describe("POST /admin/attributes", () => {
     testRequiresAuth("/admin/attributes", {
       body: { name: "Auth attribute" },

--- a/test/features/admin/attributes/crud.test.ts
+++ b/test/features/admin/attributes/crud.test.ts
@@ -8,7 +8,7 @@ import {
 import {
   attributeNameForm,
   attributeOptionForm,
-} from "#routes/admin/attributes.ts";
+} from "#templates/fields/attribute.ts";
 import { activityMessages } from "#test-utils/activity-log.ts";
 import {
   expectFlashRedirect,

--- a/test/features/admin/builder/server.test.ts
+++ b/test/features/admin/builder/server.test.ts
@@ -3,8 +3,8 @@ import { afterEach, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import { builtSites } from "#db/built-sites.ts";
 import { ALL_SETTINGS_KEYS, settings } from "#db/settings.ts";
-import { builderForm } from "#routes/admin/builder.ts";
 import { builderApi } from "#shared/builder.ts";
+import { builderForm } from "#templates/fields/builder.ts";
 import {
   MOCK_DB_RESULT,
   stubBuildSiteApis,

--- a/test/features/admin/seeds.test.ts
+++ b/test/features/admin/seeds.test.ts
@@ -2,8 +2,8 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { getAllListings } from "#db/listings/records.ts";
 import { t } from "#i18n";
-import { MAX_SEED_LISTINGS, seedsForm } from "#routes/admin/seeds.ts";
 import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
 import {
   expectFlashRedirect,
   expectHtmlContains,

--- a/test/features/admin/site/home.test.ts
+++ b/test/features/admin/site/home.test.ts
@@ -22,7 +22,7 @@ describeWithEnv("server (admin site home)", { db: true }, () => {
     // The expected labels, hints, and names are written out here so a changed
     // form definition fails this test instead of moving the expectation along.
     test("serves the home form boxes with their labels and hints", async () => {
-      const { siteHomeForm } = await import("#routes/admin/site.ts");
+      const { siteHomeForm } = await import("#templates/fields/site.ts");
       const html = siteHomeForm.render();
       expect(html).toContain("Website title");
       expect(html).toContain(
@@ -39,7 +39,7 @@ describeWithEnv("server (admin site home)", { db: true }, () => {
     });
 
     test("serves the contact form box with its label", async () => {
-      const { siteContactForm } = await import("#routes/admin/site.ts");
+      const { siteContactForm } = await import("#templates/fields/site.ts");
       const html = siteContactForm.render();
       inputNamed(html, "contact_page_text");
       expect(html).toContain("Contact page text");

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -60,8 +60,7 @@ describe("loadTimeEdges", () => {
 
   test("keeps edges under a repo path whose URL form is escaped", () => {
     // A checkout under "my repo" arrives from deno info as file:///my%20repo/.
-    // The module's own specifier is built unescaped here; the dependency
-    // carries the escaped form the way deno info emits it.
+    // The dependency carries the escaped form the way deno info emits it.
     const edges = loadTimeEdges(
       graphOf({
         dependencies: [

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -22,9 +22,11 @@ const moduleOf = (
   specifier: path.startsWith("file://") ? path : `file://${ROOT}/${path}`,
 });
 
+/** A graph whose root is the first module given. */
 const graphOf = (
-  ...modules: ModuleGraph["modules"][number][]
-): ModuleGraph => ({ modules, roots: [] });
+  root: ModuleGraph["modules"][number],
+  ...rest: ModuleGraph["modules"][number][]
+): ModuleGraph => ({ modules: [root, ...rest], roots: [root.specifier] });
 
 describe("loadTimeEdges", () => {
   test("keeps the static local imports as relative edges", () => {
@@ -33,6 +35,7 @@ describe("loadTimeEdges", () => {
         moduleOf("src/a.ts", [
           { code: { specifier: `file://${ROOT}/src/b.ts` } },
         ]),
+        moduleOf("src/b.ts", []),
       ),
       ROOT,
     );
@@ -52,6 +55,8 @@ describe("loadTimeEdges", () => {
           { code: { specifier: "file:///elsewhere/src/out.ts" } },
           { code: { specifier: `file://${ROOT}/src/a.ts` } },
         ]),
+        moduleOf("src/lazy.ts", []),
+        moduleOf("file:///elsewhere/src/out.ts", []),
       ),
       ROOT,
     );
@@ -62,15 +67,79 @@ describe("loadTimeEdges", () => {
     // A checkout under "my repo" arrives from deno info as file:///my%20repo/.
     // The dependency carries the escaped form the way deno info emits it.
     const edges = loadTimeEdges(
-      graphOf({
-        dependencies: [
-          { code: { specifier: "file:///my%20repo/src/b.ts" }, specifier: "" },
-        ],
-        specifier: "file:///my%20repo/src/a.ts",
-      }),
+      graphOf(
+        {
+          dependencies: [
+            {
+              code: { specifier: "file:///my%20repo/src/b.ts" },
+              specifier: "",
+            },
+          ],
+          specifier: "file:///my%20repo/src/a.ts",
+        },
+        {
+          dependencies: [],
+          specifier: "file:///my%20repo/src/b.ts",
+        },
+      ),
       "/my repo",
     );
     expect(edges.get("src/a.ts")).toEqual(new Set(["src/b.ts"]));
+  });
+
+  test("keeps a module whose name begins with two dots", () => {
+    // "..generated" is a folder under the root, not the parent escape.
+    const edges = loadTimeEdges(
+      graphOf(
+        moduleOf("src/entry.ts", [
+          { code: { specifier: `file://${ROOT}/..generated/a.ts` } },
+        ]),
+        moduleOf("..generated/a.ts", []),
+      ),
+      ROOT,
+    );
+    expect(edges.get("src/entry.ts")).toEqual(new Set(["..generated/a.ts"]));
+  });
+
+  test("skips a cycle nothing at runtime can reach", () => {
+    // The entry imports the pair for types only, so neither module ever
+    // evaluates and their mutual imports are no load-order tangle.
+    const edges = loadTimeEdges(
+      graphOf(
+        moduleOf("src/entry.ts", [{ specifier: "#pair/a.ts" }]),
+        moduleOf("src/pair/a.ts", [
+          { code: { specifier: `file://${ROOT}/src/pair/b.ts` } },
+        ]),
+        moduleOf("src/pair/b.ts", [
+          { code: { specifier: `file://${ROOT}/src/pair/a.ts` } },
+        ]),
+      ),
+      ROOT,
+    );
+    expect(edges.size).toBe(0);
+  });
+
+  test("keeps a cycle behind a dynamic import", () => {
+    // A deferred module still evaluates on first use, so its own static
+    // cycle is a real load-order tangle once it loads.
+    const edges = loadTimeEdges(
+      graphOf(
+        moduleOf("src/entry.ts", [
+          {
+            code: { specifier: `file://${ROOT}/src/lazy/a.ts` },
+            isDynamic: true,
+          },
+        ]),
+        moduleOf("src/lazy/a.ts", [
+          { code: { specifier: `file://${ROOT}/src/lazy/b.ts` } },
+        ]),
+        moduleOf("src/lazy/b.ts", [
+          { code: { specifier: `file://${ROOT}/src/lazy/a.ts` } },
+        ]),
+      ),
+      ROOT,
+    );
+    expect(cyclicGroups(edges)).toEqual([["src/lazy/a.ts", "src/lazy/b.ts"]]);
   });
 });
 

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -57,6 +57,22 @@ describe("loadTimeEdges", () => {
     );
     expect(edges.has("src/a.ts")).toBe(false);
   });
+
+  test("keeps edges under a repo path whose URL form is escaped", () => {
+    // A checkout under "my repo" arrives from deno info as file:///my%20repo/.
+    // The module's own specifier is built unescaped here; the dependency
+    // carries the escaped form the way deno info emits it.
+    const edges = loadTimeEdges(
+      graphOf({
+        dependencies: [
+          { code: { specifier: "file:///my%20repo/src/b.ts" }, specifier: "" },
+        ],
+        specifier: "file:///my%20repo/src/a.ts",
+      }),
+      "/my repo",
+    );
+    expect(edges.get("src/a.ts")).toEqual(new Set(["src/b.ts"]));
+  });
 });
 
 describe("cyclicGroups", () => {

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -6,14 +6,18 @@ import {
   loadTimeEdges,
 } from "#scripts/cycles/graph.ts";
 import { runCycleReport } from "#scripts/cycles/run.ts";
-import type { Dependency, ModuleGraph } from "#scripts/module-graph.ts";
+import type { ModuleGraph } from "#scripts/module-graph.ts";
 
 const ROOT = "/repo";
+
+/** One dependency as the graph reader parses it — derived from the graph
+ * type, so the fixture follows the reader's own shape. */
+type Dep = NonNullable<ModuleGraph["modules"][number]["dependencies"]>[number];
 
 /** A module in the graph: local unless its specifier says otherwise. */
 const moduleOf = (
   path: string,
-  deps: Partial<Dependency>[],
+  deps: Partial<Dep>[],
 ): ModuleGraph["modules"][number] => ({
   dependencies: deps.map((dep) => ({
     specifier: dep.specifier ?? "",

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -1,0 +1,155 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  cyclicGroups,
+  formatCycleReport,
+  loadTimeEdges,
+} from "#scripts/cycles/graph.ts";
+import { runCycleReport } from "#scripts/cycles/run.ts";
+import type { Dependency, ModuleGraph } from "#scripts/module-graph.ts";
+
+const ROOT = "/repo";
+
+/** A module in the graph: local unless its specifier says otherwise. */
+const moduleOf = (
+  path: string,
+  deps: Partial<Dependency>[],
+): ModuleGraph["modules"][number] => ({
+  dependencies: deps.map((dep) => ({
+    specifier: dep.specifier ?? "",
+    ...dep,
+  })),
+  specifier: path.startsWith("file://") ? path : `file://${ROOT}/${path}`,
+});
+
+const graphOf = (
+  ...modules: ModuleGraph["modules"][number][]
+): ModuleGraph => ({ modules, roots: [] });
+
+describe("loadTimeEdges", () => {
+  test("keeps the static local imports as relative edges", () => {
+    const edges = loadTimeEdges(
+      graphOf(
+        moduleOf("src/a.ts", [
+          { code: { specifier: `file://${ROOT}/src/b.ts` } },
+        ]),
+      ),
+      ROOT,
+    );
+    expect(edges.get("src/a.ts")).toEqual(new Set(["src/b.ts"]));
+  });
+
+  test("drops dynamic imports, type-only imports, and far modules", () => {
+    const edges = loadTimeEdges(
+      graphOf(
+        moduleOf("src/a.ts", [
+          {
+            code: { specifier: `file://${ROOT}/src/lazy.ts` },
+            isDynamic: true,
+          },
+          { specifier: "#types" },
+          { code: { specifier: "npm:valibot" } },
+          { code: { specifier: "file:///elsewhere/src/out.ts" } },
+          { code: { specifier: `file://${ROOT}/src/a.ts` } },
+        ]),
+      ),
+      ROOT,
+    );
+    expect(edges.has("src/a.ts")).toBe(false);
+  });
+});
+
+describe("cyclicGroups", () => {
+  const edgesOf = (pairs: [string, string][]): Map<string, Set<string>> => {
+    const edges = new Map<string, Set<string>>();
+    for (const [from, to] of pairs) {
+      const targets = edges.get(from) ?? new Set<string>();
+      targets.add(to);
+      edges.set(from, targets);
+    }
+    return edges;
+  };
+
+  test("finds a two-module cycle", () => {
+    expect(
+      cyclicGroups(
+        edgesOf([
+          ["a.ts", "b.ts"],
+          ["b.ts", "a.ts"],
+        ]),
+      ),
+    ).toEqual([["a.ts", "b.ts"]]);
+  });
+
+  test("finds a three-module loop beside a plain chain", () => {
+    const groups = cyclicGroups(
+      edgesOf([
+        ["a.ts", "b.ts"],
+        ["b.ts", "c.ts"],
+        ["c.ts", "a.ts"],
+        ["d.ts", "e.ts"],
+      ]),
+    );
+    expect(groups).toEqual([["a.ts", "b.ts", "c.ts"]]);
+  });
+
+  test("lists the largest group first, members sorted", () => {
+    const groups = cyclicGroups(
+      edgesOf([
+        ["y.ts", "z.ts"],
+        ["z.ts", "y.ts"],
+        ["a.ts", "c.ts"],
+        ["c.ts", "b.ts"],
+        ["b.ts", "a.ts"],
+      ]),
+    );
+    expect(groups).toEqual([
+      ["a.ts", "b.ts", "c.ts"],
+      ["y.ts", "z.ts"],
+    ]);
+  });
+
+  test("answers nothing for an acyclic graph", () => {
+    expect(
+      cyclicGroups(
+        edgesOf([
+          ["a.ts", "b.ts"],
+          ["b.ts", "c.ts"],
+        ]),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("formatCycleReport", () => {
+  test("states what was measured and names every group's members", () => {
+    const edges = new Map<string, Set<string>>([
+      ["a.ts", new Set(["b.ts"])],
+      ["b.ts", new Set(["a.ts"])],
+    ]);
+    const report = formatCycleReport(edges, [["a.ts", "b.ts"]]);
+    expect(report).toContain("modules with load-time imports: 2");
+    expect(report).toContain("cyclic groups: 1");
+    expect(report).toContain("dynamic");
+    expect(report).toContain("== group of 2 ==");
+    expect(report).toContain("  a.ts");
+    expect(report).toContain("  b.ts");
+  });
+
+  test("still explains the measurement when the tree is clean", () => {
+    const report = formatCycleReport(new Map(), []);
+    expect(report).toContain("cyclic groups: 0");
+  });
+});
+
+describe("runCycleReport", () => {
+  test("reports the real tree's known cycle", async () => {
+    const report = await runCycleReport();
+    expect(report).toContain("cyclic groups:");
+    expect(report).toContain("load-time imports:");
+    // The reporting-machinery triangle the tree has carried since the
+    // ntfy notifier grew: the one cycle every reader of this report can
+    // check a group listing against.
+    expect(report).toContain("src/shared/logger.ts");
+  });
+});

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -143,13 +143,12 @@ describe("formatCycleReport", () => {
 });
 
 describe("runCycleReport", () => {
-  test("reports the real tree's known cycle", async () => {
+  test("runs against the real tree and reports a shaped answer", async () => {
     const report = await runCycleReport();
-    expect(report).toContain("cyclic groups:");
-    expect(report).toContain("load-time imports:");
-    // The reporting-machinery triangle the tree has carried since the
-    // ntfy notifier grew: the one cycle every reader of this report can
-    // check a group listing against.
-    expect(report).toContain("src/shared/logger.ts");
+    // Structure, not debt: the report must state what it measured and count
+    // its groups, whatever the tree's current cycle count is.
+    expect(report).toMatch(/modules with load-time imports: \d+/);
+    expect(report).toMatch(/cyclic groups: \d+/);
+    expect(report).toContain("type-only imports evaluate nothing and dynamic");
   });
 });

--- a/test/scripts/cycles/graph.test.ts
+++ b/test/scripts/cycles/graph.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "@std/expect";
+import { resolve } from "@std/path";
 import { describe, it as test } from "@std/testing/bdd";
 import {
   cyclicGroups,
@@ -57,7 +58,6 @@ describe("loadTimeEdges", () => {
           { specifier: "#types" },
           { code: { specifier: "npm:valibot" } },
           { code: { specifier: "file:///elsewhere/src/out.ts" } },
-          { code: { specifier: `file://${ROOT}/src/a.ts` } },
         ]),
         moduleOf("src/lazy.ts", []),
         moduleOf("file:///elsewhere/src/out.ts", []),
@@ -65,6 +65,21 @@ describe("loadTimeEdges", () => {
       ROOT,
     );
     expect(edges.has("src/a.ts")).toBe(false);
+  });
+
+  test("reports a module that imports itself as a tangle of one", () => {
+    const edges = loadTimeEdges(
+      graphOf(
+        moduleOf("src/entry.ts", [
+          { code: { specifier: `file://${ROOT}/src/self.ts` } },
+        ]),
+        moduleOf("src/self.ts", [
+          { code: { specifier: `file://${ROOT}/src/self.ts` } },
+        ]),
+      ),
+      ROOT,
+    );
+    expect(cyclicGroups(edges)).toEqual([["src/self.ts"]]);
   });
 
   test("keeps edges under a repo path whose URL form is escaped", () => {
@@ -207,6 +222,10 @@ describe("cyclicGroups", () => {
       ),
     ).toEqual([]);
   });
+
+  test("keeps a self-edge as a one-module group", () => {
+    expect(cyclicGroups(edgesOf([["a.ts", "a.ts"]]))).toEqual([["a.ts"]]);
+  });
 });
 
 describe("formatCycleReport", () => {
@@ -231,12 +250,25 @@ describe("formatCycleReport", () => {
 });
 
 describe("runCycleReport", () => {
-  test("runs against the real tree and reports a shaped answer", async () => {
-    const report = await runCycleReport();
-    // Structure, not debt: the report must state what it measured and count
-    // its groups, whatever the tree's current cycle count is.
-    expect(report).toMatch(/modules with load-time imports: \d+/);
-    expect(report).toMatch(/cyclic groups: \d+/);
+  test("shapes the answer from whatever graph it reads", async () => {
+    // A stubbed reader keeps the deno-info subprocess out of the ordinary
+    // suite; the real read has its own direct tests. The fixture must sit
+    // under the repo root the report computes for itself.
+    const repo = resolve(import.meta.dirname!, "../../..");
+    const graph = graphOf(
+      moduleOf(`file://${repo}/src/a.ts`, [
+        { code: { specifier: `file://${repo}/src/b.ts` } },
+      ]),
+      moduleOf(`file://${repo}/src/b.ts`, [
+        { code: { specifier: `file://${repo}/src/a.ts` } },
+      ]),
+    );
+    const report = await runCycleReport(() => Promise.resolve(graph));
+    expect(report).toContain("modules with load-time imports: 2");
+    expect(report).toContain("cyclic groups: 1");
+    expect(report).toContain("== group of 2 ==");
+    expect(report).toContain("  src/a.ts");
+    expect(report).toContain("  src/b.ts");
     expect(report).toContain("type-only imports evaluate nothing and dynamic");
   });
 });

--- a/test/ui/templates/admin/builder.test.ts
+++ b/test/ui/templates/admin/builder.test.ts
@@ -71,4 +71,26 @@ describe("adminBuilderPage", () => {
     const html = adminBuilderPage(OWNER_SESSION, []);
     expect(html).toContain("Site builder");
   });
+
+  test("posts the create form to the builder route with its footer toggle", () => {
+    const html = adminBuilderPage(OWNER_SESSION, []);
+    expect(html).toContain('action="/admin/builder"');
+    expect(html).toContain('id="builder-form"');
+    // The assignment toggle posts 1, the value the route reads.
+    const toggle = html.slice(
+      html.indexOf('name="assignable"') - 80,
+      html.indexOf('name="assignable"') + 80,
+    );
+    expect(toggle).toContain('type="checkbox"');
+    expect(toggle).toContain('value="1"');
+  });
+
+  test("heads the sites table with one column per fact", () => {
+    const html = adminBuilderPage(OWNER_SESSION, [
+      { created: "1 Jan 2026", name: "Alpha", siteUrl: "alpha.b-cdn.net" },
+    ]);
+    expect(html).toContain("Name");
+    expect(html).toContain("URL");
+    expect(html).toContain("Built");
+  });
 });

--- a/test/ui/templates/admin/seeds.test.tsx
+++ b/test/ui/templates/admin/seeds.test.tsx
@@ -1,0 +1,24 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { adminSeedsPage } from "#templates/admin/seeds.tsx";
+import {
+  OWNER_SESSION,
+  setupAdminPageTest,
+} from "#test-utils/admin-page-test.ts";
+
+describe("adminSeedsPage", () => {
+  beforeAll(setupAdminPageTest);
+
+  test("renders the intro, both number boxes, and the create button", () => {
+    const html = adminSeedsPage(OWNER_SESSION);
+    expect(html).toContain("Fill the empty site with example listings");
+    expect(html).toContain('name="listing_count"');
+    expect(html).toContain('name="attendees_per_listing"');
+    expect(html).toContain("Create example data");
+    expect(html).toContain('action="/admin/seeds"');
+  });
+
+  test("offers the way back to the dashboard", () => {
+    expect(adminSeedsPage(OWNER_SESSION)).toContain('href="/admin"');
+  });
+});

--- a/test/ui/templates/admin/seeds.test.tsx
+++ b/test/ui/templates/admin/seeds.test.tsx
@@ -18,6 +18,12 @@ describe("adminSeedsPage", () => {
     expect(html).toContain('action="/admin/seeds"');
   });
 
+  test("carries the page title and the create button's icon", () => {
+    const html = adminSeedsPage(OWNER_SESSION);
+    expect(html).toContain("<title>Example data</title>");
+    expect(html).toContain("#plus");
+  });
+
   test("offers the way back to the dashboard", () => {
     expect(adminSeedsPage(OWNER_SESSION)).toContain('href="/admin"');
   });

--- a/test/ui/templates/admin/site.test.tsx
+++ b/test/ui/templates/admin/site.test.tsx
@@ -19,9 +19,28 @@ describe("site editor pages", () => {
     expect(html).toContain("Welcome!");
     expect(html).toContain('name="website_title"');
     expect(html).toContain('name="homepage_text"');
+    expect(html).toContain('action="/admin/site"');
   });
 
-  test("the contact page shows its text box and the form toggle", () => {
+  test("every site editor page links its guide chapter", () => {
+    const pages = [
+      adminSiteHomePage(OWNER_SESSION, "", ""),
+      adminSiteContactPage(OWNER_SESSION, "", {
+        botpoisonEnabled: false,
+        enabled: false,
+        hasBusinessEmail: true,
+      }),
+      adminSiteOrderPage(OWNER_SESSION, "", {
+        enabled: false,
+        listingCount: 0,
+      }),
+    ];
+    for (const html of pages) {
+      expect(html).toContain('href="/admin/guide#public-site"');
+    }
+  });
+
+  test("the contact page shows its text box, its toggle, and the spam note", () => {
     const html = adminSiteContactPage(OWNER_SESSION, "Email us", {
       botpoisonEnabled: false,
       enabled: false,
@@ -29,8 +48,27 @@ describe("site editor pages", () => {
     });
     expect(html).toContain("Email us");
     expect(html).toContain('name="contact_page_text"');
-    expect(html).toContain('name="contact_form_enabled"');
+    expect(html).toContain('action="/admin/site/contact"');
+    // The toggle posts to its own route with a checkbox the route reads.
+    expect(html).toContain('action="/admin/site/contact/form"');
+    const toggle = html.slice(
+      html.indexOf('name="contact_form_enabled"') - 100,
+      html.indexOf('name="contact_form_enabled"') + 100,
+    );
+    expect(toggle).toContain('type="checkbox"');
+    expect(toggle).toContain('value="true"');
+    expect(html).toContain("submissions are accepted without a spam check");
     expect(html).not.toContain("to receive contact form messages");
+  });
+
+  test("the contact page names Botpoison when it is active", () => {
+    const html = adminSiteContactPage(OWNER_SESSION, "", {
+      botpoisonEnabled: true,
+      enabled: false,
+      hasBusinessEmail: true,
+    });
+    expect(html).toContain("Botpoison is active.");
+    expect(html).not.toContain("without a spam check");
   });
 
   test("the contact page asks for a business email when none is set", () => {
@@ -42,13 +80,43 @@ describe("site editor pages", () => {
     expect(html).toContain("to receive contact form messages");
   });
 
-  test("the order page shows the intro box, the toggle, and the count note", () => {
+  test("the order page shows the intro box and the enable toggle", () => {
     const html = adminSiteOrderPage(OWNER_SESSION, "Before you book, note:", {
       enabled: false,
       listingCount: 2,
     });
     expect(html).toContain("Before you book, note:");
     expect(html).toContain('name="order_intro_text"');
-    expect(html).toContain('name="order_enabled"');
+    expect(html).toContain('action="/admin/site/order"');
+    expect(html).toContain('action="/admin/site/order/toggle"');
+    const toggle = html.slice(
+      html.indexOf('name="order_enabled"') - 100,
+      html.indexOf('name="order_enabled"') + 100,
+    );
+    expect(toggle).toContain('type="checkbox"');
+    expect(toggle).toContain('value="true"');
+  });
+
+  test("the order page counts the listings it will show", () => {
+    const two = adminSiteOrderPage(OWNER_SESSION, "", {
+      enabled: false,
+      listingCount: 2,
+    });
+    expect(two).toContain("2 listings will be shown on the order page.");
+    const one = adminSiteOrderPage(OWNER_SESSION, "", {
+      enabled: false,
+      listingCount: 1,
+    });
+    expect(one).toContain("1 listing will be shown on the order page.");
+  });
+
+  test("the order page warns when no listing can appear yet", () => {
+    const html = adminSiteOrderPage(OWNER_SESSION, "", {
+      enabled: false,
+      listingCount: 0,
+    });
+    expect(html).toContain("You have no bookable listings yet.");
+    expect(html).toContain('href="/admin/"');
+    expect(html).not.toContain("will be shown on the order page");
   });
 });

--- a/test/ui/templates/admin/site.test.tsx
+++ b/test/ui/templates/admin/site.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from "@std/expect";
-import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { beforeAll, it as test } from "@std/testing/bdd";
 import {
   adminSiteContactPage,
   adminSiteHomePage,
@@ -9,8 +9,10 @@ import {
   OWNER_SESSION,
   setupAdminPageTest,
 } from "#test-utils/admin-page-test.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { enableFeature } from "#test-utils/settings.ts";
 
-describe("site editor pages", () => {
+describeWithEnv("site editor pages", { db: true }, () => {
   beforeAll(setupAdminPageTest);
 
   test("the home page shows both boxes carrying the stored values", () => {
@@ -59,6 +61,9 @@ describe("site editor pages", () => {
     expect(toggle).toContain('value="true"');
     expect(html).toContain("submissions are accepted without a spam check");
     expect(html).not.toContain("to receive contact form messages");
+    // The env-key names sit one space apart, not glued.
+    expect(html).toContain("and <code>BOTPOISON_SECRET_KEY</code>");
+    expect(html).toContain('class="prose"');
   });
 
   test("the contact page names Botpoison when it is active", () => {
@@ -95,6 +100,7 @@ describe("site editor pages", () => {
     );
     expect(toggle).toContain('type="checkbox"');
     expect(toggle).toContain('value="true"');
+    expect(html).toContain('class="prose"');
   });
 
   test("the order page counts the listings it will show", () => {
@@ -116,7 +122,26 @@ describe("site editor pages", () => {
       listingCount: 0,
     });
     expect(html).toContain("You have no bookable listings yet.");
-    expect(html).toContain('href="/admin/"');
+    // The warning's own link, with its words one space apart.
+    expect(html).toContain('href="/admin/">Create a listing</a> for it');
     expect(html).not.toContain("will be shown on the order page");
+  });
+
+  test("each editor opens the Site nav section with its landing link lit", async () => {
+    await enableFeature("site");
+    for (const html of [
+      adminSiteHomePage(OWNER_SESSION, "", ""),
+      adminSiteContactPage(OWNER_SESSION, "", {
+        botpoisonEnabled: false,
+        enabled: false,
+        hasBusinessEmail: true,
+      }),
+      adminSiteOrderPage(OWNER_SESSION, "", {
+        enabled: false,
+        listingCount: 1,
+      }),
+    ]) {
+      expect(html).toContain('<a class="active" href="/admin/site">');
+    }
   });
 });

--- a/test/ui/templates/admin/site.test.tsx
+++ b/test/ui/templates/admin/site.test.tsx
@@ -9,6 +9,7 @@ import {
   OWNER_SESSION,
   setupAdminPageTest,
 } from "#test-utils/admin-page-test.ts";
+import { inputNamed } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { enableFeature } from "#test-utils/settings.ts";
 
@@ -53,14 +54,13 @@ describeWithEnv("site editor pages", { db: true }, () => {
     expect(html).toContain('action="/admin/site/contact"');
     // The toggle posts to its own route with a checkbox the route reads.
     expect(html).toContain('action="/admin/site/contact/form"');
-    const toggle = html.slice(
-      html.indexOf('name="contact_form_enabled"') - 100,
-      html.indexOf('name="contact_form_enabled"') + 200,
-    );
+    const toggle = inputNamed(html, "contact_form_enabled");
     expect(toggle).toContain('type="checkbox"');
     expect(toggle).toContain('value="true"');
     // The box and its label stay one space apart, not glued.
-    expect(toggle).toMatch(/value="true"\s*>\s+Enable contact form/);
+    expect(html).toMatch(
+      /name="contact_form_enabled"[^>]*>\s+Enable contact form/,
+    );
     expect(html).toContain("submissions are accepted without a spam check");
     expect(html).not.toContain("to receive contact form messages");
     // The env-key names sit one space apart, not glued.
@@ -96,14 +96,11 @@ describeWithEnv("site editor pages", { db: true }, () => {
     expect(html).toContain('name="order_intro_text"');
     expect(html).toContain('action="/admin/site/order"');
     expect(html).toContain('action="/admin/site/order/toggle"');
-    const toggle = html.slice(
-      html.indexOf('name="order_enabled"') - 100,
-      html.indexOf('name="order_enabled"') + 200,
-    );
+    const toggle = inputNamed(html, "order_enabled");
     expect(toggle).toContain('type="checkbox"');
     expect(toggle).toContain('value="true"');
     // The box and its label stay one space apart, not glued.
-    expect(toggle).toMatch(/value="true"\s*>\s+Enable order page/);
+    expect(html).toMatch(/name="order_enabled"[^>]*>\s+Enable order page/);
     expect(html).toContain('class="prose"');
   });
 

--- a/test/ui/templates/admin/site.test.tsx
+++ b/test/ui/templates/admin/site.test.tsx
@@ -1,0 +1,54 @@
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import {
+  adminSiteContactPage,
+  adminSiteHomePage,
+  adminSiteOrderPage,
+} from "#templates/admin/site.tsx";
+import {
+  OWNER_SESSION,
+  setupAdminPageTest,
+} from "#test-utils/admin-page-test.ts";
+
+describe("site editor pages", () => {
+  beforeAll(setupAdminPageTest);
+
+  test("the home page shows both boxes carrying the stored values", () => {
+    const html = adminSiteHomePage(OWNER_SESSION, "My site", "Welcome!");
+    expect(html).toContain('value="My site"');
+    expect(html).toContain("Welcome!");
+    expect(html).toContain('name="website_title"');
+    expect(html).toContain('name="homepage_text"');
+  });
+
+  test("the contact page shows its text box and the form toggle", () => {
+    const html = adminSiteContactPage(OWNER_SESSION, "Email us", {
+      botpoisonEnabled: false,
+      enabled: false,
+      hasBusinessEmail: true,
+    });
+    expect(html).toContain("Email us");
+    expect(html).toContain('name="contact_page_text"');
+    expect(html).toContain('name="contact_form_enabled"');
+    expect(html).not.toContain("to receive contact form messages");
+  });
+
+  test("the contact page asks for a business email when none is set", () => {
+    const html = adminSiteContactPage(OWNER_SESSION, "", {
+      botpoisonEnabled: false,
+      enabled: false,
+      hasBusinessEmail: false,
+    });
+    expect(html).toContain("to receive contact form messages");
+  });
+
+  test("the order page shows the intro box, the toggle, and the count note", () => {
+    const html = adminSiteOrderPage(OWNER_SESSION, "Before you book, note:", {
+      enabled: false,
+      listingCount: 2,
+    });
+    expect(html).toContain("Before you book, note:");
+    expect(html).toContain('name="order_intro_text"');
+    expect(html).toContain('name="order_enabled"');
+  });
+});

--- a/test/ui/templates/admin/site.test.tsx
+++ b/test/ui/templates/admin/site.test.tsx
@@ -55,10 +55,12 @@ describeWithEnv("site editor pages", { db: true }, () => {
     expect(html).toContain('action="/admin/site/contact/form"');
     const toggle = html.slice(
       html.indexOf('name="contact_form_enabled"') - 100,
-      html.indexOf('name="contact_form_enabled"') + 100,
+      html.indexOf('name="contact_form_enabled"') + 200,
     );
     expect(toggle).toContain('type="checkbox"');
     expect(toggle).toContain('value="true"');
+    // The box and its label stay one space apart, not glued.
+    expect(toggle).toMatch(/value="true"\s*>\s+Enable contact form/);
     expect(html).toContain("submissions are accepted without a spam check");
     expect(html).not.toContain("to receive contact form messages");
     // The env-key names sit one space apart, not glued.
@@ -96,10 +98,12 @@ describeWithEnv("site editor pages", { db: true }, () => {
     expect(html).toContain('action="/admin/site/order/toggle"');
     const toggle = html.slice(
       html.indexOf('name="order_enabled"') - 100,
-      html.indexOf('name="order_enabled"') + 100,
+      html.indexOf('name="order_enabled"') + 200,
     );
     expect(toggle).toContain('type="checkbox"');
     expect(toggle).toContain('value="true"');
+    // The box and its label stay one space apart, not glued.
+    expect(toggle).toMatch(/value="true"\s*>\s+Enable order page/);
     expect(html).toContain('class="prose"');
   });
 

--- a/test/ui/templates/fields/attribute.test.ts
+++ b/test/ui/templates/fields/attribute.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  attributeNameForm,
+  attributeOptionForm,
+} from "#templates/fields/attribute.ts";
+
+describe("attribute editor forms", () => {
+  test("the name form asks for an attribute name", () => {
+    expect(attributeNameForm.fields[0]!.name).toBe("name");
+    expect(attributeNameForm.render()).toContain("Attribute name");
+    expect(attributeNameForm.render()).toContain("e.g. Difficulty");
+  });
+
+  test("the option form asks for option text", () => {
+    expect(attributeOptionForm.fields[0]!.name).toBe("text");
+    expect(attributeOptionForm.render()).toContain("Option text");
+    expect(attributeOptionForm.render()).toContain("e.g. Beginner");
+  });
+});

--- a/test/ui/templates/fields/builder.test.ts
+++ b/test/ui/templates/fields/builder.test.ts
@@ -1,0 +1,21 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { builderForm } from "#templates/fields/builder.ts";
+
+describe("builder form", () => {
+  test("offers the site name, provider choices, and both db boxes", () => {
+    const names = builderForm.fields.map((field) => field.name);
+    expect(names).toContain("site_name");
+    expect(names).toContain("db_url");
+    expect(names).toContain("db_token");
+    const name = builderForm.fields[0]!;
+    expect(name.required).toBe(true);
+    expect(name.maxlength).toBe(64);
+  });
+
+  test("renders the provider wording from the catalog", () => {
+    const html = builderForm.render();
+    expect(html).toContain("Site name");
+    expect(html).toContain("db_url");
+  });
+});

--- a/test/ui/templates/fields/builder.test.ts
+++ b/test/ui/templates/fields/builder.test.ts
@@ -11,11 +11,15 @@ describe("builder form", () => {
     const name = builderForm.fields[0]!;
     expect(name.required).toBe(true);
     expect(name.maxlength).toBe(64);
+    expect(name.minlength).toBe(1);
   });
 
-  test("renders the provider wording from the catalog", () => {
+  test("renders every provider choice with the value its route reads", () => {
     const html = builderForm.render();
-    expect(html).toContain("Site name");
-    expect(html).toContain("db_url");
+    for (const value of ["bunny", "turso", "manual"]) {
+      expect(html).toContain(`value="${value}"`);
+    }
+    // The name box refuses to submit empty, so the route never sees "".
+    expect(html).toContain('name="site_name"');
   });
 });

--- a/test/ui/templates/fields/builder.test.ts
+++ b/test/ui/templates/fields/builder.test.ts
@@ -19,6 +19,9 @@ describe("builder form", () => {
     for (const value of ["bunny", "turso", "manual"]) {
       expect(html).toContain(`value="${value}"`);
     }
+    // Bunny appears once per choice list — database and hosting — and both
+    // must carry the value, or one route arm reads nothing.
+    expect(html.match(/value="bunny"/g)).toHaveLength(2);
     // The name box refuses to submit empty, so the route never sees "".
     expect(html).toContain('name="site_name"');
   });

--- a/test/ui/templates/fields/seeds.test.ts
+++ b/test/ui/templates/fields/seeds.test.ts
@@ -11,6 +11,8 @@ describe("seeds form", () => {
     expect(listings!.max).toBe(MAX_SEED_LISTINGS);
     expect(attendees!.name).toBe("attendees_per_listing");
     expect(attendees!.max).toBe(SEED_MAX_ATTENDEES);
+    // The limits themselves, pinned: the route clamps to the same numbers.
+    expect(MAX_SEED_LISTINGS).toBe(30);
   });
 
   test("starts each box at its suggested count", () => {

--- a/test/ui/templates/fields/seeds.test.ts
+++ b/test/ui/templates/fields/seeds.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
 import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
+import { inputNamed } from "#test-utils/assertions.ts";
 
 describe("seeds form", () => {
   test("offers the two number boxes between their bounds", () => {
@@ -15,5 +16,20 @@ describe("seeds form", () => {
   test("starts each box at its suggested count", () => {
     expect(seedsForm.fields[0]!.defaultValue).toBe("5");
     expect(seedsForm.fields[1]!.defaultValue).toBe("10");
+  });
+
+  test("renders both boxes required with their bounds and ids", () => {
+    const [listings, attendees] = seedsForm.fields;
+    expect(listings!.id).toBe("listing_count");
+    expect(attendees!.id).toBe("attendees_per_listing");
+    const html = seedsForm.render();
+    const listingBox = inputNamed(html, "listing_count");
+    expect(listingBox).toContain('min="1"');
+    expect(listingBox).toContain(`max="${MAX_SEED_LISTINGS}"`);
+    expect(listingBox).toContain("required");
+    const attendeeBox = inputNamed(html, "attendees_per_listing");
+    expect(attendeeBox).toContain('min="0"');
+    expect(attendeeBox).toContain(`max="${SEED_MAX_ATTENDEES}"`);
+    expect(attendeeBox).toContain("required");
   });
 });

--- a/test/ui/templates/fields/seeds.test.ts
+++ b/test/ui/templates/fields/seeds.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { SEED_MAX_ATTENDEES } from "#shared/seeds.ts";
+import { MAX_SEED_LISTINGS, seedsForm } from "#templates/fields/seeds.ts";
+
+describe("seeds form", () => {
+  test("offers the two number boxes between their bounds", () => {
+    const [listings, attendees] = seedsForm.fields;
+    expect(listings!.name).toBe("listing_count");
+    expect(listings!.max).toBe(MAX_SEED_LISTINGS);
+    expect(attendees!.name).toBe("attendees_per_listing");
+    expect(attendees!.max).toBe(SEED_MAX_ATTENDEES);
+  });
+
+  test("starts each box at its suggested count", () => {
+    expect(seedsForm.fields[0]!.defaultValue).toBe("5");
+    expect(seedsForm.fields[1]!.defaultValue).toBe("10");
+  });
+});

--- a/test/ui/templates/fields/site.test.ts
+++ b/test/ui/templates/fields/site.test.ts
@@ -20,14 +20,21 @@ describe("site editor forms", () => {
     ]);
     const title = siteHomeForm.fields[0]!;
     expect(title.maxlength).toBe(MAX_WEBSITE_TITLE_LENGTH);
-    expect(siteHomeForm.render()).toContain("Website title");
+    const html = siteHomeForm.render();
+    expect(html).toContain("Website title");
+    // The id ties the label to the box, and the browser must not offer
+    // saved site-login values for a page title.
+    expect(html).toContain('id="website_title"');
+    expect(html).toContain('autocomplete="off"');
   });
 
-  test("the contact and order forms each offer their one text box", () => {
+  test("the contact and order forms each offer their one markdown text box", () => {
     expect(fieldNames(siteContactForm)).toEqual(["contact_page_text"]);
     expect(fieldNames(siteOrderForm)).toEqual(["order_intro_text"]);
     for (const form of [siteContactForm, siteOrderForm]) {
       expect(form.fields[0]!.maxlength).toBe(MAX_TEXTAREA_LENGTH);
+      // Markdown boxes carry the live preview control plain text areas lack.
+      expect(form.render()).toContain("data-markdown-preview");
     }
   });
 });

--- a/test/ui/templates/fields/site.test.ts
+++ b/test/ui/templates/fields/site.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { MAX_WEBSITE_TITLE_LENGTH } from "#db/settings/constants.ts";
+import { MAX_TEXTAREA_LENGTH } from "#shared/limits.ts";
+import {
+  siteContactForm,
+  siteHomeForm,
+  siteOrderForm,
+} from "#templates/fields/site.ts";
+
+/** The box names each site form offers, in order. */
+const fieldNames = (form: { fields: ReadonlyArray<{ name: string }> }) =>
+  form.fields.map((field) => field.name);
+
+describe("site editor forms", () => {
+  test("the home form offers the title box and the homepage text box", () => {
+    expect(fieldNames(siteHomeForm)).toEqual([
+      "website_title",
+      "homepage_text",
+    ]);
+    const title = siteHomeForm.fields[0]!;
+    expect(title.maxlength).toBe(MAX_WEBSITE_TITLE_LENGTH);
+    expect(siteHomeForm.render()).toContain("Website title");
+  });
+
+  test("the contact and order forms each offer their one text box", () => {
+    expect(fieldNames(siteContactForm)).toEqual(["contact_page_text"]);
+    expect(fieldNames(siteOrderForm)).toEqual(["order_intro_text"]);
+    for (const form of [siteContactForm, siteOrderForm]) {
+      expect(form.fields[0]!.maxlength).toBe(MAX_TEXTAREA_LENGTH);
+    }
+  });
+});


### PR DESCRIPTION
## What changed

Four admin page templates imported their routes' form definitions, and
the routes imported the templates back — four more route-template
cycles beside the ones #2171 and #2173 broke. The forms move to
`src/ui/templates/fields/`, the established home the modifiers form
already uses, so template and route each import one definition from a
leaf instead of each other:

- `fields/site.ts` — the three site editor forms
- `fields/seeds.ts` — the seeds form, with the listing limit it bounds
- `fields/builder.ts` — the builder form
- `fields/attribute.ts` — the two attribute forms

The site route never used its forms at all — its validation is
hand-rolled per field — so it simply drops them. The seeds form's two
labels were hard-coded in the route, outside the i18n check's reach;
the move brings them into it, and they take catalog keys.

## The scanner is now `deno task cycles`

The throwaway scan behind #2171/#2173/#2177 is a repo tool: it prints
the load-time cyclic groups of the production graph, largest first —
a report, not a gate, per the TODO entry's design. Load-time edges
only: type-only imports evaluate nothing and dynamic imports are
deferred, so neither creates a load-order cycle — and modules only a
type import can reach are not scanned at all, because they never
evaluate. A module that statically imports itself reports as a tangle
of one. The `deno info` reader moved to `scripts/module-graph.ts`,
shared with the mutation state graph, whose own reachability walk now
runs on the same engine; the report's reader is injectable, so its
test runs over a fixture and the ordinary suite spawns no subprocess.

Measured with it on this branch: the four pairs are gone. What remains
is owned by open PRs (#2168's listing-page triangle, #2177's db spine)
and the logger-ntfy-sentry triangle.

## The mirrors the mutation gate demanded

Eight files gained or grew direct mirrors (the four fields modules,
the seeds and site templates, the attributes collection page). Three
mutation passes over them surfaced 65 survivors; each is now either
pinned — nav highlighting under the feature gate, the JSX spacing
literals that keep words apart, the bunny option's count of two, the
seeds limit's number — or recorded equivalent with its proof (table
keys no render reads, a nav route no section owns).

## Gates

`precommit` green; `precommit:mutation` 100% (401/401, 8 suppressed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared admin forms for attribute editing, site building, seed data, and site-page editing.
  * Added localized labels and validation for seed-data listing and attendee fields.
  * Added a command to generate import-cycle reports.

* **Improvements**
  * Improved consistency of admin form rendering, validation, labels, and navigation.

* **Tests**
  * Expanded coverage for admin pages, form behavior, validation, rendering, and import-cycle analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

