### PR TITLE
Remove the alias exports in the test helpers

### DIFF
--- a/test/features/admin/listings-uploads/attachment.test.ts
+++ b/test/features/admin/listings-uploads/attachment.test.ts
@@ -14,8 +14,7 @@ import { expectRedirectWithFlash } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import {
-  debugLogged,
-  errorLogged,
+  logLogged,
   useDebugLogSpy,
   useErrorLogSpy,
 } from "#test-utils/debug-log.ts";
@@ -122,7 +121,7 @@ describeWithEnv("uploading a listing's attachment", { db: true }, () => {
         await upload("leaflet.pdf");
 
         expect(
-          debugLogged(debugSpy, 'Attachment field "attachment" is string'),
+          logLogged(debugSpy, 'Attachment field "attachment" is string'),
         ).toBe(true);
       });
     });
@@ -158,7 +157,7 @@ describeWithEnv("uploading a listing's attachment", { db: true }, () => {
       await withCdnRejecting(new Error("storage is down"), async () => {
         await upload(leaflet());
 
-        expect(errorLogged(errorSpy, "Attachment upload failed")).toBe(true);
+        expect(logLogged(errorSpy, "Attachment upload failed")).toBe(true);
       });
     });
   });

--- a/test/features/api/payment-processing/classify/waiting-page.test.ts
+++ b/test/features/api/payment-processing/classify/waiting-page.test.ts
@@ -5,7 +5,7 @@ import type { SessionValidation } from "#routes/api/webhook-types.ts";
 import { runWithPendingWork } from "#shared/pending-work.ts";
 import { expectBuyerRefusalWithoutStaffPanel } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { debugLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
 import { webhookMeta } from "#test-utils/factories.ts";
 import {
@@ -75,7 +75,7 @@ describeWithEnv(
       expect(page).toContain("Check again");
       expect(page).not.toContain("Payment verification failed");
       // A normal provider state is not an outage: a debug line, not an error.
-      expect(debugLogged(debugSpy, "not confirmed yet")).toBe(true);
+      expect(logLogged(debugSpy, "not confirmed yet")).toBe(true);
       expect(errors.contains("E_PAYMENT_SESSION")).toBe(false);
     });
 

--- a/test/features/api/payment-processing/refunds.test.ts
+++ b/test/features/api/payment-processing/refunds.test.ts
@@ -38,8 +38,7 @@ import { stubRetrieveCheckoutSession } from "#test-utils/webhooks/stripe.ts";
 // jscpd:ignore-end
 
 import {
-  debugLogged,
-  errorLogged,
+  logLogged,
   useDebugLogSpy,
   useErrorLogSpy,
 } from "#test-utils/debug-log.ts";
@@ -127,7 +126,7 @@ describeWithEnv("server (refund helper mutations)", { db: true }, () => {
           mockRequest("/payment/success?session_id=cs_refund_log"),
         );
         await expectHtmlResponse(res, 410, "no longer accepting", "refunded");
-        expect(debugLogged(debugSpy, "Refund completed")).toBe(true);
+        expect(logLogged(debugSpy, "Refund completed")).toBe(true);
       });
     } finally {
       mockRetrieve.restore();
@@ -142,7 +141,7 @@ describeWithEnv("server (refund helper mutations)", { db: true }, () => {
       "pi_already_refunded",
       "r2@e.com",
       "R2",
-      async () => expect(debugLogged(debugSpy, "Refund completed")).toBe(true),
+      async () => expect(logLogged(debugSpy, "Refund completed")).toBe(true),
     );
   });
 
@@ -156,7 +155,7 @@ describeWithEnv("server (refund helper mutations)", { db: true }, () => {
       "R3",
       async () =>
         expect(
-          errorLogged(
+          logLogged(
             errorSpy,
             "Refund needs an owner decision for stripe payment (provider_rejected)",
           ),

--- a/test/features/api/webhooks/callbacks.test.ts
+++ b/test/features/api/webhooks/callbacks.test.ts
@@ -13,7 +13,7 @@ import { setupStripe } from "#test-utils/settings.ts";
 import { stubRetrieveCheckoutSession } from "#test-utils/webhooks/stripe.ts";
 // jscpd:ignore-end
 
-import { errorLogged, useErrorLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useErrorLogSpy } from "#test-utils/debug-log.ts";
 import {
   setupMismatchWithFailingRefund,
   setupMultiMismatchWithFailingRefund,
@@ -31,7 +31,7 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
       await handleRequest(mockRequest("/payment/success"))
     ).text();
     expect(html).toContain("Invalid payment callback");
-    expect(errorLogged(E, "params=[none] referer=none")).toBe(true);
+    expect(logLogged(E, "params=[none] referer=none")).toBe(true);
   });
 
   test("bad-token callback rejects without session_id error", async () => {
@@ -39,13 +39,13 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
       mockRequest("/payment/success?tokens=bad"),
     );
     await expectHtmlResponse(response, 400, "Invalid payment callback");
-    expect(errorLogged(E, "missing session_id")).toBe(false);
+    expect(logLogged(E, "missing session_id")).toBe(false);
   });
 
   test("cancel with no session_id returns Invalid payment callback", async () => {
     const res = await handleRequest(mockRequest("/payment/cancel"));
     await expectHtmlResponse(res, 400, "Invalid payment callback");
-    expect(errorLogged(E, "missing session_id parameter")).toBe(true);
+    expect(logLogged(E, "missing session_id parameter")).toBe(true);
   });
 
   test("cancel with no provider returns 400", async () => {
@@ -53,7 +53,7 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
       mockRequest("/payment/cancel?session_id=cs_x"),
     );
     await expectHtmlResponse(res, 400, "Payment provider not configured");
-    expect(errorLogged(E, "[cancel] No provider")).toBe(true);
+    expect(logLogged(E, "[cancel] No provider")).toBe(true);
   });
 
   test("cancel with missing session returns 400", async () => {
@@ -66,7 +66,7 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
       400,
       "We could not find this payment session.",
     );
-    expect(errorLogged(E, "Session not found")).toBe(true);
+    expect(logLogged(E, "Session not found")).toBe(true);
   });
 
   test("cancel renders an existing Stripe session while new sales are off", async () => {
@@ -219,7 +219,7 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
     req.headers.set("referer", "https://evil.example.com");
     await handleRequest(req);
     expect(
-      errorLogged(E, "params=[foo,baz] referer=https://evil.example.com"),
+      logLogged(E, "params=[foo,baz] referer=https://evil.example.com"),
     ).toBe(true);
   });
 
@@ -284,8 +284,8 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
     const req = mockRequest("/payment/success?foo=bar");
     req.headers.set("referer", "");
     await handleRequest(req);
-    expect(errorLogged(E, "referer=")).toBe(true);
-    expect(errorLogged(E, "referer=none")).toBe(false);
+    expect(logLogged(E, "referer=")).toBe(true);
+    expect(logLogged(E, "referer=none")).toBe(false);
   });
 
   test("redirect error path uses result.error when detail is absent", async () => {
@@ -305,7 +305,7 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
       mockRequest("/payment/success?session_id=cs_de_detail"),
     );
     expect(await res.text()).toContain("saved your details");
-    expect(errorLogged(E, "[redirect]")).toBe(true);
+    expect(logLogged(E, "[redirect]")).toBe(true);
   });
 
   test("redirect failure logs the first listing in a multi-listing order", async () => {
@@ -330,8 +330,8 @@ describeWithEnv("server (payment callback edge cases)", { db: true }, () => {
       mockRequest("/payment/success?session_id=cs_multi_redirect"),
     );
 
-    expect(errorLogged(E, `listing=${first.id}`)).toBe(true);
-    expect(errorLogged(E, `listing=${second.id}`)).toBe(false);
+    expect(logLogged(E, `listing=${first.id}`)).toBe(true);
+    expect(logLogged(E, `listing=${second.id}`)).toBe(false);
   });
 
   test("already-processed session without thank-you URL renders without redirect", async () => {

--- a/test/features/api/webhooks/provider.test.ts
+++ b/test/features/api/webhooks/provider.test.ts
@@ -22,8 +22,7 @@ import { stripeClient } from "#test-utils/stripe/fixtures.ts";
 
 import { providerDetail, transportError } from "#payment/transport-error.ts";
 import {
-  debugLogged,
-  errorLogged,
+  logLogged,
   useDebugLogSpy,
   useErrorLogSpy,
 } from "#test-utils/debug-log.ts";
@@ -92,7 +91,7 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
     expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(await res.text()).toBe("Payment verification failed");
     expect(E().calls.length).toBe(0);
-    expect(debugLogged(D, "Refused a payment callback retryably")).toBe(true);
+    expect(logLogged(D, "Refused a payment callback retryably")).toBe(true);
   });
 
   test("Stripe fallback read failure stays retryable", async () => {
@@ -119,7 +118,7 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
 
     expect(response.status).toBe(503);
     expect(await response.text()).not.toContain("PRIVATE_STRIPE_READ_FAILURE");
-    expect(errorLogged(E, "PRIVATE_STRIPE_READ_FAILURE")).toBe(false);
+    expect(logLogged(E, "PRIVATE_STRIPE_READ_FAILURE")).toBe(false);
   });
 
   test("site-signed unreadable booking stays retryable without local state", async () => {
@@ -173,9 +172,9 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
       }),
       (j) => {
         expect(j.status).toBe("pending");
-        expect(errorLogged(E, "not yet paid")).toBe(true);
-        expect(debugLogged(D, "Waiting for a completed payment")).toBe(true);
-        expect(debugLogged(D, "pi_unp2")).toBe(false);
+        expect(logLogged(E, "not yet paid")).toBe(true);
+        expect(logLogged(D, "Waiting for a completed payment")).toBe(true);
+        expect(logLogged(D, "pi_unp2")).toBe(false);
       },
     );
   });
@@ -193,8 +192,8 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
       (j) => {
         expect(j.received).toBe(true);
         expect(j.processed).toBeUndefined();
-        expect(debugLogged(D, "unrecognized payment session")).toBe(true);
-        expect(debugLogged(D, "pi_unrec3")).toBe(false);
+        expect(logLogged(D, "unrecognized payment session")).toBe(true);
+        expect(logLogged(D, "pi_unrec3")).toBe(false);
       },
     );
   });
@@ -217,9 +216,9 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
       (j) => {
         expect(j.received).toBe(true);
         expect(j.processed).toBeUndefined();
-        expect(debugLogged(D, "unverifiable session")).toBe(true);
-        expect(debugLogged(D, "pi_uv3")).toBe(false);
-        expect(debugLogged(D, "f@e.com")).toBe(false);
+        expect(logLogged(D, "unverifiable session")).toBe(true);
+        expect(logLogged(D, "pi_uv3")).toBe(false);
+        expect(logLogged(D, "f@e.com")).toBe(false);
       },
     );
   });
@@ -230,8 +229,8 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
     );
     expect(res.status).toBe(400);
     expect(await res.text()).toContain("Payment provider not configured");
-    expect(errorLogged(E, "provider not configured")).toBe(true);
-    expect(debugLogged(D, "Rejected webhook")).toBe(true);
+    expect(logLogged(E, "provider not configured")).toBe(true);
+    expect(logLogged(D, "Rejected webhook")).toBe(true);
   });
 
   test("webhook with missing signature returns 400 and logs", async () => {
@@ -241,9 +240,9 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
     );
     expect(res.status).toBe(400);
     expect(await res.text()).toContain("Missing signature");
-    expect(errorLogged(E, "missing signature header")).toBe(true);
-    expect(debugLogged(D, "Rejected webhook")).toBe(true);
-    expect(debugLogged(D, "PRIVATE_WEBHOOK_BODY")).toBe(false);
+    expect(logLogged(E, "missing signature header")).toBe(true);
+    expect(logLogged(D, "Rejected webhook")).toBe(true);
+    expect(logLogged(D, "PRIVATE_WEBHOOK_BODY")).toBe(false);
   });
 
   test("webhook with bad signature returns 400 and logs", async () => {
@@ -252,8 +251,8 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
       mockWebhookRequest({}, { "stripe-signature": "bad" }),
     );
     expect(res.status).toBe(400);
-    expect(errorLogged(E, "verification failed")).toBe(true);
-    expect(debugLogged(D, "Rejected webhook")).toBe(true);
+    expect(logLogged(E, "verification failed")).toBe(true);
+    expect(logLogged(D, "Rejected webhook")).toBe(true);
   });
 
   test("processed webhook returns received=true and processed=true", async () => {
@@ -317,7 +316,7 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
         expect(String(j.error)).toContain("saved your details");
       },
     );
-    expect(errorLogged(E, `listing=${l.id}`)).toBe(true);
+    expect(logLogged(E, `listing=${l.id}`)).toBe(true);
   });
 
   test("multi-listing webhook failure logs the first listing", async () => {
@@ -340,8 +339,8 @@ describeWithEnv("server (payment webhook edge cases)", { db: true }, () => {
       (json) => expect(json.processed).toBe(false),
     );
 
-    expect(errorLogged(E, `listing=${first.id}`)).toBe(true);
-    expect(errorLogged(E, `listing=${second.id}`)).toBe(false);
+    expect(logLogged(E, `listing=${first.id}`)).toBe(true);
+    expect(logLogged(E, `listing=${second.id}`)).toBe(false);
   });
 
   test("validation-failure refund returns 503 status", async () => {

--- a/test/integration/server/payments/cancel.test.ts
+++ b/test/integration/server/payments/cancel.test.ts
@@ -21,7 +21,7 @@ import {
 
 // jscpd:ignore-end
 
-import { errorLogged, useErrorLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useErrorLogSpy } from "#test-utils/debug-log.ts";
 
 /** A cancelled (unpaid) checkout session for the given id and items metadata —
  *  the shape every /payment/cancel test stubs, differing only in the id and
@@ -130,7 +130,7 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
         // The buyer's page does not name the session, so the log is the
         // operator's only record of which one was refused.
         expect(
-          errorLogged(
+          logLogged(
             errorSpy,
             "Session rejected as malformed_charge (session=cs_rejected, refunded: true)",
           ),

--- a/test/integration/server/public/closes-at.test.ts
+++ b/test/integration/server/public/closes-at.test.ts
@@ -21,7 +21,7 @@ import {
   expectFlash,
   expectHtmlResponse,
 } from "#test-utils/assertions.ts";
-import { getTicketCsrfToken } from "#test-utils/csrf.ts";
+import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import {
   createTestListing,
@@ -43,7 +43,7 @@ const expectClosesDuringSubmission = async (
   listingIdToClose: number,
 ): Promise<void> => {
   const getResponse = await handleRequest(mockRequest(path));
-  const csrfToken = getTicketCsrfToken(await getResponse.text());
+  const csrfToken = extractCsrfToken(await getResponse.text());
   if (!csrfToken) throw new Error("No CSRF token");
 
   await updateTestListing(listingIdToClose, { closesAt: pastCloseTime() });

--- a/test/integration/server/public/daily-listings-single.test.ts
+++ b/test/integration/server/public/daily-listings-single.test.ts
@@ -10,7 +10,7 @@ import {
   expectFlash,
   expectRedirect,
 } from "#test-utils/assertions.ts";
-import { getTicketCsrfToken, submitTicketForm } from "#test-utils/csrf.ts";
+import { extractCsrfToken, submitTicketForm } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
 import { setupStripe } from "#test-utils/settings.ts";
@@ -141,7 +141,7 @@ describeWithEnv(
         const getResponse = await handleRequest(
           mockRequest(`/ticket/${listing.slug}`),
         );
-        const csrfToken = getTicketCsrfToken(await getResponse.text());
+        const csrfToken = extractCsrfToken(await getResponse.text());
         if (!csrfToken) throw new Error("Failed to get CSRF token");
 
         const response = await handleRequest(

--- a/test/integration/server/public/ticket-additional-coverage.test.ts
+++ b/test/integration/server/public/ticket-additional-coverage.test.ts
@@ -15,7 +15,7 @@ import {
 } from "#test-utils/assertions.ts";
 import { setContactVisits } from "#test-utils/contact-preferences.ts";
 import {
-  getTicketCsrfToken,
+  extractCsrfToken,
   submitMultiTicketForm,
   submitTicketForm,
 } from "#test-utils/csrf.ts";
@@ -207,7 +207,7 @@ describeWithEnv(
         expect(html).toContain("Sold Out");
 
         // POST with quantity for both listings - sold out listing's quantity is ignored
-        const csrfToken = getTicketCsrfToken(html);
+        const csrfToken = extractCsrfToken(html);
         if (!csrfToken) throw new Error("Failed to get CSRF token");
 
         const response = await handleRequest(

--- a/test/integration/server/public/ticket-multi-post.test.ts
+++ b/test/integration/server/public/ticket-multi-post.test.ts
@@ -9,7 +9,7 @@ import {
   expectHtmlResponse,
   expectReservedRedirectWithTokens,
 } from "#test-utils/assertions.ts";
-import { getTicketCsrfToken } from "#test-utils/csrf.ts";
+import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
@@ -28,7 +28,7 @@ describeWithEnv(
       ): Promise<Response> => {
         const path = `/ticket/${slugs.join("+")}`;
         const getResponse = await handleRequest(mockRequest(path));
-        const csrfToken = getTicketCsrfToken(await getResponse.text());
+        const csrfToken = extractCsrfToken(await getResponse.text());
         if (!csrfToken) throw new Error("Failed to get CSRF token");
 
         return handleRequest(

--- a/test/integration/server/public/ticket-reserved-and-edge-cases.test.ts
+++ b/test/integration/server/public/ticket-reserved-and-edge-cases.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   bookTwoListings,
   expectBookOneEachRejected,
-  getTicketCsrfToken,
+  extractCsrfToken,
   submitMultiTicketForm,
   submitTicketForm,
 } from "#test-utils/csrf.ts";
@@ -129,7 +129,7 @@ describeWithEnv(
         const getResponse = await handleRequest(
           mockRequest(`/ticket/${listing.slug}?iframe=true`),
         );
-        const csrfToken = getTicketCsrfToken(await getResponse.text());
+        const csrfToken = extractCsrfToken(await getResponse.text());
         expect(csrfToken).not.toBe(null);
 
         const response = await handleRequest(

--- a/test/integration/server/public/ticket-slug-post.test.ts
+++ b/test/integration/server/public/ticket-slug-post.test.ts
@@ -10,7 +10,7 @@ import {
 } from "#test-utils/assertions.ts";
 import {
   expectMissingCsrfRejected,
-  getTicketCsrfToken,
+  extractCsrfToken,
   submitTicketForm,
 } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
@@ -63,7 +63,7 @@ describeWithEnv(
         const getResponse = await handleRequest(
           mockRequest(`/ticket/${group.slug}`),
         );
-        const csrfToken = getTicketCsrfToken(await getResponse.text());
+        const csrfToken = extractCsrfToken(await getResponse.text());
         if (!csrfToken) throw new Error("Failed to get CSRF token");
 
         const response = await handleRequest(
@@ -114,7 +114,7 @@ describeWithEnv(
         const getResponse1 = await handleRequest(
           mockRequest(`/ticket/${group.slug}`),
         );
-        const csrfToken1 = getTicketCsrfToken(await getResponse1.text());
+        const csrfToken1 = extractCsrfToken(await getResponse1.text());
         if (!csrfToken1) throw new Error("Failed to get CSRF token");
         const r1 = await handleRequest(
           mockFormRequest(
@@ -135,7 +135,7 @@ describeWithEnv(
         const getResponse2 = await handleRequest(
           mockRequest(`/ticket/${group.slug}`),
         );
-        const csrfToken2 = getTicketCsrfToken(await getResponse2.text());
+        const csrfToken2 = extractCsrfToken(await getResponse2.text());
         if (!csrfToken2) throw new Error("Failed to get CSRF token");
         const r2 = await handleRequest(
           mockFormRequest(

--- a/test/integration/server/setup-concurrency.test.ts
+++ b/test/integration/server/setup-concurrency.test.ts
@@ -4,7 +4,7 @@ import { stub } from "@std/testing/mock";
 import { getDb } from "#db/client.ts";
 import { CONFIG_KEYS, settings } from "#db/settings.ts";
 import { handleRequest } from "#routes";
-import { getSetupCsrfToken } from "#test-utils/csrf.ts";
+import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { createTestDb, describeWithEnv, resetDb } from "#test-utils/db.ts";
 import { mockRequest, mockSetupFormRequest } from "#test-utils/mocks.ts";
 
@@ -35,7 +35,7 @@ describeWithEnv("server (setup concurrency)", { db: true }, () => {
     try {
       const getToken = async (): Promise<string> => {
         const response = await handleRequest(mockRequest("/setup/"));
-        const token = getSetupCsrfToken(await response.text());
+        const token = extractCsrfToken(await response.text());
         if (!token) throw new Error("Setup page did not include a CSRF token");
         return token;
       };

--- a/test/integration/server/setup.test.ts
+++ b/test/integration/server/setup.test.ts
@@ -12,7 +12,7 @@ import {
   expectHtmlResponse,
   expectRedirect,
 } from "#test-utils/assertions.ts";
-import { getSetupCsrfToken } from "#test-utils/csrf.ts";
+import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { createTestDb, describeWithEnv, resetDb } from "#test-utils/db.ts";
 import { TEST_ADMIN_USERNAME } from "#test-utils/internal.ts";
 import {
@@ -43,7 +43,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
     fields: Record<string, string>,
   ): Promise<Response> {
     const getResponse = await handleRequest(mockRequest("/setup/"));
-    const csrfToken = getSetupCsrfToken(await getResponse.text());
+    const csrfToken = extractCsrfToken(await getResponse.text());
     expect(csrfToken).not.toBeNull();
     return handleRequest(mockSetupFormRequest(fields, csrfToken as string));
   }
@@ -74,7 +74,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
     );
     expect(getResponse.status).toBe(200);
 
-    const csrfToken = getSetupCsrfToken(await getResponse.text());
+    const csrfToken = extractCsrfToken(await getResponse.text());
     expect(csrfToken).not.toBeNull();
 
     const postResponse = await handleRequest(
@@ -457,7 +457,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
         const { settings } = await import("#db/settings.ts");
 
         const getResponse = await handleRequest(mockRequest("/setup/"));
-        const csrfToken = getSetupCsrfToken(await getResponse.text());
+        const csrfToken = extractCsrfToken(await getResponse.text());
 
         await withExpectedError(async () => {
           await withMocks(
@@ -544,7 +544,7 @@ describeWithEnv("server (setup)", { db: true }, () => {
       await createTestDb();
 
       const getResponse = await handleRequest(mockRequest("/setup/"));
-      const csrfToken = getSetupCsrfToken(await getResponse.text());
+      const csrfToken = extractCsrfToken(await getResponse.text());
 
       await handleRequest(
         mockSetupFormRequest(

--- a/test/integration/server/webhooks/refund-skip-conditions.test.ts
+++ b/test/integration/server/webhooks/refund-skip-conditions.test.ts
@@ -24,7 +24,7 @@ import {
 
 // jscpd:ignore-end
 
-import { errorLogged, useErrorLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useErrorLogSpy } from "#test-utils/debug-log.ts";
 
 describeWithEnv(
   "server webhooks > refund skip conditions",
@@ -132,7 +132,7 @@ describeWithEnv(
         // Stripe retries silently, so the log is the operator's only sign
         // that a captured charge is sitting unrefunded.
         expect(
-          errorLogged(
+          logLogged(
             errorSpy,
             "Webhook session rejected as malformed_charge (refunded: false)",
           ),

--- a/test/integration/server/webhooks/sumup.test.ts
+++ b/test/integration/server/webhooks/sumup.test.ts
@@ -9,7 +9,7 @@ import { sumupPaymentProvider } from "#shared/sumup-provider.ts";
 import { expectHtmlResponse } from "#test-utils/assertions.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { deactivateTestListing } from "#test-utils/db-helpers/listings.ts";
-import { debugLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
 import { mockRequest, mockWebhookRequest } from "#test-utils/mocks.ts";
 import {
@@ -140,7 +140,7 @@ describeWithEnv("server webhooks > SumUp", { db: true }, () => {
       expect(await response.text()).toContain(
         "30;url=/payment/success?session_id=",
       );
-      expect(debugLogged(debugSpy, "not confirmed yet")).toBe(true);
+      expect(logLogged(debugSpy, "not confirmed yet")).toBe(true);
       expect(errors.contains("E_PAYMENT_SESSION")).toBe(false);
     } finally {
       restore.restore();

--- a/test/shared/existing-payment-provider.test.ts
+++ b/test/shared/existing-payment-provider.test.ts
@@ -3,7 +3,7 @@ import { it as test } from "@std/testing/bdd";
 import { ALL_SETTINGS_KEYS, CONFIG_KEYS, settings } from "#db/settings.ts";
 import { getPaymentProviderForExistingPayments } from "#shared/payments.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { debugLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
 
 describeWithEnv("getPaymentProviderForExistingPayments", { db: true }, () => {
   const debugSpy = useDebugLogSpy();
@@ -19,7 +19,7 @@ describeWithEnv("getPaymentProviderForExistingPayments", { db: true }, () => {
       "stripe",
     );
     expect(
-      debugLogged(
+      logLogged(
         debugSpy,
         "Resolving payment provider for existing payments: stripe",
       ),
@@ -35,7 +35,7 @@ describeWithEnv("getPaymentProviderForExistingPayments", { db: true }, () => {
       "stripe",
     );
     expect(
-      debugLogged(
+      logLogged(
         debugSpy,
         "Resolving payment provider for existing payments: stripe",
       ),

--- a/test/shared/payments.test.ts
+++ b/test/shared/payments.test.ts
@@ -6,7 +6,7 @@ import {
   getPaymentProviderForExistingPayments,
 } from "#shared/payments.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { debugLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
 
 describeWithEnv("getActivePaymentProvider", { db: true }, () => {
   const debugSpy = useDebugLogSpy();
@@ -14,7 +14,7 @@ describeWithEnv("getActivePaymentProvider", { db: true }, () => {
   test("returns null when no provider is configured", async () => {
     expect(await getActivePaymentProvider()).toBeNull();
     expect(
-      debugLogged(
+      logLogged(
         debugSpy,
         "[Payment] No payment provider configured in settings",
       ),
@@ -25,7 +25,7 @@ describeWithEnv("getActivePaymentProvider", { db: true }, () => {
     await settings.update.paymentProvider("stripe");
     await getActivePaymentProvider();
     expect(
-      debugLogged(debugSpy, "[Payment] Resolving payment provider: stripe"),
+      logLogged(debugSpy, "[Payment] Resolving payment provider: stripe"),
     ).toBe(true);
   });
 
@@ -34,7 +34,7 @@ describeWithEnv("getActivePaymentProvider", { db: true }, () => {
     await settings.update.paymentProvider("stripe");
     await getPaymentProviderForExistingPayments();
     expect(
-      debugLogged(
+      logLogged(
         debugSpy,
         "[Payment] Resolving payment provider for existing payments: stripe",
       ),

--- a/test/shared/sumup/checkout-resolution.test.ts
+++ b/test/shared/sumup/checkout-resolution.test.ts
@@ -10,7 +10,7 @@ import {
 } from "#shared/sumup/checkout-resolution.ts";
 import { sumupApi } from "#shared/sumup.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { debugLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
 import {
   makeSumupCheckoutDue,
   stageSignedSumupCheckout,
@@ -49,8 +49,8 @@ describeWithEnv("sumup checkout resolution", { db: true }, () => {
     // was running says whether a customer was waiting on the answer.
     await resolveSumupCheckoutById("", "SumUp");
 
-    expect(debugLogged(debug, "[SumUp]")).toBe(true);
-    expect(debugLogged(debug, "[Webhook]")).toBe(false);
+    expect(logLogged(debug, "[SumUp]")).toBe(true);
+    expect(logLogged(debug, "[Webhook]")).toBe(false);
   });
 
   test("keeps SumUp's own word for a checkout nobody has paid", async () => {

--- a/test/shared/sumup/recovery-run.test.ts
+++ b/test/shared/sumup/recovery-run.test.ts
@@ -7,7 +7,7 @@ import { SUMUP_RECOVERY_BATCH } from "#shared/limits.ts";
 import { runSumupRecovery } from "#shared/sumup/recovery-run.ts";
 import { sumupApi } from "#shared/sumup.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { debugLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
+import { logLogged, useDebugLogSpy } from "#test-utils/debug-log.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
 import {
   makeSumupCheckoutDue,
@@ -138,7 +138,7 @@ describeWithEnv("sumup recovery run", { db: true }, () => {
         nextCheckAt: "2999-01-01T00:00:00.000Z",
         state: "waiting",
       });
-      expect(debugLogged(debug, "beaten")).toBe(true);
+      expect(logLogged(debug, "beaten")).toBe(true);
     } finally {
       read.restore();
     }

--- a/test/test-utils/csrf-and-forms.test.ts
+++ b/test/test-utils/csrf-and-forms.test.ts
@@ -3,12 +3,9 @@ import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { getSessionCookieName } from "#shared/cookies.ts";
 import {
   csrfTokenOrSignedFallback,
+  extractCsrfToken,
   extractInputValue,
-  getAdminLoginCsrfToken,
   getCsrfTokenFromCookie,
-  getJoinCsrfToken,
-  getSetupCsrfToken,
-  getTicketCsrfToken,
   hasCheckedInput,
   hasInputWithValue,
   hasSelectedOption,
@@ -221,33 +218,19 @@ describe("test-utils — csrf & form helpers", () => {
     });
   });
 
-  describe("getAdminLoginCsrfToken", () => {
+  describe("extractCsrfToken", () => {
     test("returns null when html is null", () => {
-      expect(getAdminLoginCsrfToken(null)).toBe(null);
+      expect(extractCsrfToken(null)).toBe(null);
     });
 
     test("returns null when html has no csrf_token field", () => {
-      expect(getAdminLoginCsrfToken("<form><input type='text'></form>")).toBe(
-        null,
+      expect(extractCsrfToken("<form><input type='text'></form>")).toBe(null);
+    });
+
+    test("extracts csrf_token value from html form", () => {
+      expect(extractCsrfToken('<input name="csrf_token" value="abc123">')).toBe(
+        "abc123",
       );
-    });
-
-    test("extracts csrf_token value from html form", () => {
-      expect(
-        getAdminLoginCsrfToken('<input name="csrf_token" value="abc123">'),
-      ).toBe("abc123");
-    });
-  });
-
-  describe("getJoinCsrfToken", () => {
-    test("returns null when html is null", () => {
-      expect(getJoinCsrfToken(null)).toBe(null);
-    });
-
-    test("extracts csrf_token value from html form", () => {
-      expect(
-        getJoinCsrfToken('<input name="csrf_token" value="join-token-123">'),
-      ).toBe("join-token-123");
     });
   });
 
@@ -262,38 +245,6 @@ describe("test-utils — csrf & form helpers", () => {
       expect(
         requireJoinCsrfToken('<input name="csrf_token" value="abc123">'),
       ).toBe("abc123");
-    });
-  });
-
-  describe("getSetupCsrfToken", () => {
-    test("returns null when html is null", () => {
-      expect(getSetupCsrfToken(null)).toBe(null);
-    });
-
-    test("returns null when html has no csrf_token field", () => {
-      expect(getSetupCsrfToken("<form><input type='text'></form>")).toBe(null);
-    });
-
-    test("extracts csrf_token value from html form", () => {
-      expect(
-        getSetupCsrfToken('<input name="csrf_token" value="setup-token-789">'),
-      ).toBe("setup-token-789");
-    });
-  });
-
-  describe("getTicketCsrfToken", () => {
-    test("returns null when html is null", () => {
-      expect(getTicketCsrfToken(null)).toBe(null);
-    });
-
-    test("returns null when html has no csrf_token field", () => {
-      expect(getTicketCsrfToken("<form><input type='text'></form>")).toBe(null);
-    });
-
-    test("extracts csrf_token value from html form", () => {
-      expect(
-        getTicketCsrfToken('<input name="csrf_token" value="ticket-xyz789">'),
-      ).toBe("ticket-xyz789");
     });
   });
 });

--- a/test/test-utils/csrf.ts
+++ b/test/test-utils/csrf.ts
@@ -57,12 +57,6 @@ export const hasSelectedOption = (html: string, value: string): boolean => {
   );
 };
 
-export const getAdminLoginCsrfToken = (html: string | null): string | null =>
-  extractCsrfToken(html);
-
-export const getJoinCsrfToken = (html: string | null): string | null =>
-  extractCsrfToken(html);
-
 export const requireJoinCsrfToken = (html: string | null): string => {
   const token = extractCsrfToken(html);
   if (!token) throw new Error("Failed to get CSRF token for join flow");
@@ -72,12 +66,6 @@ export const requireJoinCsrfToken = (html: string | null): string => {
 export const csrfTokenOrSignedFallback = async (
   html: string,
 ): Promise<string> => extractCsrfToken(html) ?? (await signCsrfToken());
-
-export const getSetupCsrfToken = (html: string | null): string | null =>
-  extractCsrfToken(html);
-
-export const getTicketCsrfToken = (html: string | null): string | null =>
-  extractCsrfToken(html);
 
 /** GETs a page and returns its rendered HTML plus its signed CSRF token. This
  *  is the shared first half of any test that must inspect the page —

--- a/test/test-utils/debug-log.ts
+++ b/test/test-utils/debug-log.ts
@@ -18,11 +18,5 @@ export const useDebugLogSpy = (): (() => Spy) => {
 /** Capture console.error (where logError routes) per test. */
 export const useErrorLogSpy = (): (() => Spy) => useConsoleSpy("error");
 
-const logLogged = (logSpy: () => Spy, needle: string): boolean =>
+export const logLogged = (logSpy: () => Spy, needle: string): boolean =>
   logSpy().calls.some((call) => String(call.args[0]).includes(needle));
-
-export const errorLogged = (logSpy: () => Spy, needle: string): boolean =>
-  logLogged(logSpy, needle);
-
-export const debugLogged = (logSpy: () => Spy, needle: string): boolean =>
-  logLogged(logSpy, needle);

--- a/test/test-utils/parents.ts
+++ b/test/test-utils/parents.ts
@@ -44,10 +44,10 @@ export const bookingPageHtml = async (slugs: string): Promise<string> =>
  * sold-out because it has no bookable child), falls back to a freshly-minted
  * token so the submit-side gate can still be exercised. */
 export const bookingPageToken = async (slugs: string): Promise<string> => {
-  const { getTicketCsrfToken } = await import("#test-utils/csrf.ts");
+  const { extractCsrfToken } = await import("#test-utils/csrf.ts");
   const { signCsrfToken } = await import("#shared/csrf.ts");
   return (
-    getTicketCsrfToken(await bookingPageHtml(slugs)) ?? (await signCsrfToken())
+    extractCsrfToken(await bookingPageHtml(slugs)) ?? (await signCsrfToken())
   );
 };
 


### PR DESCRIPTION
## Problem

Six helper names in the test utilities were second names for a call that already exists, which the "No alias exports" rule in AGENTS.md forbids:

- `errorLogged` and `debugLogged` in `test/test-utils/debug-log.ts` were both `logLogged` with no change.
- `getAdminLoginCsrfToken`, `getJoinCsrfToken`, `getSetupCsrfToken`, and `getTicketCsrfToken` in `test/test-utils/csrf.ts` were each `extractCsrfToken` with no change.

jscpd cannot flag an alias, because an alias is too short to reach any `minTokens` setting the configs use. Both cases were found by reading (issue #2190).

## Change

- `logLogged` is now exported from `test/test-utils/debug-log.ts`. All callers of `errorLogged`/`debugLogged` (`test/shared/payments.test.ts`, the webhook and payment-processing suites, and the SumUp suites) call `logLogged`.
- All callers of the four CSRF wrappers (`test/integration/server/setup*.test.ts`, the public ticket suites, and `test/test-utils/parents.ts`) call `extractCsrfToken`. Both aliases and the four wrappers are deleted.
- Files that imported a helper through two clauses now hold one clause per module, as the `check:imports` rule requires.
- `test/test-utils/csrf-and-forms.test.ts` held a `describe` block per alias; the four blocks collapsed into one `extractCsrfToken` block. The blocks repeated the same three assertions and differed only in the sample token string, so the collapse keeps every distinct assertion.

The four CSRF `describe` renames mean the test names changed from the wrapper names to the real call's name. No assertion changed.

## Verification

- `rg "errorLogged|debugLogged" test/` finds nothing.
- `rg "getAdminLoginCsrfToken|getJoinCsrfToken|getSetupCsrfToken|getTicketCsrfToken" test/` finds nothing.
- `deno task precommit` passed at commit time (the pre-commit hook runs it): typecheck, lint, cpd, shape checks, and the full suite.

Test-only change: `src/` is untouched, so no mutation gate applies.

Fixes #2190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized log assertions across payment, webhook, listing, and provider test coverage.
  * Consolidated CSRF token extraction in integration and utility tests.
  * Removed specialized CSRF and log assertion helper usage while preserving existing test scenarios and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->