### PR TITLE
Drive the waiting page's Check-again click through the frame-idle guard

### DIFF
--- a/e2e-payments/src/browser.ts
+++ b/e2e-payments/src/browser.ts
@@ -172,23 +172,39 @@ const armWitnessedAttempt = async (
   };
 };
 
+/** What acting through the page's own DOM APIs may be told. `onlyIfUnchecked`
+ * leaves an already checked checkbox or radio alone, because a scripted click
+ * would uncheck it where Locator.check leaves it checked. */
+type DomActOptions = { onlyIfUnchecked?: boolean };
+
 /** Act on a control through the page's own DOM APIs: `requestSubmit` for
  * a form's submit control (which runs browser validation and the app's
  * submit handlers), a scripted click for anything else. Typed without the
  * DOM library so both compile configs can check this module. */
-const actThroughDom = async (locator: Locator): Promise<void> => {
-  await locator.evaluate((element) => {
+const actThroughDom = async (
+  locator: Locator,
+  { onlyIfUnchecked = false }: DomActOptions = {},
+): Promise<void> => {
+  await locator.evaluate((element, onlyIfUnchecked) => {
     const control = element as {
       click: () => void;
       form?: { requestSubmit: (submitter?: unknown) => void } | null;
       type?: string;
+      checked?: boolean;
     };
+    if (
+      onlyIfUnchecked &&
+      (control.type === "checkbox" || control.type === "radio") &&
+      control.checked
+    ) {
+      return;
+    }
     if (control.type === "submit" && control.form) {
       control.form.requestSubmit(control);
       return;
     }
     control.click();
-  });
+  }, onlyIfUnchecked);
 };
 
 /** Whether this page's renderer is currently producing animation frames.
@@ -228,27 +244,30 @@ const frameProbeOf = (page: Page): (() => Promise<boolean>) => {
 const throughDomIfInteractable = async (
   page: Page,
   control: Locator,
+  options: DomActOptions = {},
 ): Promise<void> => {
   if (!(await interactable(control))) {
     throw new Error(`control is not visible or enabled at ${page.url()}`);
   }
-  await actThroughDom(control);
+  await actThroughDom(control, options);
 };
 
 /** Act on a control like a person when the renderer is healthy, and through
  * the page's own DOM APIs when it is frame-idle — or when the ordinary action
- * provably failed before its click dispatched (see armWitnessedAttempt). */
+ * provably failed before its click dispatched (see armWitnessedAttempt).
+ * `onlyIfUnchecked` reaches the DOM fallback, for check's idempotence. */
 const actOnControl = async (
   page: Page,
   control: Locator,
   ordinary: () => Promise<void>,
+  options: DomActOptions = {},
 ): Promise<void> => {
   const healthyRenderer = await frameProbeOf(page)();
   if (healthyRenderer) {
     const attempt = await armWitnessedAttempt(control);
     if (await attempt(ordinary)) return;
   }
-  await throughDomIfInteractable(page, control);
+  await throughDomIfInteractable(page, control, options);
 };
 
 /** Click a control on any page of a session's context — the session's own
@@ -353,7 +372,9 @@ export const launchAppBrowser = async (
                   `[name="${cssEscape(name)}"][value="${cssEscape(value)}"]`,
                 )
                 .first();
-        await actOnControl(page, control, () => control.check({ timeout: T }));
+        await actOnControl(page, control, () => control.check({ timeout: T }), {
+          onlyIfUnchecked: true,
+        });
       },
       clickButton: async (text) => {
         log(`  submit "${text}"`);

--- a/e2e-payments/src/browser.ts
+++ b/e2e-payments/src/browser.ts
@@ -33,7 +33,9 @@ export interface BrowserSession {
   goto: (path: string) => Promise<void>;
   /** Open one more page in this session's context and leave it open: the
    * same person's second tab, kept across steps. The caller closes it; the
-   * scenario's teardown closes the whole context for anything left open. */
+   * scenario's teardown closes the whole context for anything left open.
+   * Act on its controls with clickControlOn, which carries the frame-idle
+   * fallback the session's own clicks have. */
   openKeptPage: () => Promise<Page>;
   page: Page;
   screenshot: (label: string) => Promise<void>;
@@ -170,6 +172,93 @@ const armWitnessedAttempt = async (
   };
 };
 
+/** Act on a control through the page's own DOM APIs: `requestSubmit` for
+ * a form's submit control (which runs browser validation and the app's
+ * submit handlers), a scripted click for anything else. Typed without the
+ * DOM library so both compile configs can check this module. */
+const actThroughDom = async (locator: Locator): Promise<void> => {
+  await locator.evaluate((element) => {
+    const control = element as {
+      click: () => void;
+      form?: { requestSubmit: (submitter?: unknown) => void } | null;
+      type?: string;
+    };
+    if (control.type === "submit" && control.form) {
+      control.form.requestSubmit(control);
+      return;
+    }
+    control.click();
+  });
+};
+
+/** Whether this page's renderer is currently producing animation frames.
+ * Some headless Chromium builds stop scheduling compositor frames once a
+ * form POST has happened; the page stays fully functional but Playwright's
+ * pointer-action stability wait then hangs past its own timeout. Probing
+ * once per navigation lets interaction skip the doomed ordinary attempt
+ * instead of burning its whole timeout on every action. */
+const frameProbes = new WeakMap<Page, () => Promise<boolean>>();
+
+const frameProbeOf = (page: Page): (() => Promise<boolean>) => {
+  const cached = frameProbes.get(page);
+  if (cached) return cached;
+  let framesLive: Promise<boolean> | null = null;
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) framesLive = null;
+  });
+  const framesAreLive = (): Promise<boolean> => {
+    framesLive ??= page.evaluate(
+      () =>
+        new Promise<boolean>((resolve) => {
+          const frames = globalThis as {
+            requestAnimationFrame?: (callback: () => void) => number;
+          };
+          frames.requestAnimationFrame?.(() => resolve(true));
+          setTimeout(() => resolve(false), 1_200);
+        }),
+    );
+    return framesLive;
+  };
+  frameProbes.set(page, framesAreLive);
+  return framesAreLive;
+};
+
+/** Act through the page's own DOM APIs (see actThroughDom), but only for a
+ * control that is genuinely visible and enabled. */
+const throughDomIfInteractable = async (
+  page: Page,
+  control: Locator,
+): Promise<void> => {
+  if (!(await interactable(control))) {
+    throw new Error(`control is not visible or enabled at ${page.url()}`);
+  }
+  await actThroughDom(control);
+};
+
+/** Act on a control like a person when the renderer is healthy, and through
+ * the page's own DOM APIs when it is frame-idle — or when the ordinary action
+ * provably failed before its click dispatched (see armWitnessedAttempt). */
+const actOnControl = async (
+  page: Page,
+  control: Locator,
+  ordinary: () => Promise<void>,
+): Promise<void> => {
+  const healthyRenderer = await frameProbeOf(page)();
+  if (healthyRenderer) {
+    const attempt = await armWitnessedAttempt(control);
+    if (await attempt(ordinary)) return;
+  }
+  await throughDomIfInteractable(page, control);
+};
+
+/** Click a control on any page of a session's context — the session's own
+ * page or a kept page from openKeptPage — with the same frame-idle fallback
+ * as the session's own clicks (see actOnControl). */
+export const clickControlOn = (page: Page, control: Locator): Promise<void> =>
+  actOnControl(page, control, () =>
+    control.click({ timeout: config.actionTimeoutMs }),
+  );
+
 export const launchAppBrowser = async (
   baseUrl: string,
 ): Promise<AppBrowser> => {
@@ -216,81 +305,9 @@ export const launchAppBrowser = async (
       log(`  saved artifacts: ${png} (+ .html)`);
     };
 
-    /**
-     * Whether this page's renderer is currently producing animation frames.
-     * Some headless Chromium builds stop scheduling compositor frames once a
-     * form POST has happened; the page stays fully functional but Playwright's
-     * pointer-action stability wait then hangs past its own timeout. Probing
-     * once per navigation lets interaction skip the doomed ordinary attempt
-     * instead of burning its whole timeout on every action.
-     */
-    let framesLive: Promise<boolean> | null = null;
-    page.on("framenavigated", (frame) => {
-      if (frame === page.mainFrame()) framesLive = null;
-    });
-    const framesAreLive = (): Promise<boolean> => {
-      framesLive ??= page.evaluate(
-        () =>
-          new Promise<boolean>((resolve) => {
-            const frames = globalThis as {
-              requestAnimationFrame?: (callback: () => void) => number;
-            };
-            frames.requestAnimationFrame?.(() => resolve(true));
-            setTimeout(() => resolve(false), 1_200);
-          }),
-      );
-      return framesLive;
-    };
-
-    /** Act on a control through the page's own DOM APIs: `requestSubmit` for
-     * a form's submit control (which runs browser validation and the app's
-     * submit handlers), a scripted click for anything else. Typed without the
-     * DOM library so both compile configs can check this module. */
-    const actThroughDom = async (locator: Locator): Promise<void> => {
-      await locator.evaluate((element) => {
-        const control = element as {
-          click: () => void;
-          form?: { requestSubmit: (submitter?: unknown) => void } | null;
-          type?: string;
-        };
-        if (control.type === "submit" && control.form) {
-          control.form.requestSubmit(control);
-          return;
-        }
-        control.click();
-      });
-    };
-
-    /** Act through the page's own DOM APIs (see actThroughDom), but only
-     * for a control that is genuinely visible and enabled. */
-    const throughDomIfInteractable = async (
-      control: Locator,
-    ): Promise<void> => {
-      if (!(await interactable(control))) {
-        throw new Error(`control is not visible or enabled at ${page.url()}`);
-      }
-      await actThroughDom(control);
-    };
-
-    /** Act on a control like a person when the renderer is healthy, and
-     * through the page's own DOM APIs when it is frame-idle — or when the
-     * ordinary action provably failed before its click dispatched (see
-     * armWitnessedAttempt). */
-    const actOnControl = async (
-      control: Locator,
-      ordinary: () => Promise<void>,
-    ): Promise<void> => {
-      const healthyRenderer = await framesAreLive();
-      if (healthyRenderer) {
-        const attempt = await armWitnessedAttempt(control);
-        if (await attempt(ordinary)) return;
-      }
-      await throughDomIfInteractable(control);
-    };
-
     /** Click a control like a person (see actOnControl for the fallback). */
     const clickControl = (control: Locator): Promise<void> =>
-      actOnControl(control, () => control.click({ timeout: T }));
+      clickControlOn(page, control);
 
     /** Click and let the resulting navigation settle. A scripted submit's
      * navigation starts only after the click returns, so when the URL has not
@@ -336,7 +353,7 @@ export const launchAppBrowser = async (
                   `[name="${cssEscape(name)}"][value="${cssEscape(value)}"]`,
                 )
                 .first();
-        await actOnControl(control, () => control.check({ timeout: T }));
+        await actOnControl(page, control, () => control.check({ timeout: T }));
       },
       clickButton: async (text) => {
         log(`  submit "${text}"`);

--- a/e2e-payments/src/cucumber/steps/booking.ts
+++ b/e2e-payments/src/cucumber/steps/booking.ts
@@ -7,6 +7,7 @@
 import { Then, When } from "@cucumber/cucumber";
 import {
   type BrowserSession,
+  clickControlOn,
   holdFirstAppReturn,
   requirePageText,
 } from "#e2e/browser.ts";
@@ -407,7 +408,7 @@ Then(
       "payment",
       "payment.pending.check_again",
     );
-    await page.getByRole("link", { name: checkAgain }).click();
+    await clickControlOn(page, page.getByRole("link", { name: checkAgain }));
     await page.waitForLoadState("domcontentloaded");
     await pendingReturnSays(this, autoCheck);
     if ((await reloadTag.count()) !== 1) {

--- a/scripts/cpd-renamed/allowed.json
+++ b/scripts/cpd-renamed/allowed.json
@@ -1,17 +1,17 @@
 [
   {
     "first": "e2e-payments/src/browser.ts",
-    "firstStart": 277,
-    "hash": "d799c52416d3ea813c828091cfc2cdbe26092390b000875ade82776f4a22dd4f",
-    "reason": "pending merge — same code with different words; unify into one helper or curry, then delete this entry",
+    "firstStart": 244,
+    "hash": "dc8f0616619849faa1966fcf464e6327c6a46368825928038472c62766136e1d",
+    "reason": "shared signature with nothing behind it — each takes one () => Promise<void> callback and shares no step (a guarded interaction fallback, a run-failure report, a best-effort write); a curry has nothing to lift",
     "second": "e2e-payments/src/entry.ts",
     "secondStart": 12
   },
   {
     "first": "e2e-payments/src/browser.ts",
-    "firstStart": 277,
-    "hash": "3a3b494c6f57d31fdbf9550af2eb9db9fc987efa1ed6a0c77786987cb3e4333b",
-    "reason": "pending merge — same code with different words; unify into one helper or curry, then delete this entry",
+    "firstStart": 244,
+    "hash": "16516f8c30d58757bc3cb24349cac40fe0bc98cc21b19e1871bc1acd91a58b5d",
+    "reason": "shared signature with nothing behind it — each takes one () => Promise<void> callback and shares no step (a guarded interaction fallback, a run-failure report, a best-effort write); a curry has nothing to lift",
     "second": "src/shared/logger.ts",
     "secondStart": 365
   },
@@ -49,7 +49,7 @@
   },
   {
     "first": "scripts/bugs-lib.ts",
-    "firstStart": 135,
+    "firstStart": 154,
     "hash": "00c4cbd19e8fdeb66bdf78d34a5795af0e9b909bdf3f4a4f35c4c1402ba299fd",
     "reason": "two external API boundary schemas — a Bugsink project and a Deno Deploy app identity — that name an id, a name and a slug; one shared schema factory would couple the two provider contracts while each keeps its own field types",
     "second": "src/shared/deno-deploy-schema.ts",
@@ -65,7 +65,7 @@
   },
   {
     "first": "scripts/coverage-check.ts",
-    "firstStart": 217,
+    "firstStart": 223,
     "hash": "de890aed588d9efdf99a4e6612f7539bdd5418baaf5e934e4b1e44e8f76d61d9",
     "reason": "pending merge — same code with different words; unify into one helper or curry, then delete this entry",
     "second": "src/shared/order-select.ts",

--- a/scripts/cpd-renamed/allowed.json
+++ b/scripts/cpd-renamed/allowed.json
@@ -1,27 +1,19 @@
 [
   {
-    "first": "e2e-payments/src/browser.ts",
-    "firstStart": 244,
-    "hash": "dc8f0616619849faa1966fcf464e6327c6a46368825928038472c62766136e1d",
-    "reason": "shared signature with nothing behind it — each takes one () => Promise<void> callback and shares no step (a guarded interaction fallback, a run-failure report, a best-effort write); a curry has nothing to lift",
-    "second": "e2e-payments/src/entry.ts",
-    "secondStart": 12
-  },
-  {
-    "first": "e2e-payments/src/browser.ts",
-    "firstStart": 244,
-    "hash": "16516f8c30d58757bc3cb24349cac40fe0bc98cc21b19e1871bc1acd91a58b5d",
-    "reason": "shared signature with nothing behind it — each takes one () => Promise<void> callback and shares no step (a guarded interaction fallback, a run-failure report, a best-effort write); a curry has nothing to lift",
-    "second": "src/shared/logger.ts",
-    "secondStart": 365
-  },
-  {
     "first": "e2e-payments/src/cucumber/support/hooks.ts",
     "firstStart": 170,
     "hash": "1a420aa2d0567ed853db524423095caa0fbb5fafdb1a842ef02f6946fdf4ff90",
     "reason": "pending merge — same code with different words; unify into one helper or curry, then delete this entry",
     "second": "e2e-payments/src/cucumber/support/hooks.ts",
     "secondStart": 178
+  },
+  {
+    "first": "e2e-payments/src/entry.ts",
+    "firstStart": 12,
+    "hash": "e4a16de1c0af265f3fcc1cfaefc479accbca3a1f415adb61a8622ff8ea829aff",
+    "reason": "shared signature with nothing behind it — each takes one () => Promise<void> callback and shares no step (a run-failure report, a best-effort write); a curry has nothing to lift",
+    "second": "src/shared/logger.ts",
+    "secondStart": 365
   },
   {
     "first": "e2e-payments/src/providers/card.ts",


### PR DESCRIPTION
## What failed

The nightly Payment sandbox e2e failed on the sumup leg ([run 33851392628](https://github.com/chobbledotcom/tickets/actions/runs/33851392628)). The pending-return scenario — added to the nightly by #2249, on its first nightly run — died on the click of the waiting page's "Check again" link: Playwright spent its whole 45 second timeout on "waiting for element to be visible, enabled and stable" and threw.

## Why

The evidence says the click never dispatched:

- The server log holds no request to `/payment/success` after the `wait=10` page load. The link was present and the page state was right — the step's own text assertions passed seconds before.
- Playwright's actionability "stable" check needs two consecutive animation frames. The harness already documents in `e2e-payments/src/browser.ts` that some headless Chromium builds stop scheduling compositor frames once a form POST has happened, and that Playwright's pointer-action stability wait then hangs past its own timeout.
- The teardown corroborates the same state: the owner session's failure screenshot hung out its full timeout and its PNG is missing from the run's artifacts (the HTML saved), and the After hook spent 90 seconds in two such 45 second hangs.

The visitor's pending-return tab opened 0.7 seconds after the sibling tab posted the booking form, on the same site, so it shared the renderer that had gone frame-idle.

## The defect

Every interaction in this harness goes through one guarded path: probe whether the renderer still produces animation frames; click like a person when it does; act through the page's own DOM APIs when it does not (with a click witness so a dispatched action is never replayed). The pending-return tab comes from `openKeptPage()`, which returns a raw Playwright `Page` outside the session wrapper — so the guarded path was not available to it, and the step called the bare `page.getByRole(...).click()`. `testProviderConnection` already used the scripted DOM click for the same reason; this step bypassed the machinery on its first real outing. The app under test is fine.

## The change

- Move the guarded interaction machinery (`actThroughDom`, the per-page frame probe, `actOnControl`) to module level in `e2e-payments/src/browser.ts`.
- Export `clickControlOn(page, control)`, so any page of a session's context — the session's own page or a kept page — gets the same fallback.
- Route the Check-again click in `e2e-payments/src/cucumber/steps/booking.ts` through it.
- The session's own `clickControl` now delegates to the same helper, so one mechanism serves both paths.
- Preserve `Locator.check()`'s idempotence in the DOM fallback (review finding on this PR): a scripted click toggles a checkbox, so the check helper now reaches the fallback through an `onlyIfUnchecked` option that leaves an already checked checkbox or radio alone.

Two deliberate behavior changes, both confined to the harness:

1. The fixed step: worst case it spends a bounded frame probe plus a DOM click instead of a 45 second timeout.
2. The check fallback no longer unchecks a pre-checked control when the ordinary `check()` was skipped or provably never acted — it now matches `Locator.check()` for that state.

The renamed-copy registry in `scripts/cpd-renamed/allowed.json` is refreshed. Passing the option shape through untouched dissolved the two `actOnControl` pairs; the remaining `failRun`/`bestEffort` pair is the shared-signature-with-nothing-behind-it case — each takes one `() => Promise<void>` callback and shares no step — and carries that reason instead of "pending merge".

## Validation

- `deno task e2e free` run locally against real Chromium, after both commits: 2 scenarios, 13 steps, all green. That journey drives the same guarded click machinery and the check path (`accept_agreement`, the site-feature and order-gallery toggles) through setup, booking, and the complex order.
- `nix develop -c deno task precommit` passes (typecheck, lint, cpd, shapes, the full suite).
- The sumup path runs only in the nightly; the next scheduled run is the end-to-end proof of the fixed step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of interactive controls, including links and checkboxes, when standard interactions are unavailable.
  - Added more robust handling for controls rendered within embedded frames and during temporary interaction failures.
  - Improved the reliability of the booking flow’s “Check again” action.

- **Maintenance**
  - Updated internal quality checks to reflect the latest interaction-handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
