### PR TITLE
Prove the waiting page's own checks in the nightly

### DIFF
--- a/docs/pending-return-plan.md
+++ b/docs/pending-return-plan.md
@@ -284,12 +284,14 @@ Direct tests, written first:
    three TICKETS-84 owner tests keep the owner panel and the buyer-editor
    separation, now beside the waiting page.
 4. `e2e-payments`: the new scenario drives visitor to the hosted checkout, reads
-   the reference from the extended log line, opens the return in a second page,
-   asserts the waiting copy through the catalog and that the page keeps checking
-   for the visitor, asserts no payment error line in the app log, pays on the
-   hosted page, delivers the genuine callback twice, then replays the exact
-   payment return and asserts the booking confirmation, one attendee, and the
-   captured income once.
+   the reference from the extended log line, opens the return in a second tab it
+   keeps open, asserts the waiting copy through the catalog, asserts the page
+   schedules its next timed check on the exact return, observes that timed
+   reload really happen in the tab, asserts no payment error line in the app
+   log, drives the window's last check (no timed reload left) and clicks Check
+   again to open a fresh window, then closes the tab, pays on the hosted page,
+   delivers the genuine callback twice, and replays the exact payment return to
+   assert the booking confirmation, one attendee, and the captured income once.
 
 Regression proof: each new direct test fails against today's code for the named
 reason before the fix lands.

--- a/e2e-payments/README.md
+++ b/e2e-payments/README.md
@@ -71,8 +71,10 @@ The seven scenarios:
   callback); forged ids receive the one fixed refusal without a read; the
   keyless refund reaches a safe result.
 - **sumup-return-pending** — the visitor opens the payment return before paying;
-  the waiting page says the payment is not confirmed yet and keeps checking, no
-  error is logged, and the same return books once the payment is confirmed.
+  the waiting page says the payment is not confirmed yet and keeps checking on
+  its own, no error is logged, the timed window stops after ten checks with a
+  click on Check again opening a fresh one, and the same return books once the
+  payment is confirmed.
 - **stripe-invalidated-checkout-refunded** — the owner changes the price while a
   visitor is paying; the webhook processes the later charge, retains the booking
   at quantity 0, and automatically refunds.

--- a/e2e-payments/specs/live-payment-providers.feature
+++ b/e2e-payments/specs/live-payment-providers.feature
@@ -112,9 +112,10 @@ Feature: Real sandbox payments finish safely
   @rule:payments.live-sumup-return-pending-is-waited @surface:public @surface:return @surface:webhook
   Rule: A SumUp return that lands before the payment is confirmed ends well
     SumUp can send the visitor home before it confirms the payment. The
-    visitor is told the payment is not confirmed yet and the page keeps
-    checking for them. No error is recorded. Once the payment is confirmed,
-    the same return shows their booking.
+    visitor is told the payment is not confirmed yet, and the page keeps
+    checking for them on the same return. No error is recorded. When the
+    timed checks run out, one click on Check again opens a fresh window.
+    Once the payment is confirmed, the same return shows their booking.
 
     @case:live-payments.sumup-return-pending
     Scenario: A visitor returns before SumUp confirms the payment
@@ -124,7 +125,11 @@ Feature: Real sandbox payments finish safely
       And the visitor opens the payment return before paying
       Then the visitor is told the payment is not confirmed yet
       And the page keeps checking for the visitor
+      And the page schedules its next check on the exact return
+      And the page checks again by itself
       And no payment error is logged
+      When the visitor opens the waiting page's last timed check
+      Then only the visitor's click on Check again starts the checking again
       When the visitor pays on SumUp's hosted checkout
       And the genuine checkout callback is delivered twice
       And the visitor retries the exact payment return

--- a/e2e-payments/src/browser.ts
+++ b/e2e-payments/src/browser.ts
@@ -31,9 +31,10 @@ export interface BrowserSession {
   dumpPage: (label: string) => Promise<void>;
   fill: (name: string, value: string) => Promise<void>;
   goto: (path: string) => Promise<void>;
-  /** Open one more page in this session's context and run it — the same
-   * person's second tab. The page closes when run ends. */
-  openExtraPage: <T>(run: (page: Page) => Promise<T>) => Promise<T>;
+  /** Open one more page in this session's context and leave it open: the
+   * same person's second tab, kept across steps. The caller closes it; the
+   * scenario's teardown closes the whole context for anything left open. */
+  openKeptPage: () => Promise<Page>;
   page: Page;
   screenshot: (label: string) => Promise<void>;
   select: (name: string, value: string) => Promise<void>;
@@ -355,14 +356,7 @@ export const launchAppBrowser = async (
         await page.goto(path, { waitUntil: "domcontentloaded" });
         await logWhere("goto");
       },
-      openExtraPage: async <T>(run: (extra: Page) => Promise<T>) => {
-        const extra = await context.newPage();
-        try {
-          return await run(extra);
-        } finally {
-          await extra.close().catch(() => {});
-        }
-      },
+      openKeptPage: (): Promise<Page> => context.newPage(),
       page,
       screenshot: (label) => dumpPage(label),
       select: async (name, value) => {

--- a/e2e-payments/src/cucumber/steps/booking.ts
+++ b/e2e-payments/src/cucumber/steps/booking.ts
@@ -386,13 +386,21 @@ Then(
       "payment",
       "payment.pending.auto_check",
     );
+    const reloadTag = page.locator('meta[http-equiv="refresh"]');
 
-    const atEnd = await pendingReturnText(this);
+    // The window's last page still waits, but no longer checks on its own.
+    const atEnd = await pendingReturnSays(
+      this,
+      await catalogWords("payment", "payment.pending.message"),
+    );
     if (atEnd.includes(autoCheck)) {
       throw new Error(
         `the timed checking should have stopped at the window's end, but ` +
           `the page still says:\n${atEnd.slice(0, 800)}`,
       );
+    }
+    if ((await reloadTag.count()) !== 0) {
+      throw new Error("the waiting page still schedules an automatic check");
     }
 
     const checkAgain = await catalogWords(
@@ -402,6 +410,12 @@ Then(
     await page.getByRole("link", { name: checkAgain }).click();
     await page.waitForLoadState("domcontentloaded");
     await pendingReturnSays(this, autoCheck);
+    if ((await reloadTag.count()) !== 1) {
+      throw new Error(
+        `one click on "${checkAgain}" did not open a fresh ` +
+          "checking window with a scheduled check",
+      );
+    }
     await page.close();
     this.recordPhase("check-again-reopened-the-window");
   },

--- a/e2e-payments/src/cucumber/steps/booking.ts
+++ b/e2e-payments/src/cucumber/steps/booking.ts
@@ -267,21 +267,36 @@ When(
     const reference = await readSumupReturnReference(
       this.resources.server.logPath,
     );
-    this.rememberPendingReturn(
-      await this.resources.visitor.openExtraPage(async (page) => {
-        await page.goto(`/payment/success?session_id=${reference}`, {
-          waitUntil: "domcontentloaded",
-        });
-        return await page.locator("body").innerText({ timeout: 30_000 });
-      }),
-    );
+    const url = `/payment/success?session_id=${reference}`;
+    const page = await this.resources.visitor.openKeptPage();
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    this.rememberPendingReturn(page, url);
     this.recordPhase("return-opened-before-payment");
   },
 );
 
-/** One copy claim about what the pending return page told the visitor: the
- * step text, the catalog key it reads, and the journal phase it records. The
- * words come from the catalog the app renders, so a rename travels with it. */
+/** The page text of the visitor's open pending-return tab, read live so a
+ * step sees the same visit the browser itself is on. */
+const pendingReturnText = (world: LiveWorld): Promise<string> =>
+  world.pendingReturnPage.locator("body").innerText({ timeout: 30_000 });
+
+/** One claim about what the open pending-return tab says. The words come
+ * from the catalog the app renders, so a rename travels with it. */
+const pendingReturnSays = async (
+  world: LiveWorld,
+  expected: string,
+): Promise<string> => {
+  const body = await pendingReturnText(world);
+  if (!body.includes(expected)) {
+    throw new Error(
+      `the pending return page did not say "${expected}":\n${body.slice(0, 800)}`,
+    );
+  }
+  return body;
+};
+
+/** One copy claim about the pending return: the step text, the catalog key
+ * it reads, and the journal phase it records. */
 const PENDING_RETURN_STEPS: readonly [string, string, string][] = [
   [
     "the visitor is told the payment is not confirmed yet",
@@ -297,16 +312,100 @@ const PENDING_RETURN_STEPS: readonly [string, string, string][] = [
 
 for (const [text, key, phase] of PENDING_RETURN_STEPS) {
   Then(text, async function (this: LiveWorld): Promise<void> {
-    const expected = await catalogWords("payment", key);
-    const body = this.pendingReturnBody;
-    if (!body.includes(expected)) {
-      throw new Error(
-        `the pending return page did not say "${expected}":\n${body.slice(0, 800)}`,
-      );
-    }
+    await pendingReturnSays(this, await catalogWords("payment", key));
     this.recordPhase(phase);
   });
 }
+
+Then(
+  "the page schedules its next check on the exact return",
+  async function (this: LiveWorld): Promise<void> {
+    // The number of seconds belongs to the app, so the night only demands
+    // a timed check that names this return, one count up.
+    const scheduled = await this.pendingReturnPage
+      .locator('meta[http-equiv="refresh"]')
+      .getAttribute("content", { timeout: 30_000 });
+    const expected = `;url=${this.pendingReturnUrl}&wait=1`;
+    if (
+      scheduled === null ||
+      !scheduled.endsWith(expected) ||
+      !/^\d+;url=/.test(scheduled)
+    ) {
+      throw new Error(
+        `the waiting page should schedule its next check at "${expected}", ` +
+          `got: ${scheduled ?? "(no reload tag at all)"}`,
+      );
+    }
+  },
+);
+
+/** Wait until the pending-return tab carries a `wait` count, and answer the
+ * URL it reached — proof the page checked again without the visitor. */
+const pendingSelfReload = async (world: LiveWorld): Promise<string> => {
+  const page = world.pendingReturnPage;
+  const reloaded = await pollUntil(config.paymentConfirmTimeoutMs, () =>
+    Promise.resolve(
+      new URL(page.url()).searchParams.get("wait") === null ? null : page.url(),
+    ),
+  );
+  if (reloaded === null) {
+    throw new Error(
+      `the waiting page never reloaded itself (still at ${page.url()})`,
+    );
+  }
+  return reloaded;
+};
+
+Then(
+  "the page checks again by itself",
+  async function (this: LiveWorld): Promise<void> {
+    await pendingSelfReload(this);
+    await pendingReturnSays(
+      this,
+      await catalogWords("payment", "payment.pending.message"),
+    );
+    this.recordPhase("page-checked-again-by-itself");
+  },
+);
+
+When(
+  "the visitor opens the waiting page's last timed check",
+  async function (this: LiveWorld): Promise<void> {
+    await this.pendingReturnPage.goto(`${this.pendingReturnUrl}&wait=10`, {
+      waitUntil: "domcontentloaded",
+    });
+    this.recordPhase("waiting-window-last-check-opened");
+  },
+);
+
+Then(
+  "only the visitor's click on Check again starts the checking again",
+  async function (this: LiveWorld): Promise<void> {
+    const page = this.pendingReturnPage;
+    const autoCheck = await catalogWords(
+      "payment",
+      "payment.pending.auto_check",
+    );
+
+    const atEnd = await pendingReturnText(this);
+    if (atEnd.includes(autoCheck)) {
+      throw new Error(
+        `the timed checking should have stopped at the window's end, but ` +
+          `the page still says:\n${atEnd.slice(0, 800)}`,
+      );
+    }
+
+    const checkAgain = await catalogWords(
+      "payment",
+      "payment.pending.check_again",
+    );
+    await page.getByRole("link", { name: checkAgain }).click();
+    await page.waitForLoadState("domcontentloaded");
+    await pendingReturnSays(this, autoCheck);
+    await page.close();
+    this.recordPhase("check-again-reopened-the-window");
+  },
+);
 
 Then("no payment error is logged", function (this: LiveWorld): void {
   const logged = lastLoggedMatch(

--- a/e2e-payments/src/cucumber/support/world.ts
+++ b/e2e-payments/src/cucumber/support/world.ts
@@ -1,5 +1,6 @@
 // jscpd:ignore-start -- imports
 import { World } from "@cucumber/cucumber";
+import type { Page } from "playwright";
 import type { AppBrowser, BrowserSession } from "#e2e/browser.ts";
 import {
   type BookerIdentity,
@@ -77,7 +78,8 @@ export class LiveWorld extends World {
   private ownerPrepared = false;
   private builtOrder: BuiltOrderCatalog | null = null;
   private heldReturnUrl: string | null = null;
-  private pendingReturnPageText: string | null = null;
+  private pendingReturnTab: Page | null = null;
+  private pendingReturnTarget: string | null = null;
   private refusalProbeReport: RefusalProbeReport | null = null;
   private orderNames: OrderCatalog | null = null;
 
@@ -244,15 +246,27 @@ export class LiveWorld extends World {
     );
   }
 
-  rememberPendingReturn(body: string): void {
-    this.pendingReturnPageText = body;
+  /** The second tab the visitor opened on the pending payment return, and
+   * the exact return URL it sits on — kept open together, because the
+   * waiting steps read and drive the same live tab. */
+  rememberPendingReturn(page: Page, url: string): void {
+    this.pendingReturnTab = page;
+    this.pendingReturnTarget = url;
   }
 
-  /** What the payment return page told the visitor before they paid. */
-  get pendingReturnBody(): string {
+  /** The visitor's open tab on the pending payment return. */
+  get pendingReturnPage(): Page {
     return required(
-      this.pendingReturnPageText,
-      "the pending return page's words (the visitor never opened it)",
+      this.pendingReturnTab,
+      "the pending return tab (the visitor never opened it)",
+    );
+  }
+
+  /** The exact return URL the pending tab first opened. */
+  get pendingReturnUrl(): string {
+    return required(
+      this.pendingReturnTarget,
+      "the pending return URL (the visitor never opened it)",
     );
   }
 


### PR DESCRIPTION
Follow-up to #2248 (merged): the nightly's pending-return scenario asserted the waiting page's *copy* but never observed the remedy itself working in a browser.

## What the nightly proves now

The visitor's second tab stays open across the steps, and the scenario drives every half of the bounded checking window:

- **The schedule**: the waiting page's reload tag names the exact return URL one count up (`;url=…&wait=1`) — not just the words "will keep checking".
- **A real reload**: the tab's URL is polled until it carries a `wait` count and the reloaded page still shows the not-confirmed copy. The page checked again without the visitor (about 30 seconds of real time inside the step).
- **The window ends**: visiting the last timed check (`&wait=10`) stops the timer — the keeps-checking line is absent while the waiting copy remains.
- **The remedy resets**: the visitor clicks **Check again** (the link's own catalog words), and the fresh page checks again on its own. The tab closes before the pay leg so stray reloads cannot race the booking.

The pay leg is unchanged: pay on the hosted checkout, genuine callback delivered twice, exact return retried, one attendee, captured income once, system map clean.

## Shape

`openKeptPage` on the browser session replaces the self-closing second-page helper (the tab must survive across steps; the one caller moved). The world remembers the open tab plus its exact return URL; the copy claims read the live page, so each step sees the visit the browser itself is on. Four new steps in `booking.ts`, registered in the feature scenario and the step-coverage gate.

## Gates

`precommit` green (lint, typecheck, cpd at 0%, coverage 100%). `precommit:mutation` re-run after the commit: 228/228 mutants killed, no `src/` change. The branch is one commit on current `origin/main`; its tree is identical to the fully gated pre-rebase work.

Follow-up recorded nowhere new: the copy literals stay in #2247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated SumUp payment-return guidance to describe automatic checks, timed polling limits, manual “Check again” retries, and completing payment from the same return flow.
  - Clarified that polling stops after the retry window and can be restarted manually.

- **Tests**
  - Expanded end-to-end coverage for persistent payment-return pages, exact reload behavior, payment-error handling, polling timeouts, and retry flows.
  - Added verification that completing and replaying a return creates one booking and captures the expected income.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->