### PR TITLE
Break the logger-ntfy-sentry triangle at the fan-out

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -12,7 +12,6 @@ import {
   makeSuppressibleLogFlag,
   shouldSuppressDebugLogs,
 } from "#shared/log-settings.ts";
-import { sendNtfyError } from "#shared/ntfy.ts";
 import {
   addPendingWork,
   hasPendingWorkScope,
@@ -24,7 +23,6 @@ import {
   createScopedValue,
   type ScopeRunner,
 } from "#shared/request-scoped.ts";
-import { captureServerError } from "#shared/sentry.ts";
 
 /** Request-scoped random ID for correlating log entries ("" outside a request). */
 const requestId = createScopedValue(() => "");
@@ -296,11 +294,28 @@ export const logErrorLocal = (context: ErrorContext): void => {
   console.error(`${getLogPrefix()}${parts.join(" ")}`);
 };
 
+/** Deliver a reporter's copy of an error. The reporter modules are imported
+ * on first error, not at module load: each reporter reports its own delivery
+ * failure through `logErrorLocal`, so a static import here would close a
+ * cycle (logger → reporter → logger) with no sound cut point — the same
+ * reason the activity-log persistence defers its import below. */
 const fanOutError = (context: ErrorContext): void => {
   if (!hasPendingWorkScope()) return;
-  addPendingWork(sendNtfyError(context.code));
+  addPendingWork(sendNtfyCopy(context));
   addPendingWork(persistErrorToActivityLog(context));
-  addPendingWork(captureServerError(context));
+  addPendingWork(sentryCopy(context));
+};
+
+/** Send the ntfy notification for an error, loading the sender on first use. */
+const sendNtfyCopy = async (context: ErrorContext): Promise<void> => {
+  const { sendNtfyError } = await import("#shared/ntfy.ts");
+  await sendNtfyError(context.code);
+};
+
+/** Send the Sentry report for an error, loading the sender on first use. */
+const sentryCopy = async (context: ErrorContext): Promise<void> => {
+  const { captureServerError } = await import("#shared/sentry.ts");
+  await captureServerError(context);
 };
 
 /**


### PR DESCRIPTION
## What changed

The error-reporting path carried the tree's last unowned load cycle:
`logger` imports `ntfy` and `sentry` to deliver each error, and each
reporter imports `logger` back — ntfy to report its own send failures,
sentry for the error vocabulary and the request id. The recursion guard
was a doc comment on `logErrorLocal` ("use this where calling logError
would recurse"), and all three modules sat in one another's load graphs.

The fan-out now loads each reporter **on first error** instead of at
module load — the same deferral `persistErrorToActivityLog` two calls
below already uses, with a comment explaining exactly this cycle class.
The dynamic import breaks the logger→reporter load edge; the
reporter→logger edges stay, because they are now acyclic. The recursion
guard is the import graph: `logErrorLocal` fans nothing out, so a
reporter calling it can never re-enter the fan-out, structurally.

The first cut moved the shared vocabulary to a leaf module and migrated
~54 callers — and died on the mutation gate, which demands a direct
test mirror for every changed `src/` file, 52 of which had none. One
19-line change in one file achieves the same cycle break instead.

## Measured

Load-time cyclic groups on this branch: **7** — the
logger/ntfy/sentry group is gone. The seven remaining groups are owned
by open PRs (#2177's db spine, #2168's listing pages, #2171's join
pair, #2178's four admin pairs). Once those merge, `deno task cycles`
reports **zero**.

## Tests

The existing suites cover the fan-out end to end (ntfy delivery, its
failure logging, Sentry capture, the deferred-report queue) — all 117
pass unchanged, which is the point: no behaviour moved, only when the
reporter modules load.

## Gates

`precommit` green; `precommit:mutation` 100% (135/135, 1 suppressed,
MUTATION_STATIC_JOBS=1).