### PR TITLE
Gate unread exported fields with exact policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Typecheck
         run: deno task typecheck
 
+      - name: Check unread exported fields
+        run: deno task check:unread-fields
+
       - name: Check for code duplication (CPD)
         run: deno task cpd
 

--- a/deno.json
+++ b/deno.json
@@ -33,6 +33,7 @@
     "check:comments": "deno run --allow-read=src scripts/check-comments.ts",
     "check:e2e-labels": "deno run --allow-read=src,e2e-payments scripts/check-e2e-labels.ts",
     "check:imports": "deno run --allow-read=deno.json,src,test,scripts,cli scripts/check-imports.ts",
+    "check:unread-fields": "deno run --allow-read --allow-env=TSC_WATCHFILE,TSC_NONPOLLING_WATCHER,TSC_WATCHDIRECTORY,TSC_WATCH_POLLINGINTERVAL_LOW,TSC_WATCH_POLLINGINTERVAL_MEDIUM,TSC_WATCH_POLLINGINTERVAL_HIGH,TSC_WATCH_POLLINGCHUNKSIZE_LOW,TSC_WATCH_POLLINGCHUNKSIZE_MEDIUM,TSC_WATCH_POLLINGCHUNKSIZE_HIGH,TSC_WATCH_UNCHANGEDPOLLTHRESHOLDS_LOW,TSC_WATCH_UNCHANGEDPOLLTHRESHOLDS_MEDIUM,TSC_WATCH_UNCHANGEDPOLLTHRESHOLDS_HIGH,NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV scripts/check-unread-fields.ts",
     "precommit": "deno run -A scripts/precommit.ts",
     "precommit:mutation": "deno run -A scripts/precommit-mutation.ts",
     "find-unused-src": "deno run --allow-read scripts/find-unused-src.ts",

--- a/scripts/check-unread-fields.ts
+++ b/scripts/check-unread-fields.ts
@@ -1,0 +1,12 @@
+import { consoleOutput } from "#scripts/check-report.ts";
+import { UNREAD_FIELD_BASELINE } from "#scripts/unread-fields/baseline.ts";
+import { UNREAD_FIELD_EXEMPTIONS } from "#scripts/unread-fields/exemptions.ts";
+import { runUnreadFieldsCheck } from "#scripts/unread-fields/run-check.ts";
+import { scanUnreadFields } from "#scripts/unread-fields/scan.ts";
+
+const code = await runUnreadFieldsCheck(Deno.cwd(), consoleOutput, {
+  baseline: UNREAD_FIELD_BASELINE,
+  exemptions: UNREAD_FIELD_EXEMPTIONS,
+  scan: scanUnreadFields,
+});
+Deno.exit(code);

--- a/scripts/precommit/steps.ts
+++ b/scripts/precommit/steps.ts
@@ -28,6 +28,13 @@ export const getSteps = (): Step[] => {
     // Run `deno task lint` separately to auto-fix formatting before committing.
     { cmd: [deno, "task", "lint:ci"], name: "lint" },
     { cmd: [deno, "task", "typecheck"], name: "typecheck" },
+    // An exact baseline and reviewed false positives turn the whole-repository
+    // field scan into a ratchet. It follows typecheck because it asks the same
+    // compiler program which symbol each mention reaches.
+    {
+      cmd: [deno, "task", "check:unread-fields"],
+      name: "check:unread-fields",
+    },
     { cmd: [deno, "task", "cpd"], name: "cpd" },
     // Guard the user-facing copy catalog against the mechanical simple-language
     // rules (see the "Simple Language" section of AGENTS.md).

--- a/scripts/unread-fields/README.md
+++ b/scripts/unread-fields/README.md
@@ -10,6 +10,41 @@ The scan takes a few minutes. It prints a line per reported field, and it does
 not gate. It reports about one exported field in eight. Most of those are the
 false positives listed below, so the report is a place to start.
 
+Precommit runs the policy gate instead:
+
+```bash
+nix develop -c deno task check:unread-fields
+```
+
+The gate compares each reported field with two exact registries:
+
+- `baseline.ts` holds accepted debt. An entry does not say that the field is
+  valid. Do not add new entries. Remove an entry when production reads the field
+  or the field is deleted.
+- `exemptions.ts` holds reviewed false positives. Each entry names its
+  production evidence. Each entry uses one of five mechanisms: an external
+  output, a provider input, a schema-driven read, a persisted format, or a
+  dynamic read.
+
+A finite exported type uses a closed snapshot. The snapshot classifies every
+field as `check` or `exempt`. A new field stops typecheck until its policy is
+explicit. Open type, folder, and file wildcards are not available.
+
+The gate fails for:
+
+- a reported field with no policy.
+- a policy entry that no current finding matches.
+- duplicate policy or finding identities.
+- a field in both registries.
+
+The identity contains the file that exports it, each typed path step, and the
+field. Thus, a field named `"[]"` stays separate from the unnamed array element
+step. The displayed report remains a readable field path.
+
+When the gate reports a new field, find its production consumer. Connect the
+missing read or delete the unused field. Add an exemption only when the consumer
+exists but the scan cannot see it. Name that consumer in the evidence.
+
 ## Why the type checker
 
 `BulkSendResult.failed` counted a bulk email send's refused recipients. No

--- a/scripts/unread-fields/baseline.ts
+++ b/scripts/unread-fields/baseline.ts
@@ -1,6 +1,7 @@
 import { FEATURE_BASELINE } from "#scripts/unread-fields/baseline/features.ts";
 import { SHARED_A_PAYMENTS_BASELINE } from "#scripts/unread-fields/baseline/shared-a-payments.ts";
 import { SHARED_DB_BASELINE } from "#scripts/unread-fields/baseline/shared-db.ts";
+import { SHARED_FIELD_BASELINE } from "#scripts/unread-fields/baseline/shared-fields.ts";
 import { SHARED_PROVIDER_Z_BASELINE } from "#scripts/unread-fields/baseline/shared-provider-z.ts";
 import { UI_BASELINE } from "#scripts/unread-fields/baseline/ui.ts";
 import {
@@ -12,6 +13,7 @@ import {
  * field to a reviewed exemption or delete/connect it when its domain is read. */
 export const UNREAD_FIELD_BASELINE: readonly FindingIdentity[] = [
   ...FEATURE_BASELINE,
+  ...SHARED_FIELD_BASELINE,
   ...SHARED_DB_BASELINE,
   ...SHARED_A_PAYMENTS_BASELINE,
   ...SHARED_PROVIDER_Z_BASELINE,

--- a/scripts/unread-fields/baseline.ts
+++ b/scripts/unread-fields/baseline.ts
@@ -1,0 +1,19 @@
+import { FEATURE_BASELINE } from "#scripts/unread-fields/baseline/features.ts";
+import { SHARED_A_PAYMENTS_BASELINE } from "#scripts/unread-fields/baseline/shared-a-payments.ts";
+import { SHARED_DB_BASELINE } from "#scripts/unread-fields/baseline/shared-db.ts";
+import { SHARED_PROVIDER_Z_BASELINE } from "#scripts/unread-fields/baseline/shared-provider-z.ts";
+import { UI_BASELINE } from "#scripts/unread-fields/baseline/ui.ts";
+import {
+  compareFindingIdentities,
+  type FindingIdentity,
+} from "#scripts/unread-fields/identity.ts";
+
+/** Exact current debt. An entry says only that the gate must not grow. Move a
+ * field to a reviewed exemption or delete/connect it when its domain is read. */
+export const UNREAD_FIELD_BASELINE: readonly FindingIdentity[] = [
+  ...FEATURE_BASELINE,
+  ...SHARED_DB_BASELINE,
+  ...SHARED_A_PAYMENTS_BASELINE,
+  ...SHARED_PROVIDER_Z_BASELINE,
+  ...UI_BASELINE,
+].toSorted(compareFindingIdentities);

--- a/scripts/unread-fields/baseline/features.ts
+++ b/scripts/unread-fields/baseline/features.ts
@@ -1,0 +1,134 @@
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+const LISTING_BODY_FIELDS = [
+  "child_listing_ids",
+  "date",
+  "day_prices",
+  "group_ids",
+  "max_attendees",
+  "max_price",
+  "name",
+] as const;
+
+export const FEATURE_BASELINE: readonly FindingIdentity[] = [
+  ...identitiesAt("src/features/admin/actions.ts", [
+    { name: "AttendeeLinkRefs" },
+  ])(["kinds", "names"]),
+  ...identitiesAt("src/features/admin/api-groups.ts", [
+    { name: "CreateGroupBody" },
+  ])(["name", "package_members"]),
+  ...identitiesAt("src/features/admin/api-groups.ts", [
+    { name: "DeleteGroupBody" },
+  ])(["confirm_identifier"]),
+  ...identitiesAt("src/features/admin/api-groups.ts", [
+    { name: "PackageMemberBody" },
+  ])(["day_prices", "listing_id", "price", "quantity"]),
+  ...identitiesAt("src/features/admin/api-groups.ts", [
+    { name: "UpdateGroupBody" },
+  ])(["name", "package_members", "slug"]),
+  ...identitiesAt("src/features/admin/api-holidays.ts", [
+    { name: "CreateHolidayBody" },
+  ])(["end_date", "name", "start_date"]),
+  ...identitiesAt("src/features/admin/api-holidays.ts", [
+    { name: "DeleteHolidayBody" },
+  ])(["confirm_identifier"]),
+  ...identitiesAt("src/features/admin/api-holidays.ts", [
+    { name: "UpdateHolidayBody" },
+  ])(["end_date", "name", "start_date"]),
+  ...identitiesAt("src/features/admin/api-listing-body.ts", [
+    { name: "CreateListingBody" },
+  ])(LISTING_BODY_FIELDS),
+  ...identitiesAt("src/features/admin/api-listing-body.ts", [
+    { name: "UpdateListingBody" },
+  ])([...LISTING_BODY_FIELDS, "slug"]),
+  ...identitiesAt("src/features/admin/api.ts", [{ name: "DeleteListingBody" }])(
+    ["confirm_identifier"],
+  ),
+  ...identitiesAt("src/features/admin/attendee-form-model.ts", [
+    { name: "AttendeeFieldError" },
+  ])(["field"]),
+  ...identitiesAt("src/features/admin/attendee-form-model.ts", [
+    { name: "ValidationResult" },
+  ])(["lineErrors"]),
+  ...identitiesAt("src/features/admin/attendee-logistics.ts", [
+    { name: "LogisticsFormErrors" },
+  ])(["addressError", "locationError"]),
+  ...identitiesAt("src/features/admin/refunds/budget.ts", [
+    { name: "RefundBudgetCandidate" },
+  ])(["references"]),
+  ...identitiesAt("src/features/admin/refunds/budget.ts", [
+    { name: "RefundSendBudgetReference" },
+  ])(["index"]),
+  ...identitiesAt("src/features/admin/refunds/claim.ts", [
+    { name: "RefundRunBlock" },
+  ])(["reason"]),
+  ...identitiesAt("src/features/admin/refunds/ledger-findings.ts", [
+    { name: "AppliedRefundLedgerFindings" },
+  ])(["needsReview"]),
+  ...identitiesAt("src/features/admin/refunds/provider.ts", [
+    { name: "RefundBatchResult" },
+  ])(["reason"]),
+  ...identitiesAt("src/features/admin/refunds/readiness.ts", [
+    { name: "RefundReadinessRead" },
+  ])(["index"]),
+  ...identitiesAt("src/features/admin/refunds/readiness.ts", [
+    { name: "RefundReadinessResult" },
+  ])(["reads"]),
+  ...identitiesAt("src/features/admin/refunds/refresh.ts", [
+    { name: "RefreshPaymentResult" },
+  ])(["reason"]),
+  ...identitiesAt("src/features/admin/servicing/form-model.ts", [
+    { name: "ServicingCreateInput" },
+  ])(["bookings", "kind", "name"]),
+  ...identitiesAt("src/features/admin/settings-connection-lines.ts", [
+    { name: "ConnectionAnswer" },
+  ])(["lines", "ok"]),
+  ...identitiesAt("src/features/api/payment-callback.ts", [
+    { name: "CallbackOutcome" },
+  ])(["result"]),
+  ...identitiesAt("src/features/api/payment-processing/create.ts", [
+    { name: "AttendeeBaseFields" },
+  ])(["paymentId", "statusId"]),
+  ...identitiesAt("src/features/api/payment-processing/placeholder-resume.ts", [
+    { name: "PlaceholderFailureResult" },
+  ])(["status"]),
+  ...identitiesAt("src/features/api/webhook-types.ts", [
+    { name: "ListingValidation" },
+  ])(["error", "status"]),
+  ...identitiesAt("src/features/api/webhook-types.ts", [
+    { name: "PaymentResult" },
+  ])(["attendee"]),
+  ...identitiesAt("src/features/auth.ts", [{ name: "AuthSession" }])([
+    "settingsNagItems",
+  ]),
+  ...identitiesAt("src/features/entity.ts", [
+    { name: "AttendeeListingRouteParams" },
+  ])(["attendeeId", "listingId"]),
+  ...identitiesAt("src/features/public/types.ts", [{ name: "TicketCtx" }])([
+    "attributesByListing",
+    "baseUrl",
+    "cartDateItems",
+    "childDatesById",
+    "galleryImages",
+    "groupDescription",
+    "groupImage",
+    "groupName",
+    "nav",
+    "prefill",
+    "promoCodesEnabled",
+  ]),
+  ...identitiesAt("src/features/public/types.ts", [
+    { name: "TicketSharedContext" },
+  ])([
+    "cartDateItems",
+    "childDatesById",
+    "galleryImages",
+    "groupDescription",
+    "groupImage",
+    "groupName",
+    "promoCodesEnabled",
+  ]),
+];

--- a/scripts/unread-fields/baseline/features.ts
+++ b/scripts/unread-fields/baseline/features.ts
@@ -14,100 +14,100 @@ const LISTING_BODY_FIELDS = [
 ] as const;
 
 export const FEATURE_BASELINE: readonly FindingIdentity[] = [
-  ...identitiesAt("src/features/admin/actions.ts", [
-    { name: "AttendeeLinkRefs" },
+  ...identitiesAt([
+    ["src/features/admin/actions.ts", [{ name: "AttendeeLinkRefs" }]],
   ])(["kinds", "names"]),
-  ...identitiesAt("src/features/admin/api-groups.ts", [
-    { name: "CreateGroupBody" },
+  ...identitiesAt([
+    ["src/features/admin/api-groups.ts", [{ name: "CreateGroupBody" }]],
   ])(["name", "package_members"]),
-  ...identitiesAt("src/features/admin/api-groups.ts", [
-    { name: "DeleteGroupBody" },
-  ])(["confirm_identifier"]),
-  ...identitiesAt("src/features/admin/api-groups.ts", [
-    { name: "PackageMemberBody" },
+  ...identitiesAt([
+    ["src/features/admin/api-groups.ts", [{ name: "PackageMemberBody" }]],
   ])(["day_prices", "listing_id", "price", "quantity"]),
-  ...identitiesAt("src/features/admin/api-groups.ts", [
-    { name: "UpdateGroupBody" },
+  ...identitiesAt([
+    ["src/features/admin/api-groups.ts", [{ name: "UpdateGroupBody" }]],
   ])(["name", "package_members", "slug"]),
-  ...identitiesAt("src/features/admin/api-holidays.ts", [
-    { name: "CreateHolidayBody" },
-  ])(["end_date", "name", "start_date"]),
-  ...identitiesAt("src/features/admin/api-holidays.ts", [
-    { name: "DeleteHolidayBody" },
-  ])(["confirm_identifier"]),
-  ...identitiesAt("src/features/admin/api-holidays.ts", [
-    { name: "UpdateHolidayBody" },
-  ])(["end_date", "name", "start_date"]),
-  ...identitiesAt("src/features/admin/api-listing-body.ts", [
-    { name: "CreateListingBody" },
+  ...identitiesAt([
+    ["src/features/admin/api-listing-body.ts", [{ name: "CreateListingBody" }]],
   ])(LISTING_BODY_FIELDS),
-  ...identitiesAt("src/features/admin/api-listing-body.ts", [
-    { name: "UpdateListingBody" },
+  ...identitiesAt([
+    ["src/features/admin/api-listing-body.ts", [{ name: "UpdateListingBody" }]],
   ])([...LISTING_BODY_FIELDS, "slug"]),
-  ...identitiesAt("src/features/admin/api.ts", [{ name: "DeleteListingBody" }])(
-    ["confirm_identifier"],
-  ),
-  ...identitiesAt("src/features/admin/attendee-form-model.ts", [
-    { name: "AttendeeFieldError" },
+  ...identitiesAt([
+    [
+      "src/features/admin/attendee-form-model.ts",
+      [{ name: "AttendeeFieldError" }],
+    ],
   ])(["field"]),
-  ...identitiesAt("src/features/admin/attendee-form-model.ts", [
-    { name: "ValidationResult" },
+  ...identitiesAt([
+    [
+      "src/features/admin/attendee-form-model.ts",
+      [{ name: "ValidationResult" }],
+    ],
   ])(["lineErrors"]),
-  ...identitiesAt("src/features/admin/attendee-logistics.ts", [
-    { name: "LogisticsFormErrors" },
+  ...identitiesAt([
+    [
+      "src/features/admin/attendee-logistics.ts",
+      [{ name: "LogisticsFormErrors" }],
+    ],
   ])(["addressError", "locationError"]),
-  ...identitiesAt("src/features/admin/refunds/budget.ts", [
-    { name: "RefundBudgetCandidate" },
+  ...identitiesAt([
+    [
+      "src/features/admin/refunds/budget.ts",
+      [{ name: "RefundBudgetCandidate" }],
+    ],
   ])(["references"]),
-  ...identitiesAt("src/features/admin/refunds/budget.ts", [
-    { name: "RefundSendBudgetReference" },
-  ])(["index"]),
-  ...identitiesAt("src/features/admin/refunds/claim.ts", [
-    { name: "RefundRunBlock" },
-  ])(["reason"]),
-  ...identitiesAt("src/features/admin/refunds/ledger-findings.ts", [
-    { name: "AppliedRefundLedgerFindings" },
+  ...identitiesAt([
+    [
+      "src/features/admin/refunds/ledger-findings.ts",
+      [{ name: "AppliedRefundLedgerFindings" }],
+    ],
   ])(["needsReview"]),
-  ...identitiesAt("src/features/admin/refunds/provider.ts", [
-    { name: "RefundBatchResult" },
-  ])(["reason"]),
-  ...identitiesAt("src/features/admin/refunds/readiness.ts", [
-    { name: "RefundReadinessRead" },
-  ])(["index"]),
-  ...identitiesAt("src/features/admin/refunds/readiness.ts", [
-    { name: "RefundReadinessResult" },
+  ...identitiesAt([
+    [
+      "src/features/admin/refunds/readiness.ts",
+      [{ name: "RefundReadinessResult" }],
+    ],
   ])(["reads"]),
-  ...identitiesAt("src/features/admin/refunds/refresh.ts", [
-    { name: "RefreshPaymentResult" },
-  ])(["reason"]),
-  ...identitiesAt("src/features/admin/servicing/form-model.ts", [
-    { name: "ServicingCreateInput" },
+  ...identitiesAt([
+    [
+      "src/features/admin/servicing/form-model.ts",
+      [{ name: "ServicingCreateInput" }],
+    ],
   ])(["bookings", "kind", "name"]),
-  ...identitiesAt("src/features/admin/settings-connection-lines.ts", [
-    { name: "ConnectionAnswer" },
+  ...identitiesAt([
+    [
+      "src/features/admin/settings-connection-lines.ts",
+      [{ name: "ConnectionAnswer" }],
+    ],
   ])(["lines", "ok"]),
-  ...identitiesAt("src/features/api/payment-callback.ts", [
-    { name: "CallbackOutcome" },
+  ...identitiesAt([
+    ["src/features/api/payment-callback.ts", [{ name: "CallbackOutcome" }]],
   ])(["result"]),
-  ...identitiesAt("src/features/api/payment-processing/create.ts", [
-    { name: "AttendeeBaseFields" },
+  ...identitiesAt([
+    [
+      "src/features/api/payment-processing/create.ts",
+      [{ name: "AttendeeBaseFields" }],
+    ],
   ])(["paymentId", "statusId"]),
-  ...identitiesAt("src/features/api/payment-processing/placeholder-resume.ts", [
-    { name: "PlaceholderFailureResult" },
+  ...identitiesAt([
+    [
+      "src/features/api/payment-processing/placeholder-resume.ts",
+      [{ name: "PlaceholderFailureResult" }],
+    ],
   ])(["status"]),
-  ...identitiesAt("src/features/api/webhook-types.ts", [
-    { name: "ListingValidation" },
+  ...identitiesAt([
+    ["src/features/api/webhook-types.ts", [{ name: "ListingValidation" }]],
   ])(["error", "status"]),
-  ...identitiesAt("src/features/api/webhook-types.ts", [
-    { name: "PaymentResult" },
+  ...identitiesAt([
+    ["src/features/api/webhook-types.ts", [{ name: "PaymentResult" }]],
   ])(["attendee"]),
-  ...identitiesAt("src/features/auth.ts", [{ name: "AuthSession" }])([
+  ...identitiesAt([["src/features/auth.ts", [{ name: "AuthSession" }]]])([
     "settingsNagItems",
   ]),
-  ...identitiesAt("src/features/entity.ts", [
-    { name: "AttendeeListingRouteParams" },
+  ...identitiesAt([
+    ["src/features/entity.ts", [{ name: "AttendeeListingRouteParams" }]],
   ])(["attendeeId", "listingId"]),
-  ...identitiesAt("src/features/public/types.ts", [{ name: "TicketCtx" }])([
+  ...identitiesAt([["src/features/public/types.ts", [{ name: "TicketCtx" }]]])([
     "attributesByListing",
     "baseUrl",
     "cartDateItems",
@@ -120,8 +120,8 @@ export const FEATURE_BASELINE: readonly FindingIdentity[] = [
     "prefill",
     "promoCodesEnabled",
   ]),
-  ...identitiesAt("src/features/public/types.ts", [
-    { name: "TicketSharedContext" },
+  ...identitiesAt([
+    ["src/features/public/types.ts", [{ name: "TicketSharedContext" }]],
   ])([
     "cartDateItems",
     "childDatesById",

--- a/scripts/unread-fields/baseline/shared-a-payments.ts
+++ b/scripts/unread-fields/baseline/shared-a-payments.ts
@@ -1,0 +1,321 @@
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
+  ...identitiesAt("src/shared/accounting/store.ts", [{ name: "PostResult" }])([
+    "inserted",
+    "skipped",
+  ]),
+  ...identitiesAt("src/shared/admin-surface/definitions.ts", [
+    { name: "AdminSurfaceContext" },
+  ])(["active"]),
+  ...identitiesAt("src/shared/admin-surface/sections.ts", [
+    { name: "AdminNavEntry" },
+  ])(["kind"]),
+  ...identitiesAt("src/shared/admin-surface/sections.ts", [
+    { name: "AdminSectionDef" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/balance-link.ts", [{ name: "BalancePayload" }])([
+    "e",
+  ]),
+  ...identitiesAt("src/shared/booking-intent.ts", [
+    { name: "ListingAnswerRefs" },
+  ])(["listingAnswerIds", "listingTextAnswerIds"]),
+  ...identitiesAt("src/shared/booking/cart-conflicts.ts", [
+    { name: "CartDateItem" },
+  ])(["name"]),
+  ...identitiesAt("src/shared/booking/cart-conflicts.ts", [
+    { name: "CartLengthItem" },
+  ])(["name"]),
+  ...identitiesAt("src/shared/booking/fold-tree.ts", [
+    { name: "FoldChildrenResult" },
+  ])(["priceRuleByListingId"]),
+  ...identitiesAt("src/shared/booking/page-packages.ts", [
+    { name: "PagePackage" },
+  ])(["slug"]),
+  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "BookingNode" }])([
+    "dateSpan",
+    "visibility",
+  ]),
+  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "BookingTree" }])([
+    "rootRef",
+  ]),
+  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "DateSpan" }])([
+    "date",
+    "durationDays",
+    "kind",
+  ]),
+  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "PriceRule" }])([
+    "maxMinor",
+    "minMinor",
+  ]),
+  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "QuantityRule" }])([
+    "max",
+    "min",
+  ]),
+  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "RootRef" }])([
+    "kind",
+    "slugs",
+  ]),
+  ...identitiesAt("src/shared/boot-checks.ts", [{ name: "BootCheck" }])([
+    "name",
+  ]),
+  ...identitiesAt("src/shared/bunny-cdn.ts", [{ name: "EdgeScriptSecret" }])([
+    "Id",
+    "LastModified",
+  ]),
+  ...identitiesAt("src/shared/catalog-fields/fields.ts", [
+    { name: "GroupInput" },
+  ])(["description", "hidden", "termsAndConditions"]),
+  ...identitiesAt("src/shared/catalog-fields/fields.ts", [
+    { name: "ListingInput" },
+  ])([
+    "attachmentName",
+    "attachmentUrl",
+    "bookableDays",
+    "closesAt",
+    "date",
+    "description",
+    "fields",
+    "location",
+    "maxAttendees",
+    "maxQuantity",
+    "minimumDaysBefore",
+    "nonTransferable",
+    "useDefaults",
+    "usesLogistics",
+  ]),
+  ...identitiesAt("src/shared/catalog-fields/fields.ts", [
+    { name: "PackageMemberInput" },
+  ])(["dayPrices", "price"]),
+  ...identitiesAt("src/shared/checkout-pricing.ts", [
+    { name: "ModifierApplication" },
+  ])(["amountApplied", "quantity", "scopedSubtotal"]),
+  ...identitiesAt("src/shared/email-renderer.ts", [{ name: "TemplateData" }])([
+    "amount_owed",
+    "attendee",
+    "currency",
+    "entries",
+    "listing_names",
+    "ticket_url",
+  ]),
+  ...identitiesAt("src/shared/email.ts", [{ name: "EmailListing" }])([
+    "active",
+    "assign_built_site",
+    "attendee_count",
+    "can_pay_more",
+    "day_prices",
+    "hidden",
+    "initial_site_months",
+    "listing_type",
+    "max_attendees",
+    "unit_price",
+  ]),
+  ...identitiesAt("src/shared/email/bulk.ts", [{ name: "BulkBatchResponse" }])([
+    "ok",
+  ]),
+  ...identitiesAt("src/shared/email/bulk.ts", [{ name: "BulkSendResult" }])([
+    "batches",
+    "unconfirmed",
+  ]),
+  ...identitiesAt("src/shared/external-order.ts", [{ name: "Catalog" }])([
+    "generatedAt",
+  ]),
+  ...identitiesAt("src/shared/external-order.ts", [
+    { name: "CatalogSourceListing" },
+  ])(["active", "hidden"]),
+  ...identitiesAt("src/shared/forms/definition.ts", [
+    { name: "FormDefinition" },
+  ])(["sections"]),
+  ...identitiesAt("src/shared/forms/field.ts", [{ name: "ChoiceField" }])([
+    "accept",
+    "markdown",
+  ]),
+  ...identitiesAt("src/shared/forms/field.ts", [{ name: "FileField" }])([
+    "markdown",
+    "options",
+  ]),
+  ...identitiesAt("src/shared/forms/field.ts", [{ name: "InputField" }])([
+    "accept",
+    "markdown",
+    "options",
+  ]),
+  ...identitiesAt("src/shared/forms/field.ts", [{ name: "TextareaField" }])([
+    "accept",
+    "options",
+  ]),
+  ...identitiesAt("src/shared/jsx/jsx-runtime.ts", [{ name: "Child" }])([
+    "toString",
+  ]),
+  ...identitiesAt("src/shared/jsx/jsx-runtime.ts", [{ name: "SafeHtml" }])([
+    "toString",
+  ]),
+  ...identitiesAt("src/shared/ledger/reconcile.ts", [
+    { name: "LegDiscrepancy" },
+  ])(["eventGroup", "missing", "unexpected"]),
+  ...identitiesAt("src/shared/ledger/reconcile.ts", [
+    { name: "ReconcileResult" },
+  ])(["actual", "diff", "expected", "ok"]),
+  ...identitiesAt("src/shared/ledger/types.ts", [{ name: "LedgerError" }])([
+    "code",
+  ]),
+  ...identitiesAt("src/shared/ledger/types.ts", [{ name: "Transfer" }])([
+    "recordedAt",
+  ]),
+  ...identitiesAt("src/shared/listing-attribute-filter.ts", [
+    { name: "AttributeFilterGroup" },
+  ])(["sort_order"]),
+  ...identitiesAt("src/shared/listing-parents-rules.ts", [
+    { name: "EdgeListing" },
+  ])(["day_prices"]),
+  ...identitiesAt("src/shared/listing-templates.ts", [
+    { name: "ListingTemplate" },
+  ])(["requiresDate"]),
+  ...identitiesAt("src/shared/listings-actions.ts", [
+    { name: "ToggleActiveResult" },
+  ])(["noChange"]),
+  ...identitiesAt("src/shared/maintenance/definition.ts", [
+    { name: "MaintenanceTaskBudget" },
+    { name: "remaining" },
+    { way: "()" },
+    { way: "result" },
+  ])(["database", "external", "total"]),
+  ...identitiesAt("src/shared/maintenance/definition.ts", [
+    { name: "MaintenanceTaskBudget" },
+  ])(["remaining"]),
+  ...identitiesAt("src/shared/maintenance/definition.ts", [
+    { name: "MaintenanceTaskContext" },
+  ])(["budget", "deadline"]),
+  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
+    { name: "ApplyAttendeeMergeInput" },
+    { name: "targetPii" },
+  ])(["payment_id", "ticket_token"]),
+  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
+    { name: "AttendeeMergeApplyResult" },
+  ])(["success"]),
+  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
+    { name: "AttendeeMergeApplySummary" },
+  ])(["answersKept", "piiFieldsFromSource"]),
+  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
+    { name: "AttendeeMergeDiff" },
+  ])(["sourceId", "targetId"]),
+  ...identitiesAt("src/shared/order/options.ts", [
+    { name: "OrderOptionState" },
+  ])(["byKey"]),
+  ...identitiesAt("src/shared/payment-providers.ts", [
+    { name: "PaymentProviderMeta" },
+    { name: "webhook" },
+  ])(["signatureHeader"]),
+  ...identitiesAt("src/shared/payment-providers.ts", [
+    { name: "PaymentProviderMeta" },
+  ])([
+    "currencies",
+    "label",
+    "metadata",
+    "refundCapability",
+    "secretField",
+    "webhook",
+  ]),
+  ...identitiesAt("src/shared/payment/admit-move.ts", [
+    { name: "PaymentWork" },
+  ])(["recoveryAction"]),
+  ...identitiesAt("src/shared/payment/admit-refund.ts", [
+    { name: "ObservedRefundAdmission" },
+  ])(["request"]),
+  ...identitiesAt("src/shared/payment/checkout-failure.ts", [
+    { name: "ProviderCheckoutError" },
+  ])(["provider", "reason", "statusCode"]),
+  ...identitiesAt("src/shared/payment/claim.ts", [{ name: "ClaimDecision" }])([
+    "resuming",
+  ]),
+  ...identitiesAt("src/shared/payment/claim.ts", [{ name: "HeldPaymentRow" }])([
+    "attendeeId",
+  ]),
+  ...identitiesAt("src/shared/payment/claim.ts", [
+    { name: "HeldRefundCommand" },
+  ])(["commandId", "held", "heldSince"]),
+  ...identitiesAt("src/shared/payment/claim.ts", [
+    { name: "IndexedRefundClaimDecision" },
+  ])(["indexes", "kind"]),
+  ...identitiesAt("src/shared/payment/claim.ts", [
+    { name: "RefundClaimChanged" },
+  ])(["kind"]),
+  ...identitiesAt("src/shared/payment/joint-state.ts", [
+    { name: "IllegalJointState" },
+  ])(["authority", "reason", "rows"]),
+  ...identitiesAt("src/shared/payment/refund-attempt.ts", [
+    { name: "RefundActionResult" },
+  ])(["admission", "proof"]),
+  ...identitiesAt("src/shared/payment/refund-attempt.ts", [
+    { name: "RefundAttemptResult" },
+  ])(["proof"]),
+  ...identitiesAt("src/shared/payment/refund-attempt.ts", [
+    { name: "RefundProof" },
+  ])(["charge", "kind", "refund"]),
+  ...identitiesAt("src/shared/payment/refund-authority-lifecycle.ts", [
+    { name: "RefundLifecycle" },
+  ])(["blocks", "refusal", "requiresChoice"]),
+  ...identitiesAt("src/shared/payment/refund-machine-spec.ts", [
+    { name: "RefundMachineEvent" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/payment/refund-machine-spec.ts", [
+    { name: "RefundNode" },
+  ])(["awaits"]),
+  ...identitiesAt("src/shared/payment/refund-provider-authorization.ts", [
+    { name: "KeyedRefundAuthorization" },
+  ])([
+    "capability",
+    "generation",
+    "idempotencyKey",
+    "identityIndex",
+    "provider",
+  ]),
+  ...identitiesAt("src/shared/payment/refund-provider-authorization.ts", [
+    { name: "KeylessRefundAuthorization" },
+  ])(["capability", "generation", "identityIndex", "provider"]),
+  ...identitiesAt("src/shared/payment/review-machine-spec.ts", [
+    { name: "ReviewMachineEvent" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/payment/review-machine-spec.ts", [
+    { name: "ReviewNode" },
+  ])(["awaits"]),
+  ...identitiesAt("src/shared/payment/row-machine-spec.ts", [
+    { name: "RowMachineEvent" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/payment/row-machine-spec.ts", [
+    { name: "RowNode" },
+  ])(["awaits"]),
+  ...identitiesAt("src/shared/payment/row-transitions.ts", [
+    { name: "PaymentRowSettlement" },
+  ])(["claim"]),
+  ...identitiesAt("src/shared/payment/sumup-recovery-machine-spec.ts", [
+    { name: "RecoveryMachineEvent" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/payment/sumup-recovery-machine-spec.ts", [
+    { name: "RecoveryNode" },
+  ])(["awaits"]),
+  ...identitiesAt("src/shared/payment/transport-error.ts", [
+    { name: "ProviderTransportError" },
+  ])(["provider"]),
+  ...identitiesAt("src/shared/payments.ts", [{ name: "CheckoutIntent" }])([
+    "balanceAttendeeId",
+    "date",
+    "dayCount",
+    "listingAnswerIds",
+    "listingTextAnswerIds",
+  ]),
+  ...identitiesAt("src/shared/payments.ts", [
+    { name: "CheckoutSessionResult" },
+  ])(["sessionId"]),
+  ...identitiesAt("src/shared/payments.ts", [
+    { name: "ExistingPaymentProvider" },
+  ])(["setupWebhookEndpoint"]),
+  ...identitiesAt("src/shared/payments.ts", [{ name: "PaymentProvider" }])([
+    "setupWebhookEndpoint",
+  ]),
+  ...identitiesAt("src/shared/payments.ts", [{ name: "SessionMetadata" }])([
+    "_origin",
+  ]),
+];

--- a/scripts/unread-fields/baseline/shared-a-payments.ts
+++ b/scripts/unread-fields/baseline/shared-a-payments.ts
@@ -4,73 +4,49 @@ import {
 } from "#scripts/unread-fields/identity.ts";
 
 export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
-  ...identitiesAt("src/shared/accounting/store.ts", [{ name: "PostResult" }])([
-    "inserted",
-    "skipped",
-  ]),
-  ...identitiesAt("src/shared/admin-surface/definitions.ts", [
-    { name: "AdminSurfaceContext" },
-  ])(["active"]),
-  ...identitiesAt("src/shared/admin-surface/sections.ts", [
-    { name: "AdminNavEntry" },
-  ])(["kind"]),
-  ...identitiesAt("src/shared/admin-surface/sections.ts", [
-    { name: "AdminSectionDef" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/balance-link.ts", [{ name: "BalancePayload" }])([
-    "e",
-  ]),
-  ...identitiesAt("src/shared/booking-intent.ts", [
-    { name: "ListingAnswerRefs" },
+  ...identitiesAt([
+    ["src/shared/accounting/store.ts", [{ name: "PostResult" }]],
+  ])(["inserted", "skipped"]),
+  ...identitiesAt([
+    ["src/shared/booking-intent.ts", [{ name: "ListingAnswerRefs" }]],
   ])(["listingAnswerIds", "listingTextAnswerIds"]),
-  ...identitiesAt("src/shared/booking/cart-conflicts.ts", [
-    { name: "CartDateItem" },
-  ])(["name"]),
-  ...identitiesAt("src/shared/booking/cart-conflicts.ts", [
-    { name: "CartLengthItem" },
-  ])(["name"]),
-  ...identitiesAt("src/shared/booking/fold-tree.ts", [
-    { name: "FoldChildrenResult" },
+  ...identitiesAt([
+    ["src/shared/booking/fold-tree.ts", [{ name: "FoldChildrenResult" }]],
   ])(["priceRuleByListingId"]),
-  ...identitiesAt("src/shared/booking/page-packages.ts", [
-    { name: "PagePackage" },
+  ...identitiesAt([
+    ["src/shared/booking/page-packages.ts", [{ name: "PagePackage" }]],
   ])(["slug"]),
-  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "BookingNode" }])([
+  ...identitiesAt([["src/shared/booking/tree.ts", [{ name: "BookingNode" }]]])([
     "dateSpan",
     "visibility",
   ]),
-  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "BookingTree" }])([
+  ...identitiesAt([["src/shared/booking/tree.ts", [{ name: "BookingTree" }]]])([
     "rootRef",
   ]),
-  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "DateSpan" }])([
+  ...identitiesAt([["src/shared/booking/tree.ts", [{ name: "DateSpan" }]]])([
     "date",
     "durationDays",
     "kind",
   ]),
-  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "PriceRule" }])([
+  ...identitiesAt([["src/shared/booking/tree.ts", [{ name: "PriceRule" }]]])([
     "maxMinor",
     "minMinor",
   ]),
-  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "QuantityRule" }])([
-    "max",
-    "min",
-  ]),
-  ...identitiesAt("src/shared/booking/tree.ts", [{ name: "RootRef" }])([
+  ...identitiesAt([["src/shared/booking/tree.ts", [{ name: "QuantityRule" }]]])(
+    ["max", "min"],
+  ),
+  ...identitiesAt([["src/shared/booking/tree.ts", [{ name: "RootRef" }]]])([
     "kind",
     "slugs",
   ]),
-  ...identitiesAt("src/shared/boot-checks.ts", [{ name: "BootCheck" }])([
-    "name",
-  ]),
-  ...identitiesAt("src/shared/bunny-cdn.ts", [{ name: "EdgeScriptSecret" }])([
-    "Id",
-    "LastModified",
-  ]),
-  ...identitiesAt("src/shared/catalog-fields/fields.ts", [
-    { name: "GroupInput" },
+  ...identitiesAt([
+    ["src/shared/bunny-cdn.ts", [{ name: "EdgeScriptSecret" }]],
+  ])(["Id", "LastModified"]),
+  ...identitiesAt([
+    ["src/shared/catalog-fields/fields.ts", [{ name: "GroupInput" }]],
   ])(["description", "hidden", "termsAndConditions"]),
-  ...identitiesAt("src/shared/catalog-fields/fields.ts", [
-    { name: "ListingInput" },
+  ...identitiesAt([
+    ["src/shared/catalog-fields/fields.ts", [{ name: "ListingInput" }]],
   ])([
     "attachmentName",
     "attachmentUrl",
@@ -87,13 +63,15 @@ export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
     "useDefaults",
     "usesLogistics",
   ]),
-  ...identitiesAt("src/shared/catalog-fields/fields.ts", [
-    { name: "PackageMemberInput" },
+  ...identitiesAt([
+    ["src/shared/catalog-fields/fields.ts", [{ name: "PackageMemberInput" }]],
   ])(["dayPrices", "price"]),
-  ...identitiesAt("src/shared/checkout-pricing.ts", [
-    { name: "ModifierApplication" },
+  ...identitiesAt([
+    ["src/shared/checkout-pricing.ts", [{ name: "ModifierApplication" }]],
   ])(["amountApplied", "quantity", "scopedSubtotal"]),
-  ...identitiesAt("src/shared/email-renderer.ts", [{ name: "TemplateData" }])([
+  ...identitiesAt([
+    ["src/shared/email-renderer.ts", [{ name: "TemplateData" }]],
+  ])([
     "amount_owed",
     "attendee",
     "currency",
@@ -101,7 +79,7 @@ export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
     "listing_names",
     "ticket_url",
   ]),
-  ...identitiesAt("src/shared/email.ts", [{ name: "EmailListing" }])([
+  ...identitiesAt([["src/shared/email.ts", [{ name: "EmailListing" }]]])([
     "active",
     "assign_built_site",
     "attendee_count",
@@ -113,103 +91,113 @@ export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
     "max_attendees",
     "unit_price",
   ]),
-  ...identitiesAt("src/shared/email/bulk.ts", [{ name: "BulkBatchResponse" }])([
-    "ok",
-  ]),
-  ...identitiesAt("src/shared/email/bulk.ts", [{ name: "BulkSendResult" }])([
-    "batches",
-    "unconfirmed",
-  ]),
-  ...identitiesAt("src/shared/external-order.ts", [{ name: "Catalog" }])([
+  ...identitiesAt([
+    ["src/shared/email/bulk.ts", [{ name: "BulkBatchResponse" }]],
+  ])(["ok"]),
+  ...identitiesAt([["src/shared/email/bulk.ts", [{ name: "BulkSendResult" }]]])(
+    ["batches", "unconfirmed"],
+  ),
+  ...identitiesAt([["src/shared/external-order.ts", [{ name: "Catalog" }]]])([
     "generatedAt",
   ]),
-  ...identitiesAt("src/shared/external-order.ts", [
-    { name: "CatalogSourceListing" },
+  ...identitiesAt([
+    ["src/shared/external-order.ts", [{ name: "CatalogSourceListing" }]],
   ])(["active", "hidden"]),
-  ...identitiesAt("src/shared/forms/definition.ts", [
-    { name: "FormDefinition" },
+  ...identitiesAt([
+    ["src/shared/forms/definition.ts", [{ name: "FormDefinition" }]],
   ])(["sections"]),
-  ...identitiesAt("src/shared/forms/field.ts", [{ name: "ChoiceField" }])([
+  ...identitiesAt([["src/shared/forms/field.ts", [{ name: "ChoiceField" }]]])([
     "accept",
     "markdown",
   ]),
-  ...identitiesAt("src/shared/forms/field.ts", [{ name: "FileField" }])([
+  ...identitiesAt([["src/shared/forms/field.ts", [{ name: "FileField" }]]])([
     "markdown",
     "options",
   ]),
-  ...identitiesAt("src/shared/forms/field.ts", [{ name: "InputField" }])([
+  ...identitiesAt([["src/shared/forms/field.ts", [{ name: "InputField" }]]])([
     "accept",
     "markdown",
     "options",
   ]),
-  ...identitiesAt("src/shared/forms/field.ts", [{ name: "TextareaField" }])([
-    "accept",
-    "options",
-  ]),
-  ...identitiesAt("src/shared/jsx/jsx-runtime.ts", [{ name: "Child" }])([
-    "toString",
-  ]),
-  ...identitiesAt("src/shared/jsx/jsx-runtime.ts", [{ name: "SafeHtml" }])([
-    "toString",
-  ]),
-  ...identitiesAt("src/shared/ledger/reconcile.ts", [
-    { name: "LegDiscrepancy" },
+  ...identitiesAt([["src/shared/forms/field.ts", [{ name: "TextareaField" }]]])(
+    ["accept", "options"],
+  ),
+  ...identitiesAt([
+    ["src/shared/ledger/reconcile.ts", [{ name: "LegDiscrepancy" }]],
   ])(["eventGroup", "missing", "unexpected"]),
-  ...identitiesAt("src/shared/ledger/reconcile.ts", [
-    { name: "ReconcileResult" },
+  ...identitiesAt([
+    ["src/shared/ledger/reconcile.ts", [{ name: "ReconcileResult" }]],
   ])(["actual", "diff", "expected", "ok"]),
-  ...identitiesAt("src/shared/ledger/types.ts", [{ name: "LedgerError" }])([
-    "code",
-  ]),
-  ...identitiesAt("src/shared/ledger/types.ts", [{ name: "Transfer" }])([
+  ...identitiesAt([["src/shared/ledger/types.ts", [{ name: "Transfer" }]]])([
     "recordedAt",
   ]),
-  ...identitiesAt("src/shared/listing-attribute-filter.ts", [
-    { name: "AttributeFilterGroup" },
-  ])(["sort_order"]),
-  ...identitiesAt("src/shared/listing-parents-rules.ts", [
-    { name: "EdgeListing" },
+  ...identitiesAt([
+    ["src/shared/listing-parents-rules.ts", [{ name: "EdgeListing" }]],
   ])(["day_prices"]),
-  ...identitiesAt("src/shared/listing-templates.ts", [
-    { name: "ListingTemplate" },
+  ...identitiesAt([
+    ["src/shared/listing-templates.ts", [{ name: "ListingTemplate" }]],
   ])(["requiresDate"]),
-  ...identitiesAt("src/shared/listings-actions.ts", [
-    { name: "ToggleActiveResult" },
+  ...identitiesAt([
+    ["src/shared/listings-actions.ts", [{ name: "ToggleActiveResult" }]],
   ])(["noChange"]),
-  ...identitiesAt("src/shared/maintenance/definition.ts", [
-    { name: "MaintenanceTaskBudget" },
-    { name: "remaining" },
-    { way: "()" },
-    { way: "result" },
+  ...identitiesAt([
+    [
+      "src/shared/maintenance/definition.ts",
+      [
+        { name: "MaintenanceTaskBudget" },
+        { name: "remaining" },
+        { way: "()" },
+        { way: "result" },
+      ],
+    ],
   ])(["database", "external", "total"]),
-  ...identitiesAt("src/shared/maintenance/definition.ts", [
-    { name: "MaintenanceTaskBudget" },
+  ...identitiesAt([
+    [
+      "src/shared/maintenance/definition.ts",
+      [{ name: "MaintenanceTaskBudget" }],
+    ],
   ])(["remaining"]),
-  ...identitiesAt("src/shared/maintenance/definition.ts", [
-    { name: "MaintenanceTaskContext" },
+  ...identitiesAt([
+    [
+      "src/shared/maintenance/definition.ts",
+      [{ name: "MaintenanceTaskContext" }],
+    ],
   ])(["budget", "deadline"]),
-  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
-    { name: "ApplyAttendeeMergeInput" },
-    { name: "targetPii" },
+  ...identitiesAt([
+    [
+      "src/shared/merge/attendee-merge-types.ts",
+      [{ name: "ApplyAttendeeMergeInput" }, { name: "targetPii" }],
+    ],
   ])(["payment_id", "ticket_token"]),
-  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
-    { name: "AttendeeMergeApplyResult" },
+  ...identitiesAt([
+    [
+      "src/shared/merge/attendee-merge-types.ts",
+      [{ name: "AttendeeMergeApplyResult" }],
+    ],
   ])(["success"]),
-  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
-    { name: "AttendeeMergeApplySummary" },
+  ...identitiesAt([
+    [
+      "src/shared/merge/attendee-merge-types.ts",
+      [{ name: "AttendeeMergeApplySummary" }],
+    ],
   ])(["answersKept", "piiFieldsFromSource"]),
-  ...identitiesAt("src/shared/merge/attendee-merge-types.ts", [
-    { name: "AttendeeMergeDiff" },
+  ...identitiesAt([
+    [
+      "src/shared/merge/attendee-merge-types.ts",
+      [{ name: "AttendeeMergeDiff" }],
+    ],
   ])(["sourceId", "targetId"]),
-  ...identitiesAt("src/shared/order/options.ts", [
-    { name: "OrderOptionState" },
+  ...identitiesAt([
+    ["src/shared/order/options.ts", [{ name: "OrderOptionState" }]],
   ])(["byKey"]),
-  ...identitiesAt("src/shared/payment-providers.ts", [
-    { name: "PaymentProviderMeta" },
-    { name: "webhook" },
+  ...identitiesAt([
+    [
+      "src/shared/payment-providers.ts",
+      [{ name: "PaymentProviderMeta" }, { name: "webhook" }],
+    ],
   ])(["signatureHeader"]),
-  ...identitiesAt("src/shared/payment-providers.ts", [
-    { name: "PaymentProviderMeta" },
+  ...identitiesAt([
+    ["src/shared/payment-providers.ts", [{ name: "PaymentProviderMeta" }]],
   ])([
     "currencies",
     "label",
@@ -218,53 +206,56 @@ export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
     "secretField",
     "webhook",
   ]),
-  ...identitiesAt("src/shared/payment/admit-move.ts", [
-    { name: "PaymentWork" },
+  ...identitiesAt([
+    ["src/shared/payment/admit-move.ts", [{ name: "PaymentWork" }]],
   ])(["recoveryAction"]),
-  ...identitiesAt("src/shared/payment/admit-refund.ts", [
-    { name: "ObservedRefundAdmission" },
+  ...identitiesAt([
+    [
+      "src/shared/payment/admit-refund.ts",
+      [{ name: "ObservedRefundAdmission" }],
+    ],
   ])(["request"]),
-  ...identitiesAt("src/shared/payment/checkout-failure.ts", [
-    { name: "ProviderCheckoutError" },
+  ...identitiesAt([
+    [
+      "src/shared/payment/checkout-failure.ts",
+      [{ name: "ProviderCheckoutError" }],
+    ],
   ])(["provider", "reason", "statusCode"]),
-  ...identitiesAt("src/shared/payment/claim.ts", [{ name: "ClaimDecision" }])([
-    "resuming",
-  ]),
-  ...identitiesAt("src/shared/payment/claim.ts", [{ name: "HeldPaymentRow" }])([
-    "attendeeId",
-  ]),
-  ...identitiesAt("src/shared/payment/claim.ts", [
-    { name: "HeldRefundCommand" },
+  ...identitiesAt([
+    ["src/shared/payment/claim.ts", [{ name: "ClaimDecision" }]],
+  ])(["resuming"]),
+  ...identitiesAt([
+    ["src/shared/payment/claim.ts", [{ name: "HeldPaymentRow" }]],
+  ])(["attendeeId"]),
+  ...identitiesAt([
+    ["src/shared/payment/claim.ts", [{ name: "HeldRefundCommand" }]],
   ])(["commandId", "held", "heldSince"]),
-  ...identitiesAt("src/shared/payment/claim.ts", [
-    { name: "IndexedRefundClaimDecision" },
+  ...identitiesAt([
+    ["src/shared/payment/claim.ts", [{ name: "IndexedRefundClaimDecision" }]],
   ])(["indexes", "kind"]),
-  ...identitiesAt("src/shared/payment/claim.ts", [
-    { name: "RefundClaimChanged" },
-  ])(["kind"]),
-  ...identitiesAt("src/shared/payment/joint-state.ts", [
-    { name: "IllegalJointState" },
+  ...identitiesAt([
+    ["src/shared/payment/joint-state.ts", [{ name: "IllegalJointState" }]],
   ])(["authority", "reason", "rows"]),
-  ...identitiesAt("src/shared/payment/refund-attempt.ts", [
-    { name: "RefundActionResult" },
+  ...identitiesAt([
+    ["src/shared/payment/refund-attempt.ts", [{ name: "RefundActionResult" }]],
   ])(["admission", "proof"]),
-  ...identitiesAt("src/shared/payment/refund-attempt.ts", [
-    { name: "RefundAttemptResult" },
+  ...identitiesAt([
+    ["src/shared/payment/refund-attempt.ts", [{ name: "RefundAttemptResult" }]],
   ])(["proof"]),
-  ...identitiesAt("src/shared/payment/refund-attempt.ts", [
-    { name: "RefundProof" },
+  ...identitiesAt([
+    ["src/shared/payment/refund-attempt.ts", [{ name: "RefundProof" }]],
   ])(["charge", "kind", "refund"]),
-  ...identitiesAt("src/shared/payment/refund-authority-lifecycle.ts", [
-    { name: "RefundLifecycle" },
+  ...identitiesAt([
+    [
+      "src/shared/payment/refund-authority-lifecycle.ts",
+      [{ name: "RefundLifecycle" }],
+    ],
   ])(["blocks", "refusal", "requiresChoice"]),
-  ...identitiesAt("src/shared/payment/refund-machine-spec.ts", [
-    { name: "RefundMachineEvent" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/payment/refund-machine-spec.ts", [
-    { name: "RefundNode" },
-  ])(["awaits"]),
-  ...identitiesAt("src/shared/payment/refund-provider-authorization.ts", [
-    { name: "KeyedRefundAuthorization" },
+  ...identitiesAt([
+    [
+      "src/shared/payment/refund-provider-authorization.ts",
+      [{ name: "KeyedRefundAuthorization" }],
+    ],
   ])([
     "capability",
     "generation",
@@ -272,50 +263,29 @@ export const SHARED_A_PAYMENTS_BASELINE: readonly FindingIdentity[] = [
     "identityIndex",
     "provider",
   ]),
-  ...identitiesAt("src/shared/payment/refund-provider-authorization.ts", [
-    { name: "KeylessRefundAuthorization" },
+  ...identitiesAt([
+    [
+      "src/shared/payment/refund-provider-authorization.ts",
+      [{ name: "KeylessRefundAuthorization" }],
+    ],
   ])(["capability", "generation", "identityIndex", "provider"]),
-  ...identitiesAt("src/shared/payment/review-machine-spec.ts", [
-    { name: "ReviewMachineEvent" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/payment/review-machine-spec.ts", [
-    { name: "ReviewNode" },
-  ])(["awaits"]),
-  ...identitiesAt("src/shared/payment/row-machine-spec.ts", [
-    { name: "RowMachineEvent" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/payment/row-machine-spec.ts", [
-    { name: "RowNode" },
-  ])(["awaits"]),
-  ...identitiesAt("src/shared/payment/row-transitions.ts", [
-    { name: "PaymentRowSettlement" },
+  ...identitiesAt([
+    [
+      "src/shared/payment/row-transitions.ts",
+      [{ name: "PaymentRowSettlement" }],
+    ],
   ])(["claim"]),
-  ...identitiesAt("src/shared/payment/sumup-recovery-machine-spec.ts", [
-    { name: "RecoveryMachineEvent" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/payment/sumup-recovery-machine-spec.ts", [
-    { name: "RecoveryNode" },
-  ])(["awaits"]),
-  ...identitiesAt("src/shared/payment/transport-error.ts", [
-    { name: "ProviderTransportError" },
-  ])(["provider"]),
-  ...identitiesAt("src/shared/payments.ts", [{ name: "CheckoutIntent" }])([
+  ...identitiesAt([["src/shared/payments.ts", [{ name: "CheckoutIntent" }]]])([
     "balanceAttendeeId",
     "date",
     "dayCount",
     "listingAnswerIds",
     "listingTextAnswerIds",
   ]),
-  ...identitiesAt("src/shared/payments.ts", [
-    { name: "CheckoutSessionResult" },
+  ...identitiesAt([
+    ["src/shared/payments.ts", [{ name: "CheckoutSessionResult" }]],
   ])(["sessionId"]),
-  ...identitiesAt("src/shared/payments.ts", [
-    { name: "ExistingPaymentProvider" },
-  ])(["setupWebhookEndpoint"]),
-  ...identitiesAt("src/shared/payments.ts", [{ name: "PaymentProvider" }])([
-    "setupWebhookEndpoint",
-  ]),
-  ...identitiesAt("src/shared/payments.ts", [{ name: "SessionMetadata" }])([
+  ...identitiesAt([["src/shared/payments.ts", [{ name: "SessionMetadata" }]]])([
     "_origin",
   ]),
 ];

--- a/scripts/unread-fields/baseline/shared-db.ts
+++ b/scripts/unread-fields/baseline/shared-db.ts
@@ -5,139 +5,110 @@ import {
 
 const PARENT_LISTING_FIELDS = ["parentListingId"] as const;
 const ASSIGNED_LISTING_FIELDS = ["assignedListingId"] as const;
+const BUILT_SITE_SHARED_FIELD_NAMES = [
+  { input: "assignable", row: "assignable" },
+  { input: "assignedAttendeeId", row: "assigned_attendee_id" },
+  { input: "assignedListingId", row: "assigned_listing_id" },
+  { input: "readOnlyFrom", row: "read_only_from" },
+  { input: "renewalTokenIndex", row: "renewal_token_index" },
+] as const;
+const BUILT_SITE_INPUT_FIELDS = BUILT_SITE_SHARED_FIELD_NAMES.map(
+  ({ input }) => input,
+);
+const BUILT_SITE_ROW_FIELDS = BUILT_SITE_SHARED_FIELD_NAMES.map(
+  ({ row }) => row,
+);
 
 export const SHARED_DB_BASELINE: readonly FindingIdentity[] = [
-  ...identitiesAt("src/shared/db/activity-log.ts", [
-    { name: "ActivityLogEntry" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/db/activity-log.ts", [
-    { name: "ActivityLogInput" },
+  ...identitiesAt([
+    ["src/shared/db/activity-log.ts", [{ name: "ActivityLogInput" }]],
   ])(["attendeeId", "listingId", "message"]),
-  ...identitiesAt("src/shared/db/activity-log.ts", [
-    { name: "ListingWithActivityLog" },
+  ...identitiesAt([
+    ["src/shared/db/activity-log.ts", [{ name: "ListingWithActivityLog" }]],
   ])(["listing"]),
-  ...identitiesAt("src/shared/db/attendee-types.ts", [
-    { name: "DesiredListingLine" },
+  ...identitiesAt([
+    ["src/shared/db/attendee-types.ts", [{ name: "DesiredListingLine" }]],
+    [
+      "src/shared/db/attendees/atomic-update.ts",
+      [{ name: "AtomicDesiredLine" }],
+    ],
   ])(PARENT_LISTING_FIELDS),
-  ...identitiesAt("src/shared/db/attendees/atomic-update.ts", [
-    { name: "AtomicDesiredLine" },
-  ])(PARENT_LISTING_FIELDS),
-  ...identitiesAt("src/shared/db/attendees/atomic-update.ts", [
-    { name: "UpdateAttendeeAtomicResult" },
+  ...identitiesAt([
+    [
+      "src/shared/db/attendees/atomic-update.ts",
+      [{ name: "UpdateAttendeeAtomicResult" }],
+    ],
   ])(["listingIds"]),
-  ...identitiesAt("src/shared/db/attendees/balance.ts", [
-    { name: "SettleBalanceResult" },
+  ...identitiesAt([
+    ["src/shared/db/attendees/balance.ts", [{ name: "SettleBalanceResult" }]],
   ])(["amount", "listingId"]),
-  ...identitiesAt("src/shared/db/attendees/capacity/range.ts", [
-    { name: "IntervalRow" },
+  ...identitiesAt([
+    ["src/shared/db/attendees/capacity/range.ts", [{ name: "IntervalRow" }]],
   ])(["quantity"]),
-  ...identitiesAt("src/shared/db/attendees/pii.ts", [
-    { name: "DecryptedAttendeeRow" },
+  ...identitiesAt([
+    ["src/shared/db/attendees/pii.ts", [{ name: "DecryptedAttendeeRow" }]],
   ])(["checked_in", "split_logistics_agents"]),
-  ...identitiesAt("src/shared/db/attendees/select.ts", [
-    { name: "GetAttendeesQuery" },
-  ])(["order"]),
-  ...identitiesAt("src/shared/db/attendees/servicing.ts", [
-    { name: "ServicingBookingSummary" },
+  ...identitiesAt([
+    [
+      "src/shared/db/attendees/servicing.ts",
+      [{ name: "ServicingBookingSummary" }],
+    ],
   ])(["listingId"]),
-  ...identitiesAt("src/shared/db/attendees/servicing.ts", [
-    { name: "ServicingEvent" },
-  ])(["kind"]),
-  ...identitiesAt("src/shared/db/attributes.ts", [{ name: "AttributeOption" }])(
-    ["attribute_id"],
-  ),
-  ...identitiesAt("src/shared/db/backup.ts", [{ name: "BackupInspection" }])([
-    "manifest",
-    "statementCount",
-  ]),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSite" },
+  ...identitiesAt([
+    ["src/shared/db/attributes.ts", [{ name: "AttributeOption" }]],
+  ])(["attribute_id"]),
+  ...identitiesAt([
+    ["src/shared/db/backup.ts", [{ name: "BackupInspection" }]],
+  ])(["manifest", "statementCount"]),
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSite" }]],
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSitePlainFields" }]],
   ])(ASSIGNED_LISTING_FIELDS),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSiteBlobInput" },
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSiteBlobInput" }]],
   ])(["renewalToken"]),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSiteFormInput" },
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSiteFormInput" }]],
   ])(["dbProvider", "hostingProvider", "updates"]),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSiteInput" },
-  ])([
-    "assignable",
-    "assignedAttendeeId",
-    "assignedListingId",
-    "readOnlyFrom",
-    "renewalTokenIndex",
-    "siteData",
-    "updates",
-  ]),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSitePlainFields" },
-  ])(ASSIGNED_LISTING_FIELDS),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSitePlainInput" },
-  ])([
-    "assignable",
-    "assignedAttendeeId",
-    "assignedListingId",
-    "readOnlyFrom",
-    "renewalTokenIndex",
-    "updates",
-  ]),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSiteRow" },
-  ])([
-    "assignable",
-    "assigned_attendee_id",
-    "assigned_listing_id",
-    "read_only_from",
-    "renewal_token_index",
-    "site_data_revision",
-    "updates",
-  ]),
-  ...identitiesAt("src/shared/db/built-sites/types.ts", [
-    { name: "BuiltSiteUpdate" },
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSiteInput" }]],
+  ])([...BUILT_SITE_INPUT_FIELDS, "siteData", "updates"]),
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSitePlainInput" }]],
+  ])([...BUILT_SITE_INPUT_FIELDS, "updates"]),
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSiteRow" }]],
+  ])([...BUILT_SITE_ROW_FIELDS, "site_data_revision", "updates"]),
+  ...identitiesAt([
+    ["src/shared/db/built-sites/types.ts", [{ name: "BuiltSiteUpdate" }]],
   ])(["assignedListingId", "renewalToken"]),
-  ...identitiesAt("src/shared/db/common-schema.ts", [
-    { name: "AggregateRecalculation" },
-    { way: "[]" },
+  ...identitiesAt([
+    [
+      "src/shared/db/common-schema.ts",
+      [{ name: "AggregateRecalculation" }, { way: "[]" }],
+    ],
   ])(["recalculated"]),
-  ...identitiesAt("src/shared/db/common-schema.ts", [
-    { name: "NamedSortOrderInput" },
+  ...identitiesAt([
+    ["src/shared/db/common-schema.ts", [{ name: "NamedSortOrderInput" }]],
   ])(["name", "sortOrder"]),
-  ...identitiesAt("src/shared/db/contact-tokens.ts", [
-    { name: "BookingToken" },
+  ...identitiesAt([
+    ["src/shared/db/contact-tokens.ts", [{ name: "BookingToken" }]],
   ])(["token"]),
-  ...identitiesAt("src/shared/db/groups/candidates.ts", [
-    { name: "GroupListingCandidate" },
-  ])(["active"]),
-  ...identitiesAt("src/shared/db/holidays.ts", [{ name: "HolidayInput" }])([
-    "name",
-  ]),
-  ...identitiesAt("src/shared/db/images.ts", [{ name: "ImageInput" }])([
+  ...identitiesAt([["src/shared/db/images.ts", [{ name: "ImageInput" }]]])([
     "altText",
     "filename",
     "filenameThumb",
     "name",
   ]),
-  ...identitiesAt("src/shared/db/images.ts", [{ name: "OrderedImage" }])([
-    "sort_order",
-  ]),
-  ...identitiesAt("src/shared/db/listing-parents.ts", [
-    { name: "HydratedListingLinks" },
+  ...identitiesAt([
+    ["src/shared/db/listing-parents.ts", [{ name: "HydratedListingLinks" }]],
   ])(["idsByKey"]),
-  ...identitiesAt("src/shared/db/listing-parents.ts", [
-    { name: "ParentAndChildLinkMaps" },
+  ...identitiesAt([
+    ["src/shared/db/listing-parents.ts", [{ name: "ParentAndChildLinkMaps" }]],
   ])(["childIdsByParent"]),
-  ...identitiesAt("src/shared/db/listings/select.ts", [
-    { name: "GetListingsQuery" },
-  ])(["order"]),
-  ...identitiesAt("src/shared/db/logistics-agents.ts", [
-    { name: "LogisticsAgentInput" },
-  ])(["name"]),
-  ...identitiesAt("src/shared/db/modifier-resolve.ts", [
-    { name: "ListingGroupMembership" },
-  ])(["active"]),
-  ...identitiesAt("src/shared/db/modifiers.ts", [{ name: "ModifierInput" }])([
+  ...identitiesAt([
+    ["src/shared/db/modifiers.ts", [{ name: "ModifierInput" }]],
+  ])([
     "calcKind",
     "calcValue",
     "codeIndex",
@@ -145,64 +116,68 @@ export const SHARED_DB_BASELINE: readonly FindingIdentity[] = [
     "minSubtotal",
     "stock",
   ]),
-  ...identitiesAt("src/shared/db/modifiers.ts", [{ name: "ModifierRow" }])([
-    "code",
-  ]),
-  ...identitiesAt("src/shared/db/news-posts.ts", [{ name: "NewsPostInput" }])([
-    "created",
-    "slugIndex",
-  ]),
-  ...identitiesAt("src/shared/db/notes/types.ts", [{ name: "SystemNote" }])([
-    "entity_type",
-  ]),
-  ...identitiesAt("src/shared/db/notes/types.ts", [{ name: "SystemNoteRow" }])([
-    "entity_type",
-  ]),
-  ...identitiesAt("src/shared/db/numbered-statement.ts", [
-    { name: "SqlParameterToken" },
+  ...identitiesAt([
+    ["src/shared/db/news-posts.ts", [{ name: "NewsPostInput" }]],
+  ])(["created", "slugIndex"]),
+  ...identitiesAt([
+    ["src/shared/db/numbered-statement.ts", [{ name: "SqlParameterToken" }]],
   ])(["sql"]),
-  ...identitiesAt("src/shared/db/ordered-collection.ts", [
-    { name: "OrderedCollection" },
-    { name: "nextMany" },
-    { way: "()" },
-    { way: "operation" },
+  ...identitiesAt([
+    [
+      "src/shared/db/ordered-collection.ts",
+      [
+        { name: "OrderedCollection" },
+        { name: "nextMany" },
+        { way: "()" },
+        { way: "operation" },
+      ],
+    ],
   ])(["transaction"]),
-  ...identitiesAt("src/shared/db/payment-reference-rows.ts", [
-    { name: "PaymentReferenceRow" },
+  ...identitiesAt([
+    [
+      "src/shared/db/payment-reference-rows.ts",
+      [{ name: "PaymentReferenceRow" }],
+    ],
   ])(["payment_reference", "payment_reference_index"]),
-  ...identitiesAt("src/shared/db/payment-reference-store.ts", [
-    { name: "IndexedPaymentReferenceSource" },
+  ...identitiesAt([
+    [
+      "src/shared/db/payment-reference-store.ts",
+      [{ name: "IndexedPaymentReferenceSource" }],
+    ],
   ])(["payment_session_id"]),
-  ...identitiesAt("src/shared/db/payment-review.ts", [
-    { name: "PaymentReviewState" },
+  ...identitiesAt([
+    ["src/shared/db/payment-review.ts", [{ name: "PaymentReviewState" }]],
   ])(["allAcknowledged"]),
-  ...identitiesAt("src/shared/db/processed-payments.ts", [
-    { name: "ProcessedPayment" },
+  ...identitiesAt([
+    ["src/shared/db/processed-payments.ts", [{ name: "ProcessedPayment" }]],
   ])(["payment_reference", "payment_session_id", "processed_at"]),
-  ...identitiesAt("src/shared/db/provider-refund-authority.ts", [
-    { name: "RefundAuthorityRow" },
-  ])(["provider"]),
-  ...identitiesAt("src/shared/db/provider-refund-cases.ts", [
-    { name: "ProviderRefundCase" },
+  ...identitiesAt([
+    [
+      "src/shared/db/provider-refund-cases.ts",
+      [{ name: "ProviderRefundCase" }],
+    ],
   ])(["decision", "updatedAt"]),
-  ...identitiesAt("src/shared/db/provider-refund-cases.ts", [
-    { name: "ProviderRefundCaseSummary" },
+  ...identitiesAt([
+    [
+      "src/shared/db/provider-refund-cases.ts",
+      [{ name: "ProviderRefundCaseSummary" }],
+    ],
   ])(["updatedAt"]),
-  ...identitiesAt("src/shared/db/question-types.ts", [{ name: "Answer" }])([
+  ...identitiesAt([["src/shared/db/question-types.ts", [{ name: "Answer" }]]])([
     "question_id",
     "sort_order",
   ]),
-  ...identitiesAt("src/shared/db/question-types.ts", [{ name: "Question" }])([
-    "assign_all",
-  ]),
-  ...identitiesAt("src/shared/db/questions/strings.ts", [
-    { name: "PreparedStringRow" },
-  ])(["text"]),
-  ...identitiesAt("src/shared/db/refund-all-candidates.ts", [
-    { name: "RefundAllCandidateAttendee" },
+  ...identitiesAt([
+    ["src/shared/db/question-types.ts", [{ name: "Question" }]],
+  ])(["assign_all"]),
+  ...identitiesAt([
+    [
+      "src/shared/db/refund-all-candidates.ts",
+      [{ name: "RefundAllCandidateAttendee" }],
+    ],
   ])(["id", "quantity", "refunded"]),
-  ...identitiesAt("src/shared/db/settings/snapshot.ts", [
-    { name: "SettingsData" },
+  ...identitiesAt([
+    ["src/shared/db/settings/snapshot.ts", [{ name: "SettingsData" }]],
   ])([
     "auto_purge_orphans",
     "booking_fee",
@@ -224,24 +199,16 @@ export const SHARED_DB_BASELINE: readonly FindingIdentity[] = [
     "timezone",
     "underline_links",
   ]),
-  ...identitiesAt("src/shared/db/site-pages.ts", [{ name: "SitePageInput" }])([
-    "slugIndex",
-    "sortOrder",
-  ]),
-  ...identitiesAt("src/shared/db/slugged-content-input.ts", [
-    { name: "SluggedContentInput" },
+  ...identitiesAt([
+    ["src/shared/db/site-pages.ts", [{ name: "SitePageInput" }]],
+  ])(["slugIndex", "sortOrder"]),
+  ...identitiesAt([
+    [
+      "src/shared/db/slugged-content-input.ts",
+      [{ name: "SluggedContentInput" }],
+    ],
   ])(["slugIndex"]),
-  ...identitiesAt("src/shared/db/sms-messages.ts", [{ name: "SmsMessageRow" }])(
-    ["created", "provider_id"],
-  ),
-  ...identitiesAt("src/shared/db/table.ts", [{ name: "CrudTable" }])([
-    "inputKeyMap",
-    "schema",
-    "toDbValues",
-  ]),
-  ...identitiesAt("src/shared/db/table.ts", [{ name: "Table" }])([
-    "inputKeyMap",
-    "schema",
-    "toDbValues",
-  ]),
+  ...identitiesAt([
+    ["src/shared/db/sms-messages.ts", [{ name: "SmsMessageRow" }]],
+  ])(["created", "provider_id"]),
 ];

--- a/scripts/unread-fields/baseline/shared-db.ts
+++ b/scripts/unread-fields/baseline/shared-db.ts
@@ -1,0 +1,247 @@
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+const PARENT_LISTING_FIELDS = ["parentListingId"] as const;
+const ASSIGNED_LISTING_FIELDS = ["assignedListingId"] as const;
+
+export const SHARED_DB_BASELINE: readonly FindingIdentity[] = [
+  ...identitiesAt("src/shared/db/activity-log.ts", [
+    { name: "ActivityLogEntry" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/db/activity-log.ts", [
+    { name: "ActivityLogInput" },
+  ])(["attendeeId", "listingId", "message"]),
+  ...identitiesAt("src/shared/db/activity-log.ts", [
+    { name: "ListingWithActivityLog" },
+  ])(["listing"]),
+  ...identitiesAt("src/shared/db/attendee-types.ts", [
+    { name: "DesiredListingLine" },
+  ])(PARENT_LISTING_FIELDS),
+  ...identitiesAt("src/shared/db/attendees/atomic-update.ts", [
+    { name: "AtomicDesiredLine" },
+  ])(PARENT_LISTING_FIELDS),
+  ...identitiesAt("src/shared/db/attendees/atomic-update.ts", [
+    { name: "UpdateAttendeeAtomicResult" },
+  ])(["listingIds"]),
+  ...identitiesAt("src/shared/db/attendees/balance.ts", [
+    { name: "SettleBalanceResult" },
+  ])(["amount", "listingId"]),
+  ...identitiesAt("src/shared/db/attendees/capacity/range.ts", [
+    { name: "IntervalRow" },
+  ])(["quantity"]),
+  ...identitiesAt("src/shared/db/attendees/pii.ts", [
+    { name: "DecryptedAttendeeRow" },
+  ])(["checked_in", "split_logistics_agents"]),
+  ...identitiesAt("src/shared/db/attendees/select.ts", [
+    { name: "GetAttendeesQuery" },
+  ])(["order"]),
+  ...identitiesAt("src/shared/db/attendees/servicing.ts", [
+    { name: "ServicingBookingSummary" },
+  ])(["listingId"]),
+  ...identitiesAt("src/shared/db/attendees/servicing.ts", [
+    { name: "ServicingEvent" },
+  ])(["kind"]),
+  ...identitiesAt("src/shared/db/attributes.ts", [{ name: "AttributeOption" }])(
+    ["attribute_id"],
+  ),
+  ...identitiesAt("src/shared/db/backup.ts", [{ name: "BackupInspection" }])([
+    "manifest",
+    "statementCount",
+  ]),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSite" },
+  ])(ASSIGNED_LISTING_FIELDS),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSiteBlobInput" },
+  ])(["renewalToken"]),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSiteFormInput" },
+  ])(["dbProvider", "hostingProvider", "updates"]),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSiteInput" },
+  ])([
+    "assignable",
+    "assignedAttendeeId",
+    "assignedListingId",
+    "readOnlyFrom",
+    "renewalTokenIndex",
+    "siteData",
+    "updates",
+  ]),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSitePlainFields" },
+  ])(ASSIGNED_LISTING_FIELDS),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSitePlainInput" },
+  ])([
+    "assignable",
+    "assignedAttendeeId",
+    "assignedListingId",
+    "readOnlyFrom",
+    "renewalTokenIndex",
+    "updates",
+  ]),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSiteRow" },
+  ])([
+    "assignable",
+    "assigned_attendee_id",
+    "assigned_listing_id",
+    "read_only_from",
+    "renewal_token_index",
+    "site_data_revision",
+    "updates",
+  ]),
+  ...identitiesAt("src/shared/db/built-sites/types.ts", [
+    { name: "BuiltSiteUpdate" },
+  ])(["assignedListingId", "renewalToken"]),
+  ...identitiesAt("src/shared/db/common-schema.ts", [
+    { name: "AggregateRecalculation" },
+    { way: "[]" },
+  ])(["recalculated"]),
+  ...identitiesAt("src/shared/db/common-schema.ts", [
+    { name: "NamedSortOrderInput" },
+  ])(["name", "sortOrder"]),
+  ...identitiesAt("src/shared/db/contact-tokens.ts", [
+    { name: "BookingToken" },
+  ])(["token"]),
+  ...identitiesAt("src/shared/db/groups/candidates.ts", [
+    { name: "GroupListingCandidate" },
+  ])(["active"]),
+  ...identitiesAt("src/shared/db/holidays.ts", [{ name: "HolidayInput" }])([
+    "name",
+  ]),
+  ...identitiesAt("src/shared/db/images.ts", [{ name: "ImageInput" }])([
+    "altText",
+    "filename",
+    "filenameThumb",
+    "name",
+  ]),
+  ...identitiesAt("src/shared/db/images.ts", [{ name: "OrderedImage" }])([
+    "sort_order",
+  ]),
+  ...identitiesAt("src/shared/db/listing-parents.ts", [
+    { name: "HydratedListingLinks" },
+  ])(["idsByKey"]),
+  ...identitiesAt("src/shared/db/listing-parents.ts", [
+    { name: "ParentAndChildLinkMaps" },
+  ])(["childIdsByParent"]),
+  ...identitiesAt("src/shared/db/listings/select.ts", [
+    { name: "GetListingsQuery" },
+  ])(["order"]),
+  ...identitiesAt("src/shared/db/logistics-agents.ts", [
+    { name: "LogisticsAgentInput" },
+  ])(["name"]),
+  ...identitiesAt("src/shared/db/modifier-resolve.ts", [
+    { name: "ListingGroupMembership" },
+  ])(["active"]),
+  ...identitiesAt("src/shared/db/modifiers.ts", [{ name: "ModifierInput" }])([
+    "calcKind",
+    "calcValue",
+    "codeIndex",
+    "direction",
+    "minSubtotal",
+    "stock",
+  ]),
+  ...identitiesAt("src/shared/db/modifiers.ts", [{ name: "ModifierRow" }])([
+    "code",
+  ]),
+  ...identitiesAt("src/shared/db/news-posts.ts", [{ name: "NewsPostInput" }])([
+    "created",
+    "slugIndex",
+  ]),
+  ...identitiesAt("src/shared/db/notes/types.ts", [{ name: "SystemNote" }])([
+    "entity_type",
+  ]),
+  ...identitiesAt("src/shared/db/notes/types.ts", [{ name: "SystemNoteRow" }])([
+    "entity_type",
+  ]),
+  ...identitiesAt("src/shared/db/numbered-statement.ts", [
+    { name: "SqlParameterToken" },
+  ])(["sql"]),
+  ...identitiesAt("src/shared/db/ordered-collection.ts", [
+    { name: "OrderedCollection" },
+    { name: "nextMany" },
+    { way: "()" },
+    { way: "operation" },
+  ])(["transaction"]),
+  ...identitiesAt("src/shared/db/payment-reference-rows.ts", [
+    { name: "PaymentReferenceRow" },
+  ])(["payment_reference", "payment_reference_index"]),
+  ...identitiesAt("src/shared/db/payment-reference-store.ts", [
+    { name: "IndexedPaymentReferenceSource" },
+  ])(["payment_session_id"]),
+  ...identitiesAt("src/shared/db/payment-review.ts", [
+    { name: "PaymentReviewState" },
+  ])(["allAcknowledged"]),
+  ...identitiesAt("src/shared/db/processed-payments.ts", [
+    { name: "ProcessedPayment" },
+  ])(["payment_reference", "payment_session_id", "processed_at"]),
+  ...identitiesAt("src/shared/db/provider-refund-authority.ts", [
+    { name: "RefundAuthorityRow" },
+  ])(["provider"]),
+  ...identitiesAt("src/shared/db/provider-refund-cases.ts", [
+    { name: "ProviderRefundCase" },
+  ])(["decision", "updatedAt"]),
+  ...identitiesAt("src/shared/db/provider-refund-cases.ts", [
+    { name: "ProviderRefundCaseSummary" },
+  ])(["updatedAt"]),
+  ...identitiesAt("src/shared/db/question-types.ts", [{ name: "Answer" }])([
+    "question_id",
+    "sort_order",
+  ]),
+  ...identitiesAt("src/shared/db/question-types.ts", [{ name: "Question" }])([
+    "assign_all",
+  ]),
+  ...identitiesAt("src/shared/db/questions/strings.ts", [
+    { name: "PreparedStringRow" },
+  ])(["text"]),
+  ...identitiesAt("src/shared/db/refund-all-candidates.ts", [
+    { name: "RefundAllCandidateAttendee" },
+  ])(["id", "quantity", "refunded"]),
+  ...identitiesAt("src/shared/db/settings/snapshot.ts", [
+    { name: "SettingsData" },
+  ])([
+    "auto_purge_orphans",
+    "booking_fee",
+    "calendar_feeds_enabled",
+    "calendar_feeds_group_by",
+    "contact_form_enabled",
+    "country",
+    "currency",
+    "external_order_enabled",
+    "order_enabled",
+    "orphan_purge_retention",
+    "payment_provider",
+    "payment_provider_setting",
+    "phone_prefix",
+    "show_public_api",
+    "square_sandbox",
+    "superuser_choice",
+    "theme",
+    "timezone",
+    "underline_links",
+  ]),
+  ...identitiesAt("src/shared/db/site-pages.ts", [{ name: "SitePageInput" }])([
+    "slugIndex",
+    "sortOrder",
+  ]),
+  ...identitiesAt("src/shared/db/slugged-content-input.ts", [
+    { name: "SluggedContentInput" },
+  ])(["slugIndex"]),
+  ...identitiesAt("src/shared/db/sms-messages.ts", [{ name: "SmsMessageRow" }])(
+    ["created", "provider_id"],
+  ),
+  ...identitiesAt("src/shared/db/table.ts", [{ name: "CrudTable" }])([
+    "inputKeyMap",
+    "schema",
+    "toDbValues",
+  ]),
+  ...identitiesAt("src/shared/db/table.ts", [{ name: "Table" }])([
+    "inputKeyMap",
+    "schema",
+    "toDbValues",
+  ]),
+];

--- a/scripts/unread-fields/baseline/shared-fields.ts
+++ b/scripts/unread-fields/baseline/shared-fields.ts
@@ -1,0 +1,166 @@
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+/** Owners with the same unread fields share one declaration. */
+export const SHARED_FIELD_BASELINE: readonly FindingIdentity[] = [
+  ...identitiesAt([
+    [
+      "src/shared/admin-surface/definitions.ts",
+      [{ name: "AdminSurfaceContext" }],
+    ],
+    ["src/shared/db/groups/candidates.ts", [{ name: "GroupListingCandidate" }]],
+    ["src/shared/db/modifier-resolve.ts", [{ name: "ListingGroupMembership" }]],
+  ])(["active"]),
+  ...identitiesAt([
+    ["src/shared/payment/refund-machine-spec.ts", [{ name: "RefundNode" }]],
+    ["src/shared/payment/review-machine-spec.ts", [{ name: "ReviewNode" }]],
+    ["src/shared/payment/row-machine-spec.ts", [{ name: "RowNode" }]],
+    [
+      "src/shared/payment/sumup-recovery-machine-spec.ts",
+      [{ name: "RecoveryNode" }],
+    ],
+    ["src/shared/schema-atlas/machine-spec.ts", [{ name: "MachineNode" }]],
+  ])(["awaits"]),
+  ...identitiesAt([
+    ["src/shared/ledger/types.ts", [{ name: "LedgerError" }]],
+    ["src/shared/db/modifiers.ts", [{ name: "ModifierRow" }]],
+    ["src/shared/types.ts", [{ name: "Modifier" }]],
+  ])(["code"]),
+  ...identitiesAt([
+    ["src/features/admin/api-groups.ts", [{ name: "DeleteGroupBody" }]],
+    ["src/features/admin/api-holidays.ts", [{ name: "DeleteHolidayBody" }]],
+    ["src/features/admin/api.ts", [{ name: "DeleteListingBody" }]],
+    ["src/shared/rest/crud-parsers.ts", [{ name: "DeleteBody" }]],
+  ])(["confirm_identifier"]),
+  ...identitiesAt([
+    [
+      "src/ui/templates/admin/debug.tsx",
+      [{ name: "DebugPageState" }, { name: "appleWallet" }],
+    ],
+    [
+      "src/ui/templates/admin/debug.tsx",
+      [{ name: "DebugPageState" }, { name: "googleWallet" }],
+    ],
+  ])(["dbConfigured", "envConfigured", "source"]),
+  ...identitiesAt([
+    ["src/shared/provider-types.ts", [{ name: "DatabaseCredentials" }]],
+    ["src/shared/turso-api.ts", [{ name: "TursoDatabaseCredentials" }]],
+  ])(["dbId"]),
+  ...identitiesAt([
+    ["src/shared/balance-link.ts", [{ name: "BalancePayload" }]],
+    ["src/shared/qr-token.ts", [{ name: "QrBookPayload" }]],
+  ])(["e"]),
+  ...identitiesAt([
+    ["src/features/admin/api-holidays.ts", [{ name: "CreateHolidayBody" }]],
+    ["src/features/admin/api-holidays.ts", [{ name: "UpdateHolidayBody" }]],
+  ])(["end_date", "name", "start_date"]),
+  ...identitiesAt([
+    ["src/shared/db/notes/types.ts", [{ name: "SystemNote" }]],
+    ["src/shared/db/notes/types.ts", [{ name: "SystemNoteRow" }]],
+  ])(["entity_type"]),
+  ...identitiesAt([
+    ["src/shared/admin-surface/sections.ts", [{ name: "AdminSectionDef" }]],
+    ["src/shared/db/activity-log.ts", [{ name: "ActivityLogEntry" }]],
+    [
+      "src/shared/payment/refund-machine-spec.ts",
+      [{ name: "RefundMachineEvent" }],
+    ],
+    [
+      "src/shared/payment/review-machine-spec.ts",
+      [{ name: "ReviewMachineEvent" }],
+    ],
+    ["src/shared/payment/row-machine-spec.ts", [{ name: "RowMachineEvent" }]],
+    [
+      "src/shared/payment/sumup-recovery-machine-spec.ts",
+      [{ name: "RecoveryMachineEvent" }],
+    ],
+    ["src/shared/schema-atlas/machine-spec.ts", [{ name: "MachineEvent" }]],
+    [
+      "src/shared/square/wire.ts",
+      [{ name: "SquareOrder" }, { name: "tenders" }, { way: "[]" }],
+    ],
+    ["src/shared/square/wire.ts", [{ name: "SquareRefund" }]],
+    ["src/shared/types.ts", [{ name: "NagItem" }]],
+  ])(["id"]),
+  ...identitiesAt([
+    [
+      "src/features/admin/refunds/budget.ts",
+      [{ name: "RefundSendBudgetReference" }],
+    ],
+    [
+      "src/features/admin/refunds/readiness.ts",
+      [{ name: "RefundReadinessRead" }],
+    ],
+  ])(["index"]),
+  ...identitiesAt([
+    ["src/shared/db/table.ts", [{ name: "CrudTable" }]],
+    ["src/shared/db/table.ts", [{ name: "Table" }]],
+  ])(["inputKeyMap", "schema", "toDbValues"]),
+  ...identitiesAt([
+    ["src/shared/admin-surface/sections.ts", [{ name: "AdminNavEntry" }]],
+    ["src/shared/db/attendees/servicing.ts", [{ name: "ServicingEvent" }]],
+    ["src/shared/payment/claim.ts", [{ name: "RefundClaimChanged" }]],
+  ])(["kind"]),
+  ...identitiesAt([
+    ["src/shared/booking/cart-conflicts.ts", [{ name: "CartDateItem" }]],
+    ["src/shared/booking/cart-conflicts.ts", [{ name: "CartLengthItem" }]],
+    ["src/shared/boot-checks.ts", [{ name: "BootCheck" }]],
+    ["src/shared/db/holidays.ts", [{ name: "HolidayInput" }]],
+    ["src/shared/db/logistics-agents.ts", [{ name: "LogisticsAgentInput" }]],
+  ])(["name"]),
+  ...identitiesAt([
+    ["src/shared/rest/resource.ts", [{ name: "DeleteResult" }]],
+    ["src/shared/rest/resource.ts", [{ name: "UpdateResult" }]],
+  ])(["notFound"]),
+  ...identitiesAt([
+    ["src/shared/db/attendees/select.ts", [{ name: "GetAttendeesQuery" }]],
+    ["src/shared/db/listings/select.ts", [{ name: "GetListingsQuery" }]],
+  ])(["order"]),
+  ...identitiesAt([
+    [
+      "src/shared/db/provider-refund-authority.ts",
+      [{ name: "RefundAuthorityRow" }],
+    ],
+    [
+      "src/shared/payment/transport-error.ts",
+      [{ name: "ProviderTransportError" }],
+    ],
+  ])(["provider"]),
+  ...identitiesAt([
+    ["src/features/admin/refunds/claim.ts", [{ name: "RefundRunBlock" }]],
+    ["src/features/admin/refunds/provider.ts", [{ name: "RefundBatchResult" }]],
+    [
+      "src/features/admin/refunds/refresh.ts",
+      [{ name: "RefreshPaymentResult" }],
+    ],
+    ["src/shared/superuser.ts", [{ name: "SuperuserState" }]],
+  ])(["reason"]),
+  ...identitiesAt([
+    ["src/shared/payments.ts", [{ name: "ExistingPaymentProvider" }]],
+    ["src/shared/payments.ts", [{ name: "PaymentProvider" }]],
+  ])(["setupWebhookEndpoint"]),
+  ...identitiesAt([
+    ["src/shared/db/images.ts", [{ name: "OrderedImage" }]],
+    [
+      "src/shared/listing-attribute-filter.ts",
+      [{ name: "AttributeFilterGroup" }],
+    ],
+  ])(["sort_order"]),
+  ...identitiesAt([
+    ["src/shared/provider-refunds.ts", [{ name: "ProviderRefundResult" }]],
+    ["src/shared/square/wire.ts", [{ name: "SquareOrder" }]],
+  ])(["state"]),
+  ...identitiesAt([
+    ["src/shared/db/questions/strings.ts", [{ name: "PreparedStringRow" }]],
+    [
+      "src/shared/sms/gateway.ts",
+      [{ name: "EncryptedMessagePayload" }, { name: "textMessage" }],
+    ],
+  ])(["text"]),
+  ...identitiesAt([
+    ["src/shared/jsx/jsx-runtime.ts", [{ name: "Child" }]],
+    ["src/shared/jsx/jsx-runtime.ts", [{ name: "SafeHtml" }]],
+  ])(["toString"]),
+];

--- a/scripts/unread-fields/baseline/shared-provider-z.ts
+++ b/scripts/unread-fields/baseline/shared-provider-z.ts
@@ -45,82 +45,69 @@ const CONTENT_META_FIELDS = [
 ] as const;
 
 export const SHARED_PROVIDER_Z_BASELINE: readonly FindingIdentity[] = [
-  ...identitiesAt("src/shared/provider-refunds.ts", [
-    { name: "ProviderRefundResult" },
-  ])(["state"]),
-  ...identitiesAt("src/shared/provider-types.ts", [
-    { name: "DatabaseCredentials" },
-  ])(["dbId"]),
-  ...identitiesAt("src/shared/qr-token.ts", [{ name: "QrBookPayload" }])(["e"]),
-  ...identitiesAt("src/shared/reservation-amount.ts", [
-    { name: "ReservationDepositAllocation" },
+  ...identitiesAt([
+    [
+      "src/shared/reservation-amount.ts",
+      [{ name: "ReservationDepositAllocation" }],
+    ],
   ])(["perItemTotals", "total"]),
-  ...identitiesAt("src/shared/rest/crud-parsers.ts", [{ name: "DeleteBody" }])([
-    "confirm_identifier",
-  ]),
-  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "DeleteResult" }])([
-    "notFound",
-  ]),
-  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "NamedResource" }])(
-    RESOURCE_FIELDS,
-  ),
-  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "Resource" }])(
-    RESOURCE_FIELDS,
-  ),
-  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "UpdateResult" }])([
-    "notFound",
-  ]),
-  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
-    { name: "DerivedNodeIds" },
+  ...identitiesAt([
+    ["src/shared/rest/resource.ts", [{ name: "NamedResource" }]],
+    ["src/shared/rest/resource.ts", [{ name: "Resource" }]],
+  ])(RESOURCE_FIELDS),
+  ...identitiesAt([
+    ["src/shared/schema-atlas/machine-spec.ts", [{ name: "DerivedNodeIds" }]],
   ])(["terminal"]),
-  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
-    { name: "MachineEvent" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
-    { name: "MachineMovesReader" },
+  ...identitiesAt([
+    [
+      "src/shared/schema-atlas/machine-spec.ts",
+      [{ name: "MachineMovesReader" }],
+    ],
   ])(["splitTags"]),
-  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
-    { name: "MachineNode" },
-  ])(["awaits"]),
-  ...identitiesAt("src/shared/schema-atlas/types.ts", [
-    { name: "AtlasState" },
-    { name: "layout" },
+  ...identitiesAt([
+    [
+      "src/shared/schema-atlas/types.ts",
+      [{ name: "AtlasState" }, { name: "layout" }],
+    ],
   ])(["x", "y"]),
-  ...identitiesAt("src/shared/settings/form-schema.ts", [
-    { name: "BooleanSettingsFormConfig" },
+  ...identitiesAt([
+    [
+      "src/shared/settings/form-schema.ts",
+      [{ name: "BooleanSettingsFormConfig" }],
+    ],
+    ["src/shared/settings/form-schema.ts", [{ name: "SettingsFormConfig" }]],
+    [
+      "src/shared/settings/form-schema.ts",
+      [{ name: "TextareaSettingsFormConfig" }],
+    ],
+    [
+      "src/shared/settings/form-schema.ts",
+      [{ name: "TextSettingsFormConfig" }],
+    ],
   ])(KEYED_SETTINGS_CONFIG_FIELDS),
-  ...identitiesAt("src/shared/settings/form-schema.ts", [
-    { name: "FieldFormCopy" },
+  ...identitiesAt([
+    ["src/shared/settings/form-schema.ts", [{ name: "FieldFormCopy" }]],
   ])(["submitLabelKey"]),
-  ...identitiesAt("src/shared/settings/form-schema.ts", [
-    { name: "FieldsSettingsFormConfig" },
+  ...identitiesAt([
+    [
+      "src/shared/settings/form-schema.ts",
+      [{ name: "FieldsSettingsFormConfig" }],
+    ],
   ])(SETTINGS_CONFIG_FIELDS),
-  ...identitiesAt("src/shared/settings/form-schema.ts", [
-    { name: "SettingsFormConfig" },
-  ])(KEYED_SETTINGS_CONFIG_FIELDS),
-  ...identitiesAt("src/shared/settings/form-schema.ts", [
-    { name: "TextareaSettingsFormConfig" },
-  ])(KEYED_SETTINGS_CONFIG_FIELDS),
-  ...identitiesAt("src/shared/settings/form-schema.ts", [
-    { name: "TextSettingsFormConfig" },
-  ])(KEYED_SETTINGS_CONFIG_FIELDS),
-  ...identitiesAt("src/shared/settings/forms.ts", [
-    { name: "SettingsFormDefinition" },
+  ...identitiesAt([
+    ["src/shared/settings/forms.ts", [{ name: "SettingsFormDefinition" }]],
+    ["src/shared/settings/forms.ts", [{ name: "SettingsFormFor" }]],
   ])(SETTINGS_FORM_FIELDS),
-  ...identitiesAt("src/shared/settings/forms.ts", [
-    { name: "SettingsFormFor" },
-  ])(SETTINGS_FORM_FIELDS),
-  ...identitiesAt("src/shared/settings/forms.ts", [
-    { name: "SingleFieldSettingsForm" },
+  ...identitiesAt([
+    ["src/shared/settings/forms.ts", [{ name: "SingleFieldSettingsForm" }]],
   ])(SINGLE_SETTINGS_FORM_FIELDS),
-  ...identitiesAt("src/shared/site-pages/types.ts", [{ name: "NavLevel" }])([
-    "label",
-    "nodes",
-  ]),
-  ...identitiesAt("src/shared/site-pages/types.ts", [{ name: "NavModel" }])([
-    "activeRootId",
-  ]),
-  ...identitiesAt("src/shared/site-pages/types.ts", [{ name: "NavNode" }])([
+  ...identitiesAt([["src/shared/site-pages/types.ts", [{ name: "NavLevel" }]]])(
+    ["label", "nodes"],
+  ),
+  ...identitiesAt([["src/shared/site-pages/types.ts", [{ name: "NavModel" }]]])(
+    ["activeRootId"],
+  ),
+  ...identitiesAt([["src/shared/site-pages/types.ts", [{ name: "NavNode" }]]])([
     "active",
     "children",
     "href",
@@ -128,40 +115,32 @@ export const SHARED_PROVIDER_Z_BASELINE: readonly FindingIdentity[] = [
     "label",
     "live",
   ]),
-  ...identitiesAt("src/shared/sms/gateway.ts", [
-    { name: "EncryptedMessagePayload" },
-    { name: "textMessage" },
-  ])(["text"]),
-  ...identitiesAt("src/shared/sms/gateway.ts", [
-    { name: "EncryptedMessagePayload" },
+  ...identitiesAt([
+    ["src/shared/sms/gateway.ts", [{ name: "EncryptedMessagePayload" }]],
   ])(["isEncrypted", "phoneNumbers", "textMessage", "withDeliveryReport"]),
-  ...identitiesAt("src/shared/square/client.ts", [{ name: "SquareClient" }])([
-    "payments",
-    "refunds",
-  ]),
-  ...identitiesAt("src/shared/square/payment-outcomes.ts", [
-    { name: "SquarePaymentClient" },
-    { name: "payments" },
-    { name: "get" },
-    { way: "()" },
-    { way: "input" },
+  ...identitiesAt([
+    ["src/shared/square/client.ts", [{ name: "SquareClient" }]],
+  ])(["payments", "refunds"]),
+  ...identitiesAt([
+    [
+      "src/shared/square/payment-outcomes.ts",
+      [
+        { name: "SquarePaymentClient" },
+        { name: "payments" },
+        { name: "get" },
+        { way: "()" },
+        { way: "input" },
+      ],
+    ],
   ])(["paymentId"]),
-  ...identitiesAt("src/shared/square/wire.ts", [
-    { name: "SquareOrder" },
-    { name: "tenders" },
-    { way: "[]" },
-  ])(["id"]),
-  ...identitiesAt("src/shared/square/wire.ts", [{ name: "SquareOrder" }])([
-    "state",
-  ]),
-  ...identitiesAt("src/shared/square/wire.ts", [{ name: "SquareRefund" }])([
-    "id",
-  ]),
-  ...identitiesAt("src/shared/stripe/client.ts", [
-    { name: "StripeCheckoutLineItemParams" },
+  ...identitiesAt([
+    ["src/shared/stripe/client.ts", [{ name: "StripeCheckoutLineItemParams" }]],
   ])(["price_data", "quantity"]),
-  ...identitiesAt("src/shared/stripe/client.ts", [
-    { name: "StripeCheckoutSessionCreateParams" },
+  ...identitiesAt([
+    [
+      "src/shared/stripe/client.ts",
+      [{ name: "StripeCheckoutSessionCreateParams" }],
+    ],
   ])([
     "cancel_url",
     "customer_email",
@@ -171,71 +150,69 @@ export const SHARED_PROVIDER_Z_BASELINE: readonly FindingIdentity[] = [
     "payment_method_types",
     "success_url",
   ]),
-  ...identitiesAt("src/shared/stripe/client.ts", [
-    { name: "StripeWebhookEndpointCreateParams" },
+  ...identitiesAt([
+    [
+      "src/shared/stripe/client.ts",
+      [{ name: "StripeWebhookEndpointCreateParams" }],
+    ],
   ])(["api_version", "enabled_events", "url"]),
-  ...identitiesAt("src/shared/superuser.ts", [{ name: "SuperuserState" }])([
-    "reason",
-  ]),
-  ...identitiesAt("src/shared/svg-ticket.ts", [{ name: "SvgTicketData" }])([
+  ...identitiesAt([["src/shared/svg-ticket.ts", [{ name: "SvgTicketData" }]]])([
     "currency",
   ]),
-  ...identitiesAt("src/shared/tables/column.ts", [
-    { name: "ReorderColumnOptions" },
-    { name: "titles" },
+  ...identitiesAt([
+    [
+      "src/shared/tables/column.ts",
+      [{ name: "ReorderColumnOptions" }, { name: "titles" }],
+    ],
   ])(["down", "up"]),
-  ...identitiesAt("src/shared/turso-api.ts", [
-    { name: "TursoDatabaseCredentials" },
-  ])(["dbId"]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "ApiKey" }])([
+  ...identitiesAt([["src/shared/types.ts", [{ name: "ApiKey" }]]])([
     "created",
     "key_index",
     "last_used",
     "name",
   ]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "EncryptedContentRecord" }])(
-    CONTENT_META_FIELDS,
-  ),
-  ...identitiesAt("src/shared/types.ts", [{ name: "ImageUse" }])([
+  ...identitiesAt([
+    ["src/shared/types.ts", [{ name: "EncryptedContentRecord" }]],
+    ["src/shared/types.ts", [{ name: "NewsPost" }]],
+    ["src/shared/types.ts", [{ name: "SitePage" }]],
+  ])(CONTENT_META_FIELDS),
+  ...identitiesAt([["src/shared/types.ts", [{ name: "ImageUse" }]]])([
     "image_id",
     "sort_order",
   ]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "Modifier" }])(["code"]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "NagItem" }])(["id"]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "NewsPost" }])(
-    CONTENT_META_FIELDS,
-  ),
-  ...identitiesAt("src/shared/types.ts", [{ name: "PiiBlob" }])(["v"]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "Session" }])(["csrf_token"]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "Settings" }])([
+  ...identitiesAt([["src/shared/types.ts", [{ name: "PiiBlob" }]]])(["v"]),
+  ...identitiesAt([["src/shared/types.ts", [{ name: "Session" }]]])([
+    "csrf_token",
+  ]),
+  ...identitiesAt([["src/shared/types.ts", [{ name: "Settings" }]]])([
     "key",
     "value",
   ]),
-  ...identitiesAt("src/shared/types.ts", [{ name: "SitePage" }])(
-    CONTENT_META_FIELDS,
-  ),
-  ...identitiesAt("src/shared/types.ts", [{ name: "UserLogisticsAgent" }])([
+  ...identitiesAt([["src/shared/types.ts", [{ name: "UserLogisticsAgent" }]]])([
     "agent_id",
     "id",
     "user_id",
   ]),
-  ...identitiesAt("src/shared/update.ts", [{ name: "ReleaseInfo" }])([
+  ...identitiesAt([["src/shared/update.ts", [{ name: "ReleaseInfo" }]]])([
     "publishedAt",
   ]),
-  ...identitiesAt("src/shared/uptime-kuma/socket.ts", [
-    { name: "UptimeKumaWebSocket" },
+  ...identitiesAt([
+    ["src/shared/uptime-kuma/socket.ts", [{ name: "UptimeKumaWebSocket" }]],
   ])(["onclose", "onerror", "onmessage"]),
-  ...identitiesAt("src/shared/wallets/wallet-settings-types.ts", [
-    { name: "WalletReadSettings" },
+  ...identitiesAt([
+    [
+      "src/shared/wallets/wallet-settings-types.ts",
+      [{ name: "WalletReadSettings" }],
+    ],
   ])(["dbConfig", "resetHostConfig", "setHostConfigForTest"]),
-  ...identitiesAt("src/shared/webhook.ts", [{ name: "WebhookListing" }])([
+  ...identitiesAt([["src/shared/webhook.ts", [{ name: "WebhookListing" }]]])([
     "attendee_count",
     "can_pay_more",
     "day_prices",
     "max_attendees",
     "unit_price",
   ]),
-  ...identitiesAt("src/shared/webhook.ts", [{ name: "WebhookPayload" }])([
+  ...identitiesAt([["src/shared/webhook.ts", [{ name: "WebhookPayload" }]]])([
     "amount_owed",
     "business_email",
     "currency",
@@ -246,7 +223,7 @@ export const SHARED_PROVIDER_Z_BASELINE: readonly FindingIdentity[] = [
     "tickets",
     "timestamp",
   ]),
-  ...identitiesAt("src/shared/webhook.ts", [{ name: "WebhookTicket" }])([
+  ...identitiesAt([["src/shared/webhook.ts", [{ name: "WebhookTicket" }]]])([
     "date",
     "listing_name",
     "listing_slug",
@@ -254,7 +231,7 @@ export const SHARED_PROVIDER_Z_BASELINE: readonly FindingIdentity[] = [
     "ticket_token",
     "unit_price",
   ]),
-  ...identitiesAt("src/shared/webhook/delivery.ts", [
-    { name: "WebhookDelivery" },
+  ...identitiesAt([
+    ["src/shared/webhook/delivery.ts", [{ name: "WebhookDelivery" }]],
   ])(["delivered", "reason"]),
 ];

--- a/scripts/unread-fields/baseline/shared-provider-z.ts
+++ b/scripts/unread-fields/baseline/shared-provider-z.ts
@@ -1,0 +1,260 @@
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+const RESOURCE_FIELDS = [
+  "fields",
+  "parseInput",
+  "table",
+  "verifyName",
+] as const;
+const SETTINGS_CONFIG_FIELDS = [
+  "action",
+  "formId",
+  "kind",
+  "name",
+  "page",
+  "routeLabel",
+] as const;
+const KEYED_SETTINGS_CONFIG_FIELDS = [
+  ...SETTINGS_CONFIG_FIELDS,
+  "key",
+] as const;
+const SINGLE_SETTINGS_FORM_FIELDS = [
+  "action",
+  "copy",
+  "inputType",
+  "key",
+  "markdownPreview",
+  "max",
+  "min",
+  "required",
+  "stateField",
+  "step",
+  "valueFallback",
+] as const;
+const SETTINGS_FORM_FIELDS = [
+  ...SINGLE_SETTINGS_FORM_FIELDS,
+  "fields",
+] as const;
+const CONTENT_META_FIELDS = [
+  "meta_description",
+  "meta_title",
+  "slug_index",
+] as const;
+
+export const SHARED_PROVIDER_Z_BASELINE: readonly FindingIdentity[] = [
+  ...identitiesAt("src/shared/provider-refunds.ts", [
+    { name: "ProviderRefundResult" },
+  ])(["state"]),
+  ...identitiesAt("src/shared/provider-types.ts", [
+    { name: "DatabaseCredentials" },
+  ])(["dbId"]),
+  ...identitiesAt("src/shared/qr-token.ts", [{ name: "QrBookPayload" }])(["e"]),
+  ...identitiesAt("src/shared/reservation-amount.ts", [
+    { name: "ReservationDepositAllocation" },
+  ])(["perItemTotals", "total"]),
+  ...identitiesAt("src/shared/rest/crud-parsers.ts", [{ name: "DeleteBody" }])([
+    "confirm_identifier",
+  ]),
+  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "DeleteResult" }])([
+    "notFound",
+  ]),
+  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "NamedResource" }])(
+    RESOURCE_FIELDS,
+  ),
+  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "Resource" }])(
+    RESOURCE_FIELDS,
+  ),
+  ...identitiesAt("src/shared/rest/resource.ts", [{ name: "UpdateResult" }])([
+    "notFound",
+  ]),
+  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
+    { name: "DerivedNodeIds" },
+  ])(["terminal"]),
+  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
+    { name: "MachineEvent" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
+    { name: "MachineMovesReader" },
+  ])(["splitTags"]),
+  ...identitiesAt("src/shared/schema-atlas/machine-spec.ts", [
+    { name: "MachineNode" },
+  ])(["awaits"]),
+  ...identitiesAt("src/shared/schema-atlas/types.ts", [
+    { name: "AtlasState" },
+    { name: "layout" },
+  ])(["x", "y"]),
+  ...identitiesAt("src/shared/settings/form-schema.ts", [
+    { name: "BooleanSettingsFormConfig" },
+  ])(KEYED_SETTINGS_CONFIG_FIELDS),
+  ...identitiesAt("src/shared/settings/form-schema.ts", [
+    { name: "FieldFormCopy" },
+  ])(["submitLabelKey"]),
+  ...identitiesAt("src/shared/settings/form-schema.ts", [
+    { name: "FieldsSettingsFormConfig" },
+  ])(SETTINGS_CONFIG_FIELDS),
+  ...identitiesAt("src/shared/settings/form-schema.ts", [
+    { name: "SettingsFormConfig" },
+  ])(KEYED_SETTINGS_CONFIG_FIELDS),
+  ...identitiesAt("src/shared/settings/form-schema.ts", [
+    { name: "TextareaSettingsFormConfig" },
+  ])(KEYED_SETTINGS_CONFIG_FIELDS),
+  ...identitiesAt("src/shared/settings/form-schema.ts", [
+    { name: "TextSettingsFormConfig" },
+  ])(KEYED_SETTINGS_CONFIG_FIELDS),
+  ...identitiesAt("src/shared/settings/forms.ts", [
+    { name: "SettingsFormDefinition" },
+  ])(SETTINGS_FORM_FIELDS),
+  ...identitiesAt("src/shared/settings/forms.ts", [
+    { name: "SettingsFormFor" },
+  ])(SETTINGS_FORM_FIELDS),
+  ...identitiesAt("src/shared/settings/forms.ts", [
+    { name: "SingleFieldSettingsForm" },
+  ])(SINGLE_SETTINGS_FORM_FIELDS),
+  ...identitiesAt("src/shared/site-pages/types.ts", [{ name: "NavLevel" }])([
+    "label",
+    "nodes",
+  ]),
+  ...identitiesAt("src/shared/site-pages/types.ts", [{ name: "NavModel" }])([
+    "activeRootId",
+  ]),
+  ...identitiesAt("src/shared/site-pages/types.ts", [{ name: "NavNode" }])([
+    "active",
+    "children",
+    "href",
+    "key",
+    "label",
+    "live",
+  ]),
+  ...identitiesAt("src/shared/sms/gateway.ts", [
+    { name: "EncryptedMessagePayload" },
+    { name: "textMessage" },
+  ])(["text"]),
+  ...identitiesAt("src/shared/sms/gateway.ts", [
+    { name: "EncryptedMessagePayload" },
+  ])(["isEncrypted", "phoneNumbers", "textMessage", "withDeliveryReport"]),
+  ...identitiesAt("src/shared/square/client.ts", [{ name: "SquareClient" }])([
+    "payments",
+    "refunds",
+  ]),
+  ...identitiesAt("src/shared/square/payment-outcomes.ts", [
+    { name: "SquarePaymentClient" },
+    { name: "payments" },
+    { name: "get" },
+    { way: "()" },
+    { way: "input" },
+  ])(["paymentId"]),
+  ...identitiesAt("src/shared/square/wire.ts", [
+    { name: "SquareOrder" },
+    { name: "tenders" },
+    { way: "[]" },
+  ])(["id"]),
+  ...identitiesAt("src/shared/square/wire.ts", [{ name: "SquareOrder" }])([
+    "state",
+  ]),
+  ...identitiesAt("src/shared/square/wire.ts", [{ name: "SquareRefund" }])([
+    "id",
+  ]),
+  ...identitiesAt("src/shared/stripe/client.ts", [
+    { name: "StripeCheckoutLineItemParams" },
+  ])(["price_data", "quantity"]),
+  ...identitiesAt("src/shared/stripe/client.ts", [
+    { name: "StripeCheckoutSessionCreateParams" },
+  ])([
+    "cancel_url",
+    "customer_email",
+    "line_items",
+    "metadata",
+    "mode",
+    "payment_method_types",
+    "success_url",
+  ]),
+  ...identitiesAt("src/shared/stripe/client.ts", [
+    { name: "StripeWebhookEndpointCreateParams" },
+  ])(["api_version", "enabled_events", "url"]),
+  ...identitiesAt("src/shared/superuser.ts", [{ name: "SuperuserState" }])([
+    "reason",
+  ]),
+  ...identitiesAt("src/shared/svg-ticket.ts", [{ name: "SvgTicketData" }])([
+    "currency",
+  ]),
+  ...identitiesAt("src/shared/tables/column.ts", [
+    { name: "ReorderColumnOptions" },
+    { name: "titles" },
+  ])(["down", "up"]),
+  ...identitiesAt("src/shared/turso-api.ts", [
+    { name: "TursoDatabaseCredentials" },
+  ])(["dbId"]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "ApiKey" }])([
+    "created",
+    "key_index",
+    "last_used",
+    "name",
+  ]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "EncryptedContentRecord" }])(
+    CONTENT_META_FIELDS,
+  ),
+  ...identitiesAt("src/shared/types.ts", [{ name: "ImageUse" }])([
+    "image_id",
+    "sort_order",
+  ]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "Modifier" }])(["code"]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "NagItem" }])(["id"]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "NewsPost" }])(
+    CONTENT_META_FIELDS,
+  ),
+  ...identitiesAt("src/shared/types.ts", [{ name: "PiiBlob" }])(["v"]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "Session" }])(["csrf_token"]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "Settings" }])([
+    "key",
+    "value",
+  ]),
+  ...identitiesAt("src/shared/types.ts", [{ name: "SitePage" }])(
+    CONTENT_META_FIELDS,
+  ),
+  ...identitiesAt("src/shared/types.ts", [{ name: "UserLogisticsAgent" }])([
+    "agent_id",
+    "id",
+    "user_id",
+  ]),
+  ...identitiesAt("src/shared/update.ts", [{ name: "ReleaseInfo" }])([
+    "publishedAt",
+  ]),
+  ...identitiesAt("src/shared/uptime-kuma/socket.ts", [
+    { name: "UptimeKumaWebSocket" },
+  ])(["onclose", "onerror", "onmessage"]),
+  ...identitiesAt("src/shared/wallets/wallet-settings-types.ts", [
+    { name: "WalletReadSettings" },
+  ])(["dbConfig", "resetHostConfig", "setHostConfigForTest"]),
+  ...identitiesAt("src/shared/webhook.ts", [{ name: "WebhookListing" }])([
+    "attendee_count",
+    "can_pay_more",
+    "day_prices",
+    "max_attendees",
+    "unit_price",
+  ]),
+  ...identitiesAt("src/shared/webhook.ts", [{ name: "WebhookPayload" }])([
+    "amount_owed",
+    "business_email",
+    "currency",
+    "notification_type",
+    "payment_id",
+    "price_paid",
+    "ticket_url",
+    "tickets",
+    "timestamp",
+  ]),
+  ...identitiesAt("src/shared/webhook.ts", [{ name: "WebhookTicket" }])([
+    "date",
+    "listing_name",
+    "listing_slug",
+    "quantity",
+    "ticket_token",
+    "unit_price",
+  ]),
+  ...identitiesAt("src/shared/webhook/delivery.ts", [
+    { name: "WebhookDelivery" },
+  ])(["delivered", "reason"]),
+];

--- a/scripts/unread-fields/baseline/ui.ts
+++ b/scripts/unread-fields/baseline/ui.ts
@@ -3,46 +3,55 @@ import {
   identitiesAt,
 } from "#scripts/unread-fields/identity.ts";
 
+const optionPath = (owner: string) => [
+  { name: owner },
+  { name: "options" },
+  { way: "[]" as const },
+];
+const LINK_OPTION_FIELDS = ["id", "name"] as const;
+
 export const UI_BASELINE: readonly FindingIdentity[] = [
-  ...identitiesAt("src/ui/client/admin/markdown-editor.ts", [
-    { name: "MarkdownEditorHandle" },
+  ...identitiesAt([
+    [
+      "src/ui/client/admin/markdown-editor.ts",
+      [{ name: "MarkdownEditorHandle" }],
+    ],
   ])(["setMode", "view"]),
-  ...identitiesAt("src/ui/templates/admin/backup.tsx", [
-    { name: "BackupPageState" },
-    { name: "createBlocked" },
+  ...identitiesAt([
+    [
+      "src/ui/templates/admin/backup.tsx",
+      [{ name: "BackupPageState" }, { name: "createBlocked" }],
+    ],
   ])(["available", "needed"]),
-  ...identitiesAt("src/ui/templates/admin/bulk-email.tsx", [
-    { name: "BulkEmailPreviewState" },
+  ...identitiesAt([
+    [
+      "src/ui/templates/admin/bulk-email.tsx",
+      [{ name: "BulkEmailPreviewState" }],
+    ],
   ])(["recipientCount"]),
-  ...identitiesAt("src/ui/templates/admin/calendar.tsx", [
-    { name: "CalendarAttendeeRow" },
+  ...identitiesAt([
+    ["src/ui/templates/admin/calendar.tsx", [{ name: "CalendarAttendeeRow" }]],
   ])(["listingDate", "listingLocation"]),
-  ...identitiesAt("src/ui/templates/admin/debug.tsx", [
-    { name: "DebugPageState" },
-    { name: "appleWallet" },
-  ])(["dbConfigured", "envConfigured", "source"]),
-  ...identitiesAt("src/ui/templates/admin/debug.tsx", [
-    { name: "DebugPageState" },
-    { name: "googleWallet" },
-  ])(["dbConfigured", "envConfigured", "source"]),
-  ...identitiesAt("src/ui/templates/admin/entity-pages.tsx", [
-    { name: "ResolvedAction" },
+  ...identitiesAt([
+    ["src/ui/templates/admin/entity-pages.tsx", [{ name: "ResolvedAction" }]],
   ])(["danger"]),
-  ...identitiesAt("src/ui/templates/admin/listings/types.ts", [
-    { name: "ListingPanelOptions" },
+  ...identitiesAt([
+    [
+      "src/ui/templates/admin/listings/types.ts",
+      [{ name: "ListingPanelOptions" }],
+    ],
   ])(["hasEmailableAttendees"]),
-  ...identitiesAt("src/ui/templates/admin/modifiers/links.tsx", [
-    { name: "AnswerLinks" },
-    { name: "options" },
-    { way: "[]" },
-  ])(["id", "name"]),
-  ...identitiesAt("src/ui/templates/admin/modifiers/links.tsx", [
-    { name: "ScopeLinks" },
-    { name: "options" },
-    { way: "[]" },
-  ])(["active", "id", "name"]),
-  ...identitiesAt("src/ui/templates/admin/settings-advanced.tsx", [
-    { name: "AdvancedSettingsPageState" },
+  ...identitiesAt([
+    ["src/ui/templates/admin/modifiers/links.tsx", optionPath("AnswerLinks")],
+  ])(LINK_OPTION_FIELDS),
+  ...identitiesAt([
+    ["src/ui/templates/admin/modifiers/links.tsx", optionPath("ScopeLinks")],
+  ])(["active", ...LINK_OPTION_FIELDS]),
+  ...identitiesAt([
+    [
+      "src/ui/templates/admin/settings-advanced.tsx",
+      [{ name: "AdvancedSettingsPageState" }],
+    ],
   ])([
     "addressLookupApiKeyConfigured",
     "addressLookupProvider",
@@ -53,7 +62,7 @@ export const UI_BASELINE: readonly FindingIdentity[] = [
     "listingColumnOrder",
     "showPublicApi",
   ]),
-  ...identitiesAt("src/ui/templates/admin/users.tsx", [
-    { name: "UsersPageOpts" },
+  ...identitiesAt([
+    ["src/ui/templates/admin/users.tsx", [{ name: "UsersPageOpts" }]],
   ])(["currentUserId", "error", "success"]),
 ];

--- a/scripts/unread-fields/baseline/ui.ts
+++ b/scripts/unread-fields/baseline/ui.ts
@@ -1,0 +1,59 @@
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+export const UI_BASELINE: readonly FindingIdentity[] = [
+  ...identitiesAt("src/ui/client/admin/markdown-editor.ts", [
+    { name: "MarkdownEditorHandle" },
+  ])(["setMode", "view"]),
+  ...identitiesAt("src/ui/templates/admin/backup.tsx", [
+    { name: "BackupPageState" },
+    { name: "createBlocked" },
+  ])(["available", "needed"]),
+  ...identitiesAt("src/ui/templates/admin/bulk-email.tsx", [
+    { name: "BulkEmailPreviewState" },
+  ])(["recipientCount"]),
+  ...identitiesAt("src/ui/templates/admin/calendar.tsx", [
+    { name: "CalendarAttendeeRow" },
+  ])(["listingDate", "listingLocation"]),
+  ...identitiesAt("src/ui/templates/admin/debug.tsx", [
+    { name: "DebugPageState" },
+    { name: "appleWallet" },
+  ])(["dbConfigured", "envConfigured", "source"]),
+  ...identitiesAt("src/ui/templates/admin/debug.tsx", [
+    { name: "DebugPageState" },
+    { name: "googleWallet" },
+  ])(["dbConfigured", "envConfigured", "source"]),
+  ...identitiesAt("src/ui/templates/admin/entity-pages.tsx", [
+    { name: "ResolvedAction" },
+  ])(["danger"]),
+  ...identitiesAt("src/ui/templates/admin/listings/types.ts", [
+    { name: "ListingPanelOptions" },
+  ])(["hasEmailableAttendees"]),
+  ...identitiesAt("src/ui/templates/admin/modifiers/links.tsx", [
+    { name: "AnswerLinks" },
+    { name: "options" },
+    { way: "[]" },
+  ])(["id", "name"]),
+  ...identitiesAt("src/ui/templates/admin/modifiers/links.tsx", [
+    { name: "ScopeLinks" },
+    { name: "options" },
+    { way: "[]" },
+  ])(["active", "id", "name"]),
+  ...identitiesAt("src/ui/templates/admin/settings-advanced.tsx", [
+    { name: "AdvancedSettingsPageState" },
+  ])([
+    "addressLookupApiKeyConfigured",
+    "addressLookupProvider",
+    "attendeeColumnOrder",
+    "customCss",
+    "existingPaymentProvider",
+    "externalOrderEnabled",
+    "listingColumnOrder",
+    "showPublicApi",
+  ]),
+  ...identitiesAt("src/ui/templates/admin/users.tsx", [
+    { name: "UsersPageOpts" },
+  ])(["currentUserId", "error", "success"]),
+];

--- a/scripts/unread-fields/exemptions.ts
+++ b/scripts/unread-fields/exemptions.ts
@@ -1,0 +1,148 @@
+import type { SiteDataBlob } from "#db/built-sites/blob.ts";
+import type { PublicListing } from "#routes/api/public-listing.ts";
+import { compareFindingIdentities } from "#scripts/unread-fields/identity.ts";
+import {
+  exemptFieldsAt,
+  type FindingExemption,
+} from "#scripts/unread-fields/policy.ts";
+import type { SumupCheckoutRequest } from "#shared/sumup/transport.ts";
+import type { WarningDeleteProps } from "#templates/admin/confirm-page.tsx";
+import type { SettingsPageState } from "#templates/admin/settings.tsx";
+
+const publicListings = exemptFieldsAt<PublicListing>(
+  "src/features/api/public-listing.ts",
+  [{ name: "PublicListing" }],
+  {
+    evidence: "apiResponse serialises the complete public listing",
+    kind: "external-output",
+  },
+)({
+  availableDates: "exempt",
+  canPayMore: "exempt",
+  children: "exempt",
+  customisableDays: "exempt",
+  date: "check",
+  dayPrices: "exempt",
+  description: "check",
+  fields: "exempt",
+  imageAltText: "exempt",
+  imageUrl: "exempt",
+  isClosed: "exempt",
+  isSoldOut: "exempt",
+  listingType: "exempt",
+  location: "exempt",
+  maxPrice: "exempt",
+  maxPurchasable: "exempt",
+  name: "check",
+  nonTransferable: "exempt",
+  purchaseOnly: "exempt",
+  slug: "check",
+  unitPrice: "exempt",
+});
+
+const sumupCheckoutRequests = exemptFieldsAt<SumupCheckoutRequest>(
+  "src/shared/sumup/transport.ts",
+  [{ name: "SumupCheckoutRequest" }],
+  {
+    evidence: "sumupInit serialises the complete checkout request",
+    kind: "provider-input",
+  },
+)({
+  amount: "exempt",
+  checkout_reference: "exempt",
+  currency: "exempt",
+  description: "exempt",
+  hosted_checkout: "exempt",
+  merchant_code: "exempt",
+  redirect_url: "exempt",
+  return_url: "exempt",
+});
+
+const sumupHostedCheckout: FindingExemption = {
+  identity: {
+    exportedFrom: "src/shared/sumup/transport.ts",
+    field: "enabled",
+    path: [{ name: "SumupCheckoutRequest" }, { name: "hosted_checkout" }],
+  },
+  reason: {
+    evidence: "sumupInit serialises the nested hosted checkout request",
+    kind: "provider-input",
+  },
+};
+
+const siteDataBlobs = exemptFieldsAt<SiteDataBlob>(
+  "src/shared/db/built-sites/blob.ts",
+  [{ name: "SiteDataBlob" }],
+  {
+    evidence: "SiteDataBlobSchema reads the stored versioned object",
+    kind: "persisted-format",
+  },
+)({
+  d: "exempt",
+  dp: "exempt",
+  hp: "exempt",
+  n: "exempt",
+  rt: "exempt",
+  s: "exempt",
+  sk: "exempt",
+  t: "exempt",
+  u: "exempt",
+  v: "exempt",
+});
+
+const settingsPageStates = exemptFieldsAt<SettingsPageState>(
+  "src/ui/templates/admin/settings.tsx",
+  [{ name: "SettingsPageState" }],
+  {
+    evidence: "settingsForm reads state fields through each form definition",
+    kind: "schema-driven",
+  },
+)({
+  bookingFee: "exempt",
+  businessEmail: "exempt",
+  calendarFeedsEnabled: "exempt",
+  calendarFeedsGroupBy: "exempt",
+  currency: "check",
+  embedHosts: "exempt",
+  enabledFeatures: "check",
+  headerImageUrl: "check",
+  paymentProvider: "check",
+  paymentProviderRecoveryChoices: "check",
+  shownPaymentProvider: "check",
+  squareWebhookConfigured: "check",
+  storageEnabled: "check",
+  superuser: "check",
+  termsAndConditions: "exempt",
+  theme: "check",
+  underlineLinks: "exempt",
+  webhookUrl: "check",
+});
+
+const warningDeleteProps = exemptFieldsAt<WarningDeleteProps>(
+  "src/ui/templates/admin/confirm-page.tsx",
+  [{ name: "WarningDeleteProps" }],
+  {
+    evidence: "warningDeletePage spreads the remaining props into ConfirmPage",
+    kind: "dynamic-read",
+  },
+)({
+  action: "exempt",
+  buttonText: "exempt",
+  heading: "check",
+  label: "exempt",
+  name: "exempt",
+  prompt: "exempt",
+  title: "check",
+  warning: "exempt",
+});
+
+export const UNREAD_FIELD_EXEMPTIONS: readonly FindingExemption[] = [
+  ...publicListings,
+  ...settingsPageStates,
+  ...siteDataBlobs,
+  ...sumupCheckoutRequests,
+  sumupHostedCheckout,
+  ...warningDeleteProps,
+].toSorted((left, right) =>
+  compareFindingIdentities(left.identity, right.identity),
+);

--- a/scripts/unread-fields/fields.ts
+++ b/scripts/unread-fields/fields.ts
@@ -23,11 +23,10 @@ import {
 import {
   namedRecordMembers,
   type Step,
-  stepText,
   underAnUnnamedPart,
 } from "./fields/steps.ts";
 import { membersOf } from "./fields/walking.ts";
-import { reaching } from "./findings.ts";
+import { ownerPath } from "./identity.ts";
 import { carriesAModifier, quotedInBrackets } from "./writes.ts";
 
 /** A member nobody outside the class can reach is not a field it hands out.
@@ -175,17 +174,13 @@ const borrowedFields = (
  * `Record` key has no source declaration, so its checker symbol stands in. */
 export interface OwnedField {
   names: [FieldName, ...FieldName[]];
-  owner: string;
+  owner: readonly Step[];
   symbols: ts.Symbol[];
 }
 
-/** The path a reader follows, written the way the code that follows it is. */
-const ownerOf = (path: readonly Step[]): string =>
-  path.map(stepText).reduce(reaching);
-
 /** The path to the class object that holds a static member. */
 const onTheClass = (path: readonly Step[]): readonly Step[] => {
-  const owner = ownerOf(path);
+  const owner = ownerPath(path);
   return [{ way: owner.startsWith("typeof ") ? owner : `typeof ${owner}` }];
 };
 
@@ -230,7 +225,7 @@ export const exportedFields = (
     if (!line) {
       found.set(key, {
         names: [name],
-        owner: ownerOf(path),
+        owner: [...path],
         symbols: fieldSymbol ? [fieldSymbol] : [],
       });
     }

--- a/scripts/unread-fields/findings.ts
+++ b/scripts/unread-fields/findings.ts
@@ -2,30 +2,24 @@
  * What the scan concluded about one field, and how it reads on the console.
  */
 
+import {
+  compareFindingIdentities,
+  compareText,
+  type FindingIdentity,
+  findingPath,
+} from "#scripts/unread-fields/identity.ts";
+
 /** Where a field's readers live, if it has any. */
 export type Verdict = "read" | "never read" | "read only by tests";
 
 /** One exported field the scan looked at. */
-export interface Finding {
-  /** The field itself. */
-  field: string;
+export interface Finding extends FindingIdentity {
   /** The file that declares it, relative to the repository. */
   file: string;
-  /** The exported shape the field belongs to, and the path down to it. */
+  /** The readable path to the shape that owns the field. */
   owner: string;
   verdict: Verdict;
 }
-
-const IS_A_PLAIN_WORD = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-
-/** How a reader reaches one more name from where they already are. A plain
- * word goes after a dot. Any other name needs brackets and quotes, exactly as
- * the code that reads it does, so a name that holds a dot cannot read like a
- * path of its own. */
-export const reaching = (path: string, name: string): string =>
-  IS_A_PLAIN_WORD.test(name)
-    ? `${path}.${name}`
-    : `${path}[${JSON.stringify(name)}]`;
 
 /** Folders that hold tests. `scripts/email-sandbox-e2e/` and `e2e-payments/`
  * are live end-to-end harnesses, so a field only one of them reads is kept
@@ -49,10 +43,10 @@ export const verdictFor = (readers: string[]): Verdict => {
 export const worthReporting = (findings: Finding[]): Finding[] =>
   findings
     .filter((finding) => finding.verdict !== "read")
-    .sort((a, b) =>
-      a.file === b.file
-        ? reaching(a.owner, a.field).localeCompare(reaching(b.owner, b.field))
-        : a.file.localeCompare(b.file),
+    .sort((left, right) =>
+      left.file === right.file
+        ? compareFindingIdentities(left, right)
+        : compareText(left.file, right.file),
     );
 
 const countOf = (findings: Finding[], verdict: Verdict): number =>
@@ -73,7 +67,7 @@ export const reportLines = (findings: Finding[]): string[] => {
   ];
   for (const finding of worth) {
     lines.push(
-      `  ${finding.verdict.padEnd(19)} ${reaching(finding.owner, finding.field)}` +
+      `  ${finding.verdict.padEnd(19)} ${findingPath(finding)}` +
         `  ${finding.file}`,
     );
   }

--- a/scripts/unread-fields/identity.ts
+++ b/scripts/unread-fields/identity.ts
@@ -1,0 +1,74 @@
+import { type Step, stepText } from "#scripts/unread-fields/fields/steps.ts";
+
+/** The stable facts that name one field under one exported shape. */
+export interface FindingIdentity {
+  exportedFrom: string;
+  field: string;
+  path: readonly Step[];
+}
+
+const stepKey = (step: Step): readonly ["name" | "way", string] =>
+  "name" in step ? ["name", step.name] : ["way", step.way];
+
+/** The machine key for one field. Tagged steps keep a name such as `[]`
+ * separate from the unnamed route through an array element. */
+export const findingIdentityKey = (identity: FindingIdentity): string =>
+  JSON.stringify([
+    identity.exportedFrom,
+    identity.path.map(stepKey),
+    identity.field,
+  ]);
+
+/** A stable code-unit order for machine identities and paths. */
+export const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+/** A stable order for policy and diagnostic output. */
+export const compareFindingIdentities = (
+  left: FindingIdentity,
+  right: FindingIdentity,
+): number => {
+  const leftKey = findingIdentityKey(left);
+  const rightKey = findingIdentityKey(right);
+  return compareText(leftKey, rightKey);
+};
+
+const plainWord = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/** How a reader reaches one more name from an existing path. */
+export const reaching = (path: string, name: string): string =>
+  plainWord.test(name) ? `${path}.${name}` : `${path}[${JSON.stringify(name)}]`;
+
+/** The readable path to the owner of a field. */
+export const ownerPath = (owner: readonly Step[]): string => {
+  const [first, ...rest] = owner;
+  if (first === undefined) throw new Error("An unread field has no owner");
+  return rest.reduce(
+    (path, step) => reaching(path, stepText(step)),
+    stepText(first),
+  );
+};
+
+/** The field path as code reaches it. */
+export const findingPath = (identity: FindingIdentity): string =>
+  reaching(ownerPath(identity.path), identity.field);
+
+/** The exact identity in a diagnostic. Step tags make collisions visible. */
+export const findingIdentityText = (identity: FindingIdentity): string =>
+  `${identity.exportedFrom} :: ${[
+    ...identity.path.map((step) =>
+      "name" in step
+        ? `name(${JSON.stringify(step.name)})`
+        : `way(${JSON.stringify(step.way)})`,
+    ),
+    `name(${JSON.stringify(identity.field)})`,
+  ].join(" / ")}`;
+
+/** Build exact identities for fields under one exported owner. */
+export const identitiesAt =
+  (
+    exportedFrom: string,
+    owner: readonly Step[],
+  ): ((fields: readonly string[]) => FindingIdentity[]) =>
+  (fields) =>
+    fields.map((field) => ({ exportedFrom, field, path: [...owner] }));

--- a/scripts/unread-fields/identity.ts
+++ b/scripts/unread-fields/identity.ts
@@ -64,11 +64,14 @@ export const findingIdentityText = (identity: FindingIdentity): string =>
     `name(${JSON.stringify(identity.field)})`,
   ].join(" / ")}`;
 
-/** Build exact identities for fields under one exported owner. */
+type FindingOwner = readonly [exportedFrom: string, path: readonly Step[]];
+
+/** Build exact identities for fields under one or more exported owners. */
 export const identitiesAt =
   (
-    exportedFrom: string,
-    owner: readonly Step[],
+    owners: readonly FindingOwner[],
   ): ((fields: readonly string[]) => FindingIdentity[]) =>
   (fields) =>
-    fields.map((field) => ({ exportedFrom, field, path: [...owner] }));
+    owners.flatMap(([exportedFrom, path]) =>
+      fields.map((field) => ({ exportedFrom, field, path: [...path] })),
+    );

--- a/scripts/unread-fields/policy.ts
+++ b/scripts/unread-fields/policy.ts
@@ -1,0 +1,53 @@
+import type { Step } from "#scripts/unread-fields/fields/steps.ts";
+import {
+  type FindingIdentity,
+  identitiesAt,
+} from "#scripts/unread-fields/identity.ts";
+
+export type ExemptionKind =
+  | "dynamic-read"
+  | "external-output"
+  | "persisted-format"
+  | "provider-input"
+  | "schema-driven";
+
+/** Why a field has a real reader that the TypeScript reference scan cannot
+ * see. Evidence names the production boundary or consumer. */
+export interface ExemptionReason {
+  evidence: string;
+  kind: ExemptionKind;
+}
+
+export interface FindingExemption {
+  identity: FindingIdentity;
+  reason: ExemptionReason;
+}
+
+export type FieldSnapshotChoice = "check" | "exempt";
+
+/** A finite string-key shape whose every field needs an explicit choice. */
+export type ClosedFieldSnapshot<Shape> = string extends keyof Shape
+  ? never
+  : Exclude<keyof Shape, string> extends never
+    ? {
+        readonly [Field in keyof Shape]-?: FieldSnapshotChoice;
+      }
+    : never;
+
+/** Classify every field of one finite exported type. New fields stop the type
+ * check until their policy is explicit. */
+export const exemptFieldsAt =
+  <Shape>(
+    exportedFrom: string,
+    path: readonly Step[],
+    reason: ExemptionReason,
+  ): ((snapshot: ClosedFieldSnapshot<Shape>) => FindingExemption[]) =>
+  (snapshot) =>
+    identitiesAt(
+      exportedFrom,
+      path,
+    )(
+      Object.entries(snapshot)
+        .filter(([, choice]) => choice === "exempt")
+        .map(([field]) => field),
+    ).map((identity) => ({ identity, reason }));

--- a/scripts/unread-fields/policy.ts
+++ b/scripts/unread-fields/policy.ts
@@ -43,10 +43,7 @@ export const exemptFieldsAt =
     reason: ExemptionReason,
   ): ((snapshot: ClosedFieldSnapshot<Shape>) => FindingExemption[]) =>
   (snapshot) =>
-    identitiesAt(
-      exportedFrom,
-      path,
-    )(
+    identitiesAt([[exportedFrom, path]])(
       Object.entries(snapshot)
         .filter(([, choice]) => choice === "exempt")
         .map(([field]) => field),

--- a/scripts/unread-fields/reconcile.ts
+++ b/scripts/unread-fields/reconcile.ts
@@ -1,0 +1,153 @@
+import { uniqueBy } from "#fp";
+import type { Finding } from "#scripts/unread-fields/findings.ts";
+import {
+  compareFindingIdentities,
+  type FindingIdentity,
+  findingIdentityKey,
+  findingIdentityText,
+} from "#scripts/unread-fields/identity.ts";
+import type {
+  ExemptionReason,
+  FindingExemption,
+} from "#scripts/unread-fields/policy.ts";
+
+type ProblemKind =
+  | "duplicate finding"
+  | "duplicate baseline"
+  | "duplicate exemption"
+  | "policy overlap"
+  | "stale baseline"
+  | "stale exemption"
+  | "new unread field";
+
+type PlainProblemKind = Exclude<
+  ProblemKind,
+  "stale exemption" | "new unread field"
+>;
+
+interface PlainProblem {
+  identity: FindingIdentity;
+  kind: PlainProblemKind;
+}
+
+interface StaleExemptionProblem {
+  identity: FindingIdentity;
+  kind: "stale exemption";
+  reason: ExemptionReason;
+}
+
+interface NewUnreadFieldProblem {
+  file: string;
+  identity: FindingIdentity;
+  kind: "new unread field";
+  verdict: Finding["verdict"];
+}
+
+export type UnreadFieldProblem =
+  | PlainProblem
+  | StaleExemptionProblem
+  | NewUnreadFieldProblem;
+
+const KIND_ORDER: Record<ProblemKind, number> = {
+  "duplicate baseline": 1,
+  "duplicate exemption": 2,
+  "duplicate finding": 0,
+  "new unread field": 6,
+  "policy overlap": 3,
+  "stale baseline": 4,
+  "stale exemption": 5,
+};
+
+const duplicateIdentities = <Item>(
+  items: readonly Item[],
+  identityOf: (item: Item) => FindingIdentity,
+): FindingIdentity[] =>
+  [
+    ...Map.groupBy(items, (item) =>
+      findingIdentityKey(identityOf(item)),
+    ).values(),
+  ]
+    .filter((same) => same.length > 1)
+    .map(([first]) => identityOf(first!));
+
+const uniqueIdentities = (
+  identities: readonly FindingIdentity[],
+): FindingIdentity[] => uniqueBy(findingIdentityKey)([...identities]);
+
+const problem = (
+  kind: PlainProblemKind,
+  identity: FindingIdentity,
+): PlainProblem => ({ identity, kind });
+
+/** Compare the current report with accepted debt and reviewed false positives. */
+export const reconcileUnreadFields =
+  (
+    baseline: readonly FindingIdentity[],
+    exemptions: readonly FindingExemption[],
+  ): ((findings: readonly Finding[]) => UnreadFieldProblem[]) =>
+  (findings) => {
+    const unread = findings.filter(({ verdict }) => verdict !== "read");
+    const currentKeys = new Set(unread.map(findingIdentityKey));
+    const baselineKeys = new Set(baseline.map(findingIdentityKey));
+    const exemptionKeys = new Set(
+      exemptions.map(({ identity }) => findingIdentityKey(identity)),
+    );
+    const problems: UnreadFieldProblem[] = [
+      ...duplicateIdentities(baseline, (identity) => identity).map((identity) =>
+        problem("duplicate baseline", identity),
+      ),
+      ...duplicateIdentities(findings, (finding) => finding).map((identity) =>
+        problem("duplicate finding", identity),
+      ),
+      ...duplicateIdentities(exemptions, ({ identity }) => identity).map(
+        (identity) => problem("duplicate exemption", identity),
+      ),
+      ...uniqueIdentities(baseline)
+        .filter((identity) => exemptionKeys.has(findingIdentityKey(identity)))
+        .map((identity) => problem("policy overlap", identity)),
+      ...uniqueIdentities(baseline)
+        .filter((identity) => !currentKeys.has(findingIdentityKey(identity)))
+        .map((identity) => problem("stale baseline", identity)),
+      ...uniqueBy(({ identity }: FindingExemption) =>
+        findingIdentityKey(identity),
+      )([...exemptions])
+        .filter(
+          ({ identity }) => !currentKeys.has(findingIdentityKey(identity)),
+        )
+        .map(({ identity, reason }) => ({
+          identity,
+          kind: "stale exemption" as const,
+          reason,
+        })),
+      ...unread
+        .filter((finding) => {
+          const key = findingIdentityKey(finding);
+          return !baselineKeys.has(key) && !exemptionKeys.has(key);
+        })
+        .map((finding) => ({
+          file: finding.file,
+          identity: finding,
+          kind: "new unread field" as const,
+          verdict: finding.verdict,
+        })),
+    ];
+    return problems.toSorted(
+      (left, right) =>
+        KIND_ORDER[left.kind] - KIND_ORDER[right.kind] ||
+        compareFindingIdentities(left.identity, right.identity),
+    );
+  };
+
+/** One policy problem with enough identity and evidence to repair it. */
+export const formatUnreadFieldProblem = (
+  problem: UnreadFieldProblem,
+): string => {
+  const identity = findingIdentityText(problem.identity);
+  if (problem.kind === "new unread field") {
+    return `${problem.kind} [${problem.verdict}]: ${identity} -- declared in ${problem.file}`;
+  }
+  if (problem.kind === "stale exemption") {
+    return `${problem.kind}: ${identity} -- ${problem.reason.kind}: ${problem.reason.evidence}`;
+  }
+  return `${problem.kind}: ${identity}`;
+};

--- a/scripts/unread-fields/run-check.ts
+++ b/scripts/unread-fields/run-check.ts
@@ -1,0 +1,35 @@
+import { type CheckOutput, reportCheck } from "#scripts/check-report.ts";
+import type { Finding } from "#scripts/unread-fields/findings.ts";
+import type { FindingIdentity } from "#scripts/unread-fields/identity.ts";
+import type { FindingExemption } from "#scripts/unread-fields/policy.ts";
+import {
+  formatUnreadFieldProblem,
+  reconcileUnreadFields,
+} from "#scripts/unread-fields/reconcile.ts";
+
+export interface UnreadFieldsCheckDeps {
+  baseline: readonly FindingIdentity[];
+  exemptions: readonly FindingExemption[];
+  scan: (root: string) => Promise<Finding[]>;
+}
+
+/** Run the scan and compare every reportable field with its exact policy. */
+export const runUnreadFieldsCheck = async (
+  root: string,
+  output: CheckOutput,
+  deps: UnreadFieldsCheckDeps,
+): Promise<number> => {
+  const findings = await deps.scan(root);
+  const found = reconcileUnreadFields(
+    deps.baseline,
+    deps.exemptions,
+  )(findings).map(formatUnreadFieldProblem);
+  return reportCheck({
+    ...output,
+    found,
+    guide: "scripts/unread-fields/README.md",
+    noun: "unread-field",
+    success:
+      "Every reported unread field matches one exact policy entry, and every policy entry is current.",
+  });
+};

--- a/scripts/unread-fields/scan.ts
+++ b/scripts/unread-fields/scan.ts
@@ -238,7 +238,7 @@ export const scanUnreadFields = async (root: string): Promise<Finding[]> => {
       exportedFields(checker, source).map((field) => ({
         exportedFrom: source.fileName,
         field,
-      }))
+      })),
     );
   const symbols = new Set(fields.flatMap(({ field }) => field.symbols));
   const symbolReaders = readersOfSymbols(
@@ -249,12 +249,10 @@ export const scanUnreadFields = async (root: string): Promise<Finding[]> => {
     root,
   );
   const findings: Finding[] = [];
-  for (
-    const {
-      exportedFrom,
-      field: { owner, names, symbols: fieldSymbols },
-    } of fields
-  ) {
+  for (const {
+    exportedFrom,
+    field: { owner, names, symbols: fieldSymbols },
+  } of fields) {
     findings.push({
       exportedFrom: exportedFrom.replace(`${root}/`, ""),
       field: fieldNameText(names[0]),

--- a/scripts/unread-fields/scan.ts
+++ b/scripts/unread-fields/scan.ts
@@ -19,6 +19,7 @@ import {
 import { exportedFields } from "./fields.ts";
 import { type Finding, verdictFor } from "./findings.ts";
 import { answered, compilerOptions, pathIs, serviceHost } from "./host.ts";
+import { ownerPath } from "./identity.ts";
 import {
   type AskAboutAMention,
   isInside,
@@ -233,8 +234,13 @@ export const scanUnreadFields = async (root: string): Promise<Finding[]> => {
   const fields = program
     .getSourceFiles()
     .filter((source) => scanned.has(source.fileName))
-    .flatMap((source) => exportedFields(checker, source));
-  const symbols = new Set(fields.flatMap((field) => field.symbols));
+    .flatMap((source) =>
+      exportedFields(checker, source).map((field) => ({
+        exportedFrom: source.fileName,
+        field,
+      }))
+    );
+  const symbols = new Set(fields.flatMap(({ field }) => field.symbols));
   const symbolReaders = readersOfSymbols(
     program,
     checker,
@@ -243,13 +249,20 @@ export const scanUnreadFields = async (root: string): Promise<Finding[]> => {
     root,
   );
   const findings: Finding[] = [];
-  for (const { owner, names, symbols: fieldSymbols } of fields) {
+  for (
+    const {
+      exportedFrom,
+      field: { owner, names, symbols: fieldSymbols },
+    } of fields
+  ) {
     findings.push({
+      exportedFrom: exportedFrom.replace(`${root}/`, ""),
       field: fieldNameText(names[0]),
       // Where a reader has to go to find it, which is where it was written
       // down rather than the shape that hands it on.
       file: names[0].getSourceFile().fileName.replace(`${root}/`, ""),
-      owner,
+      owner: ownerPath(owner),
+      path: owner,
       verdict: verdictFor(
         readersOf(service, program, root, names, fieldSymbols, symbolReaders),
       ),

--- a/test/scripts/unread-fields/baseline.test.ts
+++ b/test/scripts/unread-fields/baseline.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { UNREAD_FIELD_BASELINE } from "#scripts/unread-fields/baseline.ts";
+import { UNREAD_FIELD_EXEMPTIONS } from "#scripts/unread-fields/exemptions.ts";
+import { findingIdentityKey } from "#scripts/unread-fields/identity.ts";
+import { expectStableUniqueIdentities } from "#test-utils/unread-field-policy.ts";
+
+describe("unread-field baseline", () => {
+  test("holds exact current debt in stable order", () => {
+    expectStableUniqueIdentities(UNREAD_FIELD_BASELINE);
+  });
+
+  test("does not claim that a reviewed exemption is debt", () => {
+    const baseline = new Set(UNREAD_FIELD_BASELINE.map(findingIdentityKey));
+    const overlaps = UNREAD_FIELD_EXEMPTIONS.filter(({ identity }) =>
+      baseline.has(findingIdentityKey(identity)),
+    );
+
+    expect(overlaps).toEqual([]);
+  });
+
+  test("names only exported production files", () => {
+    expect(
+      UNREAD_FIELD_BASELINE.every(({ exportedFrom }) =>
+        exportedFrom.startsWith("src/"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/test/scripts/unread-fields/exemptions.test.ts
+++ b/test/scripts/unread-fields/exemptions.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { UNREAD_FIELD_EXEMPTIONS } from "#scripts/unread-fields/exemptions.ts";
+import { expectStableUniqueIdentities } from "#test-utils/unread-field-policy.ts";
+
+describe("unread-field exemptions", () => {
+  test("holds reviewed exact identities in stable order", () => {
+    expectStableUniqueIdentities(
+      UNREAD_FIELD_EXEMPTIONS.map(({ identity }) => identity),
+    );
+  });
+
+  test("names production evidence for every exemption", () => {
+    expect(
+      UNREAD_FIELD_EXEMPTIONS.every(
+        ({ reason }) => reason.evidence.trim().length > 0,
+      ),
+    ).toBe(true);
+  });
+});

--- a/test/scripts/unread-fields/findings.test.ts
+++ b/test/scripts/unread-fields/findings.test.ts
@@ -7,13 +7,18 @@ import {
   worthReporting,
 } from "#scripts/unread-fields/findings.ts";
 
-const finding = (over: Partial<Finding> = {}): Finding => ({
-  field: "total",
-  file: "src/a.ts",
-  owner: "Sum",
-  verdict: "never read",
-  ...over,
-});
+const finding = (over: Partial<Finding> = {}): Finding => {
+  const owner = over.owner ?? "Sum";
+  return {
+    exportedFrom: "src/a.ts",
+    field: "total",
+    file: "src/a.ts",
+    owner,
+    path: [{ name: owner }],
+    verdict: "never read",
+    ...over,
+  };
+};
 
 describe("verdictFor", () => {
   test("calls a field with no readers never read", () => {
@@ -50,6 +55,15 @@ describe("worthReporting", () => {
     ]).map((f) => `${f.file}:${f.field}`);
 
     expect(order).toEqual(["src/a.ts:a", "src/a.ts:b", "src/z.ts:b"]);
+  });
+
+  test("keeps files that are already in order", () => {
+    const order = worthReporting([
+      finding({ file: "src/a.ts" }),
+      finding({ file: "src/z.ts" }),
+    ]).map(({ file }) => file);
+
+    expect(order).toEqual(["src/a.ts", "src/z.ts"]);
   });
 });
 

--- a/test/scripts/unread-fields/identity.test.ts
+++ b/test/scripts/unread-fields/identity.test.ts
@@ -1,0 +1,89 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  compareFindingIdentities,
+  type FindingIdentity,
+  findingIdentityKey,
+  findingIdentityText,
+  findingPath,
+  identitiesAt,
+  ownerPath,
+} from "#scripts/unread-fields/identity.ts";
+
+const identity = (
+  path: FindingIdentity["path"],
+  field = "total",
+  exportedFrom = "src/sum.ts",
+): FindingIdentity => ({ exportedFrom, field, path });
+
+describe("unread-field identities", () => {
+  test("keeps a named field separate from an unnamed route with the same text", () => {
+    const named = identity([{ name: "Rows" }, { name: "[]" }]);
+    const reached = identity([{ name: "Rows" }, { way: "[]" }]);
+
+    expect(findingIdentityKey(named)).not.toBe(findingIdentityKey(reached));
+    expect(findingIdentityText(named)).not.toBe(findingIdentityText(reached));
+  });
+
+  test("keeps one dotted name separate from two names", () => {
+    const oneName = identity([{ name: "a.b" }]);
+    const twoNames = identity([{ name: "a" }, { name: "b" }]);
+
+    expect(findingIdentityKey(oneName)).not.toBe(findingIdentityKey(twoNames));
+  });
+
+  test("keeps matching owners from different exports separate", () => {
+    const first = identity([{ name: "Sum" }]);
+    const second = identity([{ name: "Sum" }], "total", "src/other.ts");
+
+    expect(findingIdentityKey(first)).not.toBe(findingIdentityKey(second));
+  });
+
+  test("renders the path the way a reader reaches it", () => {
+    expect(
+      findingPath(
+        identity([{ name: "Rows" }, { way: "[]" }, { name: "has.a.dot" }]),
+      ),
+    ).toBe('Rows["[]"]["has.a.dot"].total');
+  });
+
+  test("builds one exact identity for each supplied field", () => {
+    expect(
+      identitiesAt("src/sum.ts", [{ name: "Sum" }])(["total", "other"]),
+    ).toEqual([
+      identity([{ name: "Sum" }]),
+      identity([{ name: "Sum" }], "other"),
+    ]);
+  });
+
+  test("sorts by export and exact structured path", () => {
+    const identities = [
+      identity([{ name: "Sum" }, { way: "[]" }]),
+      identity([{ name: "Sum" }, { name: "[]" }]),
+      identity([{ name: "Sum" }], "b"),
+      identity([{ name: "Sum" }], "a", "src/a.ts"),
+    ].toSorted(compareFindingIdentities);
+
+    expect(identities.map(findingIdentityKey)).toEqual(
+      [...identities].map(findingIdentityKey).toSorted(),
+    );
+    expect(compareFindingIdentities(identities.at(-1)!, identities[0]!)).toBe(
+      1,
+    );
+  });
+
+  test("calls two equal identities equal", () => {
+    const same = identity([{ name: "Sum" }]);
+    expect(compareFindingIdentities(same, { ...same })).toBe(0);
+  });
+
+  test("refuses a field path with no owner", () => {
+    expect(() => ownerPath([])).toThrow("An unread field has no owner");
+  });
+
+  test("shows each exact step in a diagnostic identity", () => {
+    expect(
+      findingIdentityText(identity([{ name: "Rows" }, { way: "[]" }], "total")),
+    ).toBe('src/sum.ts :: name("Rows") / way("[]") / name("total")');
+  });
+});

--- a/test/scripts/unread-fields/identity.test.ts
+++ b/test/scripts/unread-fields/identity.test.ts
@@ -49,10 +49,24 @@ describe("unread-field identities", () => {
 
   test("builds one exact identity for each supplied field", () => {
     expect(
-      identitiesAt("src/sum.ts", [{ name: "Sum" }])(["total", "other"]),
+      identitiesAt([["src/sum.ts", [{ name: "Sum" }]]])(["total", "other"]),
     ).toEqual([
       identity([{ name: "Sum" }]),
       identity([{ name: "Sum" }], "other"),
+    ]);
+  });
+
+  test("builds shared fields for several exact owners", () => {
+    expect(
+      identitiesAt([
+        ["src/sum.ts", [{ name: "Sum" }]],
+        ["src/other.ts", [{ name: "Other" }]],
+      ])(["total", "other"]),
+    ).toEqual([
+      identity([{ name: "Sum" }]),
+      identity([{ name: "Sum" }], "other"),
+      identity([{ name: "Other" }], "total", "src/other.ts"),
+      identity([{ name: "Other" }], "other", "src/other.ts"),
     ]);
   });
 

--- a/test/scripts/unread-fields/policy.test.ts
+++ b/test/scripts/unread-fields/policy.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  type ClosedFieldSnapshot,
+  exemptFieldsAt,
+} from "#scripts/unread-fields/policy.ts";
+
+type Sample = { kept: string; optional?: number };
+
+const reason = {
+  evidence: "sendSample serialises the complete value",
+  kind: "external-output",
+} as const;
+
+describe("unread-field policy", () => {
+  test("requires optional fields in a closed snapshot", () => {
+    const complete: ClosedFieldSnapshot<Sample> = {
+      kept: "check",
+      optional: "exempt",
+    };
+    expect(complete.optional).toBe("exempt");
+
+    // @ts-expect-error A closed snapshot must classify every optional field.
+    const missing: ClosedFieldSnapshot<Sample> = { kept: "check" };
+    expect(missing.kept).toBe("check");
+  });
+
+  test("refuses an open string-key type", () => {
+    // @ts-expect-error An open key domain cannot be a closed snapshot.
+    const open: ClosedFieldSnapshot<Record<string, string>> = {};
+    expect(open).toEqual({});
+  });
+
+  test("emits only fields marked exempt", () => {
+    const exemptions = exemptFieldsAt<Sample>(
+      "src/sample.ts",
+      [{ name: "Sample" }],
+      reason,
+    )({ kept: "check", optional: "exempt" });
+
+    expect(exemptions).toEqual([
+      {
+        identity: {
+          exportedFrom: "src/sample.ts",
+          field: "optional",
+          path: [{ name: "Sample" }],
+        },
+        reason,
+      },
+    ]);
+  });
+});

--- a/test/scripts/unread-fields/reconcile.test.ts
+++ b/test/scripts/unread-fields/reconcile.test.ts
@@ -1,0 +1,130 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { Finding } from "#scripts/unread-fields/findings.ts";
+import type { FindingIdentity } from "#scripts/unread-fields/identity.ts";
+import type { FindingExemption } from "#scripts/unread-fields/policy.ts";
+import {
+  formatUnreadFieldProblem,
+  reconcileUnreadFields,
+} from "#scripts/unread-fields/reconcile.ts";
+
+const identity = (field = "total"): FindingIdentity => ({
+  exportedFrom: "src/sum.ts",
+  field,
+  path: [{ name: "Sum" }],
+});
+
+const finding = (
+  field = "total",
+  verdict: Finding["verdict"] = "never read",
+): Finding => ({
+  ...identity(field),
+  file: "src/sum.ts",
+  owner: "Sum",
+  verdict,
+});
+
+const exemption = (field = "total"): FindingExemption => ({
+  identity: identity(field),
+  reason: {
+    evidence: "sendSum serialises the complete value",
+    kind: "external-output",
+  },
+});
+
+const kindsOf = (
+  findings: readonly Finding[],
+  baseline: readonly FindingIdentity[] = [],
+  exemptions: readonly FindingExemption[] = [],
+): string[] =>
+  reconcileUnreadFields(baseline, exemptions)(findings).map(({ kind }) => kind);
+
+describe("unread-field reconciliation", () => {
+  test("accepts exact baseline debt and reviewed exemptions", () => {
+    expect(
+      kindsOf(
+        [finding(), finding("external")],
+        [identity()],
+        [exemption("external")],
+      ),
+    ).toEqual([]);
+  });
+
+  test("rejects both kinds of new unread field", () => {
+    expect(
+      kindsOf([
+        finding("none"),
+        finding("tests", "read only by tests"),
+        finding("used", "read"),
+      ]),
+    ).toEqual(["new unread field", "new unread field"]);
+  });
+
+  test("calls a removed or newly read entry stale", () => {
+    expect(
+      kindsOf(
+        [finding("baseline", "read"), finding("exemption", "read")],
+        [identity("baseline")],
+        [exemption("exemption")],
+      ),
+    ).toEqual(["stale baseline", "stale exemption"]);
+  });
+
+  test("reports duplicates and policy overlap without hiding other problems", () => {
+    expect(
+      kindsOf(
+        [finding(), finding()],
+        [identity(), identity()],
+        [exemption(), exemption()],
+      ),
+    ).toEqual([
+      "duplicate finding",
+      "duplicate baseline",
+      "duplicate exemption",
+      "policy overlap",
+    ]);
+  });
+
+  test("reports one stale problem for a duplicated absent entry", () => {
+    expect(kindsOf([], [identity(), identity()])).toEqual([
+      "duplicate baseline",
+      "stale baseline",
+    ]);
+  });
+
+  test("sorts problem kinds before exact identities", () => {
+    const problems = reconcileUnreadFields(
+      [identity("z")],
+      [],
+    )([finding("b"), finding("a")]);
+
+    expect(
+      problems.map(({ kind, identity }) => `${kind}:${identity.field}`),
+    ).toEqual(["stale baseline:z", "new unread field:a", "new unread field:b"]);
+  });
+
+  test("formats enough evidence to repair a new field", () => {
+    const [problem] = reconcileUnreadFields([], [])([finding()]);
+
+    expect(formatUnreadFieldProblem(problem!)).toBe(
+      'new unread field [never read]: src/sum.ts :: name("Sum") / name("total")' +
+        " -- declared in src/sum.ts",
+    );
+  });
+
+  test("keeps the exemption reason in a stale diagnostic", () => {
+    const [problem] = reconcileUnreadFields([], [exemption()])([]);
+
+    expect(formatUnreadFieldProblem(problem!)).toContain(
+      "external-output: sendSum serialises the complete value",
+    );
+  });
+
+  test("formats a plain policy problem", () => {
+    const [problem] = reconcileUnreadFields([identity()], [])([]);
+
+    expect(formatUnreadFieldProblem(problem!)).toBe(
+      'stale baseline: src/sum.ts :: name("Sum") / name("total")',
+    );
+  });
+});

--- a/test/scripts/unread-fields/run-check.test.ts
+++ b/test/scripts/unread-fields/run-check.test.ts
@@ -1,0 +1,75 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import type { CheckOutput } from "#scripts/check-report.ts";
+import type { Finding } from "#scripts/unread-fields/findings.ts";
+import { runUnreadFieldsCheck } from "#scripts/unread-fields/run-check.ts";
+
+const finding: Finding = {
+  exportedFrom: "src/sum.ts",
+  field: "total",
+  file: "src/sum.ts",
+  owner: "Sum",
+  path: [{ name: "Sum" }],
+  verdict: "never read",
+};
+
+const output = (): {
+  errors: string[];
+  lines: string[];
+  value: CheckOutput;
+} => {
+  const errors: string[] = [];
+  const lines: string[] = [];
+  return {
+    errors,
+    lines,
+    value: {
+      log: (line) => lines.push(line),
+      logError: (line) => errors.push(line),
+    },
+  };
+};
+
+describe("unread-field check", () => {
+  test("reports success when every finding has exact policy", async () => {
+    const seen = output();
+    const code = await runUnreadFieldsCheck("/repo", seen.value, {
+      baseline: [finding],
+      exemptions: [],
+      scan: () => Promise.resolve([finding]),
+    });
+
+    expect(code).toBe(0);
+    expect(seen.lines).toEqual([
+      "Every reported unread field matches one exact policy entry, and every policy entry is current.",
+    ]);
+    expect(seen.errors).toEqual([]);
+  });
+
+  test("reports every reconciliation problem and returns failure", async () => {
+    const seen = output();
+    const code = await runUnreadFieldsCheck("/repo", seen.value, {
+      baseline: [],
+      exemptions: [],
+      scan: () => Promise.resolve([finding]),
+    });
+
+    expect(code).toBe(1);
+    expect(seen.errors[0]).toContain("new unread field [never read]");
+    expect(seen.errors.at(-1)).toBe(
+      "\n1 unread-field issue(s) found. See scripts/unread-fields/README.md.",
+    );
+  });
+
+  test("lets scan failures propagate", async () => {
+    const failure = new Error("scan failed");
+
+    await expect(
+      runUnreadFieldsCheck("/repo", output().value, {
+        baseline: [],
+        exemptions: [],
+        scan: () => Promise.reject(failure),
+      }),
+    ).rejects.toBe(failure);
+  });
+});

--- a/test/scripts/unread-fields/scan.test.ts
+++ b/test/scripts/unread-fields/scan.test.ts
@@ -71,11 +71,13 @@ describe("the reads the scan counts", () => {
   });
 
   test("names the declaring file, not the shape that hands the field on", () => {
-    expect(
-      scanned.all.find(
-        (f) => f.owner === "ExtendsFarBase" && f.field === "readFromFarAway",
-      )?.file,
-    ).toBe("src/inner/index.ts");
+    const found = scanned.all.find(
+      (f) => f.owner === "ExtendsFarBase" && f.field === "readFromFarAway",
+    );
+
+    expect(found?.file).toBe("src/inner/index.ts");
+    expect(found?.exportedFrom).toBe("src/shapes.ts");
+    expect(found?.path).toEqual([{ name: "ExtendsFarBase" }]);
   });
 
   test("sees a field read through a directory import", () => {

--- a/test/test-utils/unread-field-policy.ts
+++ b/test/test-utils/unread-field-policy.ts
@@ -1,0 +1,14 @@
+import { expect } from "@std/expect";
+import {
+  type FindingIdentity,
+  findingIdentityKey,
+} from "#scripts/unread-fields/identity.ts";
+
+export const expectStableUniqueIdentities = (
+  identities: readonly FindingIdentity[],
+): void => {
+  const keys = identities.map(findingIdentityKey);
+  expect(keys.length).toBeGreaterThan(0);
+  expect(new Set(keys).size).toBe(keys.length);
+  expect(keys).toEqual([...keys].toSorted());
+};


### PR DESCRIPTION
## Summary

This PR adds an exact policy gate for fields that the TypeScript scanner reports as unread. It builds on #2166.

The gate blocks a new unread field, a stale entry, a duplicate identity, or an identity in both registries.

## Policy

The current scan reports 636 unread fields. The baseline records 587 accepted debt entries. Reviewed exemptions cover the other 49 fields.

Each exemption names production evidence and one supported mechanism. Closed type snapshots require an explicit choice for every field when a reviewed type changes.

Each identity contains the file that exports the field, its typed owner path, and its field name. No folder, file, or open-type wildcard exists.

## Integration

The `check:unread-fields` task runs after typecheck in local precommit. CI runs the same task in its checks job.

The task uses read-only file access and a narrow environment allowlist for TypeScript. A scan error propagates and fails the task.

## Validation

- `nix develop -c deno task precommit`
- 26,213 tests
- 100% line and branch coverage
- 0% code duplication

Targeted mutation runs detected every non-equivalent mutant in the changed scanner and gate modules.

## Stack

This PR depends on #2166. That PR adds the scanner accuracy that the exact baseline requires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated unread-field policy check for identifying new, stale, duplicate, or improperly classified fields.
  * Added baseline and exemption tracking with clear diagnostic reporting.
  * Integrated the check into pre-commit validation and automated checks.

* **Documentation**
  * Added guidance covering the unread-field policy, exemptions, baseline management, and resolving findings.

* **Tests**
  * Added comprehensive coverage for scanning, identity handling, reconciliation, policy enforcement, reporting, baselines, and exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->