### PR TITLE
Stop spreadsheet formulas in every CSV export

### DIFF
--- a/src/shared/csv/index.ts
+++ b/src/shared/csv/index.ts
@@ -17,10 +17,11 @@ export type Column<T> = {
  * forms a Japanese locale accepts. */
 const FORMULA_START = /^[=+\-@\t\r\n＝＋－＠]/;
 
-/** Stop a spreadsheet from running a cell as a formula: a quote in front keeps
- * the text inert while every app still shows it. */
+/** Stop a spreadsheet from running a cell as a formula: a tab in front makes
+ * the text inert, and Excel keeps a data tab when a saved file is opened
+ * again — it can strip a quote or escape marker instead. */
 const stopFormula = (value: string): string =>
-  FORMULA_START.test(value) ? `'${value}` : value;
+  FORMULA_START.test(value) ? `\t${value}` : value;
 
 /** Escape one value for CSV (commas, quotes, newlines, carriage returns). */
 const escapeValue = (value: string): string =>

--- a/src/shared/csv/index.ts
+++ b/src/shared/csv/index.ts
@@ -13,8 +13,9 @@ export type Column<T> = {
 };
 
 /** The first characters that make Excel and Google Sheets run a cell as a
- * formula. */
-const FORMULA_START = /^[=+\-@\t\r]/;
+ * formula: the four visible starters, tab, CR, LF, and the full-width
+ * forms a Japanese locale accepts. */
+const FORMULA_START = /^[=+\-@\t\r\n＝＋－＠]/;
 
 /** Stop a spreadsheet from running a cell as a formula: a quote in front keeps
  * the text inert while every app still shows it. */

--- a/src/shared/csv/index.ts
+++ b/src/shared/csv/index.ts
@@ -12,9 +12,10 @@ export type Column<T> = {
   value: (item: T) => string;
 };
 
-/** The first characters that make Excel and Google Sheets run a cell as a
- * formula: the four visible starters, tab, CR, LF, and the full-width
- * forms a Japanese locale accepts. */
+/** The characters OWASP lists as formula starters: the four visible ones,
+ * tab, CR, LF, and the full-width forms a Japanese locale accepts. Tab is
+ * listed there as a caution for import paths, yet a quoted tab is also the
+ * page's neutralizer — see {@link stopFormula} and {@link escapeValue}. */
 const FORMULA_START = /^[=+\-@\t\r\n＝＋－＠]/;
 
 /** Stop a spreadsheet from running a cell as a formula: a tab in front makes
@@ -23,9 +24,13 @@ const FORMULA_START = /^[=+\-@\t\r\n＝＋－＠]/;
 const stopFormula = (value: string): string =>
   FORMULA_START.test(value) ? `\t${value}` : value;
 
-/** Escape one value for CSV (commas, quotes, newlines, carriage returns). */
+/** Escape one value for CSV (commas, quotes, newlines, carriage returns).
+ * A tab marker is wrapped as well, so a tab-delimited import cannot split
+ * the marker off the formula it guards. */
 const escapeValue = (value: string): string =>
-  /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  value.startsWith("\t") || /[",\n\r]/.test(value)
+    ? `"${value.replace(/"/g, '""')}"`
+    : value;
 
 /** Join a header line with already-built data rows. No trailing newline, built
  * in a single pass. */
@@ -35,7 +40,7 @@ const joinRows = (header: string, rows: readonly string[]): string =>
 /**
  * Build CSV text from items and the columns that describe them. The headers
  * and every cell are escaped, and a value that starts like a spreadsheet
- * formula gets a quote in front so no app runs it. Throws only when no
+ * formula gets a quoted tab in front so no app runs it. Throws only when no
  * columns are given — duplicate headers are allowed (e.g. two custom
  * questions sharing a name), matching what spreadsheets accept.
  */

--- a/src/shared/csv/index.ts
+++ b/src/shared/csv/index.ts
@@ -1,8 +1,9 @@
 /**
  * A pure CSV system. It knows nothing about attendees, listings, or the wider
  * application — only how to turn a list of items plus an ordered set of columns
- * into RFC 4180 CSV text. Callers describe each column with a header and a
- * function that reads its cell from an item, then call {@link CSV.generate}.
+ * into RFC 4180 CSV text whose cells cannot run as spreadsheet formulas.
+ * Callers describe each column with a header and a function that reads its
+ * cell from an item, then call {@link CSV.generate}.
  */
 
 /** A CSV column: its header and how to read a cell from a source item. */
@@ -10,6 +11,15 @@ export type Column<T> = {
   header: string;
   value: (item: T) => string;
 };
+
+/** The first characters that make Excel and Google Sheets run a cell as a
+ * formula. */
+const FORMULA_START = /^[=+\-@\t\r]/;
+
+/** Stop a spreadsheet from running a cell as a formula: a quote in front keeps
+ * the text inert while every app still shows it. */
+const stopFormula = (value: string): string =>
+  FORMULA_START.test(value) ? `'${value}` : value;
 
 /** Escape one value for CSV (commas, quotes, newlines, carriage returns). */
 const escapeValue = (value: string): string =>
@@ -21,10 +31,11 @@ const joinRows = (header: string, rows: readonly string[]): string =>
   rows.length === 0 ? header : `${header}\n${rows.join("\n")}`;
 
 /**
- * Build CSV text from items and the columns that describe them. The headers and
- * every cell are escaped. Throws only when no columns are given — duplicate
- * headers are allowed (e.g. two custom questions sharing a name), matching what
- * spreadsheets accept.
+ * Build CSV text from items and the columns that describe them. The headers
+ * and every cell are escaped, and a value that starts like a spreadsheet
+ * formula gets a quote in front so no app runs it. Throws only when no
+ * columns are given — duplicate headers are allowed (e.g. two custom
+ * questions sharing a name), matching what spreadsheets accept.
  */
 const generate = <T>(
   items: readonly T[],
@@ -34,12 +45,12 @@ const generate = <T>(
     throw new Error("CSV.generate: at least one column is required");
   }
   return joinRows(
-    columns.map((c) => escapeValue(c.header)).join(","),
+    columns.map((c) => escapeValue(stopFormula(c.header))).join(","),
     items.map((item) =>
-      columns.map((c) => escapeValue(c.value(item))).join(","),
+      columns.map((c) => escapeValue(stopFormula(c.value(item)))).join(","),
     ),
   );
 };
 
 /** The pure CSV system. */
-export const CSV = { escape: escapeValue, generate, join: joinRows };
+export const CSV = { generate };

--- a/test/features/admin/attendees-csv.test.ts
+++ b/test/features/admin/attendees-csv.test.ts
@@ -82,7 +82,29 @@ describe("generateAttendeesCsv", () => {
     const attendees = [testAttendee({ phone: "+1 555 123 4567" })];
     const csv = generateAttendeesCsv(attendees);
     const lines = csv.split("\n");
-    expect(lines[1]).toContain("+1 555 123 4567");
+    // The leading + becomes a spreadsheet formula, so the cell keeps it as
+    // text behind a quote.
+    expect(lines[1]).toContain("'+1 555 123 4567");
+  });
+
+  test("stops attacker-controlled attendee values from running as spreadsheet formulas", () => {
+    const attendees = [
+      testAttendee({
+        address: '=HYPERLINK("http://evil.example","Free trips!")',
+        email: "+44@example.com",
+        name: "=SUM(A1:A2)",
+        phone: "+1 555 123 4567",
+        special_instructions: "=cmd|' /C calc'!A0",
+      }),
+    ];
+    const row = generateAttendeesCsv(attendees).split("\n")[1]!;
+    expect(row).toContain("'=SUM(A1:A2)");
+    expect(row).toContain("'+44@example.com");
+    expect(row).toContain("'+1 555 123 4567");
+    expect(row).toContain(
+      '"\'=HYPERLINK(""http://evil.example"",""Free trips!"")"',
+    );
+    expect(row).toContain("'=cmd|' /C calc'!A0");
   });
 
   test("includes empty phone column when phone not collected", () => {

--- a/test/features/admin/attendees-csv.test.ts
+++ b/test/features/admin/attendees-csv.test.ts
@@ -82,9 +82,9 @@ describe("generateAttendeesCsv", () => {
     const attendees = [testAttendee({ phone: "+1 555 123 4567" })];
     const csv = generateAttendeesCsv(attendees);
     const lines = csv.split("\n");
-    // The leading + becomes a spreadsheet formula, so the cell keeps it as
-    // text behind a quote.
-    expect(lines[1]).toContain("'+1 555 123 4567");
+    // The leading + would become a spreadsheet formula, so a tab keeps the
+    // value readable as text.
+    expect(lines[1]).toContain("\t+1 555 123 4567");
   });
 
   test("stops attacker-controlled attendee values from running as spreadsheet formulas", () => {
@@ -98,19 +98,19 @@ describe("generateAttendeesCsv", () => {
       }),
     ];
     const row = generateAttendeesCsv(attendees).split("\n")[1]!;
-    expect(row).toContain("'=SUM(A1:A2)");
-    expect(row).toContain("'+44@example.com");
-    expect(row).toContain("'+1 555 123 4567");
+    expect(row).toContain("\t=SUM(A1:A2)");
+    expect(row).toContain("\t+44@example.com");
+    expect(row).toContain("\t+1 555 123 4567");
     expect(row).toContain(
-      '"\'=HYPERLINK(""http://evil.example"",""Free trips!"")"',
+      '"\t=HYPERLINK(""http://evil.example"",""Free trips!"")"',
     );
-    expect(row).toContain("'=cmd|' /C calc'!A0");
+    expect(row).toContain("\t=cmd|' /C calc'!A0");
   });
 
   test("stops a value whose formula hides behind a line feed", () => {
     const attendees = [testAttendee({ name: "\n=SUM(A1:A2)" })];
     const csv = generateAttendeesCsv(attendees);
-    expect(csv).toContain('"\'\n=SUM(A1:A2)"');
+    expect(csv).toContain('"\t\n=SUM(A1:A2)"');
   });
 
   test("includes empty phone column when phone not collected", () => {

--- a/test/features/admin/attendees-csv.test.ts
+++ b/test/features/admin/attendees-csv.test.ts
@@ -107,6 +107,12 @@ describe("generateAttendeesCsv", () => {
     expect(row).toContain("'=cmd|' /C calc'!A0");
   });
 
+  test("stops a value whose formula hides behind a line feed", () => {
+    const attendees = [testAttendee({ name: "\n=SUM(A1:A2)" })];
+    const csv = generateAttendeesCsv(attendees);
+    expect(csv).toContain('"\'\n=SUM(A1:A2)"');
+  });
+
   test("includes empty phone column when phone not collected", () => {
     const attendees = [testAttendee()];
     const csv = generateAttendeesCsv(attendees);

--- a/test/features/admin/attendees-csv.test.ts
+++ b/test/features/admin/attendees-csv.test.ts
@@ -82,9 +82,9 @@ describe("generateAttendeesCsv", () => {
     const attendees = [testAttendee({ phone: "+1 555 123 4567" })];
     const csv = generateAttendeesCsv(attendees);
     const lines = csv.split("\n");
-    // The leading + would become a spreadsheet formula, so a tab keeps the
-    // value readable as text.
-    expect(lines[1]).toContain("\t+1 555 123 4567");
+    // The leading + would become a spreadsheet formula, so a quoted tab
+    // keeps the value readable as text.
+    expect(lines[1]).toContain('"\t+1 555 123 4567"');
   });
 
   test("stops attacker-controlled attendee values from running as spreadsheet formulas", () => {
@@ -98,13 +98,13 @@ describe("generateAttendeesCsv", () => {
       }),
     ];
     const row = generateAttendeesCsv(attendees).split("\n")[1]!;
-    expect(row).toContain("\t=SUM(A1:A2)");
-    expect(row).toContain("\t+44@example.com");
-    expect(row).toContain("\t+1 555 123 4567");
+    expect(row).toContain('"\t=SUM(A1:A2)"');
+    expect(row).toContain('"\t+44@example.com"');
+    expect(row).toContain('"\t+1 555 123 4567"');
     expect(row).toContain(
       '"\t=HYPERLINK(""http://evil.example"",""Free trips!"")"',
     );
-    expect(row).toContain("\t=cmd|' /C calc'!A0");
+    expect(row).toContain("\"\t=cmd|' /C calc'!A0\"");
   });
 
   test("stops a value whose formula hides behind a line feed", () => {

--- a/test/features/admin/attendees-csv/questions.test.ts
+++ b/test/features/admin/attendees-csv/questions.test.ts
@@ -32,6 +32,13 @@ const DIET_Q = question(2, "Dietary Requirements", [
   { id: 21, text: "Vegetarian" },
 ]);
 
+const NOTES_Q: QuestionWithAnswers = {
+  answers: [],
+  display_type: "free_text",
+  id: 3,
+  text: "Notes",
+};
+
 const csvWithQuestions = (
   attendees: Parameters<typeof generateAttendeesCsv>[0],
   questions: QuestionWithAnswers[],
@@ -40,6 +47,14 @@ const csvWithQuestions = (
   generateAttendeesCsv(attendees, false, undefined, {
     attendeeAnswerMap,
     questions,
+  }).split("\n");
+
+/** CSV lines for one attendee and their free-text answer to "Notes". */
+const freeTextCsv = (answer: string): string[] =>
+  generateAttendeesCsv([testAttendee({ id: 1 })], false, undefined, {
+    attendeeAnswerMap: new Map(),
+    questions: [NOTES_Q],
+    textAnswerMap: new Map([[1, new Map([[3, answer]])]]),
   }).split("\n");
 
 describe("CSV with custom questions", () => {
@@ -69,24 +84,14 @@ describe("CSV with custom questions", () => {
   });
 
   test("renders free-text answers from the text-answer map", () => {
-    const freeTextQ: QuestionWithAnswers = {
-      answers: [],
-      display_type: "free_text",
-      id: 3,
-      text: "Notes",
-    };
-    const [header, row] = generateAttendeesCsv(
-      [testAttendee({ id: 1 })],
-      false,
-      undefined,
-      {
-        attendeeAnswerMap: new Map(),
-        questions: [freeTextQ],
-        textAnswerMap: new Map([[1, new Map([[3, "Coeliac, no nuts"]])]]),
-      },
-    ).split("\n");
+    const [header, row] = freeTextCsv("Coeliac, no nuts");
     expect(header!.endsWith(",Notes")).toBe(true);
     expect(row!.endsWith(',"Coeliac, no nuts"')).toBe(true);
+  });
+
+  test("stops a free-text answer that starts like a spreadsheet formula", () => {
+    const [, row] = freeTextCsv("=2+5*9");
+    expect(row!.endsWith(",'=2+5*9")).toBe(true);
   });
 
   test("leaves the question column blank when the attendee did not answer it", () => {

--- a/test/features/admin/attendees-csv/questions.test.ts
+++ b/test/features/admin/attendees-csv/questions.test.ts
@@ -91,7 +91,7 @@ describe("CSV with custom questions", () => {
 
   test("stops a free-text answer that starts like a spreadsheet formula", () => {
     const [, row] = freeTextCsv("=2+5*9");
-    expect(row!.endsWith(",\t=2+5*9")).toBe(true);
+    expect(row!.endsWith(',"\t=2+5*9"')).toBe(true);
   });
 
   test("leaves the question column blank when the attendee did not answer it", () => {

--- a/test/features/admin/attendees-csv/questions.test.ts
+++ b/test/features/admin/attendees-csv/questions.test.ts
@@ -91,7 +91,7 @@ describe("CSV with custom questions", () => {
 
   test("stops a free-text answer that starts like a spreadsheet formula", () => {
     const [, row] = freeTextCsv("=2+5*9");
-    expect(row!.endsWith(",'=2+5*9")).toBe(true);
+    expect(row!.endsWith(",\t=2+5*9")).toBe(true);
   });
 
   test("leaves the question column blank when the attendee did not answer it", () => {

--- a/test/integration/routes/renewal.test.ts
+++ b/test/integration/routes/renewal.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import { FakeTime } from "@std/testing/time";
 import { builtSites, insertBuiltSite } from "#db/built-sites.ts";
 import { handleRequest } from "#routes";
 import { bunnyCdnApi } from "#shared/bunny-cdn.ts";
@@ -308,6 +309,9 @@ describeWithEnv("routes > renewal", { db: true }, () => {
     });
 
     test("free renewal tier still applies the site renewal", async () => {
+      // Renewal extends max(now, the seeded deadline). Freeze the clock
+      // before that deadline, or a wall clock past it moves the base to now.
+      using _time = new FakeTime(new Date("2026-08-01T00:00:00.000Z"));
       const tier = await createTestListing({
         hidden: true,
         maxAttendees: 100,

--- a/test/integration/server/webhooks/extract-intent-redirect.test.ts
+++ b/test/integration/server/webhooks/extract-intent-redirect.test.ts
@@ -2,6 +2,7 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
+import { FakeTime } from "@std/testing/time";
 import { getAttendeesRaw } from "#db/attendees/queries.ts";
 import { handleRequest } from "#routes";
 import { stripeApi } from "#shared/stripe.ts";
@@ -200,6 +201,9 @@ describeWithEnv(
     });
 
     test("payment success applies multi-tier renewal months cumulatively", async () => {
+      // Renewal extends max(now, the seeded deadline). Freeze the clock
+      // before that deadline, or a wall clock past it moves the base to now.
+      using _time = new FakeTime(new Date("2026-08-01T00:00:00.000Z"));
       await setupStripe();
 
       await createTestListing({

--- a/test/shared/csv/index.test.ts
+++ b/test/shared/csv/index.test.ts
@@ -70,3 +70,51 @@ describe("CSV.generate", () => {
     expect(csv).toBe('Title,Note\nplain,\n"quoted, ""value""","line\rbreak"');
   });
 });
+
+describe("CSV.generate formula safety", () => {
+  const valueColumn: Column<{ value: string }>[] = [
+    { header: "Value", value: (row) => row.value },
+  ];
+
+  test("puts a quote in front of every character that can start a formula", () => {
+    const inertCells: [string, string][] = [
+      ["=SUM(A1:A2)", "'=SUM(A1:A2)"],
+      ["+44 20 7946", "'+44 20 7946"],
+      ["-Maria", "'-Maria"],
+      ["@handle", "'@handle"],
+      ["\tTabbed start", "'\tTabbed start"],
+    ];
+    for (const [formulaText, inertCell] of inertCells) {
+      expect(CSV.generate([{ value: formulaText }], valueColumn)).toBe(
+        `Value\n${inertCell}`,
+      );
+    }
+  });
+
+  test("puts a quote in front of a carriage return that starts a cell", () => {
+    // The CR also trips RFC 4180 quoting, so both guards apply to it.
+    expect(CSV.generate([{ value: "\rcmd" }], valueColumn)).toBe(
+      'Value\n"\'\rcmd"',
+    );
+  });
+
+  test("leaves cells that cannot start a formula alone", () => {
+    const csv = CSV.generate(
+      [{ value: "a=b" }, { value: "1+1" }, { value: "Bob" }, { value: "" }],
+      valueColumn,
+    );
+    expect(csv).toBe("Value\na=b\n1+1\nBob\n");
+  });
+
+  test("stops a formula and quotes the cell when it also has a comma", () => {
+    expect(CSV.generate([{ value: "=a,b" }], valueColumn)).toBe(
+      'Value\n"\'=a,b"',
+    );
+  });
+
+  test("puts a quote in front of a formula character that starts a header", () => {
+    expect(CSV.generate([], [{ header: "=Total", value: () => "" }])).toBe(
+      "'=Total",
+    );
+  });
+});

--- a/test/shared/csv/index.test.ts
+++ b/test/shared/csv/index.test.ts
@@ -76,17 +76,17 @@ describe("CSV.generate formula safety", () => {
     { header: "Value", value: (row) => row.value },
   ];
 
-  test("puts a quote in front of every character that can start a formula", () => {
+  test("puts a tab in front of every character that can start a formula", () => {
     const inertCells: [string, string][] = [
-      ["=SUM(A1:A2)", "'=SUM(A1:A2)"],
-      ["+44 20 7946", "'+44 20 7946"],
-      ["-Maria", "'-Maria"],
-      ["@handle", "'@handle"],
-      ["\tTabbed start", "'\tTabbed start"],
-      ["＝SUM(A1:A2)", "'＝SUM(A1:A2)"],
-      ["＋44 20 7946", "'＋44 20 7946"],
-      ["－Maria", "'－Maria"],
-      ["＠handle", "'＠handle"],
+      ["=SUM(A1:A2)", "\t=SUM(A1:A2)"],
+      ["+44 20 7946", "\t+44 20 7946"],
+      ["-Maria", "\t-Maria"],
+      ["@handle", "\t@handle"],
+      ["\tTabbed start", "\t\tTabbed start"],
+      ["＝SUM(A1:A2)", "\t＝SUM(A1:A2)"],
+      ["＋44 20 7946", "\t＋44 20 7946"],
+      ["－Maria", "\t－Maria"],
+      ["＠handle", "\t＠handle"],
     ];
     for (const [formulaText, inertCell] of inertCells) {
       expect(CSV.generate([{ value: formulaText }], valueColumn)).toBe(
@@ -95,17 +95,17 @@ describe("CSV.generate formula safety", () => {
     }
   });
 
-  test("puts a quote in front of a carriage return that starts a cell", () => {
+  test("puts a tab in front of a carriage return that starts a cell", () => {
     // The CR also trips RFC 4180 quoting, so both guards apply to it.
     expect(CSV.generate([{ value: "\rcmd" }], valueColumn)).toBe(
-      'Value\n"\'\rcmd"',
+      'Value\n"\t\rcmd"',
     );
   });
 
-  test("puts a quote in front of a line feed that starts a cell", () => {
+  test("puts a tab in front of a line feed that starts a cell", () => {
     // Same shape as the CR case: LF trips RFC 4180 quoting too.
     expect(CSV.generate([{ value: "\n=cmd" }], valueColumn)).toBe(
-      'Value\n"\'\n=cmd"',
+      'Value\n"\t\n=cmd"',
     );
   });
 
@@ -119,13 +119,13 @@ describe("CSV.generate formula safety", () => {
 
   test("stops a formula and quotes the cell when it also has a comma", () => {
     expect(CSV.generate([{ value: "=a,b" }], valueColumn)).toBe(
-      'Value\n"\'=a,b"',
+      'Value\n"\t=a,b"',
     );
   });
 
-  test("puts a quote in front of a formula character that starts a header", () => {
+  test("puts a tab in front of a formula character that starts a header", () => {
     expect(CSV.generate([], [{ header: "=Total", value: () => "" }])).toBe(
-      "'=Total",
+      "\t=Total",
     );
   });
 });

--- a/test/shared/csv/index.test.ts
+++ b/test/shared/csv/index.test.ts
@@ -78,21 +78,30 @@ describe("CSV.generate formula safety", () => {
 
   test("puts a tab in front of every character that can start a formula", () => {
     const inertCells: [string, string][] = [
-      ["=SUM(A1:A2)", "\t=SUM(A1:A2)"],
-      ["+44 20 7946", "\t+44 20 7946"],
-      ["-Maria", "\t-Maria"],
-      ["@handle", "\t@handle"],
-      ["\tTabbed start", "\t\tTabbed start"],
-      ["＝SUM(A1:A2)", "\t＝SUM(A1:A2)"],
-      ["＋44 20 7946", "\t＋44 20 7946"],
-      ["－Maria", "\t－Maria"],
-      ["＠handle", "\t＠handle"],
+      ["=SUM(A1:A2)", '"\t=SUM(A1:A2)"'],
+      ["+44 20 7946", '"\t+44 20 7946"'],
+      ["-Maria", '"\t-Maria"'],
+      ["@handle", '"\t@handle"'],
+      ["\tTabbed start", '"\t\tTabbed start"'],
+      ["＝SUM(A1:A2)", '"\t＝SUM(A1:A2)"'],
+      ["＋44 20 7946", '"\t＋44 20 7946"'],
+      ["－Maria", '"\t－Maria"'],
+      ["＠handle", '"\t＠handle"'],
     ];
     for (const [formulaText, inertCell] of inertCells) {
       expect(CSV.generate([{ value: formulaText }], valueColumn)).toBe(
         `Value\n${inertCell}`,
       );
     }
+  });
+
+  test("quotes the tab marker so a tab-delimited import cannot split it", () => {
+    // Unquoted, `⇥=cmd` splits into an empty field and a live `=cmd` when a
+    // reader takes tabs as delimiters. The quotes keep marker and value one
+    // field under every reader.
+    expect(CSV.generate([{ value: "=cmd" }], valueColumn)).toBe(
+      'Value\n"\t=cmd"',
+    );
   });
 
   test("puts a tab in front of a carriage return that starts a cell", () => {
@@ -125,7 +134,7 @@ describe("CSV.generate formula safety", () => {
 
   test("puts a tab in front of a formula character that starts a header", () => {
     expect(CSV.generate([], [{ header: "=Total", value: () => "" }])).toBe(
-      "\t=Total",
+      '"\t=Total"',
     );
   });
 });

--- a/test/shared/csv/index.test.ts
+++ b/test/shared/csv/index.test.ts
@@ -83,6 +83,10 @@ describe("CSV.generate formula safety", () => {
       ["-Maria", "'-Maria"],
       ["@handle", "'@handle"],
       ["\tTabbed start", "'\tTabbed start"],
+      ["＝SUM(A1:A2)", "'＝SUM(A1:A2)"],
+      ["＋44 20 7946", "'＋44 20 7946"],
+      ["－Maria", "'－Maria"],
+      ["＠handle", "'＠handle"],
     ];
     for (const [formulaText, inertCell] of inertCells) {
       expect(CSV.generate([{ value: formulaText }], valueColumn)).toBe(
@@ -95,6 +99,13 @@ describe("CSV.generate formula safety", () => {
     // The CR also trips RFC 4180 quoting, so both guards apply to it.
     expect(CSV.generate([{ value: "\rcmd" }], valueColumn)).toBe(
       'Value\n"\'\rcmd"',
+    );
+  });
+
+  test("puts a quote in front of a line feed that starts a cell", () => {
+    // Same shape as the CR case: LF trips RFC 4180 quoting too.
+    expect(CSV.generate([{ value: "\n=cmd" }], valueColumn)).toBe(
+      'Value\n"\'\n=cmd"',
     );
   });
 


### PR DESCRIPTION
Closes #2204

## What changed

A CSV cell that starts with a formula character runs as a formula when an
operator opens an export in Excel or Google Sheets. Attendee names, emails,
phones, addresses, special instructions and free-text answers are
person-entered, so a booking can plant one. RFC 4180 quotes alone do not
stop a spreadsheet: it strips the quotes before it evaluates the cell.

The shared CSV writer now puts a tab in front of any header or cell that
starts with a trigger character, and wraps that cell in RFC 4180 quotes.
The trigger set is the OWASP CSV injection list: `=`, `+`, `-`, `@`, tab,
CR, LF, and the full-width `＝＋－＠` forms a Japanese locale accepts. The tab
is the OWASP Excel-resistant prefix — Excel keeps a data tab through a
save-and-reopen cycle, while it can strip a quote or escape marker and turn
a stored formula live again. The quotes matter for the marker itself: a
tab-delimited reader would otherwise split `⇥=cmd` into an empty field plus
a live `=cmd`. Plain values compose with RFC quoting: `=a,b` becomes
`"\t=a,b"`, and a line-feed-prefixed formula arrives as `"\t⏎=cmd"`.

The fix lives in `src/shared/csv/index.ts` because every export is a
human-opened spreadsheet: the attendee roster, the listing export and the
calendar export all download as `text/csv` through `CSV.generate` (the
placement the issue asked us to decide). One rule covers all three surfaces.

A genuine value that starts with a trigger character stays readable: a phone
like `+44 20 7946` arrives as a quoted tab plus the number and stays text —
the accepted cost of the OWASP mitigation, and their trade-off note ("best
suited for CSV files intended for human viewing") matches exactly what
these exports are.

Also removed: `CSV.escape` and `CSV.join` exports. A search across `src/`,
`test/` and `scripts/` found no callers, and the dead-code rule says remove
them. Callers lose nothing: the same functions run inside `CSV.generate`.

## Production caller

`CSV.generate` feeds `generateAttendeesCsv`, `generateListingsCsv` and
`generateCalendarCsv`, served by the admin export routes through
`downloadResponse(..., "text/csv; charset=utf-8")` in
`src/features/admin/actions.ts`.

## Tests

Tests were written first. Each one failed against the raw formula before the
fix existed (confirmed for the full-width, line-feed and quote-wrapping cases
by holding the new tests against the old writer).

- `test/shared/csv/index.test.ts` covers every trigger character, plain values
  that must not change, the CR and LF cases with their RFC quoting, the
  neutralize-then-quote combination, and a named test that a tab-delimited
  import cannot split the marker.
- `test/features/admin/attendees-csv.test.ts` drives the real attendee export
  with attacker-controlled values: name `=SUM(A1:A2)`, a line-feed-prefixed
  name, email `+44@example.com`, phone, address `=HYPERLINK(...)` and special
  instructions `=cmd|' /C calc'!A0`. Each arrives as a quoted tab plus the
  value.
- `test/features/admin/attendees-csv/questions.test.ts` covers the free-text
  answer channel. The two free-text tests share one `freeTextCsv` helper;
  the cpd gate asked for that merge.

## The renewal test fix (own commit)

The full suite was red on a clean main checkout, before this branch touched
anything: two renewal tests seed a read-only deadline of
`2026-09-01T00:00:00Z` and assert the exact extension. Renewal extends
`max(now, deadline)` (`src/shared/site-assignment.ts`), so the wall clock
passed the seed at midnight UTC on 1 September. The base moved to now and the
exact-date assertions broke. The fix freezes the clock at `2026-08-01` with
`FakeTime`, the pattern the suite already uses. A stash of the branch
confirmed the clean-tree failure; the frozen tests are the regression tests.

## Review findings

Three rounds, all fixed on this branch:

1. CodeRabbit and Codex caught that the first matcher missed line feed and
   the full-width forms (both on the OWASP list).
2. CodeRabbit caught that the apostrophe prefix could be stripped by an
   Excel save/reopen cycle — replaced with the OWASP Excel-resistant tab.
3. Codex caught that an unquoted tab marker could be split off by a
   tab-delimited import — the writer now always quotes a tab-marked cell,
   the exact shape of the OWASP `"\t=1+2"` example, and the stale comments
   that still described the apostrophe were corrected.

One ask CI cannot answer is a literal save-and-reopen round trip in Excel:
CI has no Excel, so the tests pin the emitted bytes and the documented basis
instead.

## Gates

- `nix develop -c deno task precommit` — passed
- `nix develop -c deno task precommit:mutation` — 16/16 mutants killed,
  100% score

## Numbers

- 5 commits, 6 files: 155 insertions, 28 deletions
- Source: `src/shared/csv/index.ts` +29/-11; the rest is tests
- No database or provider calls: the change is a pure string transform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSV exports to protect against spreadsheet formula injection.
  - Formula-like values, headers, tabs, and line breaks are safely prefixed and correctly quoted.
  - Preserved formatting for comma-containing and ordinary CSV values.

- **Tests**
  - Expanded coverage for malicious and special-character inputs.
  - Stabilized renewal tests by using fixed dates for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->