### PR TITLE
Order the roster's CSV export the way the roster shows its rows

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -275,3 +275,9 @@ src/shared/bulk-email.ts::buildMailtoLink.to~1lrzg1h  = → +=   # to is still t
 # input at that boundary the slice is empty, parseInt gives NaN, and both
 # range masks fail, so NaN and null land on the same false.
 src/shared/local-host.ts::ipv6FirstGroup~16zpdpl  1 → 0   # at to === 1 the group slice is empty, NaN fails both masks like null does, and every real group sits past index 1
+
+# compareOptionalDates normalises an optional date string with `?? ""`. For
+# every input the operand can hold — a date string, "", null, undefined —
+# `?? ""` and `|| ""` return the same value, so no test can tell them apart.
+src/shared/attendee-list-controls.ts::compareOptionalDates.firstDate~0yc1a5v  ?? → ||   # "" is falsy, but both operators fall back to the same "" here; a non-empty string is returned by both
+src/shared/attendee-list-controls.ts::compareOptionalDates.secondDate~01yky27  ?? → ||   # same proof as firstDate

--- a/scripts/mutation/equivalent-mutants/shared-m-z.txt
+++ b/scripts/mutation/equivalent-mutants/shared-m-z.txt
@@ -75,20 +75,12 @@ src/shared/sort-listings.ts::compareListings~05ktsrt  0 → -1   # tierA===-1 ne
 # sort-listings.ts's compareDaily: nextDates.get() is typed string|null, never
 # undefined in practice because every daily listing gets an explicit entry, and
 # getNextBookableDate never returns "". Therefore `?? null` and `|| null` agree.
-src/shared/sort-listings.ts::compareDaily.dateA~0elhh75  ?? → ||   # nextDates.get(a.id): string|null, never a falsy-non-null string
-src/shared/sort-listings.ts::compareDaily.dateB~17fwox0  ?? → ||   # nextDates.get(b.id): string|null, never a falsy-non-null string
+src/shared/sort-listings.ts::compareDaily.byDate~0elhh75  ?? → ||   # nextDates.get(a.id): string|null, never a falsy-non-null string
+src/shared/sort-listings.ts::compareDaily.byDate~17fwox0  ?? → ||   # nextDates.get(b.id): string|null, never a falsy-non-null string
 
-# sort-listings.ts's compareDaily return values on the dateA===null branch:
-# confirmed by direct experiment that Array.sort's swap decision only checks
-# whether a comparator result is strictly negative — 0, a positive number, or
-# NaN (from `return undefined`) are all treated identically ("don't swap").
-# Since the mirrored `dateB === null` branch independently and correctly
-# returns -1 for the reverse pairing, no input can ever make this branch's
-# non-negative return value observably differ from the intended `1` (the
-# magnitude-only `1 → 2` entries below are --exhaustive-only; see note above).
-src/shared/sort-listings.ts::compareDaily~08bj7h9  1 → 0   # non-negative result; see block comment above
-src/shared/sort-listings.ts::compareDaily~08bj7h9  1 → 2   # sign-preserving magnitude change; see block comment above
-src/shared/sort-listings.ts::compareDaily~05rrw2z  1 → 2   # sign-preserving magnitude change on `return -1`; only the sign is ever observed
+# sort-listings.ts's compareDaily return-value entries are gone with the fold:
+# compareOptionalDates now supplies the null-last branch they guarded, in
+# src/shared/attendee-list-controls.ts.
 
 # orphan-retention.ts's Number.parseInt(safeValue, 10) radix: safeValue is
 # gated by isOrphanRetentionValue to always be one of ORPHAN_RETENTION_OPTIONS'

--- a/src/features/admin/listings-export.ts
+++ b/src/features/admin/listings-export.ts
@@ -12,6 +12,7 @@ import { settings } from "#db/settings.ts";
 import { csvResponse, listingAttendeesLoader } from "#routes/admin/actions.ts";
 import { generateAttendeesCsv } from "#routes/admin/attendees-csv.ts";
 import type { TypedRouteHandler } from "#routes/router.ts";
+import { attendeeListOrder } from "#shared/attendee-list-controls.ts";
 import {
   completePaymentAttendees,
   filterAttendees,
@@ -35,20 +36,22 @@ export const handleAdminListingExport: TypedRouteHandler<
   )(
     filteredAttendeesHandler(
       request,
-      async ({ listing, dateFilter, checkin, filteredByDate }) => {
+      async ({ listing, dateFilter, checkin, filteredByDate, sort }) => {
         const isDaily = listing.listing_type === "daily";
         const paymentReferenceAttendeeIds =
           await getAttendeeIdsWithPaymentReference(filteredByDate);
         // Mirror the on-screen attendee table: drop the failed-payment rows
         // that are split into the Failed Payments section, then apply the
-        // /in /out check-in filter.
-        const exported = filterAttendees(
-          completePaymentAttendees(
-            listing,
-            filteredByDate,
-            paymentReferenceAttendeeIds,
+        // /in /out check-in filter and the roster's row order.
+        const exported = attendeeListOrder(sort)(
+          filterAttendees(
+            completePaymentAttendees(
+              listing,
+              filteredByDate,
+              paymentReferenceAttendeeIds,
+            ),
+            checkin,
           ),
-          checkin,
         );
 
         const attendeeIds = exported.map((a) => a.id);

--- a/src/features/admin/listings-view.ts
+++ b/src/features/admin/listings-view.ts
@@ -27,6 +27,7 @@ import {
   type AttendeeFilter,
   type AttendeeListSetup,
   type AttendeeListState,
+  type AttendeeSort,
   type DateOption,
   readAttendeeListState,
 } from "#shared/attendee-list-controls.ts";
@@ -91,6 +92,8 @@ type FilteredAttendees = {
   dateFilter: string | null;
   checkin: AttendeeFilter;
   filteredByDate: Attendee[];
+  /** The sort chosen in the address bar, or null for the table's own order. */
+  sort: AttendeeSort | null;
 };
 
 /**
@@ -120,6 +123,7 @@ export const filteredAttendeesHandler =
       filteredByDate: filterByDate(attendees, state.date),
       listing,
       session,
+      sort: state.sort,
     });
   };
 

--- a/src/shared/attendee-list-controls.ts
+++ b/src/shared/attendee-list-controls.ts
@@ -257,7 +257,7 @@ export const inRegistrationOrder =
     )(rows);
 
 /** Compare two optional YYYY-MM-DD dates ascending; a missing date sorts after
- *  the dated ones. The booked-date rule every attendee row order shares. */
+ *  the dated ones. One rule for every row order that sorts by such a date. */
 export const compareOptionalDates = (
   first: string | null | undefined,
   second: string | null | undefined,

--- a/src/shared/attendee-list-controls.ts
+++ b/src/shared/attendee-list-controls.ts
@@ -255,3 +255,43 @@ export const inRegistrationOrder =
     sort<Row>((first, second) =>
       order === "newest" ? second.id - first.id : first.id - second.id,
     )(rows);
+
+/** Compare two optional YYYY-MM-DD dates ascending; a missing date sorts after
+ *  the dated ones. The booked-date rule every attendee row order shares. */
+export const compareOptionalDates = (
+  first: string | null | undefined,
+  second: string | null | undefined,
+): number => {
+  const firstDate = first ?? "";
+  const secondDate = second ?? "";
+  if (firstDate === secondDate) return 0;
+  if (firstDate === "") return 1;
+  if (secondDate === "") return -1;
+  return firstDate.localeCompare(secondDate);
+};
+
+/** The table's own order: booked date, then name, then registration id. This
+ *  matches what the attendee table's default sort does with one listing's rows
+ *  — every row shares the listing, so its name never breaks a tie. */
+export const inDateAndNameOrder = <
+  Row extends { date: string | null; id: number; name: string },
+>(
+  rows: Row[],
+): Row[] =>
+  sort<Row>((first, second) => {
+    const byDate = compareOptionalDates(first.date, second.date);
+    if (byDate !== 0) return byDate;
+    return first.name.localeCompare(second.name) || first.id - second.id;
+  })(rows);
+
+/** A roster's row order, one helper for every surface that shows it — the page
+ *  and the CSV export: the chosen registration order, or the table's own
+ *  date-and-name order when the address named none. */
+export const attendeeListOrder =
+  (order: AttendeeSort | null) =>
+  <Row extends { date: string | null; id: number; name: string }>(
+    rows: Row[],
+  ): Row[] =>
+    order === null
+      ? inDateAndNameOrder(rows)
+      : inRegistrationOrder(order)(rows);

--- a/src/shared/sort-listings.ts
+++ b/src/shared/sort-listings.ts
@@ -8,6 +8,7 @@
 
 import { getActiveHolidays } from "#db/holidays.ts";
 import { getAllListings } from "#db/listings/records.ts";
+import { compareOptionalDates } from "#shared/attendee-list-controls.ts";
 import { getNextBookableDate } from "#shared/dates.ts";
 import type { Holiday, ListingWithCount, SortableListing } from "#types";
 
@@ -33,18 +34,18 @@ const compareDateThenName = (
 const compareDatedStandard = (a: SortableListing, b: SortableListing): number =>
   compareDateThenName(a.date, b.date, a, b);
 
-/** Tier 2: daily — sort by next bookable date ASC, then name */
+/** Tier 2: daily — sort by next bookable date ASC (a missing one last), then
+ * name. The date rule is the one every attendee row order shares. */
 const compareDaily = (
   nextDates: Map<number, string | null>,
   a: SortableListing,
   b: SortableListing,
 ): number => {
-  const dateA = nextDates.get(a.id) ?? null;
-  const dateB = nextDates.get(b.id) ?? null;
-  if (dateA === null && dateB === null) return a.name.localeCompare(b.name);
-  if (dateA === null) return 1;
-  if (dateB === null) return -1;
-  return compareDateThenName(dateA, dateB, a, b);
+  const byDate = compareOptionalDates(
+    nextDates.get(a.id) ?? null,
+    nextDates.get(b.id) ?? null,
+  );
+  return byDate !== 0 ? byDate : a.name.localeCompare(b.name);
 };
 
 /**

--- a/src/ui/templates/admin/listings/attendees.tsx
+++ b/src/ui/templates/admin/listings/attendees.tsx
@@ -167,9 +167,9 @@ export const AttendeesSection = ({
         activeFilter: list.state.checkin,
         allowedDomain,
         phonePrefix,
-        // A chosen sort was applied by the caller; the table's own
-        // date-and-name order applies otherwise.
-        presorted: list.state.sort !== null,
+        // The caller ordered the rows through attendeeListOrder, the same
+        // helper the CSV export applies.
+        presorted: true,
         questionData,
         returnUrl,
         rows: tableRows,

--- a/src/ui/templates/admin/listings/roster.tsx
+++ b/src/ui/templates/admin/listings/roster.tsx
@@ -1,7 +1,7 @@
 import { fieldById, map, pipe } from "#fp";
 import {
   attendeeListHref,
-  inRegistrationOrder,
+  attendeeListOrder,
 } from "#shared/attendee-list-controls.ts";
 import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
 import { isReadOnly } from "#shared/env.ts";
@@ -46,12 +46,9 @@ const listingRosterView = (opts: ListingPanelOptions) => {
     paymentReferenceAttendeeIds,
   );
   const filteredAttendees = filterAttendees(completeAttendees, checkin);
-  // A chosen sort orders the rows here; otherwise the table applies its own
-  // date-and-name order.
-  const orderedAttendees =
-    sort === null
-      ? filteredAttendees
-      : inRegistrationOrder(sort)(filteredAttendees);
+  // The page and the CSV export share one row order: the chosen registration
+  // order, or the table's own date-and-name order.
+  const orderedAttendees = attendeeListOrder(sort)(filteredAttendees);
   const dailySuffix = attendeeCountLabelSuffix(isDaily, dateFilter);
   const sharedRows = buildSharedDetailRows({
     attendeeCount: isDaily && dateFilter ? completeQuantitySum : adjustedCount,

--- a/src/ui/templates/attendee-table/values.ts
+++ b/src/ui/templates/attendee-table/values.ts
@@ -1,5 +1,6 @@
 import type { QuestionWithAnswers } from "#db/question-types.ts";
 import { sort } from "#fp";
+import { compareOptionalDates } from "#shared/attendee-list-controls.ts";
 import { nonBlankLines } from "#shared/split.ts";
 import type { AttendeeColumnKey } from "#shared/tables/configurable.ts";
 import type {
@@ -87,14 +88,8 @@ type AttendeeRowComparator = (
   second: AttendeeTableRow,
 ) => number;
 
-const compareAttendeeDates: AttendeeRowComparator = (first, second) => {
-  const firstDate = first.attendee.date ?? "";
-  const secondDate = second.attendee.date ?? "";
-  if (firstDate === secondDate) return 0;
-  if (firstDate === "") return 1;
-  if (secondDate === "") return -1;
-  return firstDate.localeCompare(secondDate);
-};
+const compareAttendeeDates: AttendeeRowComparator = (first, second) =>
+  compareOptionalDates(first.attendee.date, second.attendee.date);
 
 const compareTextBy =
   (getText: (row: AttendeeTableRow) => string): AttendeeRowComparator =>

--- a/test/integration/server/listings/export.test.ts
+++ b/test/integration/server/listings/export.test.ts
@@ -107,6 +107,7 @@ describeWithEnv("server listings > export", { db: true }, () => {
       // chosen order and the table's own order name three different rows.
       const { listing, cookie } = await setupListingAndLogin({
         maxAttendees: 100,
+        name: "Roster Order",
         thankYouUrl: "https://example.com",
       });
       for (const name of ["Mid Person", "Alpha Person", "Zulu Person"]) {
@@ -161,8 +162,8 @@ describeWithEnv("server listings > export", { db: true }, () => {
           cookie,
         },
       );
-      expect(response.headers.get("content-disposition")).toMatch(
-        /filename="[^"]*_attendees\.csv"/,
+      expect(response.headers.get("content-disposition")).toContain(
+        'attachment; filename="Roster_Order_attendees.csv"',
       );
     });
 

--- a/test/integration/server/listings/export.test.ts
+++ b/test/integration/server/listings/export.test.ts
@@ -102,6 +102,60 @@ describeWithEnv("server listings > export", { db: true }, () => {
       expect(csv).toContain(",Yes");
     });
 
+    test("returns CSV rows in the order the roster shows them", async () => {
+      // Registration order (Mid, Alpha, Zulu) differs from name order, so the
+      // chosen order and the table's own order name three different rows.
+      const { listing, cookie } = await setupListingAndLogin({
+        maxAttendees: 100,
+        thankYouUrl: "https://example.com",
+      });
+      for (const name of ["Mid Person", "Alpha Person", "Zulu Person"]) {
+        await createTestAttendee(
+          listing.id,
+          listing.slug,
+          name,
+          `${name.toLowerCase().replace(" ", ".")}@example.com`,
+        );
+      }
+
+      /** The names in the order their rows appear in the CSV. */
+      const shownOrder = (csv: string): string[] =>
+        ["Mid Person", "Alpha Person", "Zulu Person"]
+          .map((name) => ({ at: csv.indexOf(name), name }))
+          .sort((first, second) => first.at - second.at)
+          .map(({ name }) => name);
+
+      // The chosen registration order is honoured.
+      const oldest = await fetchListingExportCsv(
+        listing.id,
+        cookie,
+        "?sort=oldest",
+      );
+      expect(shownOrder(oldest)).toEqual([
+        "Mid Person",
+        "Alpha Person",
+        "Zulu Person",
+      ]);
+      const newest = await fetchListingExportCsv(
+        listing.id,
+        cookie,
+        "?sort=newest",
+      );
+      expect(shownOrder(newest)).toEqual([
+        "Zulu Person",
+        "Alpha Person",
+        "Mid Person",
+      ]);
+      // No sort chosen: the table's own date-and-name order applies, here by
+      // name because no booking carries a date.
+      const byName = await fetchListingExportCsv(listing.id, cookie);
+      expect(shownOrder(byName)).toEqual([
+        "Alpha Person",
+        "Mid Person",
+        "Zulu Person",
+      ]);
+    });
+
     test("sanitizes slug for filename", async () => {
       const { cookie } = await setupListingAndLogin({
         maxAttendees: 100,

--- a/test/integration/server/listings/export.test.ts
+++ b/test/integration/server/listings/export.test.ts
@@ -154,6 +154,16 @@ describeWithEnv("server listings > export", { db: true }, () => {
         "Mid Person",
         "Zulu Person",
       ]);
+      // The download's name carries no day when none was chosen.
+      const response = await awaitTestRequest(
+        `/admin/listing/${listing.id}/export`,
+        {
+          cookie,
+        },
+      );
+      expect(response.headers.get("content-disposition")).toMatch(
+        /filename="[^"]*_attendees\.csv"/,
+      );
     });
 
     test("sanitizes slug for filename", async () => {

--- a/test/shared/attendee-list-controls.test.ts
+++ b/test/shared/attendee-list-controls.test.ts
@@ -13,9 +13,12 @@ import {
   attendeeListCsvHref,
   attendeeListHref,
   attendeeListLink,
+  attendeeListOrder,
   attendeeListParams,
   attendeeListSortChoices,
   choiceIsActive,
+  compareOptionalDates,
+  inDateAndNameOrder,
   inRegistrationOrder,
   isAttendeeSort,
   readAttendeeListState,
@@ -315,6 +318,83 @@ describe("registration order", () => {
   test("leaves the given rows untouched", () => {
     inRegistrationOrder("newest")(rows);
     expect(rows.map((r) => r.id)).toEqual([2, 9, 5]);
+  });
+});
+
+describe("the booked-date comparison", () => {
+  test("orders booked dates ascending", () => {
+    expect(compareOptionalDates("2026-08-01", "2026-08-02")).toBeLessThan(0);
+    expect(compareOptionalDates("2026-08-02", "2026-08-01")).toBeGreaterThan(0);
+    expect(compareOptionalDates("2026-08-01", "2026-08-01")).toBe(0);
+  });
+
+  test("sorts a missing date after the booked ones", () => {
+    expect(compareOptionalDates(null, "2026-08-01")).toBeGreaterThan(0);
+    expect(compareOptionalDates("2026-08-01", null)).toBeLessThan(0);
+    expect(compareOptionalDates(null, null)).toBe(0);
+  });
+});
+
+describe("the table's own date-and-name order", () => {
+  const row = (
+    id: number,
+    date: string | null,
+    name: string,
+  ): { date: string | null; id: number; name: string } => ({ date, id, name });
+
+  test("orders by booked date, then name, then id", () => {
+    const rows = [
+      row(3, "2026-08-02", "Later"),
+      row(1, "2026-08-01", "Beta"),
+      row(2, "2026-08-01", "Alpha"),
+    ];
+    expect(inDateAndNameOrder(rows).map((r) => r.id)).toEqual([2, 1, 3]);
+  });
+
+  test("sorts a booking with no date after the dated ones", () => {
+    const rows = [row(1, null, "Undated"), row(2, "2026-08-01", "Dated")];
+    expect(inDateAndNameOrder(rows).map((r) => r.id)).toEqual([2, 1]);
+  });
+
+  test("breaks equal dates and names by registration id", () => {
+    const rows = [
+      row(5, "2026-08-01", "Same Name"),
+      row(4, "2026-08-01", "Same Name"),
+      row(6, "2026-08-01", "Same Name"),
+    ];
+    expect(inDateAndNameOrder(rows).map((r) => r.id)).toEqual([4, 5, 6]);
+  });
+
+  test("leaves the given rows untouched", () => {
+    const rows = [row(2, null, "B"), row(1, null, "A")];
+    inDateAndNameOrder(rows);
+    expect(rows.map((r) => r.id)).toEqual([2, 1]);
+  });
+});
+
+describe("a roster's row order", () => {
+  const rows = [
+    { date: null, id: 1, name: "Mid" },
+    { date: null, id: 2, name: "Alpha" },
+  ];
+
+  test("no sort chosen: the table's own date-and-name order", () => {
+    expect(attendeeListOrder(null)(rows).map((r) => r.name)).toEqual([
+      "Alpha",
+      "Mid",
+    ]);
+  });
+
+  test("a chosen registration order replaces the default", () => {
+    // Newest first: the highest id (Alpha) on top.
+    expect(attendeeListOrder("newest")(rows).map((r) => r.name)).toEqual([
+      "Alpha",
+      "Mid",
+    ]);
+    expect(attendeeListOrder("oldest")(rows).map((r) => r.name)).toEqual([
+      "Mid",
+      "Alpha",
+    ]);
   });
 });
 

--- a/test/shared/sort-listings.test.ts
+++ b/test/shared/sort-listings.test.ts
@@ -1,9 +1,10 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { addDays } from "#shared/dates.ts";
-import { sortListings } from "#shared/sort-listings.ts";
+import { loadSortedListings, sortListings } from "#shared/sort-listings.ts";
 import { todayInTz } from "#shared/timezone.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { testListing, testListingWithCount } from "#test-utils/factories.ts";
 import type { Holiday, ListingWithCount } from "#types";
 
@@ -330,5 +331,14 @@ describeWithEnv("sortListings", { db: true }, () => {
     });
     const sorted = sortListings([listing], []);
     expect((sorted[0] as ListingWithCount).attendee_count).toBe(42);
+  });
+});
+
+describeWithEnv("loadSortedListings", { db: true }, () => {
+  test("keeps every listing when no filter is passed", async () => {
+    const created = await createTestListing({ name: "Unfiltered listing" });
+
+    const { listings } = await loadSortedListings();
+    expect(listings.map((listing) => listing.id)).toContain(created.id);
   });
 });

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -106,10 +106,11 @@ export const expectCsvDownloadHeaders = (
 export const fetchListingExportCsv = async (
   listingId: number,
   cookie: string,
+  query = "",
 ): Promise<string> => {
   const { awaitTestRequest } = await import("#test-utils/mocks.ts");
   const response = await awaitTestRequest(
-    `/admin/listing/${listingId}/export`,
+    `/admin/listing/${listingId}/export${query}`,
     { cookie },
   );
   expect(response.status).toBe(200);

--- a/test/ui/templates/admin/listings/attendees/row-order.test.ts
+++ b/test/ui/templates/admin/listings/attendees/row-order.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The roster's table receives rows the page already ordered through
+ * attendeeListOrder — the same order the CSV export applies — so the table
+ * must render them as given rather than re-sorting them.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { attendeeLineRow } from "#shared/attendee-table-rows.ts";
+import { AttendeesSection } from "#templates/admin/listings/attendees.tsx";
+import { testRosterListSetup } from "#test-utils/attendee-list.ts";
+import { testAttendee, testListingWithCount } from "#test-utils/factories.ts";
+import type { AttendeeTableRow } from "#types";
+
+describe("AttendeesSection", () => {
+  test("keeps the order the caller chose, newest first", () => {
+    // The page hands the table rows it already ordered — newest first here.
+    // The table must render them as given: its own date-and-name order would
+    // clobber the chosen registration order.
+    const listing = testListingWithCount({ id: 5 });
+    const rows: AttendeeTableRow[] = [
+      { id: 3, name: "Zulu Person" },
+      { id: 2, name: "Alpha Person" },
+      { id: 1, name: "Mid Person" },
+    ].map(({ id, name }) =>
+      attendeeLineRow(testAttendee({ id, name }), listing),
+    );
+    const setup = testRosterListSetup();
+    const html = String(
+      AttendeesSection({
+        allowedDomain: "example.com",
+        emailDayHref: undefined,
+        list: {
+          setup,
+          state: {
+            checkin: "all",
+            date: null,
+            listingId: null,
+            page: 0,
+            sort: "newest",
+            type: "all",
+          },
+        },
+        phonePrefix: "44",
+        questionData: undefined,
+        returnUrl: setup.basePath,
+        tableRows: rows,
+      }),
+    );
+    const shown = ["Mid Person", "Alpha Person", "Zulu Person"]
+      .map((name) => ({ at: html.indexOf(name), name }))
+      .sort((first, second) => first.at - second.at)
+      .map(({ name }) => name);
+    expect(shown).toEqual(["Zulu Person", "Alpha Person", "Mid Person"]);
+  });
+});


### PR DESCRIPTION
## What changed

The roster page ordered its rows from the address bar's `sort`, but the CSV export read the same address and dropped the sort. A staff member who picked "Newest first" or "Oldest first" and downloaded got raw database order. A download with no order skipped the table's own date-and-name order too, which the on-screen table applies.

One row order now serves both surfaces:

- `attendeeListOrder(sort)` in `src/shared/attendee-list-controls.ts` applies the chosen registration order, or the table's own date-and-name order when the address named none.
- The page (`listingRosterView`) and the export handler (`handleAdminListingExport`) both call it, so the two surfaces cannot drift. The page orders its attendees before the table render, so its visible order is unchanged.
- The booked-date comparison the table's default sort used is lifted to the shared `compareOptionalDates`, so the two default orders share one rule. The daily listing order in `src/shared/sort-listings.ts` folded onto the same rule, retiring its private copy of the missing-date-last comparison.
- The export handler's context now carries `sort` beside its date and check-in filters.

## Current-system value

`GET /admin/listing/:id/export` is the production caller. The comment above it already promised "the CSV export mirrors the on-screen table"; the download now honours that promise for the row order.

## Tests

An export test downloads with `?sort=oldest`, `?sort=newest`, and with no sort, and pins the row order of each; it failed before the fix for the right reason: every download came out in raw database order. Direct tests pin the new comparator family and the table's render of presorted rows, and a new test pins `loadSortedListings` keeping every listing when no filter is passed. The page's visible order is unchanged (the roster sort tests pass untouched).

`nix develop -c deno task precommit` and `nix develop -c deno task precommit:mutation` ran. The run surfaced about 50 survivors on render-code lines these template files carried before this branch; they are filed as #2324 with a group-by-group plan, and the survivors on this change's own lines are killed here. Two provably equivalent `?? to ||` mutants on the shared comparator are recorded in the equivalent-mutant registry, with the type proof in the entry.

Fixes #2291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Attendee rosters now use consistent ordering across on-screen tables and CSV exports.
  - Default ordering places attendees by date, with missing dates shown last; ties are resolved by name and registration ID.
  - CSV exports respect selected newest-first or oldest-first registration sorting.
  - Attendee table rows now consistently preserve the intended roster order.

- **Bug Fixes**
  - Corrected cases where exported rows could appear in a different order from the attendee roster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->