### PR TITLE
Ask the budget scope for the migration cap, not the query log

### DIFF
--- a/src/shared/db/migrations/runner.ts
+++ b/src/shared/db/migrations/runner.ts
@@ -3,13 +3,13 @@
  * how each one is applied and re-checked, and how partial progress is kept.
  */
 
-import { isDatabaseRoundTripLimited } from "#db/query-log.ts";
 import { errorMessage } from "#shared/error-message.ts";
 import { logDebug } from "#shared/logger.ts";
 import { retryWithBackoff } from "#shared/retry.ts";
 import {
   BUNNY_SUBREQUEST_LIMIT,
   getSubrequestRemaining,
+  hasSubrequestBudget,
   SubrequestBudgetError,
   withSubrequestAllowance,
 } from "#shared/subrequest-budget.ts";
@@ -170,7 +170,7 @@ export const runPendingMigrations = async (
 ): Promise<Migration[]> => {
   const completed: Migration[] = [];
   try {
-    if (isDatabaseRoundTripLimited()) {
+    if (hasSubrequestBudget()) {
       const budget = Math.max(
         1,
         getSubrequestRemaining().database - MIGRATION_BOOKKEEPING_RESERVE,

--- a/src/shared/db/query-log.ts
+++ b/src/shared/db/query-log.ts
@@ -69,10 +69,6 @@ const getState = (): QueryLogState => queryLogScope.current() ?? fallbackState;
 export const runWithQueryLogContext = <T>(fn: () => T): T =>
   queryLogScope.run(freshState(), fn);
 
-/** Whether database calls are currently subject to Bunny's per-request cap. */
-export const isDatabaseRoundTripLimited = (): boolean =>
-  queryLogScope.current() !== undefined;
-
 /** Enable query logging and clear previous entries */
 export const enableQueryLog = (): void => {
   const state = getState();

--- a/src/shared/subrequest-budget.ts
+++ b/src/shared/subrequest-budget.ts
@@ -50,6 +50,12 @@ const usageOf = ({ database, external }: Counts): SubrequestCounts => ({
 export const getSubrequestUsage = (): SubrequestCounts =>
   usageOf(budgetScope.current()?.counts ?? { database: 0, external: 0 });
 
+/** Whether this request carries a subrequest budget at all. A caller outside a
+ *  request (a CLI or backup run) reads defaults from
+ *  {@link getSubrequestRemaining} but has no cap to honour. */
+export const hasSubrequestBudget = (): boolean =>
+  budgetScope.current() !== undefined;
+
 export const getSubrequestRemaining = (): SubrequestCounts => {
   const state = budgetScope.current();
   if (!state) {

--- a/test/shared/db/migrations/runner/budget.test.ts
+++ b/test/shared/db/migrations/runner/budget.test.ts
@@ -79,20 +79,29 @@ describeWithEnv(
   "db > migrations > runner subrequest budget against a database",
   { db: true },
   () => {
-    /** Run `work` the way a request does: one subrequest budget, one query log,
-     *  with the migration lock held for it. */
-    const asOneRequest = async <T>(
+    /** Hold the migration lock while `work` runs — the lock handling every
+     *  runner below shares. */
+    const withMigrationLock = async <T>(
       work: (lockToken: string) => Promise<T>,
     ): Promise<T> => {
       const lockToken = await takeMigrationLock();
       try {
-        return await runWithSubrequestBudget(() =>
-          runWithQueryLogContext(() => work(lockToken)),
-        );
+        return await work(lockToken);
       } finally {
         await releaseMigrationLock(lockToken);
       }
     };
+
+    /** Run `work` the way a request does: one subrequest budget, one query log,
+     *  with the migration lock held for it. */
+    const asOneRequest = <T>(
+      work: (lockToken: string) => Promise<T>,
+    ): Promise<T> =>
+      withMigrationLock((lockToken) =>
+        runWithSubrequestBudget(() =>
+          runWithQueryLogContext(() => work(lockToken)),
+        ),
+      );
 
     const runBatch = (pending: Migration[]): Promise<Migration[]> =>
       asOneRequest((lockToken) => runPendingMigrations(pending, lockToken));
@@ -103,16 +112,20 @@ describeWithEnv(
       for (let i = 0; i < calls; i += 1) await getDb().execute("SELECT 1");
     };
 
+    /** Six migrations, each spending 12 round-trips — 72 calls in all, more
+     *  than any one request's budget can cover. */
+    const spendyMigrations = (): Migration[] =>
+      ["m1", "m2", "m3", "m4", "m5", "m6"].map((id) =>
+        migrationOf(id, async () => {
+          for (let i = 0; i < 12; i += 1) await getDb().execute("SELECT 1");
+        }),
+      );
+
     test("inside a request, runs as many migrations as fit and returns the finished prefix", async () => {
       // Each migration spends several round-trips; the batch as a whole exceeds
       // the request's budget, so the run stops partway and leaves headroom for
       // the caller's bookkeeping.
-      const spend = async (): Promise<void> => {
-        for (let i = 0; i < 12; i += 1) await getDb().execute("SELECT 1");
-      };
-      const pending = ["m1", "m2", "m3", "m4", "m5", "m6"].map((id) =>
-        migrationOf(id, spend),
-      );
+      const pending = spendyMigrations();
       const completed = await runBatch(pending);
       // Some — but not all — ran: the budget stopped the batch.
       expect(completed.length).toBeGreaterThan(0);
@@ -121,6 +134,28 @@ describeWithEnv(
       expect(completed.map((migration) => migration.id)).toEqual(
         pending.slice(0, completed.length).map((migration) => migration.id),
       );
+    });
+
+    test("caps the run from the budget scope alone — no query log needed", async () => {
+      // The runner asks the budget scope for its cap, not the query-log scope.
+      // The two enter together in a request, but only the budget owns the
+      // number, so the cap must follow it.
+      const pending = spendyMigrations();
+      await withMigrationLock(async (lockToken) => {
+        const completed = await runWithSubrequestBudget(() =>
+          runPendingMigrations(pending, lockToken),
+        );
+        // The cap is the budget minus its bookkeeping reserve (50 − 5), so
+        // three 12-call migrations fit and the fourth dies at call 46. The
+        // finished prefix is in order, and the reserve still lets the caller
+        // record the batch for the next request.
+        expect(completed.map((migration) => migration.id)).toEqual([
+          "m1",
+          "m2",
+          "m3",
+        ]);
+        await recordMigrationBatch(completed, false, lockToken);
+      });
     });
 
     test("stops the batch when a migration cannot reserve its transaction rollback", async () => {

--- a/test/shared/db/migrations/runner/budget.test.ts
+++ b/test/shared/db/migrations/runner/budget.test.ts
@@ -142,19 +142,21 @@ describeWithEnv(
       // number, so the cap must follow it.
       const pending = spendyMigrations();
       await withMigrationLock(async (lockToken) => {
-        const completed = await runWithSubrequestBudget(() =>
-          runPendingMigrations(pending, lockToken),
-        );
         // The cap is the budget minus its bookkeeping reserve (50 − 5), so
         // three 12-call migrations fit and the fourth dies at call 46. The
         // finished prefix is in order, and the reserve still lets the caller
-        // record the batch for the next request.
+        // record the batch for the next request — inside the same budget, as
+        // the production caller does.
+        const completed = await runWithSubrequestBudget(async () => {
+          const ran = await runPendingMigrations(pending, lockToken);
+          await recordMigrationBatch(ran, false, lockToken);
+          return ran;
+        });
         expect(completed.map((migration) => migration.id)).toEqual([
           "m1",
           "m2",
           "m3",
         ]);
-        await recordMigrationBatch(completed, false, lockToken);
       });
     });
 

--- a/test/shared/db/query-log.test.ts
+++ b/test/shared/db/query-log.test.ts
@@ -25,6 +25,8 @@ import {
   BUNNY_SUBREQUEST_LIMIT,
   getSubrequestUsage,
   runWithSubrequestBudget,
+  SubrequestBudgetError,
+  withSubrequestAllowance,
 } from "#shared/subrequest-budget.ts";
 
 describe("query-log", () => {
@@ -389,6 +391,19 @@ describe("query-log", () => {
           total: 1,
         });
       });
+    });
+
+    test("blocks a plain call once the subrequest allowance is spent", () => {
+      // Enforcement is the default: only a caller that names its call as
+      // cleanup (enforceBudget: false) gets past a spent allowance.
+      runWithSubrequestBudget(() =>
+        withSubrequestAllowance({ database: 1, external: 0, total: 1 }, () => {
+          countDatabaseRoundTrip("the allowed call");
+          expect(() =>
+            countDatabaseRoundTrip("the call past the allowance"),
+          ).toThrow(SubrequestBudgetError);
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## What changed

`runPendingMigrations` decided whether to cap its batch with `isDatabaseRoundTripLimited`, which reports the **query-log** scope, and then read the cap from `getSubrequestRemaining`, which reads the **subrequest-budget** scope. The two are separate `createScope` stores. Today the one production path enters both together, so the answer was right by accident. A caller inside the budget scope alone ran uncapped until the hard platform limit threw mid-flight, with no reserve left for the caller's bookkeeping.

The runner now asks `hasSubrequestBudget()` from the same module that owns the number (`src/shared/subrequest-budget.ts`). The query-log ask had no other caller and is deleted.

## Current-system value

The migration runner is the production caller: an upgrade on the edge stops its batch with its reserve intact and records progress, instead of running until Bunny's 50-subrequest cap cuts it off mid-bookkeeping.

## Tests

A direct test opens the budget scope without the query-log scope and pins the capped prefix (three 12-call migrations fit; the fourth dies at the cap) and that the caller can still record the batch. It failed before the fix for the right reason: the runner ran a fourth migration and spent the reserve.

`nix develop -c deno task precommit` and `nix develop -c deno task precommit:mutation` pass; the run initially survived a mutant in `countDatabaseRoundTrip`'s default `enforceBudget`, which the query-log tests now pin.

Fixes #2292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Migration execution now consistently respects the available request budget while preserving capacity to record completion.
  - Database operations that exceed the fully consumed request allowance now report the appropriate budget error.

- **Refactor**
  - Improved request-budget detection and internal request handling without changing migration progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->