### PR TITLE
Pin the CI tools that run with credentials, and verify their checksums

### DIFF
--- a/.github/actions/sentry-sourcemaps/action.yml
+++ b/.github/actions/sentry-sourcemaps/action.yml
@@ -33,6 +33,27 @@ inputs:
 runs:
   using: composite
   steps:
+    # The CLI runs with SENTRY_AUTH_TOKEN in its environment, so it is
+    # downloaded at a pinned version and verified against a recorded sha256
+    # before it runs. The standalone binary is the same one the npm wrapper
+    # spawns, without npm's unpinned dependency resolution.
+    - name: Install sentry-cli
+      if: ${{ inputs.auth_token != '' }}
+      shell: bash
+      env:
+        SENTRY_CLI_VERSION: "3.7.0"
+        # sha256 of sentry-cli-Linux-x86_64 for the version above.
+        SENTRY_CLI_SHA256: cec71d46a7cc394c94b6e75f1601985c710d457376c546ef3975567b3671563b
+      run: |
+        set -euo pipefail
+        mkdir -p "$RUNNER_TEMP/bin"
+        curl -fsSL -o "$RUNNER_TEMP/bin/sentry-cli" \
+          "https://github.com/getsentry/sentry-cli/releases/download/${SENTRY_CLI_VERSION}/sentry-cli-Linux-x86_64"
+        echo "${SENTRY_CLI_SHA256}  $RUNNER_TEMP/bin/sentry-cli" \
+          | sha256sum --check --strict -
+        chmod +x "$RUNNER_TEMP/bin/sentry-cli"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
     # Inject debug IDs into the bundle and its map *before* deploy, so the code
     # that actually runs in Bunny carries the IDs Sentry matches maps by. This
     # is filename-independent, which matters because we can't predict the path
@@ -49,7 +70,7 @@ runs:
       run: |
         js="$(deno run --allow-read --allow-write \
           scripts/sentry-debug-ids.ts prepare "${{ inputs.file }}")"
-        npx @sentry/cli@^2 sourcemaps inject "$js" "$js.map"
+        sentry-cli sourcemaps inject "$js" "$js.map"
         grep -q "_sentryDebugIds" "$js" || {
           echo "::error::sentry-cli injected no debug ID into $js"
           exit 1
@@ -74,6 +95,6 @@ runs:
       run: |
         js="$(deno run --allow-read scripts/sentry-debug-ids.ts \
           js-path "${{ inputs.file }}")"
-        npx @sentry/cli@^2 sourcemaps upload \
+        sentry-cli sourcemaps upload \
           --release "${{ inputs.release }}" \
           "$js" "$js.map"

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -67,12 +67,36 @@ jobs:
 
           file="opencode-${target}.tar.gz"
           url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${file}"
+
+          # sha256 of each archive for the pinned version above. The archive
+          # runs with NEURALWATT_API_KEY in its environment, so an unlisted
+          # target fails instead of skipping verification.
+          case "$file" in
+            opencode-linux-arm64.tar.gz)
+              sha256="23aad358a8489cda9e9c46cde7ce87b2fc4847203ddb4d2179be34215ad6eeae" ;;
+            opencode-linux-arm64-musl.tar.gz)
+              sha256="ec753c4fcc2b5e2e6948f06c18c82c1160976a0cd85e7c6c7e911c35c82ebb5f" ;;
+            opencode-linux-x64.tar.gz)
+              sha256="0e1353771192c7d2dc0c610d61ff70668bb8a4420dc4d9e35cfd33d7245f3e67" ;;
+            opencode-linux-x64-musl.tar.gz)
+              sha256="782c5d6fc3762fbdfaebcebc7457ed797acbab199969b3b237acfac195fd09d8" ;;
+            opencode-linux-x64-baseline.tar.gz)
+              sha256="de0c16440b50f04823dc5fa240d24899e444a626ec8e4b8ebb6083bdf2176ad0" ;;
+            opencode-linux-x64-baseline-musl.tar.gz)
+              sha256="ea69bfdacfbfab9d1efc435b8326dc5b19692e1ce534c4cf6ee6dd00c7dfb9c9" ;;
+            *)
+              echo "No pinned sha256 for ${file}" >&2
+              exit 1
+              ;;
+          esac
+
           install_dir="${HOME}/.opencode/bin"
           tmp_dir="$(mktemp -d)"
           trap 'rm -rf "${tmp_dir}"' EXIT
 
           mkdir -p "${install_dir}"
           curl -fsSL "${url}" -o "${tmp_dir}/${file}"
+          echo "${sha256}  ${tmp_dir}/${file}" | sha256sum --check --strict -
           tar -xzf "${tmp_dir}/${file}" -C "${tmp_dir}"
           install -m 755 "${tmp_dir}/opencode" "${install_dir}/opencode"
           echo "${install_dir}" >> "${GITHUB_PATH}"

--- a/.github/workflows/payment-sandbox-e2e.yml
+++ b/.github/workflows/payment-sandbox-e2e.yml
@@ -65,11 +65,17 @@ jobs:
         uses: ./.github/actions/setup-deno
 
       - name: Install cloudflared
+        env:
+          CLOUDFLARED_VERSION: "2026.8.3"
+          # sha256 of cloudflared-linux-amd64 for the version above.
+          CLOUDFLARED_SHA256: f29324fe934d1e100617484c78deef803c4dc2cd351d645bbde42e96b4fccc5e
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/bin"
           curl -fsSL -o "$RUNNER_TEMP/bin/cloudflared" \
-            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+            "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64"
+          echo "${CLOUDFLARED_SHA256}  $RUNNER_TEMP/bin/cloudflared" \
+            | sha256sum --check --strict -
           chmod +x "$RUNNER_TEMP/bin/cloudflared"
           # $GITHUB_PATH only affects later steps, so verify via the full path here.
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Problem

Three CI downloads ran with secrets in their environment, without a pinned version or a verified checksum:

- `cloudflared` in `.github/workflows/payment-sandbox-e2e.yml` took `releases/latest/download`.
- `.github/actions/sentry-sourcemaps/action.yml` ran `npx @sentry/cli@^2` with `SENTRY_AUTH_TOKEN` set. npm resolved the version and the platform binary through unpinned ranges and optional dependencies.
- `.github/workflows/opencode.yml` named an exact opencode version but verified no checksum, and the archive runs with `NEURALWATT_API_KEY` present.

A compromised or silently changed download could run with those credentials.

## Change

Each download now pins an exact version and fails unless the downloaded bytes match a recorded sha256:

- **cloudflared** pins `2026.8.3` and checks `cloudflared-linux-amd64` with `sha256sum --check --strict` before the binary is made executable.
- **sentry-cli** installs the standalone binary `3.7.0` in a new `Install sentry-cli` step and verifies it the same way. The standalone binary is the same one the npm wrapper spawns; the step replaces `npx @sentry/cli@^2` in the inject and upload steps. npm cannot offer a recorded checksum for the binary, because the wrapper pulls it through unpinned optional dependencies. The install step keeps the `auth_token` gate, so deploys without Sentry still skip the tool entirely.
- **opencode** records a sha256 for every one of the six `opencode-linux-*.tar.gz` target variants at the pinned `1.17.15`. An unlisted target fails the job instead of skipping verification.

## Verification

I downloaded every artifact and computed its sha256 from the bytes before recording it. Each recorded value matches the digest the GitHub release API reports for the asset. I YAML-parsed all three edited files.

`deno task precommit` passed at commit time (the pre-commit hook runs it).

No runtime code changes: `src/` and `test/` are untouched, so no test or mutation gate applies beyond the standard precommit.

Fixes #2206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security and Reliability**
  * Added checksum verification for downloaded Sentry CLI, OpenCode, and cloudflared binaries.
  * Pinned tool versions and supported archive targets to ensure consistent workflow execution.
  * Workflows now stop before installation when targets are unsupported or downloaded files fail integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->