### PR TITLE
Clear the loader path before spawning gh in the PR queue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,9 @@
               pkgs.biome
               pkgs.openssl
               pkgs.buildah
+              # The PR queue report (`deno task pr-queue`) and the stacked-PR
+              # workflow both run gh commands.
+              pkgs.gh
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.chromium ];
             shellHook = ''

--- a/scripts/pr-queue/gh.ts
+++ b/scripts/pr-queue/gh.ts
@@ -39,6 +39,8 @@ export const runGhCommand: GhRunner = async (args) => {
   const captured = await captureOutput(
     new Deno.Command("gh", {
       args,
+      // Deno rejects loader overrides when `--allow-run` permits only `gh`.
+      env: { LD_LIBRARY_PATH: "" },
       signal,
       stderr: "piped",
       stdout: "piped",

--- a/test/scripts/pr-queue/gh.test.ts
+++ b/test/scripts/pr-queue/gh.test.ts
@@ -18,8 +18,8 @@ import { ghSaying, queueReply } from "./fixtures.ts";
  * inherits a non-empty `LD_LIBRARY_PATH`, which makes Deno refuse to spawn a
  * subprocess while `--allow-run` permits only `gh` — unless the spawn clears
  * the variable, which is what the production runner does. The script exits 0
- * when the real `gh --version` ran; on any other outcome it writes the
- * failure to stderr and exits 1, so the parent can name what broke.
+ * when gh ran; on any other outcome it writes the failure to stderr and
+ * exits 1, so the parent can name what broke.
  *
  * The module is imported there by its own resolved URL, because the child
  * cannot reach the repo's import map for aliases.
@@ -32,6 +32,18 @@ if (result.code !== 0) {
   Deno.exit(1);
 }
 `;
+
+/** A `gh` that always succeeds, on a PATH the child owns alone. The Nix
+ * shell ships no gh, and the permission and loader-path checks this test
+ * exists for fire in Deno before any gh binary runs, so a stub answers the
+ * spawn as well as the real one would. */
+const stubGhOn = async (dir: string): Promise<string> => {
+  const bin = `${dir}/gh-bin`;
+  await Deno.mkdir(bin);
+  await Deno.writeTextFile(`${bin}/gh`, "#!/bin/sh\nexit 0\n");
+  await Deno.chmod(`${bin}/gh`, 0o755);
+  return bin;
+};
 /** The failure a call threw, so its message and exit code can be checked. */
 const failureFrom = async (call: Promise<unknown>): Promise<GhFailure> => {
   const error = await call.catch((error: unknown) => error);
@@ -84,7 +96,7 @@ describe("running the gh command itself", () => {
     expect(captured.commands[0]?.options.stderr).toBe("piped");
   });
 
-  test("spawns the real gh from a loader-path environment under --allow-run=gh", async () => {
+  test("spawns gh from a loader-path environment under --allow-run=gh", async () => {
     // Reproduces the NixOS failure the env clear fixes: the child runs with
     // only gh permitted, a non-empty loader path inherited, and the production
     // spawn. Without the clear, Deno refuses the spawn with NotCapable.
@@ -112,7 +124,8 @@ describe("running the gh command itself", () => {
           // never sees a script whose source is already gone.
           DENO_COVERAGE_DIR: `${dir}/child-coverage`,
           LD_LIBRARY_PATH: "/nowhere-useful",
-          PATH: Deno.env.get("PATH") ?? "",
+          // The stub's directory alone, so the test needs no host gh.
+          PATH: await stubGhOn(dir),
         },
         stderr: "piped",
         stdout: "piped",

--- a/test/scripts/pr-queue/gh.test.ts
+++ b/test/scripts/pr-queue/gh.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "@std/expect";
+import { resolve } from "@std/path";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
 import {
@@ -9,8 +10,28 @@ import {
 } from "#scripts/pr-queue/gh.ts";
 import type { GraphQlPr } from "#scripts/pr-queue/types.ts";
 import { captureCommands } from "#test-utils/command-capture.ts";
+import { withTempDir } from "#test-utils/files.ts";
 import { ghSaying, queueReply } from "./fixtures.ts";
 
+/**
+ * Runs in a child Deno under the report task's exact permissions. The child
+ * inherits a non-empty `LD_LIBRARY_PATH`, which makes Deno refuse to spawn a
+ * subprocess while `--allow-run` permits only `gh` — unless the spawn clears
+ * the variable, which is what the production runner does. The script exits 0
+ * when the real `gh --version` ran; on any other outcome it writes the
+ * failure to stderr and exits 1, so the parent can name what broke.
+ *
+ * The module is imported there by its own resolved URL, because the child
+ * cannot reach the repo's import map for aliases.
+ */
+const spawnScript = (runnerUrl: string): string => `
+import { runGhCommand } from "${runnerUrl}";
+const result = await runGhCommand(["--version"]);
+if (result.code !== 0) {
+  console.error("gh --version exited " + result.code + ": " + result.stderr);
+  Deno.exit(1);
+}
+`;
 /** The failure a call threw, so its message and exit code can be checked. */
 const failureFrom = async (call: Promise<unknown>): Promise<GhFailure> => {
   const error = await call.catch((error: unknown) => error);
@@ -61,6 +82,44 @@ describe("running the gh command itself", () => {
     expect(captured.commands[0]?.options.env).toEqual({ LD_LIBRARY_PATH: "" });
     expect(captured.commands[0]?.options.stdout).toBe("piped");
     expect(captured.commands[0]?.options.stderr).toBe("piped");
+  });
+
+  test("spawns the real gh from a loader-path environment under --allow-run=gh", async () => {
+    // Reproduces the NixOS failure the env clear fixes: the child runs with
+    // only gh permitted, a non-empty loader path inherited, and the production
+    // spawn. Without the clear, Deno refuses the spawn with NotCapable.
+    await withTempDir(async (dir) => {
+      const childPath = `${dir}/spawn-gh.ts`;
+      await Deno.writeTextFile(
+        childPath,
+        spawnScript(import.meta.resolve("#scripts/pr-queue/gh.ts")),
+      );
+      const repoRoot = resolve(import.meta.dirname!, "../../..");
+      const child = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "run",
+          "--no-check",
+          "--config",
+          `${repoRoot}/deno.json`,
+          "--allow-run=gh",
+          childPath,
+        ],
+        env: {
+          // Deno injects the run's coverage dir into a spawned deno even
+          // when the env is replaced, and the child would dump a record for
+          // the temp script this test deletes before the merge reads it.
+          // Point the child at a throwaway dir so the run's coverage data
+          // never sees a script whose source is already gone.
+          DENO_COVERAGE_DIR: `${dir}/child-coverage`,
+          LD_LIBRARY_PATH: "/nowhere-useful",
+          PATH: Deno.env.get("PATH") ?? "",
+        },
+        stderr: "piped",
+        stdout: "piped",
+      }).output();
+      expect(new TextDecoder().decode(child.stderr)).toBe("");
+      expect(child.code).toBe(0);
+    });
   });
 });
 

--- a/test/scripts/pr-queue/gh.test.ts
+++ b/test/scripts/pr-queue/gh.test.ts
@@ -58,6 +58,7 @@ describe("running the gh command itself", () => {
     });
     expect(captured.commands[0]?.command).toBe("gh");
     expect(captured.commands[0]?.options.args).toEqual(["pr", "list"]);
+    expect(captured.commands[0]?.options.env).toEqual({ LD_LIBRARY_PATH: "" });
     expect(captured.commands[0]?.options.stdout).toBe("piped");
     expect(captured.commands[0]?.options.stderr).toBe("piped");
   });

--- a/test/scripts/pr-queue/gh.test.ts
+++ b/test/scripts/pr-queue/gh.test.ts
@@ -33,10 +33,12 @@ if (result.code !== 0) {
 }
 `;
 
-/** A `gh` that always succeeds, on a PATH the child owns alone. The Nix
- * shell ships no gh, and the permission and loader-path checks this test
- * exists for fire in Deno before any gh binary runs, so a stub answers the
- * spawn as well as the real one would. */
+/** A `gh` that always succeeds, on a PATH the child owns alone. The dev
+ * shell ships gh for the report task itself, but the regression this test
+ * exists for is in Deno's spawn, not in gh: the permission and loader-path
+ * checks fire before any gh binary runs, so a stub answers the spawn as
+ * well as the real one would — and the test stays green wherever `deno
+ * test` runs, nix shell or not. */
 const stubGhOn = async (dir: string): Promise<string> => {
   const bin = `${dir}/gh-bin`;
   await Deno.mkdir(bin);


### PR DESCRIPTION
## What changed

`deno task pr-queue` runs under `--allow-run=gh`. Under a Deno shell
on NixOS, `LD_LIBRARY_PATH` points at the nix store, and Deno refuses
to spawn a subprocess that inherits a loader-path override it was not
granted — `NotCapable: Requires --allow-run permissions to spawn
subprocess with LD_LIBRARY_PATH environment variable` — so the task
died before its first gh call on affected machines.

The gh spawn now clears the variable explicitly. The command assertion
in the direct test pins the cleared environment.

Three lines, made in a separate window on top of the renewal-tier
branch; this PR moves them onto main where they belong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the GitHub CLI to the development environment for GitHub-related workflows.

* **Bug Fixes**
  * Improved GitHub CLI command execution in environments with inherited library-path settings.
  * Added regression coverage to ensure GitHub CLI commands run reliably with restricted permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->