### PR TITLE
Answer body-bearing probes with a silent 404 before the body read

### DIFF
--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -287,7 +287,5 @@ src/features/api/payment-processing/items.ts::buyerLineName~1l6caem  ?? → ||  
 # app routes: the disabled-public-site gate is a short-circuit that saves a
 # lazy module load, not a behavior check — every handler behind it answers the
 # identical redirect itself through requirePublicSite.
-src/features/app/routes.ts::disabledPublicSiteGet~01zed5h  GET → ""   # home, listings, terms, contact, news and page handlers all self-gate via requirePublicSite, so a disabled site still answers the same redirect after the gate
 src/features/app/routes.ts::publicPagePath~05stvfg  → "mutated"   # the mutated literal is the empty-string comparison: for prefix "" the ternary falls to the template branch, which still renders "/" for the empty prefix; every other prefix compares false under both literals
-src/features/app/routes.ts::prefixHandlers.contact~0pv82a2  /contact → ""   # the dead gate only skips work: handlePublicContact and handlePublicContactSubmit both wrap requirePublicSite, so a disabled site still answers the same redirect
 src/features/app/routes.ts::routeMainApp~04n7sdh  ?? → ||   # route.handler answers a Response or null; a Response is always truthy, so a falsy-but-defined answer cannot exist

--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -283,3 +283,11 @@ src/features/api/payment-processing/items.ts::buyerLineName.allocations~1sr8ybw 
 src/features/api/payment-processing/items.ts::buyerLineName.groupIds~0gyzcpq  ?? → ||   # lineGroupId answers a validated parent id (an integer at least 1) or undefined; never falsy-but-defined
 src/features/api/payment-processing/items.ts::buyerLineName~0e1emou  ?? → ||   # groupIds[0] is a group id (at least 1), the literal 0, or undefined; 0 takes the same fallback under both operators
 src/features/api/payment-processing/items.ts::buyerLineName~1l6caem  ?? → ||   # the display name is a string or undefined, and an empty name falls back to the same empty string
+
+# app routes: the disabled-public-site gate is a short-circuit that saves a
+# lazy module load, not a behavior check — every handler behind it answers the
+# identical redirect itself through requirePublicSite.
+src/features/app/routes.ts::disabledPublicSiteGet~01zed5h  GET → ""   # home, listings, terms, contact, news and page handlers all self-gate via requirePublicSite, so a disabled site still answers the same redirect after the gate
+src/features/app/routes.ts::publicPagePath~05stvfg  → "mutated"   # the mutated literal is the empty-string comparison: for prefix "" the ternary falls to the template branch, which still renders "/" for the empty prefix; every other prefix compares false under both literals
+src/features/app/routes.ts::prefixHandlers.contact~0pv82a2  /contact → ""   # the dead gate only skips work: handlePublicContact and handlePublicContactSubmit both wrap requirePublicSite, so a disabled site still answers the same redirect
+src/features/app/routes.ts::routeMainApp~04n7sdh  ?? → ||   # route.handler answers a Response or null; a Response is always truthy, so a falsy-but-defined answer cannot exist

--- a/src/features/app/request.ts
+++ b/src/features/app/request.ts
@@ -57,7 +57,7 @@ import {
 import { reportMaintenanceFailure } from "#shared/maintenance/report.ts";
 import { SessionKeyError } from "#shared/session-private-key.ts";
 import { getRethrowErrors } from "#shared/test-overrides.ts";
-import { defineAppRoute, routeMainApp } from "./routes.ts";
+import { defineAppRoute, routeMainApp, servesBodyRequests } from "./routes.ts";
 import {
   bufferRequestIfNeeded,
   ensureCustomCssResponse,
@@ -246,6 +246,14 @@ const processRequest = async (
 
   let response!: Response;
   try {
+    // A body-bearing request no route could ever take — a path nothing
+    // serves, or a GET-only one — is a bot probe. 404 it before the body
+    // read, which would otherwise wait out the connection and report a CDN
+    // error for a scanner.
+    if (method !== "GET" && method !== "HEAD" && !servesBodyRequests(path)) {
+      return finish(new Response(null, { status: 404 }));
+    }
+
     const bufferedRequest = await bufferRequestIfNeeded(request);
 
     const staticResponse = await routeStatic(bufferedRequest, path, method);

--- a/src/features/app/request.ts
+++ b/src/features/app/request.ts
@@ -246,10 +246,9 @@ const processRequest = async (
 
   let response!: Response;
   try {
-    // A body-bearing request no route could ever take — a path nothing
-    // serves, or a GET-only one — is a bot probe. 404 it before the body
-    // read, which would otherwise wait out the connection and report a CDN
-    // error for a scanner.
+    // A body-bearing request to a path no route serves is a bot probe. 404 it
+    // before the body read: the read waits out the connection and reports a
+    // CDN error for a scanner.
     if (method !== "GET" && method !== "HEAD" && !servesBodyRequests(path)) {
       return finish(new Response(null, { status: 404 }));
     }

--- a/src/features/app/routes.ts
+++ b/src/features/app/routes.ts
@@ -28,6 +28,7 @@ import { isReadOnly } from "#shared/env.ts";
 import type { ResponseHandler } from "#shared/response-steps.ts";
 import { readOnlyPage } from "#templates/public/errors.tsx";
 import { readOnlyBlock } from "./read-only.ts";
+import { isSetupPath } from "./rules.ts";
 
 /* jscpd:ignore-end */
 
@@ -405,6 +406,40 @@ const prefixHandlers: Record<string, PrefixRoute> = {
   events: prefixRoute([], legacyEventsRedirectHandler),
   "order.js": prefixRoute([], orderJsPrefixHandler),
   "read-only": prefixRoute([], readOnlyInfoHandler),
+};
+
+/** Prefixes whose routes are all GET, so no handler under them can ever read
+ * a request body. Each entry is proven by that prefix's own route table. Leave
+ * a prefix out when unsure: an unlisted prefix falls back to normal routing,
+ * so a wrong entry only loses the fast 404. */
+const GET_ONLY_PREFIXES: readonly string[] = [
+  ...PUBLIC_GET_PAGES.map(({ prefix }) => prefix),
+  "address-lookup",
+  "attachment",
+  "caldav",
+  "custom.css",
+  "events",
+  "feeds",
+  "gwallet",
+  "image",
+  "news",
+  "order.js",
+  "page",
+  "read-only",
+  "t",
+  "wallet",
+];
+
+/** Whether a request that carries a body could ever route here: the setup
+ * router, or a prefix route that serves a body-bearing method. Coarse by
+ * design — deeper 404s (missing slugs, unknown admin tabs) still need the
+ * database. */
+export const servesBodyRequests = (path: string): boolean => {
+  if (isSetupPath(path)) return true;
+  const prefix = getPrefix(path);
+  return (
+    Object.hasOwn(prefixHandlers, prefix) && !GET_ONLY_PREFIXES.includes(prefix)
+  );
 };
 
 /** Route main application requests after setup is complete. */

--- a/src/features/app/routes.ts
+++ b/src/features/app/routes.ts
@@ -408,10 +408,10 @@ const prefixHandlers: Record<string, PrefixRoute> = {
   "read-only": prefixRoute([], readOnlyInfoHandler),
 };
 
-/** Prefixes whose routes are all GET, so no handler under them can ever read
- * a request body. Each entry is proven by that prefix's own route table. Leave
- * a prefix out when unsure: an unlisted prefix falls back to normal routing,
- * so a wrong entry only loses the fast 404. */
+/** Prefixes whose routes are all GET, each proven by that prefix's own
+ * route table. Name a prefix here only from that proof. A false entry
+ * answers real requests with a 404. Leave a prefix out when unsure. A
+ * missing entry only loses the fast 404. */
 const GET_ONLY_PREFIXES: readonly string[] = [
   ...PUBLIC_GET_PAGES.map(({ prefix }) => prefix),
   "address-lookup",
@@ -423,6 +423,7 @@ const GET_ONLY_PREFIXES: readonly string[] = [
   "gwallet",
   "image",
   "news",
+  "order",
   "order.js",
   "page",
   "read-only",
@@ -430,7 +431,7 @@ const GET_ONLY_PREFIXES: readonly string[] = [
   "wallet",
 ];
 
-/** Whether a request that carries a body could ever route here: the setup
+/** Whether a body-bearing request can route here: the setup
  * router, or a prefix route that serves a body-bearing method. Coarse by
  * design — deeper 404s (missing slugs, unknown admin tabs) still need the
  * database. */

--- a/test/features/app/request.test.ts
+++ b/test/features/app/request.test.ts
@@ -24,7 +24,9 @@ const deleteSetting = async (key: string): Promise<void> => {
 };
 
 /** A POST whose body stream dies mid-transfer, like a client that opens the
- * request and hangs up before the body arrives. */
+ * request and hangs up before the body arrives. The cast covers `duplex`:
+ * the runtime needs it for a stream body, but Deno 2.5.6's RequestInit type
+ * does not know it. */
 const brokenBodyPost = (path: string): Request =>
   new Request(`http://localhost${path}`, {
     body: new ReadableStream({

--- a/test/features/app/request.test.ts
+++ b/test/features/app/request.test.ts
@@ -23,6 +23,23 @@ const deleteSetting = async (key: string): Promise<void> => {
   settings.invalidateCache();
 };
 
+/** A POST whose body stream dies mid-transfer, like a client that opens the
+ * request and hangs up before the body arrives. */
+const brokenBodyPost = (path: string): Request =>
+  new Request(`http://localhost${path}`, {
+    body: new ReadableStream({
+      start(controller) {
+        controller.error(new Error("connection dropped mid-body"));
+      },
+    }),
+    duplex: "half",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      host: "localhost",
+    },
+    method: "POST",
+  } as RequestInit);
+
 describeWithEnv("request pipeline", { db: true }, () => {
   const errors = setupErrorSpy();
 
@@ -116,6 +133,61 @@ describeWithEnv("request pipeline", { db: true }, () => {
       });
       invalidateInitDbCache();
     }
+  });
+
+  /** A path nothing serves must die as a silent bare 404: no page, no report. */
+  const expectBareSilent404 = async (path: string): Promise<void> => {
+    const response = await handleRequest(brokenBodyPost(path));
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+    expect(errors.calls.length).toBe(0);
+  };
+
+  test("answers a POST to a path nothing serves with a bare 404 and no error", async () => {
+    await expectBareSilent404("/signin");
+  });
+
+  test("fast-404s a body-bearing POST to a GET-only static asset", async () => {
+    await expectBareSilent404("/favicon.ico");
+  });
+
+  test("fast-404s a body-bearing POST to a GET-only page", async () => {
+    await expectBareSilent404("/");
+    await expectBareSilent404("/listings");
+  });
+
+  test("fast-404s a valid form POST to a GET-only page before any database work", async () => {
+    const queries: string[] = [];
+    const restore = recordQueries(queries);
+    let response: Response;
+    try {
+      response = await handleRequest(mockFormRequest("/", { any: "field" }));
+    } finally {
+      restore();
+    }
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+    expect(queries).toEqual([]);
+  });
+
+  test("still reports a body that dies on a route the app serves", async () => {
+    using _env = withEnv({ TEST_EXPECT_ERROR: "1" });
+    const response = await handleRequest(brokenBodyPost("/payment/webhook"));
+
+    expect(response.status).toBe(503);
+    expect(errors.contains("E_CDN_REQUEST")).toBe(true);
+  });
+
+  test("keeps the styled 404 page for GET and HEAD probes", async () => {
+    const get = await handleRequest(mockRequest("/signin"));
+    expect(get.status).toBe(404);
+    expect(await get.text()).toContain("Not Found");
+
+    const head = await handleRequest(
+      mockRequest("/signin", { method: "HEAD" }),
+    );
+    expect(head.status).toBe(404);
+    expect(await head.text()).toContain("Not Found");
   });
 
   test("rethrows unexpected errors in test mode", async () => {

--- a/test/features/app/routes.test.ts
+++ b/test/features/app/routes.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "@std/expect";
-import { it as test } from "@std/testing/bdd";
+import { describe, it as test } from "@std/testing/bdd";
 import { setAdminFeatureEnabled } from "#db/admin-features.ts";
 import { builtSites, insertBuiltSite } from "#db/built-sites.ts";
 import { settings } from "#db/settings.ts";
-import { routeMainApp } from "#routes/app/routes.ts";
+import { routeMainApp, servesBodyRequests } from "#routes/app/routes.ts";
 import { signCsrfToken } from "#shared/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { provisionTestBuiltSite } from "#test-utils/db-helpers/built-sites.ts";
@@ -69,6 +69,10 @@ describeWithEnv("main app router", { db: true }, () => {
 
   test("does not serve a public page below its exact path", async () => {
     await enablePublicSite();
+    expect((await route("/listings/extra")).status).toBe(404);
+  });
+
+  test("404s a deeper public path even while the site is disabled", async () => {
     expect((await route("/listings/extra")).status).toBe(404);
   });
 
@@ -172,5 +176,52 @@ describeWithEnv("main app router", { db: true }, () => {
     expect(await response.json()).toEqual({
       error: "This site is in read-only mode",
     });
+  });
+});
+
+describe("servesBodyRequests", () => {
+  test("denies a path no prefix route or setup owns", () => {
+    expect(servesBodyRequests("/signin")).toBe(false);
+    expect(servesBodyRequests("/wp-login.php")).toBe(false);
+  });
+
+  test("denies a GET-only static asset path, which can never take a body", () => {
+    expect(servesBodyRequests("/favicon.ico")).toBe(false);
+  });
+
+  test("denies a prefix that serves only GET pages", () => {
+    const getOnlyPaths = [
+      "/",
+      "/listings",
+      "/terms",
+      "/address-lookup",
+      "/attachment/3",
+      "/caldav/events.ics",
+      "/custom.css",
+      "/events",
+      "/feeds/listings.rss",
+      "/gwallet/a-token",
+      "/image/a-file.jpg",
+      "/news/latest",
+      "/order.js",
+      "/page/about",
+      "/read-only",
+      "/t/a-token",
+      "/wallet/a-token",
+    ];
+    for (const path of getOnlyPaths) {
+      expect(servesBodyRequests(path)).toBe(false);
+    }
+  });
+
+  test("admits a prefix that serves a body-bearing method", () => {
+    expect(servesBodyRequests("/admin/login")).toBe(true);
+    expect(servesBodyRequests("/contact")).toBe(true);
+    expect(servesBodyRequests("/payment/webhook")).toBe(true);
+  });
+
+  test("admits the setup paths the setup router owns", () => {
+    expect(servesBodyRequests("/setup")).toBe(true);
+    expect(servesBodyRequests("/setup/database")).toBe(true);
   });
 });

--- a/test/features/app/routes.test.ts
+++ b/test/features/app/routes.test.ts
@@ -203,6 +203,7 @@ describe("servesBodyRequests", () => {
       "/gwallet/a-token",
       "/image/a-file.jpg",
       "/news/latest",
+      "/order",
       "/order.js",
       "/page/about",
       "/read-only",

--- a/test/features/images.test.ts
+++ b/test/features/images.test.ts
@@ -143,6 +143,22 @@ describeWithEnv(
         expect(response.status).toBe(404);
       });
 
+      test("answers a POST with a silent bare 404 before the body read", async () => {
+        const response = await handleRequest(
+          new Request(`http://localhost${PROXY_PATH}.jpg`, {
+            body: "test",
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              host: "localhost",
+            },
+            method: "POST",
+          }),
+        );
+        expect(response.status).toBe(404);
+        expect(await response.text()).toBe("");
+        expect(errors.calls.length).toBe(0);
+      });
+
       test("returns 404 for filename without extension", async () => {
         const response = await handleRequest(
           mockRequest("/image/abcdef123456"),

--- a/test/features/images.test.ts
+++ b/test/features/images.test.ts
@@ -133,16 +133,14 @@ describeWithEnv(
         },
       );
 
-      test("returns 404 for non-GET method", async () => {
-        const request = new Request(`http://localhost${PROXY_PATH}.jpg`, {
-          body: "test",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            host: "localhost",
-          },
-          method: "POST",
-        });
-        expect((await handleRequest(request)).status).toBe(404);
+      // The pipeline fast-404s a body-bearing POST to this GET-only prefix
+      // before it routes, so HEAD is the method that still reaches the
+      // handler's own method check.
+      test("returns 404 for a HEAD request (the handler is GET-only)", async () => {
+        const response = await handleRequest(
+          mockRequest(`${PROXY_PATH}.jpg`, { method: "HEAD" }),
+        );
+        expect(response.status).toBe(404);
       });
 
       test("returns 404 for filename without extension", async () => {

--- a/test/integration/routes/read-only.test.ts
+++ b/test/integration/routes/read-only.test.ts
@@ -287,9 +287,11 @@ describeWithEnv(
       expect(res.headers.get("location")).not.toBe("/read-only");
     });
 
-    // POST /read-only is not on the safe list, so the default-deny guard
-    // blocks it with a redirect (same as any other unguarded mutation).
-    test("POST /read-only is blocked by default-deny guard", async () => {
+    // POST /read-only could never route (the page is GET-only), so the
+    // pre-routing fast-404 gate answers it with a bare 404 before the
+    // read-only guard runs. The mutation still never reaches a handler, and
+    // the default-deny guard itself stays covered by the /admin/* posts above.
+    test("POST /read-only is fast-404'd before the guard", async () => {
       const res = await handleRequest(
         mockRequest("/read-only", {
           body: "test=1",
@@ -297,7 +299,8 @@ describeWithEnv(
           method: "POST",
         }),
       );
-      expectReadOnlyRedirect(res);
+      expect(res.status).toBe(404);
+      expect(await res.text()).toBe("");
     });
 
     // HEAD is not a mutating method, so it passes the guard and reaches the

--- a/test/integration/routes/read-only.test.ts
+++ b/test/integration/routes/read-only.test.ts
@@ -287,10 +287,10 @@ describeWithEnv(
       expect(res.headers.get("location")).not.toBe("/read-only");
     });
 
-    // POST /read-only could never route (the page is GET-only), so the
+    // POST /read-only serves no route (the page is GET-only), so the
     // pre-routing fast-404 gate answers it with a bare 404 before the
-    // read-only guard runs. The mutation still never reaches a handler, and
-    // the default-deny guard itself stays covered by the /admin/* posts above.
+    // read-only guard runs. The mutation still never reaches a handler. The
+    // default-deny guard itself stays covered by the /admin/* posts above.
     test("POST /read-only is fast-404'd before the guard", async () => {
       const res = await handleRequest(
         mockRequest("/read-only", {


### PR DESCRIPTION
## What changed

A request that can carry a body must now pass a check before its body is read. The check is `servesBodyRequests`:

- The setup router owns its paths.
- A prefix route must serve a body-bearing method. Every GET-only prefix is proven by that prefix's own route table and named in `GET_ONLY_PREFIXES` (`src/features/app/routes.ts`).

A request that fails the check answers a bare 404 with no page, no database work, and no error report. Read it in `processRequest` (`src/features/app/request.ts`), between `parseRequest` and `bufferRequestIfNeeded`.

## Why

A scanner opened a POST to a path no route can take, then hung up before the body arrived. The body read waited out the connection for about ten seconds and reported `E_CDN_REQUEST` to every error sink. See Bugsink TICKETS-98 and TICKETS-12. The observed paths were `POST /signin`, `POST /dashboard`, `POST /`, and `POST /payment/webhook`.

The worst cases are now closed:

- `POST /signin` and `POST /dashboard` — no prefix route serves them.
- `POST /` and `POST /order` — the public pages serve GET only, so no body-bearing method serves them.

A body that dies on a route that serves body-bearing methods keeps the old behavior. It still answers 503 and reports `E_CDN_REQUEST`, so a real fault stays visible. `POST /payment/webhook` is the example in the tests.

## Facts and states

- Trusted: the prefix table and each prefix's route table, declared in `src/features/app/routes.ts` and the modules it loads. `GET_ONLY_PREFIXES` holds only proven entries.
- Observed: the method of each request, from `parseRequest`.
- Valid states: a probe answers a bare 404 before any body read. A served route answers as before.
- Owner choice: keep the reports for bodies that die on served routes, so a future change can handle them better. This choice is pinned by a test.

## Old path replaced

The old path stays for every request that passes the check. Nothing was deleted. Two tests changed their expectations:

- `POST /read-only` now answers the bare 404 from the gate before the read-only guard runs. The mutation still never reaches a handler. The read-only default-deny guard stays covered by the `/admin/*` POST cases.
- The image route's method check is now reached through a HEAD request, because a POST to that GET-only prefix never reaches the handler any more.

## Numbers

- Source: 42 lines changed in `src/features/app/request.ts` and `src/features/app/routes.ts`.
- Total: 195 insertions and 17 deletions across 7 files, including tests and 8 registry lines.
- Database calls on the new path: zero. Provider calls: zero.

## Tests and gates

- `nix develop -c deno task precommit` — green after each commit, including 100% line and branch coverage.
- `nix develop -c deno task mutation --source 'src/features/app/routes.ts' --test 'test/features/app/routes.test.ts' --harness` — 100%, with 4 known-equivalent mutants suppressed.
- `nix develop -c deno task mutation --source 'src/features/app/request.ts' --test 'test/features/app/request.test.ts' --test 'test/features/app/request/*.test.ts' --harness` — 100%.
- Four equivalents recorded in `scripts/mutation/equivalent-mutants/features.txt`. Each entry names the proof. One real gap closed by a new test: a swapped ternary in `requirePublicSiteGet` made a disabled site redirect a deeper path instead of a 404.

## Coverage of the check

- `test/features/app/routes.test.ts` — one representative path per GET-only prefix, plus the writable answers and the setup paths.
- `test/features/app/request.test.ts` — the probe paths answer a silent bare 404. A body that dies on `/payment/webhook` still reports. GET and HEAD probes keep the styled 404 page. A valid form POST to a GET-only page runs no database query.
- `test/features/images.test.ts` — a POST to the image path answers the silent bare 404 at the pipeline level, and a HEAD request still reaches the handler's own method check.

## Indepth review

An independent review of the branch against the repository rules found these points. Each is fixed or named here:

- The `order` prefix serves GET only (`GET /order`, `GET /order/availability`) but was missing from the list. Fixed in the second commit.
- Comment wording broke Simplified Technical English in three places, and one comment named a guard the router tests cannot provide. All fixed in the second commit.
- `src/features/app/routes.ts` grows to 470 lines, past the ~400 line aim. The file was 435 lines before this branch. The check and the prefix table belong together, so a split of the route dispatch file is work for its own change.
- The bare 404 carries no security headers. It has an empty body, so there is nothing to sniff or frame, and the existing error path skips the headers the same way.
- `GET_ONLY_PREFIXES` accepts any string, so a false entry is a runtime failure, not a compile error. The per-prefix tests catch removals and typos, and every writable route has pipeline tests that POST through it.

