### PR TITLE
Keep the provider's reply out of the console and Sentry

### DIFF
--- a/src/shared/email.ts
+++ b/src/shared/email.ts
@@ -266,7 +266,7 @@ export type EmailDeliveryResult =
   | { delivered: true; status: number }
   | {
       delivered: false;
-      /** For the console line: the provider and the status alone. */
+      /** The provider and status, safe for every error sink. */
       detail: string;
       /** The provider's own error message, safe to show to the operator.
        * Empty when there is no usable message — a network failure has no

--- a/src/shared/email.ts
+++ b/src/shared/email.ts
@@ -266,7 +266,7 @@ export type EmailDeliveryResult =
   | { delivered: true; status: number }
   | {
       delivered: false;
-      /** For the log line: provider, status, and the reason when known. */
+      /** For the console line: the provider and the status alone. */
       detail: string;
       /** The provider's own error message, safe to show to the operator.
        * Empty when there is no usable message — a network failure has no
@@ -330,12 +330,10 @@ const emailDelivery =
         signal,
       );
       if (ok) return { delivered: true, status };
-      const reason = failureReason(text);
-      const base = `provider=${config.provider} status=${status}`;
       return {
         delivered: false,
-        detail: reason ? `${base}: ${reason}` : base,
-        reason,
+        detail: `provider=${config.provider} status=${status}`,
+        reason: failureReason(text),
         status,
       };
     } catch (error) {
@@ -355,7 +353,11 @@ export const deliverRegistrationEmail: EmailDeliveryFn = emailDelivery(
 export const sendEmail: EmailDeliveryFn = async (config, msg, signal) => {
   const delivery = await reportedEmailDelivery(config, msg, signal);
   if (!delivery.delivered) {
-    logError({ code: ErrorCode.EMAIL_SEND, detail: delivery.detail });
+    logError({
+      code: ErrorCode.EMAIL_SEND,
+      detail: delivery.detail,
+      operatorDetail: delivery.reason || undefined,
+    });
   }
   return delivery;
 };

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -218,7 +218,7 @@ export const logRequest = (entry: RequestLogEntry): void => {
 };
 
 /**
- * Error log context (privacy-safe metadata only)
+ * Error facts routed to the applicable sinks.
  */
 export type ErrorContext = {
   /** Error code for classification */
@@ -227,14 +227,9 @@ export type ErrorContext = {
   listingId?: number | undefined;
   /** Optional: attendee ID */
   attendeeId?: number | undefined;
-  /** Optional: additional safe context */
+  /** Optional context that is safe for every error sink. */
   detail?: string | undefined;
-  /**
-   * Optional operator-only context. Reaches only the encrypted activity log —
-   * never the console line, ntfy, or Sentry — so a caller may quote here what
-   * an operator must read and every other sink must not carry (a provider's
-   * reply, after the caller has scrubbed personal data from it).
-   */
+  /** Activity-log context. It can contain personal data and must not reach other sinks. */
   operatorDetail?: string | undefined;
   /**
    * Optional original thrown error. Forwarded to Sentry (never to the console
@@ -255,8 +250,7 @@ export const formatRequestError = (
   return `${method} ${redactPath(path)}: ${msg}`;
 };
 
-/** Format an error context into the shared safe message: the shape the console
- *  line and the Sentry report both carry, without any operator-only detail. */
+/** Format the safe Sentry message and activity-log base. */
 export const formatErrorMessage = (context: ErrorContext): string => {
   const label = errorCodeLabel[context.code];
   return context.detail
@@ -264,8 +258,6 @@ export const formatErrorMessage = (context: ErrorContext): string => {
     : `Error: ${label}`;
 };
 
-/** Format an error context for the encrypted activity log: the operator's copy
- *  also carries the operator-only detail. */
 export const formatOperatorMessage = (context: ErrorContext): string => {
   const base = formatErrorMessage(context);
   return context.operatorDetail ? `${base} — ${context.operatorDetail}` : base;
@@ -297,23 +289,29 @@ const persistErrorToActivityLog = async (
   });
 };
 
-/**
- * Log a classified error to console.error only (no ntfy, no activity log).
- * Use this where calling logError would cause infinite recursion (e.g. ntfy.ts).
- */
-export const logErrorLocal = (context: ErrorContext): void => {
+const writeConsoleError = (
+  context: ErrorContext,
+  showMarker: boolean,
+): void => {
   const parts = [
     `[Error] ${context.code}`,
     context.listingId !== undefined ? `listing=${context.listingId}` : null,
     context.attendeeId !== undefined ? `attendee=${context.attendeeId}` : null,
     context.detail ? `detail="${context.detail}"` : null,
-    // Name the operator-only detail without quoting it: the console line says
-    // a fuller version sits in the encrypted activity log.
-    context.operatorDetail ? `operatorDetail="(activity log)"` : null,
+    context.operatorDetail && showMarker
+      ? `operatorDetail="(activity log)"`
+      : null,
   ].filter(Boolean);
 
   console.error(`${getLogPrefix()}${parts.join(" ")}`);
 };
+
+/**
+ * Log a classified error to console.error only (no ntfy, no activity log).
+ * Use this where calling logError would cause infinite recursion (e.g. ntfy.ts).
+ */
+export const logErrorLocal = (context: ErrorContext): void =>
+  writeConsoleError(context, false);
 
 /** Deliver a reporter's copy of an error. The reporter modules are imported
  * on first error, not at module load: each reporter reports its own delivery
@@ -345,7 +343,7 @@ const sentryCopy = async (context: ErrorContext): Promise<void> => {
  * Activity log entry is encrypted and visible to admins on the log pages.
  */
 export const logError = (context: ErrorContext): void => {
-  logErrorLocal(context);
+  writeConsoleError(context, hasPendingWorkScope());
   const deferred = deferredErrorReports.current();
   if (deferred !== undefined) {
     deferred.push(context);

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -230,6 +230,13 @@ export type ErrorContext = {
   /** Optional: additional safe context */
   detail?: string | undefined;
   /**
+   * Optional operator-only context. Reaches only the encrypted activity log —
+   * never the console line, ntfy, or Sentry — so a caller may quote here what
+   * an operator must read and every other sink must not carry (a provider's
+   * reply, after the caller has scrubbed personal data from it).
+   */
+  operatorDetail?: string | undefined;
+  /**
    * Optional original thrown error. Forwarded to Sentry (never to the console
    * line, ntfy, or the activity log) so server-side reports carry a real stack
    * trace. Attach it wherever a `catch` would otherwise stringify the error
@@ -248,12 +255,20 @@ export const formatRequestError = (
   return `${method} ${redactPath(path)}: ${msg}`;
 };
 
-/** Format an error context into a human-readable activity log message */
+/** Format an error context into the shared safe message: the shape the console
+ *  line and the Sentry report both carry, without any operator-only detail. */
 export const formatErrorMessage = (context: ErrorContext): string => {
   const label = errorCodeLabel[context.code];
   return context.detail
     ? `Error: ${label} (${context.detail})`
     : `Error: ${label}`;
+};
+
+/** Format an error context for the encrypted activity log: the operator's copy
+ *  also carries the operator-only detail. */
+export const formatOperatorMessage = (context: ErrorContext): string => {
+  const base = formatErrorMessage(context);
+  return context.operatorDetail ? `${base} — ${context.operatorDetail}` : base;
 };
 
 /** Only logging raised by the persistence itself is recursive. Independent
@@ -272,7 +287,10 @@ const persistErrorToActivityLog = async (
       // drag the activity-log table — and the listing helpers it queries with —
       // into every page's graph.
       const { logActivity } = await import("#db/activity-log.ts");
-      await logActivity(formatErrorMessage(context), context.listingId ?? null);
+      await logActivity(
+        formatOperatorMessage(context),
+        context.listingId ?? null,
+      );
     } catch {
       // An error log cannot recover when its own durable log is unavailable.
     }
@@ -289,6 +307,9 @@ export const logErrorLocal = (context: ErrorContext): void => {
     context.listingId !== undefined ? `listing=${context.listingId}` : null,
     context.attendeeId !== undefined ? `attendee=${context.attendeeId}` : null,
     context.detail ? `detail="${context.detail}"` : null,
+    // Name the operator-only detail without quoting it: the console line says
+    // a fuller version sits in the encrypted activity log.
+    context.operatorDetail ? `operatorDetail="(activity log)"` : null,
   ].filter(Boolean);
 
   console.error(`${getLogPrefix()}${parts.join(" ")}`);

--- a/test/integration/logger/log-error.test.ts
+++ b/test/integration/logger/log-error.test.ts
@@ -207,6 +207,24 @@ describe("log-error", () => {
         expect(match).toBeDefined();
       });
 
+      test("persists the operator-only detail to the activity log", async () => {
+        await runWithPendingWork(async () => {
+          logError({
+            code: ErrorCode.EMAIL_SEND,
+            detail: "provider=postmark status=422",
+            operatorDetail: "Suppressed recipient",
+          });
+          await flushPendingWork();
+        });
+
+        const messages = (await getAllActivityLog()).map(
+          ({ message }) => message,
+        );
+        expect(messages).toContain(
+          "Error: Email send failed (provider=postmark status=422) — Suppressed recipient",
+        );
+      });
+
       test("persists every independent error in one request", async () => {
         await runWithPendingWork(async () => {
           logError({ code: ErrorCode.DB_CONNECTION });

--- a/test/integration/logger/log-error.test.ts
+++ b/test/integration/logger/log-error.test.ts
@@ -7,6 +7,7 @@ import {
   trackSql,
 } from "#db/query-log.ts";
 import { CONFIG_KEYS, settings } from "#db/settings.ts";
+import { sendEmail } from "#shared/email.ts";
 import {
   bestEffort,
   ErrorCode,
@@ -19,6 +20,7 @@ import { flushPendingWork, runWithPendingWork } from "#shared/pending-work.ts";
 import { getAllActivityLog } from "#test-utils/activity-log.ts";
 import { createTestDbWithSetup, resetDb } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { minimalEmailMessage, testEmailConfig } from "#test-utils/email.ts";
 import { type EnvScope, withEnv } from "#test-utils/env.ts";
 import { setupErrorSpy } from "#test-utils/error-spy.ts";
 import { stubFetch } from "#test-utils/fetch-stub.ts";
@@ -207,21 +209,22 @@ describe("log-error", () => {
         expect(match).toBeDefined();
       });
 
-      test("persists the operator-only detail to the activity log", async () => {
-        await runWithPendingWork(async () => {
-          logError({
-            code: ErrorCode.EMAIL_SEND,
-            detail: "provider=postmark status=422",
-            operatorDetail: "Suppressed recipient",
-          });
-          await flushPendingWork();
-        });
+      test("persists a failed email provider reason", async () => {
+        using _fetch = stubFetch(
+          new Response('{"message":"provider-activity-marker"}', {
+            status: 422,
+          }),
+        );
+
+        await runWithPendingWork(() =>
+          sendEmail(testEmailConfig, minimalEmailMessage),
+        );
 
         const messages = (await getAllActivityLog()).map(
           ({ message }) => message,
         );
         expect(messages).toContain(
-          "Error: Email send failed (provider=postmark status=422) — Suppressed recipient",
+          "Error: Email send failed (provider=resend status=422) — provider-activity-marker",
         );
       });
 

--- a/test/shared/email.test.ts
+++ b/test/shared/email.test.ts
@@ -30,12 +30,7 @@ const sendWithProvider = (
 ) => sendEmail({ ...testEmailConfig, provider }, msg);
 
 type ExpectedFailure = {
-  /** Substring the E_EMAIL_SEND console line must carry — pass the whole
-   * `detail="…"` fragment to pin the exact detail. The scrubbed reply itself
-   * reaches only the encrypted activity log. */
   logged: string;
-  /** The operator-facing reason, asserted exactly when given. The console
-   * line names it (as an activity-log pointer) but never quotes it. */
   reason?: string;
   status: number | undefined;
 };
@@ -57,11 +52,8 @@ const sendEmailExpectingError = async (
     const logs = errorSpy.calls.map((c) => c.args[0] as string);
     expect(logs.join("\n")).not.toContain(msg.to);
     const line = logs.find((l) => l.includes("E_EMAIL_SEND"));
-    expect(line).toBeDefined();
-    expect(line!.includes(expected.logged)).toBe(true);
-    expect(line!.includes('operatorDetail="(activity log)"')).toBe(
-      (expected.reason ?? "") !== "",
-    );
+    expect(line).toBe(`[Error] E_EMAIL_SEND ${expected.logged}`);
+    if (expected.reason) expect(line).not.toContain(expected.reason);
   } finally {
     errorSpy.restore();
   }
@@ -239,17 +231,17 @@ describe("sendEmail", () => {
   const restubReply = (body: string | null, status: number): void =>
     fetch.restubFetch(() => Promise.resolve(new Response(body, { status })));
 
-  test("logs the provider's reply body on a non-OK response", async () => {
-    restubReply("Error", 500);
+  test("keeps the provider reply body out of the console", async () => {
+    restubReply("provider-reply-marker", 500);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
       logged: 'detail="provider=resend status=500"',
-      reason: "Error",
+      reason: "provider-reply-marker",
       status: 500,
     });
   });
 
-  test("logs SendGrid's message from its errors array", async () => {
+  test("reads SendGrid's message from its errors array", async () => {
     const message =
       "The from address does not match a verified Sender Identity";
     restubReply(
@@ -340,7 +332,7 @@ describe("sendEmail", () => {
     );
   });
 
-  test("puts a multi-line reply onto one log line", async () => {
+  test("puts a multi-line reply onto one reason line", async () => {
     restubReply("Access\n\n  denied", 403);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {

--- a/test/shared/email.test.ts
+++ b/test/shared/email.test.ts
@@ -30,10 +30,12 @@ const sendWithProvider = (
 ) => sendEmail({ ...testEmailConfig, provider }, msg);
 
 type ExpectedFailure = {
-  /** Substring the E_EMAIL_SEND log line must carry — pass the whole
-   * `detail="…"` fragment to pin the exact detail. */
+  /** Substring the E_EMAIL_SEND console line must carry — pass the whole
+   * `detail="…"` fragment to pin the exact detail. The scrubbed reply itself
+   * reaches only the encrypted activity log. */
   logged: string;
-  /** The operator-facing reason, asserted exactly when given. */
+  /** The operator-facing reason, asserted exactly when given. The console
+   * line names it (as an activity-log pointer) but never quotes it. */
   reason?: string;
   status: number | undefined;
 };
@@ -54,11 +56,12 @@ const sendEmailExpectingError = async (
     }
     const logs = errorSpy.calls.map((c) => c.args[0] as string);
     expect(logs.join("\n")).not.toContain(msg.to);
-    expect(
-      logs.some(
-        (l) => l.includes("E_EMAIL_SEND") && l.includes(expected.logged),
-      ),
-    ).toBe(true);
+    const line = logs.find((l) => l.includes("E_EMAIL_SEND"));
+    expect(line).toBeDefined();
+    expect(line!.includes(expected.logged)).toBe(true);
+    expect(line!.includes('operatorDetail="(activity log)"')).toBe(
+      (expected.reason ?? "") !== "",
+    );
   } finally {
     errorSpy.restore();
   }
@@ -240,7 +243,7 @@ describe("sendEmail", () => {
     restubReply("Error", 500);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
-      logged: 'detail="provider=resend status=500: Error"',
+      logged: 'detail="provider=resend status=500"',
       reason: "Error",
       status: 500,
     });
@@ -258,7 +261,7 @@ describe("sendEmail", () => {
       { ...testEmailConfig, provider: "sendgrid" },
       minimalEmailMessage,
       {
-        logged: `detail="provider=sendgrid status=403: ${message}"`,
+        logged: 'detail="provider=sendgrid status=403"',
         reason: message,
         status: 403,
       },
@@ -269,7 +272,7 @@ describe("sendEmail", () => {
     restubReply('{"error":"Invalid API key"}', 401);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
-      logged: 'detail="provider=resend status=401: Invalid API key"',
+      logged: 'detail="provider=resend status=401"',
       reason: "Invalid API key",
       status: 401,
     });
@@ -282,7 +285,8 @@ describe("sendEmail", () => {
       { ...testEmailConfig, provider: "postmark" },
       minimalEmailMessage,
       {
-        logged: 'detail="provider=postmark status=401: Bad API token"',
+        logged: 'detail="provider=postmark status=401"',
+        reason: "Bad API token",
         status: 401,
       },
     );
@@ -298,8 +302,8 @@ describe("sendEmail", () => {
       testEmailConfig,
       { ...minimalEmailMessage, replyTo: validEmail("reply@test.com") },
       {
-        logged:
-          'detail="provider=resend status=400: [redacted] [redacted] and [redacted] are not allowed"',
+        logged: 'detail="provider=resend status=400"',
+        reason: "[redacted] [redacted] and [redacted] are not allowed",
         status: 400,
       },
     );
@@ -312,8 +316,7 @@ describe("sendEmail", () => {
     );
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
-      logged:
-        'detail="provider=resend status=403: You can only send testing emails to your own email address [redacted]"',
+      logged: 'detail="provider=resend status=403"',
       reason:
         "You can only send testing emails to your own email address [redacted]",
       status: 403,
@@ -330,8 +333,7 @@ describe("sendEmail", () => {
       { ...testEmailConfig, provider: "sendgrid" },
       minimalEmailMessage,
       {
-        logged:
-          'detail="provider=sendgrid status=403: The from address [redacted] is not a verified Sender Identity"',
+        logged: 'detail="provider=sendgrid status=403"',
         reason: "The from address [redacted] is not a verified Sender Identity",
         status: 403,
       },
@@ -342,7 +344,7 @@ describe("sendEmail", () => {
     restubReply("Access\n\n  denied", 403);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
-      logged: 'detail="provider=resend status=403: Access denied"',
+      logged: 'detail="provider=resend status=403"',
       reason: "Access denied",
       status: 403,
     });
@@ -352,7 +354,7 @@ describe("sendEmail", () => {
     restubReply("x".repeat(1000), 500);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
-      logged: `detail="provider=resend status=500: ${"x".repeat(300)}..."`,
+      logged: 'detail="provider=resend status=500"',
       reason: `${"x".repeat(300)}...`,
       status: 500,
     });
@@ -362,7 +364,8 @@ describe("sendEmail", () => {
     restubReply("y".repeat(300), 500);
 
     await sendEmailExpectingError(testEmailConfig, minimalEmailMessage, {
-      logged: `detail="provider=resend status=500: ${"y".repeat(300)}"`,
+      logged: 'detail="provider=resend status=500"',
+      reason: "y".repeat(300),
       status: 500,
     });
   });

--- a/test/shared/logger/error-fan-out.test.ts
+++ b/test/shared/logger/error-fan-out.test.ts
@@ -4,6 +4,7 @@ import { type Spy, spy } from "@std/testing/mock";
 import {
   ErrorCode,
   logError,
+  logErrorLocal,
   runWithRequestId,
   withDeferredErrorReports,
 } from "#shared/logger.ts";
@@ -34,6 +35,16 @@ describe("error fan-out", () => {
   const ntfyCalls = (): number =>
     fetchStub.calls.filter((call) => String(call.args[0]).includes("ntfy"))
       .length;
+  const operatorError = {
+    code: ErrorCode.EMAIL_SEND,
+    detail: "provider=postmark status=422",
+    operatorDetail: "Suppressed recipient boss@example.com",
+  } as const;
+  const firstErrorLine = (): string => String(errorSpy.calls[0]?.args[0]);
+  const expectOperatorDetailHidden = (line: string): void => {
+    expect(line).not.toContain("Suppressed");
+    expect(line).not.toContain("boss@example.com");
+  };
 
   test("writes the console line for every error", () => {
     logError({ code: ErrorCode.DB_QUERY, detail: "select failed" });
@@ -51,18 +62,30 @@ describe("error fan-out", () => {
     );
   });
 
-  test("names the operator-only detail without quoting it", () => {
-    logError({
-      code: ErrorCode.EMAIL_SEND,
-      detail: "provider=postmark status=422",
-      operatorDetail: "Suppressed recipient boss@example.com",
-    });
+  test("does not promise an activity-log copy outside a request", () => {
+    logError(operatorError);
 
-    const line = String(errorSpy.calls[0]?.args[0]);
+    const line = firstErrorLine();
     expect(line).toContain('detail="provider=postmark status=422"');
-    expect(line).toContain('operatorDetail="(activity log)"');
-    expect(line).not.toContain("Suppressed");
-    expect(line).not.toContain("boss@example.com");
+    expect(line).not.toContain("operatorDetail");
+    expectOperatorDetailHidden(line);
+  });
+
+  test("marks operator detail when its activity-log copy is queued", async () => {
+    await runWithRequestId(async () => {
+      logError(operatorError);
+
+      const line = firstErrorLine();
+      expect(line).toContain('operatorDetail="(activity log)"');
+      expectOperatorDetailHidden(line);
+    });
+  });
+
+  test("does not mark operator detail for local-only errors", async () => {
+    await runWithRequestId(async () => {
+      logErrorLocal(operatorError);
+      expect(firstErrorLine()).not.toContain("operatorDetail");
+    });
   });
 
   test("omits the operator marker when there is no operator-only detail", () => {

--- a/test/shared/logger/error-fan-out.test.ts
+++ b/test/shared/logger/error-fan-out.test.ts
@@ -51,6 +51,26 @@ describe("error fan-out", () => {
     );
   });
 
+  test("names the operator-only detail without quoting it", () => {
+    logError({
+      code: ErrorCode.EMAIL_SEND,
+      detail: "provider=postmark status=422",
+      operatorDetail: "Suppressed recipient boss@example.com",
+    });
+
+    const line = String(errorSpy.calls[0]?.args[0]);
+    expect(line).toContain('detail="provider=postmark status=422"');
+    expect(line).toContain('operatorDetail="(activity log)"');
+    expect(line).not.toContain("Suppressed");
+    expect(line).not.toContain("boss@example.com");
+  });
+
+  test("omits the operator marker when there is no operator-only detail", () => {
+    logError({ code: ErrorCode.DB_QUERY, detail: "boom" });
+
+    expect(String(errorSpy.calls[0]?.args[0])).not.toContain("operatorDetail");
+  });
+
   test("sends the report out from inside a request", async () => {
     using _env = withEnv({ NTFY_URL });
 

--- a/test/shared/logger/formatting.test.ts
+++ b/test/shared/logger/formatting.test.ts
@@ -55,7 +55,7 @@ describe("formatErrorMessage", () => {
     expect(formatErrorMessage(context)).not.toContain("42");
   });
 
-  test("ignores the operator-only detail (it must not reach Sentry)", () => {
+  test("ignores the operator-only detail", () => {
     const context: ErrorContext = {
       code: ErrorCode.EMAIL_SEND,
       detail: "provider=postmark status=422",

--- a/test/shared/logger/formatting.test.ts
+++ b/test/shared/logger/formatting.test.ts
@@ -6,6 +6,7 @@ import {
   type ErrorContext,
   errorCodeLabel,
   formatErrorMessage,
+  formatOperatorMessage,
   formatRequestError,
 } from "#shared/logger.ts";
 
@@ -52,6 +53,52 @@ describe("formatErrorMessage", () => {
       "Error: Payment session error (price mismatch)",
     );
     expect(formatErrorMessage(context)).not.toContain("42");
+  });
+
+  test("ignores the operator-only detail (it must not reach Sentry)", () => {
+    const context: ErrorContext = {
+      code: ErrorCode.EMAIL_SEND,
+      detail: "provider=postmark status=422",
+      operatorDetail: "Suppressed recipient",
+    };
+    expect(formatErrorMessage(context)).toBe(
+      "Error: Email send failed (provider=postmark status=422)",
+    );
+    expect(formatErrorMessage(context)).not.toContain("Suppressed");
+  });
+});
+
+describe("formatOperatorMessage", () => {
+  test("carries the operator-only detail after the shared message", () => {
+    const context: ErrorContext = {
+      code: ErrorCode.EMAIL_SEND,
+      detail: "provider=postmark status=422",
+      operatorDetail: "Suppressed recipient",
+    };
+    expect(formatOperatorMessage(context)).toBe(
+      "Error: Email send failed (provider=postmark status=422) — Suppressed recipient",
+    );
+  });
+
+  test("is the shared message when there is no operator-only detail", () => {
+    const context: ErrorContext = {
+      code: ErrorCode.DB_CONNECTION,
+      detail: "pool drained",
+    };
+    expect(formatOperatorMessage(context)).toBe(
+      "Error: Database connection failed (pool drained)",
+    );
+  });
+
+  test("treats an empty operator-only detail as absent", () => {
+    const context: ErrorContext = {
+      code: ErrorCode.EMAIL_SEND,
+      detail: "provider=resend status=500",
+      operatorDetail: "",
+    };
+    expect(formatOperatorMessage(context)).toBe(
+      "Error: Email send failed (provider=resend status=500)",
+    );
   });
 });
 

--- a/test/shared/sentry.test.ts
+++ b/test/shared/sentry.test.ts
@@ -223,6 +223,23 @@ describe("sentry", () => {
       );
     });
 
+    test("keeps the operator-only detail out of the report", async () => {
+      using _env = withEnv({ SENTRY_URL: DSN });
+      await initSentry();
+
+      await captureServerError({
+        code: ErrorCode.EMAIL_SEND,
+        detail: "provider=postmark status=422",
+        operatorDetail: "Suppressed recipient boss@example.com",
+      });
+
+      const body = firstFetchBody();
+      expect(body).toContain("provider=postmark status=422");
+      expect(body).not.toContain("Suppressed recipient");
+      expect(body).not.toContain("boss@example.com");
+      expect(body).not.toContain("operatorDetail");
+    });
+
     test("marks the event as level error", async () => {
       const levels =
         (await captureDbErrorBody()).match(/"level":"[^"]*"/g) ?? [];


### PR DESCRIPTION
## Behavior

`sendEmail` now passes the provider name and status through `detail`. Every
error sink can receive this value.

The same call passes provider response text through `operatorDetail`. Only the
encrypted activity log stores this value.

Console and Sentry payloads exclude provider response text. Ntfy still receives
only the error code.

`logError` prints an activity-log marker only when a request scope can queue the
copy. `logErrorLocal` never prints this marker because it never queues the copy.

The old path put provider response text in `detail`. This change deletes that
path.

## Current-system value

Operators can read a useful provider reason. Shared telemetry does not receive
it. `sendEmail` is the exact production caller. It calls `logError` after a
failed provider response or provider request.

## Facts

Trusted facts:

- Production request setup owns the pending-work scope.
- The activity-log sink encrypts its message before database storage.
- `logErrorLocal` has no durable sink.

Observed facts:

- `sendEmail` observes the provider name, response status, and response text.
- Provider response text can contain personal data.
- A network exception has no provider response text.
- `logError` observes the pending-work scope before it prints the marker.

## Calls and size

- Provider calls remain one per email attempt.
- Database calls remain unchanged through the current activity-log path.
- An out-of-scope or local-only error makes no activity-log call.
- Source churn is 53 changed lines.
- Total churn is 228 changed lines.

## Verification

- `test/shared/logger/error-fan-out.test.ts` covers scope and local-only states.
- `test/shared/email.test.ts` excludes each provider reason from the console.
- `test/shared/sentry.test.ts` proves payload exclusion.
- `test/integration/logger/log-error.test.ts` proves activity-log storage.
- `nix develop -c deno task precommit` passes.
- `nix develop -c deno task precommit:mutation` passes.
- Mutation score is 100 percent. All 240 detectable mutants fail tests.
- Five repository-approved equivalent mutants remain suppressed.

Completed contract rows:

- A provider refusal keeps its reason in the encrypted activity log.
- Console and Sentry payloads exclude the provider reason.
- A scoped error prints the safe marker and queues the durable copy.
- An out-of-scope error prints no marker and queues no durable copy.
- A local-only error prints no marker, even inside a request.
- An empty provider reason adds no operator detail.

This completes known fault #2193 and both review rows.

Fixes #2193
