### PR TITLE
Parse the listing price source rows instead of claiming them

### DIFF
--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -277,6 +277,13 @@ export const dayCountPriceStatements = (
   ]);
 };
 
+/** One `listing_prices` `day_count` row: the day count it prices and its
+ * per-unit price. */
+const DayCountPriceRowSchema = v.object({
+  price_id: v.string(),
+  unit_price: v.number(),
+});
+
 /** One listing's per-day-count prices from its `day_count` rows, as a
  * {@link DayPrices} map. The bounded single-listing read used to keep an entity
  * honest when the write path can't supply the day prices (a partial update),
@@ -289,12 +296,10 @@ export const getListingDayPrices = async (
       WHERE listing_id = ? AND price_type = ?`,
     [listingId, PRICE_TYPE_DAY_COUNT],
   );
-  const rows = result.rows as unknown as {
-    price_id: string;
-    unit_price: number;
-  }[];
   const dayPrices: DayPrices = {};
-  for (const row of rows) dayPrices[Number(row.price_id)] = row.unit_price;
+  for (const row of v.parse(v.array(DayCountPriceRowSchema), result.rows)) {
+    dayPrices[Number(row.price_id)] = row.unit_price;
+  }
   return parseDayPrices(dayPrices);
 };
 

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -10,6 +10,7 @@
  *    admits it with no schema change, and nothing writes it yet.
  */
 
+import * as v from "valibot";
 import {
   execute,
   executeBatch,
@@ -314,10 +315,12 @@ export const writeListingDayCounts = async (
 
 /** A `listings` row projected to the one column the `base` mirror derives from.
  * `unit_price` may be NULL (read as 0). */
-export type ListingPriceSourceRow = {
-  id: number;
-  unit_price: number | null;
-};
+const ListingPriceSourceRowSchema = v.object({
+  id: v.number(),
+  unit_price: v.nullable(v.number()),
+});
+
+type ListingPriceSourceRow = v.InferOutput<typeof ListingPriceSourceRowSchema>;
 
 /** The `base`-mirror statements for one raw `listings` row — shared by the
  * backfill and the per-listing {@link syncListingPrices}. A NULL `unit_price`
@@ -343,7 +346,7 @@ const readSourceRows = async (
       WHERE id IN (${inPlaceholders(ids)})`,
     [...ids],
   );
-  return rows.rows as unknown as ListingPriceSourceRow[];
+  return v.parse(v.array(ListingPriceSourceRowSchema), rows.rows);
 };
 
 /** Execute the statements in bounded batches so no single write batch grows past

--- a/src/shared/db/listing-prices.ts
+++ b/src/shared/db/listing-prices.ts
@@ -395,12 +395,17 @@ export const syncListingPricesForIds = async (
  * after every listing insert/update (the form/API `afterCommit`) so the mirror
  * never drifts from the column. The source row is read on the primary
  * (write-mode batch) so it reflects the just-committed write rather than a
- * lagging replica. A missing listing is a no-op. Day-count rows are written from
- * input by the write paths, not re-derived here. */
+ * lagging replica, and parsed there — it does not go through
+ * {@link readSourceRows}, whose bulk read need not be primary-pinned. A
+ * missing listing is a no-op. Day-count rows are written from input by the
+ * write paths, not re-derived here. */
 export const syncListingPrices = async (listingId: number): Promise<void> => {
-  const row = await queryOnePrimary<ListingPriceSourceRow>(
+  const row = await queryOnePrimary<unknown>(
     "SELECT id, unit_price FROM listings WHERE id = ?",
     [listingId],
   );
-  if (row) await executeBatch(sourceRowStatements(row));
+  if (row === null) return;
+  await executeBatch(
+    sourceRowStatements(v.parse(ListingPriceSourceRowSchema, row)),
+  );
 };

--- a/test/shared/db/listing-prices.test.ts
+++ b/test/shared/db/listing-prices.test.ts
@@ -301,12 +301,27 @@ describeWithEnv("listing_prices persistence", { db: true }, () => {
   test("a source row whose price is not a number fails the backfill loudly", async () => {
     // SQLite stores whatever survives the column's affinity: a price that
     // reached the column as text is a drifted shape the read must refuse, not
-    // silently book as 0.
+    // pass through to the base row as-is.
     const listing = await createTestListing({ unitPrice: 750 });
     await queryAll("UPDATE listings SET unit_price = 'free' WHERE id = ?", [
       listing.id,
     ]);
     await expect(backfillListingPrices()).rejects.toThrow("Invalid type");
+  });
+
+  test("a day-count row whose price is not a number fails the read loudly", async () => {
+    // Before the parse, a drifted row let parseDayPrices quietly drop the day
+    // from the projection, so an editor read a price that was not the stored
+    // one — or none at all.
+    const listing = await createDayPricedListing({ 2: 640 });
+    await queryAll(
+      "UPDATE listing_prices SET unit_price = 'free' " +
+        "WHERE price_type = 'day_count' AND listing_id = ?",
+      [listing.id],
+    );
+    await expect(getListingDayPrices(listing.id)).rejects.toThrow(
+      "Invalid type",
+    );
   });
 
   test("deleting a listing removes its price rows", async () => {

--- a/test/shared/db/listing-prices.test.ts
+++ b/test/shared/db/listing-prices.test.ts
@@ -298,6 +298,17 @@ describeWithEnv("listing_prices persistence", { db: true }, () => {
     ]);
   });
 
+  test("a source row whose price is not a number fails the backfill loudly", async () => {
+    // SQLite stores whatever survives the column's affinity: a price that
+    // reached the column as text is a drifted shape the read must refuse, not
+    // silently book as 0.
+    const listing = await createTestListing({ unitPrice: 750 });
+    await queryAll("UPDATE listings SET unit_price = 'free' WHERE id = ?", [
+      listing.id,
+    ]);
+    await expect(backfillListingPrices()).rejects.toThrow("Invalid type");
+  });
+
   test("deleting a listing removes its price rows", async () => {
     const listing = await createDayPricedListing({ 1: 640 });
     expect((await priceRows(listing.id)).length).toBe(2);

--- a/test/shared/db/listing-prices.test.ts
+++ b/test/shared/db/listing-prices.test.ts
@@ -378,6 +378,14 @@ describeWithEnv("listing_prices persistence", { db: true }, () => {
     expect(await priceRows(987654)).toEqual([]);
   });
 
+  test("a source row that is not a number fails the sync loudly", async () => {
+    const listing = await createTestListing({ unitPrice: 750 });
+    await queryAll("UPDATE listings SET unit_price = 'free' WHERE id = ?", [
+      listing.id,
+    ]);
+    await expect(syncListingPrices(listing.id)).rejects.toThrow("Invalid type");
+  });
+
   test("updating a missing listing writes no price rows", async () => {
     // The table wrapper only re-syncs when the update returns a row; a missing
     // id yields null and must not touch listing_prices.


### PR DESCRIPTION
## What changed

`src/shared/db/listing-prices.ts` claimed its row shapes three times instead of checking them:

1. `readSourceRows` ended in `rows.rows as unknown as ListingPriceSourceRow[]`. The cast claimed a shape the code never checked, so a column renamed or re-typed in the SELECT above it reached its two callers (`backfillListingPrices` and `syncListingPricesForIds`) as `undefined` rather than failing at the read — and a price that arrived as text passed through unvalidated.
2. `getListingDayPrices` read its `day_count` rows through the same cast, with a worse failure mode: `parseDayPrices` skips an entry it cannot read, so a drifted row quietly vanished from the projection an entity edit trusts.
3. `syncListingPrices` read its source row through `queryOnePrimary`'s generic, which arrives by an unchecked cast, so a drifted `unit_price` reached the base-row write unvalidated.

All three reads now parse their rows with a valibot schema at the boundary, the way other database reads do (`ExistingFeatureUsageSchema` is the precedent), and the row shapes derive from those schemas. The sync reads as `unknown` and parses with the source-row schema, so it shares one checked shape with the backfill. The source-row type had no caller outside the module, so the export goes.

## Current-system value

Three production callers: the migration backfill that populates every listing's `base` price row, the single-listing day-count read that keeps an edited entity honest, and the per-write sync that keeps the `base` mirror in step with its column. A drifted row now stops its read loudly instead of corrupting a base price, silently dropping a day, or writing an unvalidated mirror.

## Tests

Three regression tests plant a text price in each read's column and expect the read to refuse it. Each was confirmed failing against the cast first: the backfill completed silently, the day-count read resolved with the day silently dropped, and the sync passed the text price to the write.

`nix develop -c deno task precommit` passes and `nix develop -c deno task precommit:mutation` runs at 100 percent on the changed file.

Fixes #2293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of stored listing prices and day-count values.
  - Invalid non-numeric prices are now rejected with a clear error instead of being accepted or silently ignored.
- **Tests**
  - Added coverage for price backfills, day-count reads, and single-listing synchronization involving invalid stored values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->