### PR TITLE
Bind each repeated id list once through the numbered SQL binder

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,9 @@
       "**/*.tsx",
       "!src/static",
       "!src/ui/static",
-      "!src/ui/client/scanner.js"
+      "!src/ui/client/scanner.js",
+      "!**/.pi-worktrees/**",
+      "!**/.security-worktrees/**"
     ]
   },
   "formatter": {

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -235,3 +235,8 @@ src/shared/db/listings/records.ts::withDayPrices~12esd4i  ?? → ||   # a provid
 src/shared/db/listings/records.ts::withDayPrices~0jasiuh  ?? → ||   # a projected image column set is an object (always truthy), so the fetch fallback runs only when it is undefined
 src/shared/db/listings/records.ts::getStoredListingWithCount~0s7oh7g  ?? → ||   # the array element is a listing object or undefined; a present listing is truthy
 src/shared/db/listing-relationship-validation.ts::listingById.listingPrices~0p5a2j2  ?? → ||   # the day-price map holds record objects, and a record is always truthy even when empty
+
+# The one-direction link reader's fold throws when a row's key falls outside
+# the requested key set, but the reader's WHERE clause already restricts every
+# returned row to a requested key, so the throw is unreachable.
+src/shared/db/link-table.ts::oneDirectionReader.fetchIdsByKeys~0a4lik4 Unexpected link key→""   # unreachable: WHERE key_id IN (...) lets only requested keys through

--- a/src/shared/db/link-table.ts
+++ b/src/shared/db/link-table.ts
@@ -13,12 +13,12 @@
 import {
   deleteByField,
   executeBatch,
-  inPlaceholders,
   queryAll,
   resultRows,
   type SqlStatement,
   type TxScope,
 } from "#db/client.ts";
+import { type NumberedSql, numberedStatement } from "#db/numbered-statement.ts";
 import { reduce, requiredMapValue, unique } from "#fp";
 import { registerTableInvalidation } from "#shared/cache-registry.ts";
 import { requestBatchCache } from "#shared/request-cache.ts";
@@ -69,20 +69,24 @@ type ReadIdsByKeys = (
 /** Rows of one link table, as the two id columns this module works in. */
 type LinkRow = { key_id: number; value_id: number };
 
+/** Rows of one link table, as the two id columns this module works in. The
+ *  where body is built through the numbered binder, so a where that reads one
+ *  id list through several columns binds that list once. */
 const linkRows = (
   table: string,
   keyColumn: string,
   valueColumn: string,
-  where: string,
-  args: number[],
-): Promise<LinkRow[]> =>
-  queryAll<LinkRow>(
+  where: NumberedSql,
+): Promise<LinkRow[]> => {
+  const { sql, args } = numberedStatement(where);
+  return queryAll<LinkRow>(
     `SELECT ${keyColumn} AS key_id, ${valueColumn} AS value_id
        FROM ${table}
-       WHERE ${where}
+       WHERE ${sql}
        ORDER BY ${keyColumn}, ${valueColumn}`,
     args,
   );
+};
 
 /** One direction's reader: its own query, remembered per request. */
 const oneDirectionReader = (
@@ -99,8 +103,7 @@ const oneDirectionReader = (
       table,
       keyColumn,
       valueColumn,
-      `${keyColumn} IN (${inPlaceholders(keys)})`,
-      keys,
+      (bind) => `${keyColumn} IN (${keys.map(bind).join(", ")})`,
     );
     return reduce((acc: Map<number, number[]>, row: LinkRow) => {
       requiredMapValue(acc, row.key_id, "Unexpected link key").push(
@@ -237,14 +240,12 @@ export const selfLinkTableSides = (
   ): Promise<Map<number, BothDirections>> => {
     const linksById = emptyBothDirections(ids);
     if (ids.length === 0) return linksById;
-    const slots = inPlaceholders(ids);
-    const rows = await linkRows(
-      table,
-      keyColumn,
-      valueColumn,
-      `${keyColumn} IN (${slots}) OR ${valueColumn} IN (${slots})`,
-      [...ids, ...ids],
-    );
+    // Both directions read the same ids, so the list is bound once and its
+    // slots appear under both columns.
+    const rows = await linkRows(table, keyColumn, valueColumn, (bind) => {
+      const idSlots = ids.map(bind).join(", ");
+      return `${keyColumn} IN (${idSlots}) OR ${valueColumn} IN (${idSlots})`;
+    });
     for (const { key_id, value_id } of rows) {
       // A row matched on either column, so only one of its two records has to
       // be one the caller asked about.

--- a/src/shared/db/listing-edge-write.ts
+++ b/src/shared/db/listing-edge-write.ts
@@ -77,6 +77,31 @@ const requireExists = (
   if (count !== expected) throw new TransactionValidationError(message);
 };
 
+/** Whether any of these listings sits inside a package group. The hidden-only
+ *  form also requires the package to hide what is inside it. */
+const packageMembershipExists = (
+  listingSlots: string,
+  hiddenOnly: boolean,
+): string =>
+  `EXISTS(SELECT 1
+           FROM group_listings AS membership
+                JOIN groups AS package
+                  ON package.id = membership.group_id
+           WHERE membership.listing_id IN (${listingSlots})
+             AND package.is_package = 1${hiddenOnly ? " AND package.hide_package_listings = 1" : ""})`;
+
+/** Whether any parent→child edge names one of these listings on that side of
+ *  the edge. */
+const edgeExists = (
+  edgeColumn: "child_listing_id" | "parent_listing_id",
+  listingSlots: string,
+): string =>
+  `EXISTS(SELECT 1 FROM listing_parents
+           WHERE ${edgeColumn} IN (${listingSlots}))`;
+
+const listingCount = (listingSlots: string): string =>
+  `(SELECT COUNT(*) FROM listings WHERE id IN (${listingSlots}))`;
+
 /** The edge-state checks shared by both writers, in one SELECT. `parentIds`/`
  *  `childIds` are the role id sets; each set is bound once and its slots
  *  reused by every check that reads it, so the query never builds an empty
@@ -95,33 +120,14 @@ export const guardEdgeWriteTx = async (
       numberedStatement((bind) => {
         const childSlots = uniqueChildIds.map(bind).join(", ");
         const parentSlots = uniqueParentIds.map(bind).join(", ");
-        return `SELECT EXISTS(
-                        SELECT 1
-                          FROM group_listings AS childMembership
-                          JOIN groups AS childGroup
-                            ON childGroup.id = childMembership.group_id
-                         WHERE childMembership.listing_id IN (${childSlots})
-                           AND childGroup.is_package = 1
-                     ) AS child_is_package_member,
-                     EXISTS(
-                       SELECT 1
-                         FROM group_listings AS parentMembership
-                         JOIN groups AS parentGroup
-                           ON parentGroup.id = parentMembership.group_id
-                        WHERE parentMembership.listing_id IN (${parentSlots})
-                          AND parentGroup.is_package = 1
-                          AND parentGroup.hide_package_listings = 1
-                     ) AS parent_is_hidden_package_member,
-                     (SELECT COUNT(*) FROM listings
-                        WHERE id IN (${childSlots})) AS child_count,
-                     (SELECT COUNT(*) FROM listings
-                        WHERE id IN (${parentSlots})) AS parent_count,
-                     EXISTS(SELECT 1 FROM listing_parents
-                              WHERE child_listing_id IN (${parentSlots}))
-                        AS parent_has_parent,
-                     EXISTS(SELECT 1 FROM listing_parents
-                              WHERE parent_listing_id IN (${childSlots}))
-                        AS child_has_children`;
+        // One fact per line, named for the role set it reads.
+        return `SELECT
+          ${packageMembershipExists(childSlots, false)} AS child_is_package_member,
+          ${packageMembershipExists(parentSlots, true)} AS parent_is_hidden_package_member,
+          ${listingCount(childSlots)} AS child_count,
+          ${listingCount(parentSlots)} AS parent_count,
+          ${edgeExists("child_listing_id", parentSlots)} AS parent_has_parent,
+          ${edgeExists("parent_listing_id", childSlots)} AS child_has_children`;
       }),
     ),
   );

--- a/src/shared/db/listing-edge-write.ts
+++ b/src/shared/db/listing-edge-write.ts
@@ -8,7 +8,8 @@
  * two writers in step.
  */
 
-import { inPlaceholders, resultRows, type TxScope } from "#db/client.ts";
+import { resultRows, type TxScope } from "#db/client.ts";
+import { numberedStatement } from "#db/numbered-statement.ts";
 import { TransactionValidationError } from "#db/transaction.ts";
 import { t } from "#i18n";
 import {
@@ -77,8 +78,9 @@ const requireExists = (
 };
 
 /** The edge-state checks shared by both writers, in one SELECT. `parentIds`/`
- *  `childIds` are the role id sets; each `IN` clause is filled by its own bound
- *  args so the query never builds an empty `IN ()`. */
+ *  `childIds` are the role id sets; each set is bound once and its slots
+ *  reused by every check that reads it, so the query never builds an empty
+ *  `IN ()`. */
 export const guardEdgeWriteTx = async (
   input: GuardEdgeWriteInput,
 ): Promise<PackageChildEdgeBlock | null> => {
@@ -89,43 +91,39 @@ export const guardEdgeWriteTx = async (
   const uniqueChildIds = [...childSet];
 
   const [state] = resultRows<EdgeState>(
-    await tx.execute({
-      args: [
-        ...uniqueChildIds,
-        ...uniqueParentIds,
-        ...uniqueChildIds,
-        ...uniqueParentIds,
-        ...uniqueParentIds,
-        ...uniqueChildIds,
-      ],
-      sql: `SELECT EXISTS(
-                      SELECT 1
-                        FROM group_listings AS childMembership
-                        JOIN groups AS childGroup
-                          ON childGroup.id = childMembership.group_id
-                       WHERE childMembership.listing_id IN (${inPlaceholders(uniqueChildIds)})
-                         AND childGroup.is_package = 1
-                    ) AS child_is_package_member,
-                    EXISTS(
-                      SELECT 1
-                        FROM group_listings AS parentMembership
-                        JOIN groups AS parentGroup
-                          ON parentGroup.id = parentMembership.group_id
-                       WHERE parentMembership.listing_id IN (${inPlaceholders(uniqueParentIds)})
-                         AND parentGroup.is_package = 1
-                         AND parentGroup.hide_package_listings = 1
-                    ) AS parent_is_hidden_package_member,
-                    (SELECT COUNT(*) FROM listings
-                       WHERE id IN (${inPlaceholders(uniqueChildIds)})) AS child_count,
-                    (SELECT COUNT(*) FROM listings
-                       WHERE id IN (${inPlaceholders(uniqueParentIds)})) AS parent_count,
-                    EXISTS(SELECT 1 FROM listing_parents
-                             WHERE child_listing_id IN (${inPlaceholders(uniqueParentIds)}))
-                       AS parent_has_parent,
-                    EXISTS(SELECT 1 FROM listing_parents
-                             WHERE parent_listing_id IN (${inPlaceholders(uniqueChildIds)}))
-                       AS child_has_children`,
-    }),
+    await tx.execute(
+      numberedStatement((bind) => {
+        const childSlots = uniqueChildIds.map(bind).join(", ");
+        const parentSlots = uniqueParentIds.map(bind).join(", ");
+        return `SELECT EXISTS(
+                        SELECT 1
+                          FROM group_listings AS childMembership
+                          JOIN groups AS childGroup
+                            ON childGroup.id = childMembership.group_id
+                         WHERE childMembership.listing_id IN (${childSlots})
+                           AND childGroup.is_package = 1
+                     ) AS child_is_package_member,
+                     EXISTS(
+                       SELECT 1
+                         FROM group_listings AS parentMembership
+                         JOIN groups AS parentGroup
+                           ON parentGroup.id = parentMembership.group_id
+                        WHERE parentMembership.listing_id IN (${parentSlots})
+                          AND parentGroup.is_package = 1
+                          AND parentGroup.hide_package_listings = 1
+                     ) AS parent_is_hidden_package_member,
+                     (SELECT COUNT(*) FROM listings
+                        WHERE id IN (${childSlots})) AS child_count,
+                     (SELECT COUNT(*) FROM listings
+                        WHERE id IN (${parentSlots})) AS parent_count,
+                     EXISTS(SELECT 1 FROM listing_parents
+                              WHERE child_listing_id IN (${parentSlots}))
+                        AS parent_has_parent,
+                     EXISTS(SELECT 1 FROM listing_parents
+                              WHERE parent_listing_id IN (${childSlots}))
+                        AS child_has_children`;
+      }),
+    ),
   );
 
   // Existence: the parent side must still exist (the parent itself on the

--- a/src/shared/db/logistics-run-sheet.ts
+++ b/src/shared/db/logistics-run-sheet.ts
@@ -14,6 +14,10 @@ import {
   type DeliveryBookingRef,
   mapBookingRows,
 } from "#db/logistics.ts";
+import {
+  numberedStatement,
+  type SqlParameter,
+} from "#db/numbered-statement.ts";
 import { columnFrom } from "#db/query.ts";
 import { compact, flatMap, uniqueBy } from "#fp";
 
@@ -66,16 +70,44 @@ const buildLeg = (
   };
 };
 
-const runSheetLegWhere = (
-  sourceName: string,
-  agentPlaceholders: string,
-  datePlaceholders: string,
-): string => {
-  const column = columnFrom(sourceName);
-  return `((${column("start_agent_id")} IN (${agentPlaceholders}) AND DATE(${column("start_at")}) IN (${datePlaceholders}))
-        OR (${column("end_agent_id")} IN (${agentPlaceholders}) AND DATE(${column("end_at")}, '-1 day') IN (${datePlaceholders})))
+/** The alias every run-sheet read walks `listing_attendees` rows under. */
+const SOURCE = "listingAttendee";
+
+const runSheetLegWhere = (agentSlots: string, dateSlots: string): string => {
+  const column = columnFrom(SOURCE);
+  return `((${column("start_agent_id")} IN (${agentSlots}) AND DATE(${column("start_at")}) IN (${dateSlots}))
+        OR (${column("end_agent_id")} IN (${agentSlots}) AND DATE(${column("end_at")}, '-1 day') IN (${dateSlots})))
         AND ${column("quantity")} > 0`;
 };
+
+/** Runs a run-sheet read for the given agents and dates: both id lists bind
+ *  once, and the writer receives the slot lists its SQL reads wherever it
+ *  needs them again. Callers must return early on empty id lists. */
+const queryRunSheetLegs = async <Row>(
+  agentIds: number[],
+  dates: string[],
+  write: (
+    slots: { agentSlots: string; dateSlots: string },
+    bind: SqlParameter,
+  ) => string,
+): Promise<Row[]> => {
+  const { sql, args } = numberedStatement((bind) =>
+    write(
+      {
+        agentSlots: agentIds.map(bind).join(", "),
+        dateSlots: dates.map(bind).join(", "),
+      },
+      bind,
+    ),
+  );
+  return queryAll<Row>(sql, args);
+};
+
+/** The run-sheet rows' source: every listing_attendees row whose drop-off or
+ *  collection leg one of the bound agents owns on one of the bound dates. */
+const runSheetRowsWhere = (agentSlots: string, dateSlots: string): string =>
+  `FROM listing_attendees AS ${SOURCE}
+      WHERE ${runSheetLegWhere(agentSlots, dateSlots)}`;
 
 /** Collapse the identical legs a multi-path booking yields (a listing booked
  *  * through a package beside its standalone or second-package row is several
@@ -121,16 +153,14 @@ export const getAgentRunSheet = async (
   dates: string[],
 ): Promise<AgentRunLeg[]> => {
   if (agentIds.length === 0 || dates.length === 0) return [];
-  const sourceName = "listingAttendee";
-  const agentPlaceholders = inPlaceholders(agentIds);
-  const datePlaceholders = inPlaceholders(dates);
-  const rows = await queryAll<RunSheetRow>(
-    `SELECT attendee_id, listing_id, start_agent_id, end_agent_id,
+  const rows = await queryRunSheetLegs<RunSheetRow>(
+    agentIds,
+    dates,
+    ({ agentSlots, dateSlots }) =>
+      `SELECT attendee_id, listing_id, start_agent_id, end_agent_id,
             start_time, end_time, start_done, end_done,
             DATE(start_at) AS start_date, DATE(end_at, '-1 day') AS end_date
-     FROM listing_attendees AS ${sourceName}
-     WHERE ${runSheetLegWhere(sourceName, agentPlaceholders, datePlaceholders)}`,
-    [...agentIds, ...dates, ...agentIds, ...dates],
+     ${runSheetRowsWhere(agentSlots, dateSlots)}`,
   );
   const agentSet = new Set(agentIds);
   const dateSet = new Set(dates);
@@ -147,12 +177,6 @@ export const getAgentRunSheet = async (
 
 const bookingRefKey = (booking: DeliveryBookingRef): string =>
   bookingAssignmentKey(booking.attendeeId, booking.listingId);
-
-const bookingRefValues = (bookings: DeliveryBookingRef[]): string =>
-  bookings.map(() => "(?, ?)").join(", ");
-
-const bookingRefArgs = (bookings: DeliveryBookingRef[]): number[] =>
-  bookings.flatMap((booking) => [booking.attendeeId, booking.listingId]);
 
 /** A booking row matched on an agent's run sheet, with its full slot identity
  * (attendee + listing + date + parent + package) populated from the database
@@ -212,37 +236,35 @@ export const getAgentRunSheetBookings = async (
   if (bookings.length === 0) return [];
 
   const uniqueBookings = uniqueBy(bookingRefKey)(bookings);
-  const agentPlaceholders = inPlaceholders(agentIds);
-  const datePlaceholders = inPlaceholders(dates);
-  const sourceName = "listingAttendee";
-  const rows = await queryAll<{
+  // The agent and date lists bind first; the VALUES pairs bind through the
+  // same binder, so no list is bound twice.
+  const rows = await queryRunSheetLegs<{
     attendee_id: number;
     date: string | null;
     listing_id: number;
     parent_listing_id: number;
     package_group_id: number;
-  }>(
-    `WITH requested_booking(attendee_id, listing_id) AS (
-       VALUES ${bookingRefValues(uniqueBookings)}
+  }>(agentIds, dates, ({ agentSlots, dateSlots }, bind) => {
+    const bookingPairs = uniqueBookings
+      .map(
+        (booking) =>
+          `(${bind(booking.attendeeId)}, ${bind(booking.listingId)})`,
+      )
+      .join(", ");
+    return `WITH requested_booking(attendee_id, listing_id) AS (
+       VALUES ${bookingPairs}
      )
-     SELECT DISTINCT ${sourceName}.attendee_id,
-                      ${sourceName}.listing_id,
-                      DATE(${sourceName}.start_at) AS date,
-                      ${sourceName}.parent_listing_id,
-                      ${sourceName}.package_group_id
-     FROM listing_attendees AS ${sourceName}
+     SELECT DISTINCT ${SOURCE}.attendee_id,
+                      ${SOURCE}.listing_id,
+                      DATE(${SOURCE}.start_at) AS date,
+                      ${SOURCE}.parent_listing_id,
+                      ${SOURCE}.package_group_id
+     FROM listing_attendees AS ${SOURCE}
      JOIN requested_booking AS requestedBooking
-       ON requestedBooking.attendee_id = ${sourceName}.attendee_id
-      AND requestedBooking.listing_id = ${sourceName}.listing_id
-     WHERE ${runSheetLegWhere(sourceName, agentPlaceholders, datePlaceholders)}`,
-    [
-      ...bookingRefArgs(uniqueBookings),
-      ...agentIds,
-      ...dates,
-      ...agentIds,
-      ...dates,
-    ],
-  );
+       ON requestedBooking.attendee_id = ${SOURCE}.attendee_id
+      AND requestedBooking.listing_id = ${SOURCE}.listing_id
+     WHERE ${runSheetLegWhere(agentSlots, dateSlots)}`;
+  });
   return mapBookingRows(rows, (row) => ({
     date: row.date,
     packageGroupId: row.package_group_id,
@@ -261,19 +283,20 @@ export const getAgentRunSheetDates = async (
   agentIds: number[],
 ): Promise<string[]> => {
   if (agentIds.length === 0) return [];
-  const placeholders = inPlaceholders(agentIds);
-  const rows = await queryAll<{ date: string }>(
+  // Both UNION arms read the same agents, so the list is bound once.
+  const { sql, args } = numberedStatement((bind) => {
+    const agentSlots = agentIds.map(bind).join(", ");
     // quantity > 0 mirrors the run-sheet query: a no-quantity sentinel line is
     // never an operational delivery, so it must not offer a date to open.
-    `SELECT DATE(start_at) AS date FROM listing_attendees
-        WHERE start_agent_id IN (${placeholders})
+    return `SELECT DATE(start_at) AS date FROM listing_attendees
+        WHERE start_agent_id IN (${agentSlots})
           AND start_at IS NOT NULL AND quantity > 0
       UNION
       SELECT DATE(end_at, '-1 day') AS date FROM listing_attendees
-        WHERE end_agent_id IN (${placeholders})
-          AND end_at IS NOT NULL AND quantity > 0`,
-    [...agentIds, ...agentIds],
-  );
+        WHERE end_agent_id IN (${agentSlots})
+          AND end_at IS NOT NULL AND quantity > 0`;
+  });
+  const rows = await queryAll<{ date: string }>(sql, args);
   return rows.map((row) => row.date).sort((a, b) => a.localeCompare(b));
 };
 

--- a/test/shared/db/link-table.test.ts
+++ b/test/shared/db/link-table.test.ts
@@ -218,4 +218,13 @@ describeWithEnv("db link-table", { db: true }, () => {
       });
     });
   });
+
+  test("a write makes a plain side's next read fetch again", async () => {
+    await byUser.setIds(1, [3]);
+    await runWithRequestCache(async () => {
+      expect(await byAgent.getIds(3)).toEqual([1]);
+      await byUser.setIds(2, [3]);
+      expect(await byAgent.getIds(3)).toEqual([1, 2]);
+    });
+  });
 });

--- a/test/shared/db/listing-edge-write.test.ts
+++ b/test/shared/db/listing-edge-write.test.ts
@@ -182,6 +182,14 @@ describeWithEnv(
       });
     });
 
+    /** Assert the guard stops the write with the given package conflict. */
+    const expectBlocked = async (
+      params: Omit<Parameters<typeof guardEdgeWriteTx>[0], "tx">,
+      block: "child_is_member" | "gate_in_hidden",
+    ): Promise<void> => {
+      await expect(guard(params)).resolves.toBe(block);
+    };
+
     test("returns the package conflict for the children contract", async () => {
       const { assignListingsToGroup } = await import(
         "#db/groups/membership.ts"
@@ -194,14 +202,65 @@ describeWithEnv(
       const group = await createTestGroup({ isPackage: true, name: "Pkg" });
       await assignListingsToGroup([child.id], group.id);
 
-      await expect(
-        guard({
+      await expectBlocked(
+        {
           childIds: [child.id],
           contract: "children",
           missingParentError: t("error.listing_deleted"),
           parentIds: [parent.id],
-        }),
-      ).resolves.toBe("child_is_member");
+        },
+        "child_is_member",
+      );
+    });
+
+    test("returns the package conflict when the parent sits in a hidden package", async () => {
+      const { assignListingsToGroup } = await import(
+        "#db/groups/membership.ts"
+      );
+      const { createHiddenPackageGroup } = await import(
+        "#test-utils/db-helpers/groups.ts"
+      );
+      const parent = await createTestListing({ name: "Hidden-package parent" });
+      const child = await createTestListing({ name: "Child" });
+      const hidden = await createHiddenPackageGroup("Hidden pkg");
+      await assignListingsToGroup([parent.id], hidden.id);
+
+      await expectBlocked(
+        {
+          childIds: [child.id],
+          contract: "children",
+          missingParentError: t("error.listing_deleted"),
+          parentIds: [parent.id],
+        },
+        "gate_in_hidden",
+      );
+    });
+
+    test("lets a parent inside a visible package take child edges", async () => {
+      // Only a package that HIDES its members gates the write, so a parent
+      // inside a visible package may take children normally.
+      const { assignListingsToGroup } = await import(
+        "#db/groups/membership.ts"
+      );
+      const { createTestGroup } = await import(
+        "#test-utils/db-helpers/groups.ts"
+      );
+      const parent = await createTestListing({
+        name: "Visible-package parent",
+      });
+      const child = await createTestListing({ name: "Child" });
+      const visible = await createTestGroup({
+        isPackage: true,
+        name: "Visible pkg",
+      });
+      await assignListingsToGroup([parent.id], visible.id);
+
+      await expectAccepted({
+        childIds: [child.id],
+        contract: "children",
+        missingParentError: t("error.listing_deleted"),
+        parentIds: [parent.id],
+      });
     });
   },
 );

--- a/test/shared/db/listing-edge-write.test.ts
+++ b/test/shared/db/listing-edge-write.test.ts
@@ -17,20 +17,25 @@ describeWithEnv(
     ): Promise<unknown> =>
       withTransaction((tx) => guardEdgeWriteTx({ ...params, tx }));
 
+    /** Assert the guard lets an edge write through. */
+    const expectAccepted = async (
+      params: Omit<Parameters<typeof guardEdgeWriteTx>[0], "tx">,
+    ): Promise<void> => {
+      await expect(guard(params)).resolves.toBeNull();
+    };
+
     test("allows clearing an empty child set regardless of the parent's own state", async () => {
       // An empty save clears edges and is always allowed: when the parent is a
       // hidden-package member (the package conflict only applies once child
       // edges exist) and when the parent is itself a child (the nesting gate is
       // skipped once there are no edges to write).
       const expectEmptyClear = async (parentId: number): Promise<void> => {
-        await expect(
-          guard({
-            childIds: [],
-            contract: "children",
-            missingParentError: t("error.listing_deleted"),
-            parentIds: [parentId],
-          }),
-        ).resolves.toBeNull();
+        await expectAccepted({
+          childIds: [],
+          contract: "children",
+          missingParentError: t("error.listing_deleted"),
+          parentIds: [parentId],
+        });
       };
 
       const { assignListingsToGroup } = await import(
@@ -154,35 +159,27 @@ describeWithEnv(
     });
 
     test("accepts several children and several parents when nothing blocks them", async () => {
-      // Both id sets reach the checks through a multi-value IN list, so a
-      // multi-id save on each contract must pass every check at once.
-      const parent = await createTestListing({ name: "Multi parent" });
+      // Both id sets reach the checks through multi-value IN lists, so a
+      // multi-id save on each contract must pass every check at once. The
+      // guard is read-only, so both contracts share one fixture.
+      const parentA = await createTestListing({ name: "Parent A" });
+      const parentB = await createTestListing({ name: "Parent B" });
       const childA = await createTestListing({ name: "Child A" });
       const childB = await createTestListing({ name: "Child B" });
-      await expect(
-        guard({
-          childIds: [childA.id, childB.id],
-          contract: "children",
-          missingParentError: t("error.listing_deleted"),
-          parentIds: [parent.id],
-        }),
-      ).resolves.toBeNull();
+      await expectAccepted({
+        childIds: [childA.id, childB.id],
+        contract: "children",
+        missingParentError: t("error.listing_deleted"),
+        parentIds: [parentA.id, parentB.id],
+      });
 
-      const importParentA = await createTestListing({
-        name: "Import parent A",
-      });
-      const importParentB = await createTestListing({
-        name: "Import parent B",
-      });
       const importChild = await createTestListing({ name: "Import child" });
-      await expect(
-        guard({
-          childIds: [importChild.id],
-          contract: "parents",
-          missingParentError: t("catalog_transfer.parent_missing"),
-          parentIds: [importParentA.id, importParentB.id],
-        }),
-      ).resolves.toBeNull();
+      await expectAccepted({
+        childIds: [importChild.id],
+        contract: "parents",
+        missingParentError: t("catalog_transfer.parent_missing"),
+        parentIds: [parentA.id, parentB.id],
+      });
     });
 
     test("returns the package conflict for the children contract", async () => {

--- a/test/shared/db/listing-edge-write.test.ts
+++ b/test/shared/db/listing-edge-write.test.ts
@@ -153,6 +153,38 @@ describeWithEnv(
       ).rejects.toThrow(t("error.child_listing_deleted"));
     });
 
+    test("accepts several children and several parents when nothing blocks them", async () => {
+      // Both id sets reach the checks through a multi-value IN list, so a
+      // multi-id save on each contract must pass every check at once.
+      const parent = await createTestListing({ name: "Multi parent" });
+      const childA = await createTestListing({ name: "Child A" });
+      const childB = await createTestListing({ name: "Child B" });
+      await expect(
+        guard({
+          childIds: [childA.id, childB.id],
+          contract: "children",
+          missingParentError: t("error.listing_deleted"),
+          parentIds: [parent.id],
+        }),
+      ).resolves.toBeNull();
+
+      const importParentA = await createTestListing({
+        name: "Import parent A",
+      });
+      const importParentB = await createTestListing({
+        name: "Import parent B",
+      });
+      const importChild = await createTestListing({ name: "Import child" });
+      await expect(
+        guard({
+          childIds: [importChild.id],
+          contract: "parents",
+          missingParentError: t("catalog_transfer.parent_missing"),
+          parentIds: [importParentA.id, importParentB.id],
+        }),
+      ).resolves.toBeNull();
+    });
+
     test("returns the package conflict for the children contract", async () => {
       const { assignListingsToGroup } = await import(
         "#db/groups/membership.ts"

--- a/test/shared/db/logistics-run-sheet.test.ts
+++ b/test/shared/db/logistics-run-sheet.test.ts
@@ -11,6 +11,7 @@ import { logisticsAgents } from "#db/logistics-agents.ts";
 import {
   type DeliveryLegKind,
   getAgentRunSheet,
+  getAgentRunSheetBookings,
   getAgentRunSheetDates,
   setLegDone,
 } from "#db/logistics-run-sheet.ts";
@@ -207,6 +208,32 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
       expect(legs.map((l) => l.kind).sort()).toEqual(["end", "start"]);
     });
 
+    test("yields each agent's legs when several agents share the window", async () => {
+      const a = await makeBooking({
+        endAgentId: null,
+        endDate: D2,
+        startAgentId: van,
+        startDate: D1,
+        startTime: "09:00",
+      });
+      const b = await makeBooking({
+        endAgentId: other,
+        endDate: D3,
+        startAgentId: other,
+        startDate: D1,
+        startTime: "10:00",
+      });
+      const legs = await getAgentRunSheet([van, other], [D1]);
+      expect(
+        legs
+          .map((l) => [l.agentId, l.attendeeId] as const)
+          .sort((x, y) => x[0] - y[0]),
+      ).toEqual([
+        [other, b.attendeeId],
+        [van, a.attendeeId],
+      ]);
+    });
+
     test("excludes legs whose date is outside the window", async () => {
       // Drop-off on D3 and collection on D3 (end_at = D4), both past [D1, D2].
       await makeBooking({
@@ -380,6 +407,87 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
     });
   });
 
+  describe("getAgentRunSheetBookings", () => {
+    test("returns [] for no agent ids", async () => {
+      expect(
+        await getAgentRunSheetBookings(
+          [],
+          [D1],
+          [{ attendeeId: 1, listingId: 1 }],
+        ),
+      ).toEqual([]);
+    });
+
+    test("returns [] for no dates", async () => {
+      expect(
+        await getAgentRunSheetBookings(
+          [van],
+          [],
+          [{ attendeeId: 1, listingId: 1 }],
+        ),
+      ).toEqual([]);
+    });
+
+    test("returns [] for no bookings", async () => {
+      expect(await getAgentRunSheetBookings([van], [D1], [])).toEqual([]);
+    });
+
+    test("returns the requested bookings whose legs two agents own on the dates", async () => {
+      const a = await makeBooking({
+        endAgentId: other,
+        endDate: D3,
+        startAgentId: van,
+        startDate: D1,
+      });
+      const b = await makeBooking({
+        endAgentId: van,
+        endDate: D3,
+        startAgentId: other,
+        startDate: D1,
+      });
+      const rows = await getAgentRunSheetBookings(
+        [van, other],
+        [D1],
+        [
+          { attendeeId: a.attendeeId, listingId: a.listingId },
+          { attendeeId: b.attendeeId, listingId: b.listingId },
+        ],
+      );
+      expect(
+        rows
+          .map((r) => [r.attendeeId, r.listingId, r.date] as const)
+          .sort((x, y) => x[0] - y[0]),
+      ).toEqual([
+        [a.attendeeId, a.listingId, D1],
+        [b.attendeeId, b.listingId, D1],
+      ]);
+    });
+
+    test("leaves out a requested booking whose legs fall outside the dates", async () => {
+      const inside = await makeBooking({
+        endAgentId: null,
+        endDate: D2,
+        startAgentId: van,
+        startDate: D1,
+      });
+      const outside = await makeBooking({
+        endAgentId: null,
+        endDate: D3,
+        startAgentId: van,
+        startDate: D3,
+      });
+      const rows = await getAgentRunSheetBookings(
+        [van],
+        [D1],
+        [
+          { attendeeId: inside.attendeeId, listingId: inside.listingId },
+          { attendeeId: outside.attendeeId, listingId: outside.listingId },
+        ],
+      );
+      expect(rows.map((r) => r.attendeeId)).toEqual([inside.attendeeId]);
+    });
+  });
+
   describe("getAgentRunSheetDates", () => {
     test("returns [] for no agent ids without hitting the database", async () => {
       const { entries, dates } = await runWithQueryLogContext(async () => {
@@ -418,6 +526,22 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
         startDate: D1,
       });
       expect(await getAgentRunSheetDates([van])).toEqual([]);
+    });
+
+    test("collects dates from every agent in the set", async () => {
+      await makeBooking({
+        endAgentId: null,
+        endDate: D2,
+        startAgentId: van,
+        startDate: D1,
+      });
+      await makeBooking({
+        endAgentId: null,
+        endDate: D3,
+        startAgentId: other,
+        startDate: D2,
+      });
+      expect(await getAgentRunSheetDates([van, other])).toEqual([D1, D2]);
     });
 
     test("ignores no-quantity sentinel lines", async () => {
@@ -511,6 +635,29 @@ describeWithEnv("db logistics run-sheet", { db: true }, () => {
       expect(ok).toBe(false);
       const legs = await getAgentRunSheet([van], [D3]);
       expect(legs[0]?.done).toBe(false);
+    });
+
+    test("marks each leg on its own date when drop-off and collection differ", async () => {
+      // start D1, end D3: the collection's run-sheet day is D2, so the two
+      // date predicates must stay on their own legs' arms.
+      const { attendeeId, listingId } = await makeBooking({
+        endAgentId: van,
+        endDate: D3,
+        startAgentId: van,
+        startDate: D1,
+      });
+      expect(
+        await setLegDone(attendeeId, listingId, "start", D1, true, [van]),
+      ).toBe(true);
+      expect(
+        await setLegDone(attendeeId, listingId, "end", D1, true, [van]),
+      ).toBe(false);
+      const legs = await getAgentRunSheet([van], [D1, D2]);
+      expect(legs.find((l) => l.kind === "start")?.done).toBe(true);
+      expect(legs.find((l) => l.kind === "end")?.done).toBe(false);
+      expect(
+        await setLegDone(attendeeId, listingId, "end", D2, true, [van]),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What changed

Three SQL sites repeated an id list across clauses. Each use wrote its
own copy of the values. The SQL text and the values array had to stay
aligned by hand. Each site now binds its list once through
`numberedStatement` and reuses the slots it returns.

- `guardEdgeWriteTx` (`src/shared/db/listing-edge-write.ts`) binds the
  child and parent id sets once. All six edge checks reuse the same
  slots.
- `linkRows` (`src/shared/db/link-table.ts`) takes its `WHERE` clause
  as a numbered statement. The two-direction reader binds the id list
  once for both columns.
- The run-sheet reads (`src/shared/db/logistics-run-sheet.ts`) share
  `queryRunSheetLegs`. The agent and date lists bind once. The
  bookings read reuses the same slots for its requested-booking pairs.

No values array repeats a list, so the SQL text and the values cannot
drift apart. An edit to one clause can no longer leave another
clause's copy behind.

## Deferred site

`accountsScope` (`src/shared/accounting/queries.ts`) stays positional.
Its clause rides the shared `WhereClause` assembly
(`src/shared/db/where-clauses.ts`, `src/shared/db/read.ts`), which
cannot carry a clause that reuses slots. Converting it belongs to the
reader-pipeline rework tracked in `ADMIN_SURFACE_PLAN`. Issue #2198
stays open for that site.

## Verification

- `deno task precommit` passes: typecheck, lint, duplication checks,
  and the full suite.
- The three mirror tests cover the changed sites:
  `test/shared/db/listing-edge-write.test.ts`,
  `test/shared/db/link-table.test.ts`, and
  `test/shared/db/logistics/runsheet.test.ts`.

Refs #2198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when retrieving linked records, relationship data, and run-sheet bookings.
  - Ensured linked-record cache updates are reflected when accessed through reverse relationships.
  - Preserved existing results, ordering, validation behavior, and returned data.

- **Tests**
  - Added coverage for relationship validation and run-sheet filtering across agents, dates, bookings, and leg ownership.
  - Added regression coverage for multi-parent and multi-child relationship scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->