### PR TITLE
Print Bugsink issue details as JSON with deno task bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1556,6 +1556,12 @@ query logging and table-scoped cache invalidation stay automatic.
 - `deno task restore <backup.zip>` - Restore the database named by `DB_URL` /
   `DB_TOKEN` in `.env` using its `DB_ENCRYPTION_KEY`. Shows the backup details,
   asks for typed confirmation, and reports each restore step in the console.
+- `deno task bugs <issue-url-or-id>` - Print one Bugsink issue and its latest
+  event as JSON, so an LLM can study a live error. The event payload includes
+  the stacktrace rendered as Markdown. `--events N` sets how many events to
+  fetch. `deno task bugs list` prints unresolved issues, newest first, and
+  `--all` adds resolved ones. Reads `SENTRY_BASE_URL` (or `SENTRY_BASE`) and
+  `SENTRY_API_KEY` from `.env`.
 - `deno task snapshot --out <path.sqlite>` - Sync the complete remote database
   to a standalone local SQLite file. The task prefers `DB_URL` and `DB_TOKEN`
   from `.env` over shell values. This developer-only task checkpoints and

--- a/deno.json
+++ b/deno.json
@@ -43,6 +43,7 @@
     "unit-tests-report": "deno run --allow-read=src,test,deno.json scripts/unit-tests-report.ts",
     "upgrade": "deno run --allow-read --allow-write --allow-net scripts/safe-upgrade.ts",
     "backup": "deno run --env-file --allow-env --allow-read --allow-write --allow-net --allow-sys --allow-ffi scripts/backup.ts",
+    "bugs": "deno run --env-file --allow-env --allow-net scripts/bugs.ts",
     "restore": "deno run --allow-env --allow-read --allow-write --allow-net --allow-sys --allow-ffi scripts/restore.ts",
     "snapshot": "deno run --allow-env --allow-read --allow-write --allow-net --allow-sys --allow-ffi scripts/database-snapshot.ts",
     "migrate:turso": "deno run --allow-env --allow-read --allow-write --allow-net --allow-sys --allow-ffi scripts/turso-migration.ts",

--- a/scripts/bugs-lib.ts
+++ b/scripts/bugs-lib.ts
@@ -1,0 +1,329 @@
+/**
+ * Fetch Bugsink issue details as JSON, so an LLM can dig into a live error.
+ * The command line lives in `bugs.ts`.
+ */
+
+import { parseArgs } from "@std/cli/parse-args";
+import * as v from "valibot";
+import { sort } from "#fp";
+import { fetchText } from "#scripts/fetch-text.ts";
+import { parseJsonWith } from "#scripts/read-json.ts";
+import type { ScriptIo } from "#scripts/script-runner.ts";
+
+export interface BugsConfig {
+  apiKey: string;
+  /** Bugsink site origin, without a trailing slash. */
+  baseUrl: string;
+}
+
+const firstSetEnv = (
+  getEnv: (key: string) => string | undefined,
+  keys: string[],
+): string | undefined =>
+  keys.map(getEnv).find((value) => value !== undefined && value !== "");
+
+export const bugsConfig = (
+  getEnv: (key: string) => string | undefined,
+): BugsConfig => {
+  const baseUrl = firstSetEnv(getEnv, ["SENTRY_BASE_URL", "SENTRY_BASE"]);
+  if (baseUrl === undefined) {
+    throw new Error(
+      "Set SENTRY_BASE_URL in .env, for example https://bugs.chobble.com",
+    );
+  }
+  const apiKey = firstSetEnv(getEnv, ["SENTRY_API_KEY"]);
+  if (apiKey === undefined) {
+    throw new Error(
+      "Set SENTRY_API_KEY in .env. Create the token in Bugsink under Tokens.",
+    );
+  }
+  let origin: URL;
+  try {
+    origin = new URL(baseUrl);
+  } catch {
+    throw new Error(`SENTRY_BASE_URL is not a URL: ${baseUrl}`);
+  }
+  if (origin.protocol !== "https:" && origin.protocol !== "http:") {
+    throw new Error(`SENTRY_BASE_URL must be an http or https URL: ${baseUrl}`);
+  }
+  return { apiKey, baseUrl: baseUrl.replace(/\/+$/, "") };
+};
+
+const UUID_PATTERN =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+/** Accept an issue page URL, a bare issue UUID, or a friendly issue id. */
+export const parseIssueRef = (ref: string): string => {
+  const uuid = UUID_PATTERN.exec(ref)?.[0];
+  if (uuid !== undefined) return uuid;
+  if (/^https?:\/\//i.test(ref)) {
+    throw new Error(
+      `No issue id found in ${ref}. Pass the issue page URL or an issue id.`,
+    );
+  }
+  return ref;
+};
+
+const parseJsonBody = (text: string, url: string): unknown =>
+  parseJsonWith((error) => {
+    throw new Error(
+      `Bugsink sent non-JSON for ${url}: ${(error as Error).message}`,
+    );
+  })(text);
+
+const apiGet = async (config: BugsConfig, url: string): Promise<unknown> => {
+  const result = await fetchText(url, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${config.apiKey}`,
+    },
+  });
+  if (!result.ok) {
+    throw new Error(
+      `Bugsink returned ${result.status} for ${url}: ${result.text.slice(0, 200)}`,
+    );
+  }
+  return parseJsonBody(result.text, url);
+};
+
+/** Check the fields the tool uses, and hand back the full raw object. */
+const getJson = async <S extends v.GenericSchema>(
+  config: BugsConfig,
+  url: string,
+  schema: S,
+): Promise<v.InferOutput<S>> => {
+  const raw = await apiGet(config, url);
+  const parsed = v.safeParse(schema, raw);
+  if (!parsed.success) {
+    const first = parsed.issues[0]!;
+    throw new Error(
+      `Bugsink sent an unexpected shape for ${url}: ${first.message} at ${
+        v.getDotPath(first) ?? "root"
+      }`,
+    );
+  }
+  return raw as v.InferOutput<S>;
+};
+
+const IssueSchema = v.object({
+  calculated_type: v.string(),
+  calculated_value: v.nullable(v.string()),
+  digested_event_count: v.number(),
+  first_seen: v.string(),
+  friendly_id: v.string(),
+  id: v.string(),
+  is_muted: v.boolean(),
+  is_resolved: v.boolean(),
+  last_seen: v.string(),
+  project: v.number(),
+  stored_event_count: v.number(),
+});
+type IssueRecord = v.InferOutput<typeof IssueSchema>;
+
+/** The events list omits the payload; only the id is needed to fetch it. */
+const EventListItemSchema = v.object({ id: v.string() });
+
+const EventSchema = v.object({
+  data: v.nullable(v.unknown()),
+  id: v.string(),
+  issue: v.string(),
+  stacktrace_md: v.nullable(v.string()),
+});
+
+const ProjectSchema = v.object({
+  id: v.number(),
+  name: v.string(),
+  slug: v.string(),
+});
+type ProjectRecord = v.InferOutput<typeof ProjectSchema>;
+
+const listPageSchema = <S extends v.GenericSchema>(item: S) =>
+  v.object({ next: v.nullable(v.string()), results: v.array(item) });
+
+/** Read a cursor-paginated list until it runs out or reaches the limit. */
+const listAll = async <S extends v.GenericSchema>(
+  config: BugsConfig,
+  firstUrl: string,
+  item: S,
+  limit: number,
+): Promise<v.InferOutput<S>[]> => {
+  const items: v.InferOutput<S>[] = [];
+  let url: string | null = firstUrl;
+  while (url !== null && items.length < limit) {
+    const page: { next: string | null; results: v.InferOutput<S>[] } =
+      await getJson(config, url, listPageSchema(item));
+    items.push(...page.results);
+    url = page.next;
+  }
+  return items.slice(0, limit);
+};
+
+const apiIssueUrl = (config: BugsConfig, issueId: string): string =>
+  `${config.baseUrl}/api/canonical/0/issues/${encodeURIComponent(issueId)}/`;
+
+export interface IssueBundle {
+  events: Record<string, unknown>[];
+  issue: Record<string, unknown>;
+  issue_url: string;
+}
+
+/** Fetch one issue plus its latest events, with the full event payloads. */
+export const fetchIssueBundle = async (
+  config: BugsConfig,
+  ref: string,
+  eventCount: number,
+): Promise<IssueBundle> => {
+  const issue = await getJson(
+    config,
+    apiIssueUrl(config, parseIssueRef(ref)),
+    IssueSchema,
+  );
+  const eventsUrl = `${config.baseUrl}/api/canonical/0/events/?issue=${encodeURIComponent(issue.id)}&order=desc`;
+  const latest = await listAll(
+    config,
+    eventsUrl,
+    EventListItemSchema,
+    eventCount,
+  );
+  const events: Record<string, unknown>[] = [];
+  for (const listed of latest) {
+    events.push(
+      await getJson(
+        config,
+        `${config.baseUrl}/api/canonical/0/events/${listed.id}/`,
+        EventSchema,
+      ),
+    );
+  }
+  return {
+    events,
+    issue,
+    issue_url: `${config.baseUrl}/issues/issue/${issue.id}/`,
+  };
+};
+
+export interface IssueSummary {
+  events: number;
+  first_seen: string;
+  friendly_id: string;
+  id: string;
+  issue_url: string;
+  last_seen: string;
+  muted: boolean;
+  project: string;
+  project_id: number;
+  stored_events: number;
+  type: string;
+  value: string | null;
+}
+
+const summarize =
+  (baseUrl: string, project: ProjectRecord) =>
+  (issue: IssueRecord): IssueSummary => ({
+    events: issue.digested_event_count,
+    first_seen: issue.first_seen,
+    friendly_id: issue.friendly_id,
+    id: issue.id,
+    issue_url: `${baseUrl}/issues/issue/${issue.id}/`,
+    last_seen: issue.last_seen,
+    muted: issue.is_muted,
+    project: project.name,
+    project_id: project.id,
+    stored_events: issue.stored_event_count,
+    type: issue.calculated_type,
+    value: issue.calculated_value,
+  });
+
+/** List the issues of every project, newest first. */
+export const fetchIssueSummaries = async (
+  config: BugsConfig,
+  includeResolved: boolean,
+): Promise<IssueSummary[]> => {
+  const projects = await listAll(
+    config,
+    `${config.baseUrl}/api/canonical/0/projects/`,
+    ProjectSchema,
+    Number.POSITIVE_INFINITY,
+  );
+  const summaries: IssueSummary[] = [];
+  for (const project of projects) {
+    const issuesUrl = `${config.baseUrl}/api/canonical/0/issues/?project=${project.id}&sort=last_seen&order=desc`;
+    const issues = await listAll(
+      config,
+      issuesUrl,
+      IssueSchema,
+      Number.POSITIVE_INFINITY,
+    );
+    summaries.push(
+      ...issues
+        .filter((issue) => includeResolved || !issue.is_resolved)
+        .map(summarize(config.baseUrl, project)),
+    );
+  }
+  return sort((a: IssueSummary, b: IssueSummary) =>
+    b.last_seen.localeCompare(a.last_seen),
+  )(summaries);
+};
+
+export const USAGE = `Fetch Bugsink issue details as JSON.
+
+Usage: deno task bugs <issue-url-or-id>... [--events N]
+       deno task bugs list [--all]
+
+Options:
+  --events N   Fetch the latest N events per issue. Default 1. 0 prints the issue only.
+  --all        With list, also print resolved issues.
+  -h, --help   Print this text.
+
+Reads SENTRY_BASE_URL (or SENTRY_BASE) and SENTRY_API_KEY from .env.
+Create a token in Bugsink under Tokens.
+`;
+
+const wholeNumber = (text: string): number | undefined =>
+  /^\d+$/.test(text) ? Number(text) : undefined;
+
+export const runBugsCli = async (io: ScriptIo): Promise<number> => {
+  const flags = parseArgs(io.args, {
+    alias: { h: "help" },
+    boolean: ["all", "help"],
+    string: ["events"],
+  });
+  if (flags.help || flags._.length === 0) {
+    io.stderr(USAGE);
+    return flags.help ? 0 : 1;
+  }
+  const eventCount = wholeNumber(flags.events ?? "1");
+  if (eventCount === undefined) {
+    io.stderr(
+      `The --events value must be a whole number, got: ${flags.events}`,
+    );
+    io.stderr(USAGE);
+    return 1;
+  }
+  try {
+    const config = bugsConfig(io.getEnv);
+    const refs = flags._.map((value) => String(value));
+    if (refs[0] === "list") {
+      if (refs.length > 1) {
+        io.stderr("The list command takes no issue ids.");
+        return 1;
+      }
+      io.stdout(
+        JSON.stringify(await fetchIssueSummaries(config, flags.all), null, 2),
+      );
+      return 0;
+    }
+    const bundles: IssueBundle[] = [];
+    for (const ref of refs) {
+      io.stderr(`Fetching ${ref}`);
+      bundles.push(await fetchIssueBundle(config, ref, eventCount));
+    }
+    io.stdout(
+      JSON.stringify(bundles.length === 1 ? bundles[0] : bundles, null, 2),
+    );
+    return 0;
+  } catch (error) {
+    io.stderr(`error: ${(error as Error).message}`);
+    return 1;
+  }
+};

--- a/scripts/bugs-lib.ts
+++ b/scripts/bugs-lib.ts
@@ -9,11 +9,14 @@ import { sort } from "#fp";
 import { fetchText } from "#scripts/fetch-text.ts";
 import { parseJsonWith } from "#scripts/read-json.ts";
 import type { ScriptIo } from "#scripts/script-runner.ts";
+import { isLocalHttpHost } from "#shared/local-host.ts";
 
 export interface BugsConfig {
   apiKey: string;
   /** Bugsink site origin, without a trailing slash. */
   baseUrl: string;
+  /** The URL origin every request, pagination included, stays inside. */
+  origin: string;
 }
 
 const firstSetEnv = (
@@ -37,16 +40,32 @@ export const bugsConfig = (
       "Set SENTRY_API_KEY in .env. Create the token in Bugsink under Tokens.",
     );
   }
-  let origin: URL;
+  let parsed: URL;
   try {
-    origin = new URL(baseUrl);
+    parsed = new URL(baseUrl);
   } catch {
     throw new Error(`SENTRY_BASE_URL is not a URL: ${baseUrl}`);
   }
-  if (origin.protocol !== "https:" && origin.protocol !== "http:") {
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     throw new Error(`SENTRY_BASE_URL must be an http or https URL: ${baseUrl}`);
   }
-  return { apiKey, baseUrl: baseUrl.replace(/\/+$/, "") };
+  // The API key rides every request as a Bearer token, so cleartext http is
+  // for local networks only, the same rule as UPTIME_KUMA_URL.
+  if (parsed.protocol === "http:" && !isLocalHttpHost(parsed.hostname)) {
+    throw new Error(
+      `SENTRY_BASE_URL must use HTTPS outside a local network: ${baseUrl}`,
+    );
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error(
+      `SENTRY_BASE_URL must not contain a query or fragment: ${baseUrl}`,
+    );
+  }
+  return {
+    apiKey,
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    origin: parsed.origin,
+  };
 };
 
 const UUID_PATTERN =
@@ -140,6 +159,26 @@ type ProjectRecord = v.InferOutput<typeof ProjectSchema>;
 const listPageSchema = <S extends v.GenericSchema>(item: S) =>
   v.object({ next: v.nullable(v.string()), results: v.array(item) });
 
+/** Pin a pagination URL to the configured origin and the canonical API, so a
+ * tampered response cannot point the Bearer token somewhere else. */
+const pinnedNextUrl = (config: BugsConfig, next: string): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(next);
+  } catch {
+    throw new Error(`Bugsink sent a pagination URL that is not a URL: ${next}`);
+  }
+  if (
+    parsed.origin !== config.origin ||
+    !parsed.pathname.startsWith("/api/canonical/0/")
+  ) {
+    throw new Error(
+      `Bugsink sent a pagination URL outside its own canonical API: ${next}`,
+    );
+  }
+  return parsed.href;
+};
+
 /** Read a cursor-paginated list until it runs out or reaches the limit. */
 const listAll = async <S extends v.GenericSchema>(
   config: BugsConfig,
@@ -153,7 +192,7 @@ const listAll = async <S extends v.GenericSchema>(
     const page: { next: string | null; results: v.InferOutput<S>[] } =
       await getJson(config, url, listPageSchema(item));
     items.push(...page.results);
-    url = page.next;
+    url = page.next === null ? null : pinnedNextUrl(config, page.next);
   }
   return items.slice(0, limit);
 };

--- a/scripts/bugs.ts
+++ b/scripts/bugs.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S deno run --env-file --allow-env --allow-net
+
+/**
+ * Print Bugsink issue details as JSON, so an LLM can dig into a live error.
+ * See `bugs-lib.ts`.
+ */
+
+import { runBugsCli } from "#scripts/bugs-lib.ts";
+import { runDenoScript } from "#scripts/script-runner.ts";
+
+await runDenoScript(runBugsCli);

--- a/scripts/cpd-renamed/allowed.json
+++ b/scripts/cpd-renamed/allowed.json
@@ -48,8 +48,16 @@
     "secondStart": 535
   },
   {
+    "first": "scripts/bugs-lib.ts",
+    "firstStart": 135,
+    "hash": "00c4cbd19e8fdeb66bdf78d34a5795af0e9b909bdf3f4a4f35c4c1402ba299fd",
+    "reason": "two external API boundary schemas — a Bugsink project and a Deno Deploy app identity — that name an id, a name and a slug; one shared schema factory would couple the two provider contracts while each keeps its own field types",
+    "second": "src/shared/deno-deploy-schema.ts",
+    "secondStart": 4
+  },
+  {
     "first": "scripts/check-shapes/accepted.ts",
-    "firstStart": 53,
+    "firstStart": 55,
     "hash": "1171f38a79cc385714f1fad06e280960e3d41ed5c89d97c91ee8f1579d187162",
     "reason": "two opening lines only — a set to fill and the entries to walk; the loops share no step after them, one dedupes accepted keys while the gate runs, so a curry has nothing to lift",
     "second": "scripts/mutation/equivalent-audit.ts",
@@ -713,7 +721,7 @@
   },
   {
     "first": "src/ui/templates/admin/bulk-email.tsx",
-    "firstStart": 40,
+    "firstStart": 42,
     "hash": "e4fdb2943e1474cb754661ad6e843c188f3dae2b4611d640f24c8d195408336b",
     "reason": "pending merge — same code with different words; unify into one helper or curry, then delete this entry",
     "second": "src/ui/templates/admin/listings/form-pages.tsx",

--- a/scripts/mutation/equivalent-mutants/scripts.txt
+++ b/scripts/mutation/equivalent-mutants/scripts.txt
@@ -107,3 +107,8 @@ scripts/check-comments/rules.ts::widestLine.width~1myoetc  0 → 1   # same firs
 scripts/check-comments/rules.ts::namesMentioned~1nnu9xx  ?? → ||   # String.match with a global regex returns null or a non-empty array, and every array is truthy, so only null reaches the fallback and both operators yield the same []
 scripts/check-comments/rules.ts::findDeadLinks.line~1my9h0w  0 → 1   # the count runs from the comment's own start, and a comment always begins with "/", so skipping character 0 can never miss a newline
 scripts/check-comments/rules.ts::namesMentioned~1ugmzzy  %20 → ""   # the link pattern captures identifier characters greedily, so the character after every match is always a non-identifier that already separates the tokens — replacing a link with a space and with nothing give the same names for every input
+
+# bugs-lib.ts — getDotPath answers a dotted path for any issue that carries a
+# key, and null for a root-level issue; it never returns a non-null falsy
+# value, so the root fallback agrees under both operators.
+scripts/bugs-lib.ts::getJson~0yt17y4  ?? → ||   # v.getDotPath returns a non-empty dotted path or null, never "", so ?? and || pick the same side for every issue

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -6,8 +6,6 @@ src/features/admin/dashboard.ts::handleAdminLog.entries~1bmdvzm  1 → 2   # The
 src/shared/bearer.ts::bearerTokenOrNull~0zm5hxk  ?? → ||   # the optional regex capture is non-empty because the capture uses +, so only undefined reaches the null fallback
 src/shared/uptime-kuma/socket.ts::KumaSocket.%23changeListeners~0x9mfb4  0 → -1   # the private map's missing set and retained empty set behave identically: once adds to either, while off and emit are no-ops for both
 src/shared/uptime-kuma/matching.ts::SCHEDULED_MONITOR_RULES.holds~14f0p4m  1000 → 1001   # timeout is a positive whole number of seconds and the 25,000ms deadline lies between the same integer seconds under either multiplier
-src/shared/uptime-kuma/config.ts::ipv6FirstGroup~1a8w32z  [ → ""   # startsWith("") is always true. A non-bracketed URL hostname can never contain a colon. Every host this lets through still fails the to > 1 check. The result is null either way
-src/shared/uptime-kuma/config.ts::ipv6FirstGroup~16zpdpl  1 → 0   # only "[:"-form hosts have their first colon at index 1. The empty first group parses to NaN. The mask comparisons are false. This refuses the host exactly like the null it replaces
 
 # `x ?? F` vs `x || F` differ only when x is falsy-but-not-null; these are all
 # cases where x can't be such a value, or F equals the only one it can be.
@@ -271,3 +269,9 @@ src/shared/bulk-email.ts::resolveRecipientEmails.decrypted~0cin95y  false → tr
 src/shared/bulk-email.ts::buildMailtoLink.to~0u9lgeh  = → +=   # to is still the empty string here, so assigning the address and appending it give the same to
 src/shared/bulk-email.ts::buildMailtoLink~1gzgdij  1 → 0   # the branch above already took every one-address call, so this else-if can only see two or more either way
 src/shared/bulk-email.ts::buildMailtoLink.to~1lrzg1h  = → +=   # to is still the empty string here, so assigning the business email and appending it give the same to
+
+# local-host.ts — the only bracketed host with its first colon at index 1 is
+# "[::1]", which the caller answers before this helper runs. For any other
+# input at that boundary the slice is empty, parseInt gives NaN, and both
+# range masks fail, so NaN and null land on the same false.
+src/shared/local-host.ts::ipv6FirstGroup~16zpdpl  1 → 0   # at to === 1 the group slice is empty, NaN fails both masks like null does, and every real group sits past index 1

--- a/scripts/read-json.ts
+++ b/scripts/read-json.ts
@@ -5,15 +5,19 @@
 import * as v from "valibot";
 import { nullIfNotFound } from "#scripts/not-found.ts";
 
-/** JSON that may have been left half-written, as data or as null. */
-const parseOrNull = (text: string): unknown => {
-  try {
-    return JSON.parse(text);
-  } catch {
-    // Torn text reads as "nothing here", which every caller already handles.
-    return null;
-  }
-};
+/** Parse JSON text, and let the caller decide what a torn text becomes. */
+export const parseJsonWith =
+  (onParseError: (error: unknown) => unknown) =>
+  (text: string): unknown => {
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      return onParseError(error);
+    }
+  };
+
+/** Torn text reads as "nothing here", which every caller already handles. */
+const parseOrNull = parseJsonWith(() => null);
 
 /**
  * What the file at `path` holds, checked against `schema`. `null` means there

--- a/src/shared/local-host.ts
+++ b/src/shared/local-host.ts
@@ -1,0 +1,57 @@
+/** Hosts that can use cleartext http for a credential-carrying request.
+ * Loopback is one. The rest are ranges no packet can leave the operator's
+ * network for: the private blocks, the CGNAT space where VPNs such as
+ * Tailscale live, and link-local. Every other host needs HTTPS, so a bearer
+ * token never crosses a public network unencrypted. */
+
+/** The first 16-bit group of a bracketed IPv6 host, or null for any host that
+ * is not one. The URL parser already rejects a bracketed host that is not
+ * canonical IPv6. Every group of a canonical host is hex. */
+const ipv6FirstGroup = (hostname: string): number | null => {
+  if (!hostname.startsWith("[")) return null;
+  const to = hostname.indexOf(":");
+  return to > 1 ? Number.parseInt(hostname.slice(1, to), 16) : null;
+};
+
+/** A fully qualified name keeps one trailing root dot. "localhost." is still
+ * the name "localhost". */
+const withoutRootDot = (hostname: string): string =>
+  hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+
+/** True for an IPv4 host inside a range no packet can leave the operator's
+ * network for. That covers loopback, the private blocks, CGNAT, and
+ * link-local. */
+const isLocalIpv4 = (hostname: string): boolean => {
+  // A real IPv4 host arrives in canonical dotted decimal, digits only. A
+  // lookalike DNS name such as "10.0.0.1e0" must not reach the octet
+  // checks. Number("1e0") is 1, so only digit labels can pass.
+  const labels = hostname.split(".");
+  const isIpv4 =
+    labels.length === 4 && labels.every((label) => /^\d{1,3}$/.test(label));
+  if (!isIpv4) return false;
+  const first = Number(labels[0]!);
+  const second = Number(labels[1]!);
+  return (
+    first === 10 || // 10.0.0.0/8
+    first === 127 || // 127.0.0.0/8
+    (first === 100 && second >= 64 && second <= 127) || // 100.64.0.0/10
+    (first === 169 && second === 254) || // 169.254.0.0/16
+    (first === 172 && second >= 16 && second <= 31) || // 172.16.0.0/12
+    (first === 192 && second === 168) // 192.168.0.0/16
+  );
+};
+
+export const isLocalHttpHost = (rawHostname: string): boolean => {
+  const hostname = withoutRootDot(rawHostname);
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    return true;
+  }
+  if (hostname === "[::1]") return true;
+  if (isLocalIpv4(hostname)) return true;
+  const firstGroup = ipv6FirstGroup(hostname);
+  return (
+    firstGroup !== null &&
+    ((firstGroup & 0xfe00) === 0xfc00 || // fc00::/7 unique local
+      (firstGroup & 0xffc0) === 0xfe80) // fe80::/10 link local
+  );
+};

--- a/src/shared/uptime-kuma/config.ts
+++ b/src/shared/uptime-kuma/config.ts
@@ -1,5 +1,6 @@
 import { isBuilderEnabled } from "#shared/config.ts";
 import { getEnv } from "#shared/env.ts";
+import { isLocalHttpHost } from "#shared/local-host.ts";
 import { parsePositiveInt } from "#shared/validation/number.ts";
 
 const DEFAULT_UPTIME_KUMA_INTERVAL_MINUTES = 15;
@@ -20,63 +21,6 @@ export type UptimeKumaConfig = {
 const nonBlank = (name: string, value: string): string => {
   if (value.trim().length === 0) throw new Error(`${name} must not be blank`);
   return value;
-};
-
-/** The first 16-bit group of a bracketed IPv6 host, or null for any host that
- * is not one. The URL parser already rejects a bracketed host that is not
- * canonical IPv6. Every group of a canonical host is hex. */
-const ipv6FirstGroup = (hostname: string): number | null => {
-  if (!hostname.startsWith("[")) return null;
-  const to = hostname.indexOf(":");
-  return to > 1 ? Number.parseInt(hostname.slice(1, to), 16) : null;
-};
-
-/** A fully qualified name keeps one trailing root dot. "localhost." is still
- * the name "localhost". */
-const withoutRootDot = (hostname: string): string =>
-  hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
-
-/** True for an IPv4 host inside a range no packet can leave the operator's
- * network for. That covers loopback, the private blocks, CGNAT, and
- * link-local. */
-const isLocalIpv4 = (hostname: string): boolean => {
-  // A real IPv4 host arrives in canonical dotted decimal, digits only. A
-  // lookalike DNS name such as "10.0.0.1e0" must not reach the octet
-  // checks. Number("1e0") is 1, so only digit labels can pass.
-  const labels = hostname.split(".");
-  const isIpv4 =
-    labels.length === 4 && labels.every((label) => /^\d{1,3}$/.test(label));
-  if (!isIpv4) return false;
-  const first = Number(labels[0]!);
-  const second = Number(labels[1]!);
-  return (
-    first === 10 || // 10.0.0.0/8
-    first === 127 || // 127.0.0.0/8
-    (first === 100 && second >= 64 && second <= 127) || // 100.64.0.0/10
-    (first === 169 && second === 254) || // 169.254.0.0/16
-    (first === 172 && second >= 16 && second <= 31) || // 172.16.0.0/12
-    (first === 192 && second === 168) // 192.168.0.0/16
-  );
-};
-
-/** Hosts that can use cleartext http for the Kuma login. Loopback is one.
- * The rest are ranges no packet can leave the operator's network for. These
- * are the private blocks, the CGNAT space where VPNs such as Tailscale live,
- * and link-local. Every other host needs HTTPS, so the Kuma password never
- * crosses a public network unencrypted. */
-const isLocalHttpHost = (rawHostname: string): boolean => {
-  const hostname = withoutRootDot(rawHostname);
-  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
-    return true;
-  }
-  if (hostname === "[::1]") return true;
-  if (isLocalIpv4(hostname)) return true;
-  const firstGroup = ipv6FirstGroup(hostname);
-  return (
-    firstGroup !== null &&
-    ((firstGroup & 0xfe00) === 0xfc00 || // fc00::/7 unique local
-      (firstGroup & 0xffc0) === 0xfe80) // fe80::/10 link local
-  );
 };
 
 const parseBaseUrl = (value: string): string => {

--- a/test/scripts/bugs-lib/cli.test.ts
+++ b/test/scripts/bugs-lib/cli.test.ts
@@ -1,0 +1,142 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import {
+  type IssueBundle,
+  type IssueSummary,
+  runBugsCli,
+  USAGE,
+} from "#scripts/bugs-lib.ts";
+import { stubFetchEachTest } from "#test-utils/fetch-stub.ts";
+import {
+  BASE,
+  ENV,
+  EVENT,
+  EVENT_ID,
+  ISSUE,
+  ISSUE_ID,
+  ioWith,
+  json,
+  OTHER_ISSUE_ID,
+  page,
+  route,
+  singleProjectRoutes,
+} from "./support.ts";
+
+describe("runBugsCli", () => {
+  const fetcher = stubFetchEachTest(new Response("{}", { status: 404 }));
+  const answerBy = route(fetcher);
+
+  test("prints usage and fails without arguments", async () => {
+    const { io, err } = ioWith([]);
+
+    expect(await runBugsCli(io)).toBe(1);
+    expect(err[0]).toBe(USAGE);
+  });
+
+  test("prints usage and succeeds with --help", async () => {
+    const { io, err } = ioWith(["--help"]);
+
+    expect(await runBugsCli(io)).toBe(0);
+    expect(err[0]).toBe(USAGE);
+  });
+
+  test("prints usage and succeeds with -h", async () => {
+    const { io, err } = ioWith(["-h"]);
+
+    expect(await runBugsCli(io)).toBe(0);
+    expect(err[0]).toBe(USAGE);
+  });
+
+  test("treats --help=false as no help request and fails without arguments", async () => {
+    const { io, err } = ioWith(["--help=false"]);
+
+    expect(await runBugsCli(io)).toBe(1);
+    expect(err[0]).toBe(USAGE);
+  });
+
+  test("refuses an --events value that is not a whole number", async () => {
+    const { io, err } = ioWith([ISSUE_ID, "--events", "latest"], ENV);
+
+    expect(await runBugsCli(io)).toBe(1);
+    expect(err[0]).toContain("must be a whole number");
+    expect(err[1]).toBe(USAGE);
+  });
+
+  test("refuses an empty --events value", async () => {
+    const { io, err } = ioWith([ISSUE_ID, "--events", ""], ENV);
+
+    expect(await runBugsCli(io)).toBe(1);
+    expect(err[0]).toContain("must be a whole number");
+  });
+
+  test("prints one bundle for one issue", async () => {
+    answerBy((url) => {
+      if (url.endsWith(`/issues/${ISSUE_ID}/`)) return json(ISSUE);
+      if (url.includes("/events/?issue="))
+        return json(page([{ id: EVENT_ID }]));
+      return json(EVENT);
+    });
+    const { io, out, err } = ioWith(
+      [`https://bugs.chobble.com/issues/issue/${ISSUE_ID}/`],
+      ENV,
+    );
+
+    expect(await runBugsCli(io)).toBe(0);
+
+    expect(err[0]).toBe(
+      `Fetching https://bugs.chobble.com/issues/issue/${ISSUE_ID}/`,
+    );
+    expect(out[0]!.startsWith('{\n  "')).toBe(true);
+    const bundle = JSON.parse(out[0]!) as IssueBundle;
+    expect(bundle.issue_url).toBe(`${BASE}/issues/issue/${ISSUE_ID}/`);
+    expect(bundle.events.length).toBe(1);
+  });
+
+  test("prints an array for several issues", async () => {
+    answerBy((url) => {
+      if (url.includes("/issues/TIC-1/")) return json(ISSUE);
+      if (url.includes("/issues/TIC-3/")) {
+        return json({ ...ISSUE, friendly_id: "TIC-3", id: OTHER_ISSUE_ID });
+      }
+      if (url.includes("/events/?issue=")) return json(page([]));
+      return json({ detail: "not found" }, 404);
+    });
+    const { io, out } = ioWith(["TIC-1", "TIC-3"], ENV);
+
+    expect(await runBugsCli(io)).toBe(0);
+
+    expect(out[0]!.startsWith("[\n  {")).toBe(true);
+    const bundles = JSON.parse(out[0]!) as IssueBundle[];
+    expect(bundles.map((bundle) => bundle.issue.friendly_id)).toEqual([
+      "TIC-1",
+      "TIC-3",
+    ]);
+  });
+
+  test("prints summaries for list", async () => {
+    answerBy(singleProjectRoutes([ISSUE]));
+    const { io, out } = ioWith(["list"], ENV);
+
+    expect(await runBugsCli(io)).toBe(0);
+
+    expect(out[0]!.startsWith("[\n  {")).toBe(true);
+    const summaries = JSON.parse(out[0]!) as IssueSummary[];
+    expect(summaries.map((issue) => issue.friendly_id)).toEqual(["TIC-1"]);
+  });
+
+  test("reports a configuration problem and fails", async () => {
+    const { io, err } = ioWith(["list"], {});
+
+    expect(await runBugsCli(io)).toBe(1);
+    expect(err[0]).toBe(
+      "error: Set SENTRY_BASE_URL in .env, for example https://bugs.chobble.com",
+    );
+  });
+
+  test("refuses issue ids beside the list command", async () => {
+    const { io, err } = ioWith(["list", ISSUE_ID], ENV);
+
+    expect(await runBugsCli(io)).toBe(1);
+    expect(err[0]).toBe("The list command takes no issue ids.");
+  });
+});

--- a/test/scripts/bugs-lib/config.test.ts
+++ b/test/scripts/bugs-lib/config.test.ts
@@ -37,12 +37,12 @@ describe("bugsConfig", () => {
   test("reads SENTRY_BASE_URL and strips the trailing slash", () => {
     expect(
       bugsConfig(env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: `${BASE}/` })),
-    ).toEqual({ apiKey: "k", baseUrl: BASE });
+    ).toEqual({ apiKey: "k", baseUrl: BASE, origin: BASE });
   });
 
   test("falls back to SENTRY_BASE", () => {
     expect(bugsConfig(env({ SENTRY_API_KEY: "k", SENTRY_BASE: BASE }))).toEqual(
-      { apiKey: "k", baseUrl: BASE },
+      { apiKey: "k", baseUrl: BASE, origin: BASE },
     );
   });
 
@@ -55,15 +55,44 @@ describe("bugsConfig", () => {
           SENTRY_BASE_URL: "",
         }),
       ),
-    ).toEqual({ apiKey: "k", baseUrl: BASE });
+    ).toEqual({ apiKey: "k", baseUrl: BASE, origin: BASE });
   });
 
-  test("accepts an http base URL for a local instance", () => {
+  test("accepts an http base URL on a local network host", () => {
     expect(
       bugsConfig(
-        env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: "http://bugs.local" }),
+        env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: "http://127.0.0.1:8080" }),
       ),
-    ).toEqual({ apiKey: "k", baseUrl: "http://bugs.local" });
+    ).toEqual({
+      apiKey: "k",
+      baseUrl: "http://127.0.0.1:8080",
+      origin: "http://127.0.0.1:8080",
+    });
+  });
+
+  test("refuses a public http base URL", () => {
+    expect(() =>
+      bugsConfig(
+        env({
+          SENTRY_API_KEY: "k",
+          SENTRY_BASE_URL: "http://bugs.example.com",
+        }),
+      ),
+    ).toThrow("must use HTTPS outside a local network");
+  });
+
+  test("refuses a query in the base URL", () => {
+    expect(() =>
+      bugsConfig(
+        env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: `${BASE}/?view=all` }),
+      ),
+    ).toThrow("must not contain a query or fragment");
+  });
+
+  test("refuses a fragment in the base URL", () => {
+    expect(() =>
+      bugsConfig(env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: `${BASE}/#top` })),
+    ).toThrow("must not contain a query or fragment");
   });
 
   test("refuses to run without a base URL", () => {

--- a/test/scripts/bugs-lib/config.test.ts
+++ b/test/scripts/bugs-lib/config.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { bugsConfig, parseIssueRef } from "#scripts/bugs-lib.ts";
+import { BASE, ISSUE_ID } from "./support.ts";
+
+describe("parseIssueRef", () => {
+  test("extracts the issue id from an issue page URL", () => {
+    expect(
+      parseIssueRef(`https://bugs.chobble.com/issues/issue/${ISSUE_ID}/`),
+    ).toBe(ISSUE_ID);
+  });
+
+  test("extracts the issue id from a markdown summary URL", () => {
+    expect(parseIssueRef(`${BASE}/issues/issue/${ISSUE_ID}/md/`)).toBe(
+      ISSUE_ID,
+    );
+  });
+
+  test("passes a bare issue id through", () => {
+    expect(parseIssueRef(ISSUE_ID)).toBe(ISSUE_ID);
+  });
+
+  test("passes a friendly issue id through", () => {
+    expect(parseIssueRef("TIC-1")).toBe("TIC-1");
+  });
+
+  test("refuses a URL that holds no issue id", () => {
+    expect(() => parseIssueRef(`${BASE}/projects/`)).toThrow(
+      "No issue id found",
+    );
+  });
+});
+
+describe("bugsConfig", () => {
+  const env = (values: Record<string, string>) => (key: string) => values[key];
+
+  test("reads SENTRY_BASE_URL and strips the trailing slash", () => {
+    expect(
+      bugsConfig(env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: `${BASE}/` })),
+    ).toEqual({ apiKey: "k", baseUrl: BASE });
+  });
+
+  test("falls back to SENTRY_BASE", () => {
+    expect(bugsConfig(env({ SENTRY_API_KEY: "k", SENTRY_BASE: BASE }))).toEqual(
+      { apiKey: "k", baseUrl: BASE },
+    );
+  });
+
+  test("an empty SENTRY_BASE_URL falls through to SENTRY_BASE", () => {
+    expect(
+      bugsConfig(
+        env({
+          SENTRY_API_KEY: "k",
+          SENTRY_BASE: BASE,
+          SENTRY_BASE_URL: "",
+        }),
+      ),
+    ).toEqual({ apiKey: "k", baseUrl: BASE });
+  });
+
+  test("accepts an http base URL for a local instance", () => {
+    expect(
+      bugsConfig(
+        env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: "http://bugs.local" }),
+      ),
+    ).toEqual({ apiKey: "k", baseUrl: "http://bugs.local" });
+  });
+
+  test("refuses to run without a base URL", () => {
+    expect(() => bugsConfig(env({ SENTRY_API_KEY: "k" }))).toThrow(
+      "Set SENTRY_BASE_URL",
+    );
+  });
+
+  test("refuses to run without an API key", () => {
+    expect(() => bugsConfig(env({ SENTRY_BASE_URL: BASE }))).toThrow(
+      "Set SENTRY_API_KEY",
+    );
+  });
+
+  test("refuses a base URL that is not a URL", () => {
+    expect(() =>
+      bugsConfig(env({ SENTRY_API_KEY: "k", SENTRY_BASE_URL: "bugs" })),
+    ).toThrow("is not a URL");
+  });
+
+  test("refuses a base URL that is not http or https", () => {
+    expect(() =>
+      bugsConfig(
+        env({
+          SENTRY_API_KEY: "k",
+          SENTRY_BASE_URL: "ftp://bugs.example.com",
+        }),
+      ),
+    ).toThrow("must be an http or https URL");
+  });
+});

--- a/test/scripts/bugs-lib/fetch.test.ts
+++ b/test/scripts/bugs-lib/fetch.test.ts
@@ -1,0 +1,232 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { fetchIssueBundle, fetchIssueSummaries } from "#scripts/bugs-lib.ts";
+import { stubFetchEachTest, type TestFetch } from "#test-utils/fetch-stub.ts";
+import {
+  BASE,
+  CONFIG,
+  callsOf,
+  EVENT,
+  EVENT_2_ID,
+  EVENT_ID,
+  eventDetail,
+  ISSUE,
+  ISSUE_ID,
+  json,
+  OTHER_ISSUE_ID,
+  page,
+  route,
+  singleProjectRoutes,
+} from "./support.ts";
+
+describe("fetchIssueBundle", () => {
+  const fetcher = stubFetchEachTest(new Response("{}", { status: 404 }));
+  const answerBy = route(fetcher);
+
+  test("fetches the issue and its latest event, and keeps the raw payloads", async () => {
+    answerBy((url) => {
+      if (url === `${BASE}/api/canonical/0/issues/${ISSUE_ID}/`)
+        return json(ISSUE);
+      if (
+        url === `${BASE}/api/canonical/0/events/?issue=${ISSUE_ID}&order=desc`
+      ) {
+        return json(page([{ id: EVENT_ID }]));
+      }
+      if (url === `${BASE}/api/canonical/0/events/${EVENT_ID}/`)
+        return json(EVENT);
+      return json({ detail: "not found" }, 404);
+    });
+
+    const bundle = await fetchIssueBundle(
+      CONFIG,
+      `https://bugs.chobble.com/issues/issue/${ISSUE_ID}/`,
+      1,
+    );
+
+    const calls = callsOf(fetcher);
+    expect(calls.map((call) => call.url)).toEqual([
+      `${BASE}/api/canonical/0/issues/${ISSUE_ID}/`,
+      `${BASE}/api/canonical/0/events/?issue=${ISSUE_ID}&order=desc`,
+      `${BASE}/api/canonical/0/events/${EVENT_ID}/`,
+    ]);
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-key");
+    expect(headers.Accept).toBe("application/json");
+    expect(bundle.issue_url).toBe(`${BASE}/issues/issue/${ISSUE_ID}/`);
+    expect(bundle.issue.friendly_id).toBe("TIC-1");
+    expect(bundle.issue.bugsink_extra).toBe("kept");
+    expect(bundle.events.length).toBe(1);
+    expect(bundle.events[0]!.stacktrace_md).toBe(EVENT.stacktrace_md);
+    expect(bundle.events[0]!.data).toEqual(EVENT.data);
+  });
+
+  test("with an event count of 0, fetches the issue only", async () => {
+    answerBy((url) => {
+      if (url.endsWith(`/issues/${ISSUE_ID}/`)) return json(ISSUE);
+      return json({ detail: "not found" }, 404);
+    });
+
+    const bundle = await fetchIssueBundle(CONFIG, ISSUE_ID, 0);
+
+    expect(bundle.events).toEqual([]);
+    expect(callsOf(fetcher).length).toBe(1);
+  });
+
+  test("follows pagination until it has the wanted number of events", async () => {
+    answerBy((url) => {
+      if (url.endsWith(`/issues/${ISSUE_ID}/`)) return json(ISSUE);
+      if (url.includes("cursor=2")) return json(page([{ id: EVENT_2_ID }]));
+      if (url.includes("/events/?issue=")) {
+        return json(
+          page(
+            [{ id: EVENT_ID }],
+            `${BASE}/api/canonical/0/events/?issue=${ISSUE_ID}&cursor=2`,
+          ),
+        );
+      }
+      return json(eventDetail(url.split("/").slice(-2)[0]!));
+    });
+
+    const bundle = await fetchIssueBundle(CONFIG, ISSUE_ID, 2);
+
+    expect(bundle.events.map((event) => event.id)).toEqual([
+      EVENT_ID,
+      EVENT_2_ID,
+    ]);
+    expect(
+      callsOf(fetcher).filter((call) => call.url.includes("cursor=2")).length,
+    ).toBe(1);
+  });
+
+  test("stops reading pages once the event limit is reached", async () => {
+    answerBy((url) => {
+      if (url.endsWith(`/issues/${ISSUE_ID}/`)) return json(ISSUE);
+      if (url.includes("cursor=2")) return json(page([]));
+      if (url.includes("/events/?issue=")) {
+        return json(
+          page(
+            [{ id: EVENT_ID }, { id: EVENT_2_ID }],
+            `${BASE}/api/canonical/0/events/?cursor=2`,
+          ),
+        );
+      }
+      return json(eventDetail(url.split("/").slice(-2)[0]!));
+    });
+
+    const bundle = await fetchIssueBundle(CONFIG, ISSUE_ID, 1);
+
+    expect(bundle.events.length).toBe(1);
+    expect(callsOf(fetcher).some((call) => call.url.includes("cursor=2"))).toBe(
+      false,
+    );
+  });
+
+  test("reports a missing issue with its status and body", async () => {
+    answerBy(() => json({ detail: "issue TIC-999 unknown" }, 404));
+
+    await expect(fetchIssueBundle(CONFIG, "TIC-999", 1)).rejects.toThrow(
+      "Bugsink returned 404",
+    );
+    await expect(fetchIssueBundle(CONFIG, "TIC-999", 1)).rejects.toThrow(
+      '{"detail":"issue TIC-999 unknown"}',
+    );
+  });
+
+  test("reports an unexpected payload shape", async () => {
+    answerBy(() => json({ id: ISSUE_ID, project: "one" }));
+
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 1)).rejects.toThrow(
+      "unexpected shape",
+    );
+  });
+
+  test("reports a payload that fails at the root", async () => {
+    answerBy(() => json("nope"));
+
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 1)).rejects.toThrow(
+      "unexpected shape for https://bugs.example.com",
+    );
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 1)).rejects.toThrow(
+      " at root",
+    );
+  });
+
+  test("reports a non-JSON body", async () => {
+    fetcher.reply(new Response("<html>busy</html>", { status: 200 }));
+
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 1)).rejects.toThrow(
+      "non-JSON",
+    );
+  });
+});
+
+describe("fetchIssueSummaries", () => {
+  const fetcher: TestFetch = stubFetchEachTest(
+    new Response("{}", { status: 404 }),
+  );
+  const answerBy = route(fetcher);
+
+  const RESOLVED = {
+    ...ISSUE,
+    calculated_value: "old boom",
+    friendly_id: "TIC-2",
+    id: OTHER_ISSUE_ID,
+    is_resolved: true,
+    last_seen: "2026-09-01T10:00:00Z",
+  };
+
+  const OTHER_UNRESOLVED = {
+    ...ISSUE,
+    calculated_value: "other boom",
+    friendly_id: "TIC-3",
+    id: OTHER_ISSUE_ID,
+    last_seen: "2026-09-01T12:00:00Z",
+  };
+
+  test("lists unresolved issues of every project, newest first", async () => {
+    answerBy((url) => {
+      if (url.endsWith("/api/canonical/0/projects/")) {
+        return json(
+          page([
+            { id: 1, name: "Tickets", slug: "tickets" },
+            { id: 2, name: "Website", slug: "website" },
+          ]),
+        );
+      }
+      if (url.includes("project=1")) return json(page([ISSUE]));
+      if (url.includes("project=2")) {
+        return json(page([RESOLVED, OTHER_UNRESOLVED]));
+      }
+      return json({ detail: "not found" }, 404);
+    });
+
+    const summaries = await fetchIssueSummaries(CONFIG, false);
+
+    expect(summaries.map((issue) => issue.friendly_id)).toEqual([
+      "TIC-1",
+      "TIC-3",
+    ]);
+    expect(summaries[0]).toEqual({
+      events: 3,
+      first_seen: "2026-09-01T10:00:00Z",
+      friendly_id: "TIC-1",
+      id: ISSUE_ID,
+      issue_url: `${BASE}/issues/issue/${ISSUE_ID}/`,
+      last_seen: "2026-09-02T11:00:00Z",
+      muted: false,
+      project: "Tickets",
+      project_id: 1,
+      stored_events: 3,
+      type: "Error",
+      value: "boom",
+    });
+  });
+
+  test("with the flag, resolved issues are listed too", async () => {
+    answerBy(singleProjectRoutes([RESOLVED]));
+
+    const summaries = await fetchIssueSummaries(CONFIG, true);
+
+    expect(summaries.map((issue) => issue.friendly_id)).toEqual(["TIC-2"]);
+  });
+});

--- a/test/scripts/bugs-lib/fetch.test.ts
+++ b/test/scripts/bugs-lib/fetch.test.ts
@@ -23,6 +23,16 @@ describe("fetchIssueBundle", () => {
   const fetcher = stubFetchEachTest(new Response("{}", { status: 404 }));
   const answerBy = route(fetcher);
 
+  /** Route an issue whose events page hands back this next URL. */
+  const routeEventsNext = (next: string) =>
+    answerBy((url) => {
+      if (url.endsWith(`/issues/${ISSUE_ID}/`)) return json(ISSUE);
+      if (url.includes("/events/?issue=")) {
+        return json(page([{ id: EVENT_ID }], next));
+      }
+      return json(eventDetail(url.split("/").slice(-2)[0]!));
+    });
+
   test("fetches the issue and its latest event, and keeps the raw payloads", async () => {
     answerBy((url) => {
       if (url === `${BASE}/api/canonical/0/issues/${ISSUE_ID}/`)
@@ -118,6 +128,33 @@ describe("fetchIssueBundle", () => {
     expect(bundle.events.length).toBe(1);
     expect(callsOf(fetcher).some((call) => call.url.includes("cursor=2"))).toBe(
       false,
+    );
+  });
+
+  test("refuses a pagination URL on another origin", async () => {
+    routeEventsNext("https://evil.example/api/canonical/0/events/?cursor=2");
+
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 2)).rejects.toThrow(
+      "pagination URL outside its own canonical API",
+    );
+    expect(
+      callsOf(fetcher).some((call) => call.url.includes("evil.example")),
+    ).toBe(false);
+  });
+
+  test("refuses a pagination URL outside the canonical API", async () => {
+    routeEventsNext(`${BASE}/other?cursor=2`);
+
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 2)).rejects.toThrow(
+      "pagination URL outside its own canonical API",
+    );
+  });
+
+  test("refuses a pagination URL that is not a URL", async () => {
+    routeEventsNext("not a URL");
+
+    await expect(fetchIssueBundle(CONFIG, ISSUE_ID, 2)).rejects.toThrow(
+      "pagination URL that is not a URL",
     );
   });
 

--- a/test/scripts/bugs-lib/support.ts
+++ b/test/scripts/bugs-lib/support.ts
@@ -7,7 +7,11 @@ export const ISSUE_ID = "c9d31a6a-fd2f-4ecf-9369-cc5cb221c606";
 export const OTHER_ISSUE_ID = "11111111-2222-4333-8444-555555555555";
 export const EVENT_ID = "497f6eca-6276-4993-bfeb-53cbbbba6f08";
 export const EVENT_2_ID = "a7a26ff2-e851-45b6-9634-d595f45458b7";
-export const CONFIG = { apiKey: "test-key", baseUrl: BASE };
+export const CONFIG = {
+  apiKey: "test-key",
+  baseUrl: BASE,
+  origin: "https://bugs.example.com",
+};
 export const ENV = { SENTRY_API_KEY: "test-key", SENTRY_BASE_URL: BASE };
 
 export const ISSUE = {

--- a/test/scripts/bugs-lib/support.ts
+++ b/test/scripts/bugs-lib/support.ts
@@ -1,0 +1,92 @@
+/** Fixtures and helpers shared by the bugs-lib test files. */
+
+import type { TestFetch } from "#test-utils/fetch-stub.ts";
+
+export const BASE = "https://bugs.example.com";
+export const ISSUE_ID = "c9d31a6a-fd2f-4ecf-9369-cc5cb221c606";
+export const OTHER_ISSUE_ID = "11111111-2222-4333-8444-555555555555";
+export const EVENT_ID = "497f6eca-6276-4993-bfeb-53cbbbba6f08";
+export const EVENT_2_ID = "a7a26ff2-e851-45b6-9634-d595f45458b7";
+export const CONFIG = { apiKey: "test-key", baseUrl: BASE };
+export const ENV = { SENTRY_API_KEY: "test-key", SENTRY_BASE_URL: BASE };
+
+export const ISSUE = {
+  bugsink_extra: "kept",
+  calculated_type: "Error",
+  calculated_value: "boom",
+  digest_order: 12,
+  digested_event_count: 3,
+  first_seen: "2026-09-01T10:00:00Z",
+  friendly_id: "TIC-1",
+  id: ISSUE_ID,
+  is_muted: false,
+  is_resolved: false,
+  last_seen: "2026-09-02T11:00:00Z",
+  project: 1,
+  stored_event_count: 3,
+  transaction: null,
+};
+
+export const EVENT = {
+  data: { exception: { values: [{ type: "Error", value: "boom" }] } },
+  event_id: "sdk-event-1",
+  id: EVENT_ID,
+  issue: ISSUE_ID,
+  stacktrace_md: "Traceback (most recent call last)...",
+  timestamp: "2026-09-02T11:00:00Z",
+};
+
+export const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    status,
+  });
+
+export const page = (
+  results: unknown[],
+  next: string | null = null,
+): unknown => ({
+  next,
+  previous: null,
+  results,
+});
+
+export const eventDetail = (id: string) => ({ ...EVENT, id });
+
+interface FetchCall {
+  init: RequestInit;
+  url: string;
+}
+
+export const callsOf = (fetcher: TestFetch): FetchCall[] =>
+  fetcher.calls.map((call) => {
+    const [url, init] = call.args as [string, RequestInit];
+    return { init, url };
+  });
+
+/** Answer every request of one test by URL. */
+export const route =
+  (fetcher: TestFetch) => (answer: (url: string) => Response) =>
+    fetcher.reply((url) => answer(url));
+
+/** Bugsink list routes for a setup with one project holding the given issues. */
+/** Bugsink list routes for a setup with one project holding the given issues.
+ * The flow asks exactly two URLs, so anything else reads as the projects list. */
+export const singleProjectRoutes =
+  (issues: unknown[]) =>
+  (url: string): Response =>
+    url.includes("project=1")
+      ? json(page(issues))
+      : json(page([{ id: 1, name: "Tickets", slug: "tickets" }]));
+
+export const ioWith = (args: string[], env: Record<string, string> = {}) => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const io = {
+    args,
+    getEnv: (key: string) => env[key],
+    stderr: (line: string) => err.push(line),
+    stdout: (line: string) => out.push(line),
+  };
+  return { err, io, out };
+};

--- a/test/shared/local-host.test.ts
+++ b/test/shared/local-host.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { isLocalHttpHost } from "#shared/local-host.ts";
+
+describe("isLocalHttpHost", () => {
+  for (const host of [
+    "localhost",
+    "localhost.",
+    "kuma.localhost",
+    "kuma.localhost.",
+    "[::1]",
+    "127.0.0.1",
+    "10.0.1.2",
+    "100.64.0.1",
+    "100.127.1.2",
+    "169.254.10.5",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.168.1.10",
+    "[fd00::1]",
+    "[fd7a:115c:a1e0::1]",
+    "[fc00::1]",
+    "[fe80::1]",
+    "[feb0::1]",
+  ]) {
+    test(`accepts the local host ${host}`, () => {
+      expect(isLocalHttpHost(host)).toBe(true);
+    });
+  }
+
+  for (const host of [
+    "kuma.example.test",
+    "bugs.local",
+    // An unbracketed IPv6 name never comes from a URL parser, and the helper
+    // must not read colon groups out of one.
+    "fd00::1",
+    "xfc00::1",
+    "0.0.0.0",
+    "8.8.8.8",
+    "9.0.0.1",
+    "11.0.0.1",
+    "100.63.1.2",
+    "100.128.1.2",
+    "169.255.1.2",
+    "172.15.0.1",
+    "172.32.0.1",
+    "192.169.0.1",
+    "10.0.1.x",
+    "10.0.0.1e0",
+    "[::ffff:127.0.0.1]",
+    "[2001:db8::1]",
+    "[ff02::1]",
+    "[fec0::1]",
+    "[ff00::1]",
+  ]) {
+    test(`rejects the non-local host ${host}`, () => {
+      expect(isLocalHttpHost(host)).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
## What this adds

`deno task bugs` fetches error details from our Bugsink instance (for example `bugs.chobble.com`) and prints them as JSON. An LLM can read that JSON and study a live error in place, with the real stacktrace, tags, and context.

```
deno task bugs https://bugs.chobble.com/issues/issue/<id>/   # one issue plus its latest event
deno task bugs TICKETS-84 --events 3                         # friendly id, more events
deno task bugs list                                          # unresolved issues, newest first
deno task bugs list --all                                    # include resolved issues
```

## How it works

- The command calls the Bugsink canonical API under `/api/canonical/0/` with a bearer token.
- An issue ref can be an issue page URL, a bare UUID, or a friendly id such as `TICKETS-84`.
- The JSON output carries the raw issue and event objects from the API and adds the web `issue_url`. The event payload includes the stacktrace that Bugsink renders as Markdown, with source context and local variables.
- `--events N` sets how many events the command fetches. `0` prints the issue only. The default is `1`.
- The command reads `SENTRY_BASE_URL` (or `SENTRY_BASE`) and `SENTRY_API_KEY` from `.env`. Errors print to stderr, and the exit code is not zero, so scripts and agents can tell failure from success.
- The base URL must use HTTPS outside a local network, the same rule as `UPTIME_KUMA_URL`, because the API key rides every request. The base URL may not carry a query or fragment. The shared local-host check lives in `src/shared/local-host.ts`.
- Pagination follows only `next` URLs that stay on the configured origin and inside the canonical API path, so a tampered response cannot send the API key to another host.

## Design notes

- valibot schemas check the fields the tool uses at the API boundary. A missing field, a non-JSON body, or a bad status fails the run with a message that names the URL and the status.
- The JSON parse tail now lives once: `read-json.ts` exports `parseJsonWith`, and `bugs-lib.ts` and `read-json.ts` both use it.
- The command is JSON on stdout, status on stderr, so a person and a tool can share one invocation.
- The tests live in `test/scripts/bugs-lib/` (39 tests), mirror the source path for mutation runs, and stub every fetch, so the suite stays offline and fast.

## Verification

- `deno task precommit` passes: typecheck, lint, the duplication scans, the full test suite, and 100% line and branch coverage.
- `deno task mutation scripts/bugs-lib.ts test/scripts/bugs-lib/*.test.ts` detects every mutant. One mutant is equivalent, and it carries its proof in `scripts/mutation/equivalent-mutants/scripts.txt`.
- `deno task mutation src/shared/local-host.ts test/shared/local-host.test.ts` also reaches 100% (one equivalent recorded, and two old uptime-kuma entries moved with the extracted code).
- The renamed-copy scan needed one registry entry, because two external API schemas share a field shape. The reason is in `scripts/cpd-renamed/allowed.json`.
- Verified against the live instance: fetch by URL, fetch by friendly id, `--events 0`, and `list`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `bugs` command for retrieving Bugsink issues and recent events as JSON, including Markdown stack traces.
  - Supports fetching individual issues, limiting event history, listing unresolved issues, and optionally including resolved issues.
  - Accepts issue-page URLs, Markdown links, or issue identifiers.
  - Reads Bugsink connection settings from `.env`.
  - Reports progress and clear validation errors for missing configuration or invalid arguments.

- **Documentation**
  - Added command usage and option guidance for the Bugsink workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->