### PR TITLE
Say in AGENTS.md that a branch fixes the defects it introduces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,19 @@ GitHub.
   coverage. Write the failing test first, confirm it fails for the right reason,
   then apply the fix and watch it go green. This locks the bug out for good and
   proves the fix actually addresses it.
+- **A branch fixes the defects it introduces**: A review finding about code the
+  branch adds is that branch's work. Fix it in the branch, pin it with a
+  regression test, and merge the branch clean. Never record it as a follow-up
+  issue and merge anyway: the defect exists nowhere but the open branch, and the
+  issue hands work to a future person who must rebuild the context in front of
+  you now. An issue is for a defect that is already on main, or for one that is
+  genuinely outside the branch's scope. If the fix would complicate the branch,
+  split the branch instead of merging a known defect. In a stack, the fix
+  belongs to the layer that introduces it.
+
+  The worked example: issues #2226–#2233 were opened for review findings on PR
+  #2166's own new code, and the defects they describe existed nowhere but that
+  open branch. The fixes belong in the same pull request.
 - **Offensive, not defensive, programming**: Fail loudly and immediately instead
   of tolerating bad states — never suppress, default away, or paper over an
   error. See


### PR DESCRIPTION
Adds one preference between the regression-test rule and the offensive-programming rule:

## The rule

A review finding about code the branch adds is that branch's work. Fix it in the branch, pin it with a regression test, and merge the branch clean. Never record it as a follow-up issue and merge anyway. An issue is for a defect that is already on main, or for one that is genuinely outside the branch scope. In a stack, the fix belongs to the layer that introduces it.

## Why now

The review of #2166 produced eight findings about that pull request's own new code, and eight issues (#2226–#2233) were opened instead of fixes. Every defect those issues describe existed nowhere but the open branch. The issues will close with fixes inside #2166 itself, and this rule keeps the next branch from repeating the detour.

An issue that names work must hold work a person can still pick up without rebuilding context an open branch already holds. Deferring a branch's own known defect breaks that, so the rule says fix, pin, and merge clean.

## Checks

`deno fmt --check` and `deno task lint:ci` pass (the precommit hook ran on the commit).