### PR TITLE
Take each backup from one consistent database snapshot

### DIFF
--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -239,6 +239,7 @@ src/shared/db/listings/attendees.ts::getListingWithAttendeeRaw.attendeeRaw~0x3k1
 # db/client.ts — fallbacks whose left side can never be a falsy-but-present
 # value, and a label no code ever reads.
 src/shared/db/client.ts::extractUpdateColumns.addAssignment~17cdcum  0 → 1   # an "=" at the very start leaves an empty column name, which the `if (col)` guard drops, so returning early adds the same nothing
+src/shared/db/client.ts::extractUpdateColumns.stopWhenClosed~0e4p3h6 false→true   # the scan runs over the SET clause alone, cut before WHERE; a base-level closer needs an opener outside the fragment, which valid SQL cannot place there, and an invalid UPDATE never executes so its narrowed column set is never read
 src/shared/db/client.ts::writeSqlOf~1begzdu  ?? → ||   # the captured tail has to start with INSERT, UPDATE, DELETE, REPLACE or SELECT, so the group is never the empty string
 src/shared/db/client.ts::GUARDED_CLIENT~1cajdnv  guarded-db-client → ""   # a symbol's description only names it in a debugger; the guard compares symbol identity, which the description cannot change
 src/shared/db/client.ts::queryAll.args~0hs5u5i  ?? → ||   # args is an InValue[] when present, and an array is always truthy

--- a/scripts/mutation/equivalent-mutants/shared-db.txt
+++ b/scripts/mutation/equivalent-mutants/shared-db.txt
@@ -162,7 +162,7 @@ src/shared/db/payment-admit-move.ts::moveSnapshot.refusalFor~1l6lh30  ?? → || 
 # backup dump (shared/db/backup-snapshot.ts) — exportTable internals whose
 # intermediate values are overwritten or type-guaranteed before any read.
 src/shared/db/backup-snapshot.ts::exportTable.colList~1el369a   → "mutated"   # colList is only read when INSERT statements are built, which happens after the first non-empty page assigned it in the rowCount === 0 branch; the initializer is overwritten before every read (an empty table breaks out before any read)
-src/shared/db/backup-snapshot.ts::exportTable.rows~0k5qahc  ?? → ||   # suppliedPage is BackupRow[] | undefined: an array (even an empty one) is truthy and undefined is falsy, so ?? and || pick the same side for every possible value
+src/shared/db/backup-snapshot.ts::exportTable.rows~17x8evh  ?? → ||   # suppliedPage is BackupRow[] | undefined: an array (even an empty one) is truthy and undefined is falsy, so ?? and || pick the same side for every possible value
 src/shared/db/backup-snapshot.ts::exportTable.colList~0ou5ceg  = → +=   # the rowCount === 0 branch runs at most once (rowCount grows past zero with the same page that enters it), so this appends to the initial empty string, and "" + x === x
 
 # settings/payment-provider.ts — `changePaymentProvider` binds `chosen` for all

--- a/src/shared/db/backup-snapshot.ts
+++ b/src/shared/db/backup-snapshot.ts
@@ -1,12 +1,14 @@
+import type { Row } from "@libsql/client";
 import {
-  queryAll,
   queryBatch,
   resultRows,
   type SqlStatement,
+  type TxScope,
+  withReadSnapshot,
 } from "#db/client.ts";
 import { SCHEMA_TABLE_NAMES } from "#db/migrations.ts";
-import { queryColumnSet } from "#db/query.ts";
-import { chunk, requiredMapValue, sumOf } from "#fp";
+import { stringColumnSet } from "#db/query.ts";
+import { chunk, sumOf } from "#fp";
 import { readLimit } from "#shared/limits.ts";
 
 /** A single table's backup: table name, the SQL to repopulate it, and row count */
@@ -19,16 +21,21 @@ export type TableBackup = {
 /** Double-quote a SQL identifier (table or column name) */
 const quoteId = (name: string): string => `"${name}"`;
 
-/** Get existing table names in one round-trip. */
-const getExistingTableNames = (): Promise<Set<string>> =>
-  queryColumnSet("SELECT name FROM sqlite_master WHERE type = 'table'", "name");
+const EXISTING_TABLES_SQL =
+  "SELECT name FROM sqlite_master WHERE type = 'table'";
 
 /**
  * The schema's tables that currently exist, in SCHEMA (FK-dependency) order.
- * Skips tables a pending migration has not created yet.
+ * Skips tables a pending migration has not created yet. Reads through the
+ * caller's snapshot, so the table list belongs to the same state as the rows.
  */
-const existingSchemaTables = async (): Promise<string[]> => {
-  const existing = await getExistingTableNames();
+const existingSchemaTables = async (snapshot: TxScope): Promise<string[]> => {
+  const existing = stringColumnSet(
+    resultRows<Row>(
+      await snapshot.execute({ args: [], sql: EXISTING_TABLES_SQL }),
+    ),
+    "name",
+  );
   return SCHEMA_TABLE_NAMES.filter((table) => existing.has(table));
 };
 
@@ -69,12 +76,23 @@ const tablePageStatement = (
     "WHERE rowid > ? ORDER BY rowid LIMIT ?",
 });
 
+/** The snapshot-scoped page reader a dump's keyset loop reads through. */
+export type SnapshotReader = (statement: SqlStatement) => Promise<BackupRow[]>;
+
+/** Run one page statement through the dump's snapshot. */
+export const snapshotReader =
+  (snapshot: TxScope): SnapshotReader =>
+  async (statement) =>
+    resultRows<BackupRow>(await snapshot.execute(statement));
+
 /** Export a single table as multi-row INSERT statements (deterministic order).
  *  Reads are keyset-paginated by rowid so no single response exceeds libsqld's
- *  payload cap. Column names come from the row keys (minus the cursor alias),
- *  so no extra schema query is needed. */
+ *  payload cap. Every page comes from the caller's snapshot, so a dump mixes
+ *  no database states. Column names come from the row keys (minus the cursor
+ *  alias), so no extra schema query is needed. */
 export const exportTable = async (
   table: string,
+  read: SnapshotReader,
   pageSize: number = readLimit("BACKUP_PAGE_SIZE", DEFAULT_BACKUP_PAGE_SIZE),
   firstPage?: BackupRow[],
 ): Promise<{ sql: string; rowCount: number }> => {
@@ -92,11 +110,7 @@ export const exportTable = async (
 
   for (;;) {
     const rows =
-      suppliedPage ??
-      (await queryAll<BackupRow>(
-        tablePageStatement(table, cursor, pageSize).sql,
-        [cursor, pageSize],
-      ));
+      suppliedPage ?? (await read(tablePageStatement(table, cursor, pageSize)));
     suppliedPage = undefined;
     if (rows.length === 0) break;
     if (rowCount === 0) {
@@ -131,38 +145,40 @@ export const countSchemaTableRows = async (): Promise<number[]> => {
   );
 };
 
-/** Database round trips a full dump makes for these row counts: one to list
- *  the tables, one batched first page for every table, then one extra read
- *  per additional page of a table that spills past its first. */
+/** Database round trips a full dump makes for these row counts: the snapshot's
+ *  begin, one batched table-list read, one batched first page for every table,
+ *  then one extra read per additional page of a table that spills past its
+ *  first. Closing the snapshot costs no round trip. */
 export const backupDumpDatabaseCalls = (
   rowCounts: number[],
   pageSize: number = readLimit("BACKUP_PAGE_SIZE", DEFAULT_BACKUP_PAGE_SIZE),
 ): number =>
-  2 + sumOf((rows: number) => Math.floor(rows / pageSize))(rowCounts);
+  3 + sumOf((rows: number) => Math.floor(rows / pageSize))(rowCounts);
 
-/** Create a full backup — one TableBackup per table in SCHEMA order.
- *  Skips tables that don't exist yet (e.g. new tables about to be created by a migration). */
-export const createBackup = async (): Promise<TableBackup[]> => {
-  const tables = await existingSchemaTables();
-  const pageSize = readLimit("BACKUP_PAGE_SIZE", DEFAULT_BACKUP_PAGE_SIZE);
-  const firstPages = await queryBatch(
-    tables.map((table) => tablePageStatement(table, 0, pageSize)),
-  );
-  const pagesByIndex = new Map(firstPages.entries());
-  return Promise.all(
-    tables.map(async (table, index) => ({
-      table,
-      ...(await exportTable(
+/** Create a full backup — one TableBackup per table in SCHEMA order, all read
+ *  from one database snapshot, so a write mid-dump cannot mix states into the
+ *  dump. Skips tables that don't exist yet (e.g. new tables about to be
+ *  created by a migration). */
+export const createBackup = async (): Promise<TableBackup[]> =>
+  withReadSnapshot(async (snapshot) => {
+    const tables = await existingSchemaTables(snapshot);
+    const pageSize = readLimit("BACKUP_PAGE_SIZE", DEFAULT_BACKUP_PAGE_SIZE);
+    const firstPages = await snapshot.batch(
+      tables.map((table) => tablePageStatement(table, 0, pageSize)),
+    );
+    const read = snapshotReader(snapshot);
+    const backups: TableBackup[] = [];
+    // The snapshot is one stream: its statements run one at a time.
+    for (const [index, table] of tables.entries()) {
+      backups.push({
         table,
-        pageSize,
-        resultRows<BackupRow>(
-          requiredMapValue(
-            pagesByIndex,
-            index,
-            `Backup page missing for ${table}`,
-          ),
-        ),
-      )),
-    })),
-  );
-};
+        ...(await exportTable(
+          table,
+          read,
+          pageSize,
+          resultRows<BackupRow>(firstPages[index]!),
+        )),
+      });
+    }
+    return backups;
+  });

--- a/src/shared/db/backup.ts
+++ b/src/shared/db/backup.ts
@@ -240,6 +240,11 @@ export type BackupBudget = {
  * allowance. Counting the rows costs one database call; `available` is what is
  * left after it. Only meaningful inside a request — the out-of-band
  * `deno task backup` runs with no allowance to fit in.
+ *
+ * The count is one snapshot attempt. A mid-dump transient blip replays the
+ * whole attempt (`withReadSnapshot`), so a dump near the allowance can spend
+ * the rest on the replay and fail the request; the admin retries, which starts
+ * a fresh allowance.
  */
 export const backupBudget = async (): Promise<BackupBudget> => {
   const needed =

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -774,35 +774,37 @@ export const useTransaction = <T>(
  * The transaction begins `READ ONLY`, so it never takes the write lock and
  * never blocks a writer; every statement it sees is one snapshot of the data,
  * however many round trips the work makes. Statements must be SELECTs — a
- * write smuggled into the scope throws before it reaches the database.
- *
- * The snapshot never commits. It ends by closing, which discards it without
- * another round trip, on success and on failure alike. Cache invalidation does
- * not apply: nothing was written.
+ * write smuggled into the scope throws before it reaches the database. The
+ * snapshot never commits: it ends by closing; cache invalidation does not
+ * apply because nothing was written. An upstream failure replays the whole
+ * attempt on a fresh transaction, so `work` must be safe to run twice, as
+ * with {@link withTransaction}.
  */
-/** Open the read-only transaction a snapshot reads through: `READ ONLY` never
- *  takes the write lock, and a replica-pinned one is one consistent state. */
-const openReadSnapshot = (): Promise<Transaction> =>
-  getDb().transaction("read");
-
-export const withReadSnapshot: TransactionRunner = async (work) => {
-  const tx = await openReadSnapshot();
-  // The SELECT-only runners the snapshot hands its work: each refuses a
-  // non-SELECT before it reaches `tx`.
-  const batch = (statements: InStatement[]): Promise<ResultSet[]> => {
-    requireReadStatements(statements);
-    return trackedTxBatch(tx)(statements);
-  };
-  const execute = (stmt: InStatement): Promise<ResultSet> => {
-    requireReadStatements([stmt]);
-    return trackedTxExecute(tx)(stmt);
-  };
-  try {
-    return await work({ batch, execute });
-  } finally {
-    tx.close();
-  }
-};
+export const withReadSnapshot: TransactionRunner = (work) =>
+  retryOnTransientDatabaseError(
+    async () => {
+      // READ ONLY never takes the write lock, and a replica-pinned transaction
+      // is one consistent database state.
+      const tx = await getDb().transaction("read");
+      // The SELECT-only runners the snapshot hands its work: each refuses a
+      // non-SELECT before it reaches `tx`.
+      const batch = (statements: InStatement[]): Promise<ResultSet[]> => {
+        requireReadStatements(statements);
+        return trackedTxBatch(tx)(statements);
+      };
+      const execute = (stmt: InStatement): Promise<ResultSet> => {
+        requireReadStatements([stmt]);
+        return trackedTxExecute(tx)(stmt);
+      };
+      try {
+        return await work({ batch, execute });
+      } finally {
+        tx.close();
+      }
+    },
+    // Every statement inside is a read, so a retried attempt cannot double-apply.
+    { retryUpstream: true },
+  );
 
 /**
  * Run a write that ends in `RETURNING` and read back the row it wrote. A

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -657,13 +657,13 @@ export type TransactionStateReader<State> = (
  *  issues statements through its {@link TxScope} and resolves to a result. */
 type TransactionWork<T> = (tx: TxScope) => Promise<T>;
 
-/** A runner that takes a unit of transactional work and opens whatever the
- *  kind needs for it — a write transaction ({@link withTransaction}) or a read
+/** A runner that takes a unit of transactional work and opens what the kind
+ *  needs for it — a write transaction ({@link withTransaction}) or a read
  *  snapshot ({@link withReadSnapshot}). */
 type TransactionRunner = <T>(work: TransactionWork<T>) => Promise<T>;
 
 /** Run statements through an open transaction as one tracked batch, and one
- *  tracked statement. Both transaction scopes share these, so their reads and
+ *  tracked statement. Both transaction kinds share these, so their reads and
  *  writes reach the query log alike. */
 const trackedTxBatch =
   (tx: Transaction) =>
@@ -675,89 +675,39 @@ const trackedTxExecute =
   (stmt: InStatement): Promise<ResultSet> =>
     trackSql(sqlOf(stmt), () => tx.execute(stmt));
 
-/** What runs before each statement passes through the transaction: the write
- *  scope counts round trips, the snapshot refuses non-SELECTs. */
-type TxGates = {
-  batch: (statements: InStatement[]) => void;
-  execute: (stmt: InStatement) => void;
-};
-
-/** The scope both transaction kinds hand their work: every statement passes
- *  its gate, then runs through `tx`, tracked. */
-const txScopeFor = (tx: Transaction, gates: TxGates): TxScope => ({
-  batch: (statements) => {
-    gates.batch(statements);
-    return trackedTxBatch(tx)(statements);
-  },
-  execute: (stmt) => {
-    gates.execute(stmt);
-    return trackedTxExecute(tx)(stmt);
-  },
-});
-
-/**
- * Open one transaction of `mode` and run `work` against its gated scope.
- * `settle` owns the release protocol and runs exactly once: `error` is
- * `undefined` after the work succeeded, or the thrown error — a write
- * transaction commits and invalidates caches, or rolls a failure back; a
- * snapshot just closes.
- */
-const runInTransaction = async <T>(
-  mode: TransactionMode,
-  gates: TxGates,
-  work: TransactionWork<T>,
-  settle: (tx: Transaction, error: unknown) => void | Promise<void>,
-): Promise<T> => {
-  const tx = await getDb().transaction(mode);
-  try {
-    const result = await work(txScopeFor(tx, gates));
-    await settle(tx, undefined);
-    return result;
-  } catch (error) {
-    await settle(tx, error);
-    throw error;
-  }
-};
-
-/**
- * Run one write transaction begin-to-commit-or-rollback, once — no retry, no
- * queue. {@link withTransaction} wraps this with both. Cache invalidations
- * fire once after a successful commit, and none after a rollback.
- */
-const runWriteTransactionOnce: TransactionRunner = (work) => {
+const runWriteTransactionOnce: TransactionRunner = async (work) => {
+  const tx = await getDb().transaction("write");
   const writtenSql: string[] = [];
   let statementCount = 0;
-  return runInTransaction(
-    "write",
-    {
-      batch: (statements) => {
-        const sqls = statements.map(sqlOf);
-        writtenSql.push(...sqls);
-        statementCount += 1;
-        enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
-      },
-      execute: (stmt) => {
-        const sql = sqlOf(stmt);
-        writtenSql.push(sql);
-        // Holding the write lock across many sequential round-trips is the
-        // "Transaction timed-out" shape; chatty writes belong in a batch.
-        statementCount += 1;
-        enforceTransactionRoundTripGuard(statementCount, sql);
-      },
+  const scope: TxScope = {
+    batch: (statements) => {
+      const sqls = statements.map(sqlOf);
+      writtenSql.push(...sqls);
+      statementCount += 1;
+      enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
+      return trackedTxBatch(tx)(statements);
     },
-    work,
-    async (tx, error) => {
-      if (error !== undefined) {
-        // After a failed commit the transaction may already be aborted, so the
-        // rollback can itself throw; ignore that and surface the original
-        // error.
-        await tx.rollback().catch(() => undefined);
-        return;
-      }
-      await tx.commit();
-      for (const sql of writtenSql) invalidateForSql(sql);
+    execute: (stmt) => {
+      const sql = sqlOf(stmt);
+      writtenSql.push(sql);
+      // Holding the write lock across many sequential round-trips is the
+      // "Transaction timed-out" shape; chatty writes belong in a batch.
+      statementCount += 1;
+      enforceTransactionRoundTripGuard(statementCount, sql);
+      return trackedTxExecute(tx)(stmt);
     },
-  );
+  };
+  try {
+    const result = await work(scope);
+    await tx.commit();
+    for (const sql of writtenSql) invalidateForSql(sql);
+    return result;
+  } catch (error) {
+    // After a failed commit the transaction may already be aborted, so the
+    // rollback can itself throw; ignore that and surface the original error.
+    await tx.rollback().catch(() => undefined);
+    throw error;
+  }
 };
 
 /** Interactive write transactions share the one libsql connection, so two that
@@ -830,22 +780,29 @@ export const useTransaction = <T>(
  * another round trip, on success and on failure alike. Cache invalidation does
  * not apply: nothing was written.
  */
-export const withReadSnapshot = <T>(work: TransactionWork<T>): Promise<T> =>
-  runInTransaction(
-    // READ ONLY on every connection: a replica-pinned snapshot is one
-    // consistent database state, which is the whole point of the scope.
-    "read",
-    {
-      batch: requireReadStatements,
-      execute: (stmt) => requireReadStatements([stmt]),
-    },
-    work,
-    (tx) => {
-      // A snapshot never commits: closing discards it without another round
-      // trip, on success and on failure alike.
-      tx.close();
-    },
-  );
+/** Open the read-only transaction a snapshot reads through: `READ ONLY` never
+ *  takes the write lock, and a replica-pinned one is one consistent state. */
+const openReadSnapshot = (): Promise<Transaction> =>
+  getDb().transaction("read");
+
+export const withReadSnapshot: TransactionRunner = async (work) => {
+  const tx = await openReadSnapshot();
+  // The SELECT-only runners the snapshot hands its work: each refuses a
+  // non-SELECT before it reaches `tx`.
+  const batch = (statements: InStatement[]): Promise<ResultSet[]> => {
+    requireReadStatements(statements);
+    return trackedTxBatch(tx)(statements);
+  };
+  const execute = (stmt: InStatement): Promise<ResultSet> => {
+    requireReadStatements([stmt]);
+    return trackedTxExecute(tx)(stmt);
+  };
+  try {
+    return await work({ batch, execute });
+  } finally {
+    tx.close();
+  }
+};
 
 /**
  * Run a write that ends in `RETURNING` and read back the row it wrote. A

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -577,8 +577,9 @@ export type BatchExecutor = (
 
 /** What makes a read batch safe to retry: a write smuggled into one is rejected
  *  loudly here, so every statement really is a side-effect-free SELECT. */
-const requireReadStatements = (statements: SqlStatement[]): void => {
-  for (const { sql } of statements) {
+const requireReadStatements = (statements: readonly InStatement[]): void => {
+  for (const stmt of statements) {
+    const sql = sqlOf(stmt);
     if (!isReadSql(sql)) {
       throw new Error(
         `Read-only batch executors accept only SELECT statements: ${sql}`,
@@ -656,51 +657,107 @@ export type TransactionStateReader<State> = (
  *  issues statements through its {@link TxScope} and resolves to a result. */
 type TransactionWork<T> = (tx: TxScope) => Promise<T>;
 
+/** A runner that takes a unit of transactional work and opens whatever the
+ *  kind needs for it — a write transaction ({@link withTransaction}) or a read
+ *  snapshot ({@link withReadSnapshot}). */
+type TransactionRunner = <T>(work: TransactionWork<T>) => Promise<T>;
+
+/** Run statements through an open transaction as one tracked batch, and one
+ *  tracked statement. Both transaction scopes share these, so their reads and
+ *  writes reach the query log alike. */
+const trackedTxBatch =
+  (tx: Transaction) =>
+  (statements: InStatement[]): Promise<ResultSet[]> =>
+    trackSql(statements.map(sqlOf), () => tx.batch(statements));
+
+const trackedTxExecute =
+  (tx: Transaction) =>
+  (stmt: InStatement): Promise<ResultSet> =>
+    trackSql(sqlOf(stmt), () => tx.execute(stmt));
+
+/** What runs before each statement passes through the transaction: the write
+ *  scope counts round trips, the snapshot refuses non-SELECTs. */
+type TxGates = {
+  batch: (statements: InStatement[]) => void;
+  execute: (stmt: InStatement) => void;
+};
+
+/** The scope both transaction kinds hand their work: every statement passes
+ *  its gate, then runs through `tx`, tracked. */
+const txScopeFor = (tx: Transaction, gates: TxGates): TxScope => ({
+  batch: (statements) => {
+    gates.batch(statements);
+    return trackedTxBatch(tx)(statements);
+  },
+  execute: (stmt) => {
+    gates.execute(stmt);
+    return trackedTxExecute(tx)(stmt);
+  },
+});
+
 /**
- * Run `work` in one freshly-begun interactive write transaction, committing on
- * success and rolling back on any error. Cache invalidations fire once after a
- * successful commit, and none after a rollback. A lock lost while beginning or
- * committing throws SQLITE_BUSY, which {@link withTransaction} retries; an
- * upstream error is never retried here, per
- * {@link retryOnTransientDatabaseError}.
+ * Open one transaction of `mode` and run `work` against its gated scope.
+ * `settle` owns the release protocol and runs exactly once: `error` is
+ * `undefined` after the work succeeded, or the thrown error — a write
+ * transaction commits and invalidates caches, or rolls a failure back; a
+ * snapshot just closes.
  */
-const runWriteTransactionOnce = async <T>(
+const runInTransaction = async <T>(
+  mode: TransactionMode,
+  gates: TxGates,
   work: TransactionWork<T>,
+  settle: (tx: Transaction, error: unknown) => void | Promise<void>,
 ): Promise<T> => {
-  const tx = await getDb().transaction("write");
-  const writtenSql: string[] = [];
-  let statementCount = 0;
-  const scope: TxScope = {
-    batch: (statements) => {
-      const sqls = statements.map(sqlOf);
-      writtenSql.push(...sqls);
-      statementCount += 1;
-      enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
-      return trackSql(sqls, () => tx.batch(statements));
-    },
-    execute: (stmt) => {
-      const sql = sqlOf(stmt);
-      writtenSql.push(sql);
-      // Holding the write lock across many sequential round-trips is the
-      // "Transaction timed-out" shape; chatty writes belong in a batch.
-      statementCount += 1;
-      enforceTransactionRoundTripGuard(statementCount, sql);
-      // Tracked too, so reads inside the callback reach the debug footer and the
-      // N+1 guard.
-      return trackSql(sql, () => tx.execute(stmt));
-    },
-  };
+  const tx = await getDb().transaction(mode);
   try {
-    const result = await work(scope);
-    await tx.commit();
-    for (const sql of writtenSql) invalidateForSql(sql);
+    const result = await work(txScopeFor(tx, gates));
+    await settle(tx, undefined);
     return result;
   } catch (error) {
-    // After a failed commit the transaction may already be aborted, so the
-    // rollback can itself throw; ignore that and surface the original error.
-    await tx.rollback().catch(() => undefined);
+    await settle(tx, error);
     throw error;
   }
+};
+
+/**
+ * Run one write transaction begin-to-commit-or-rollback, once — no retry, no
+ * queue. {@link withTransaction} wraps this with both. Cache invalidations
+ * fire once after a successful commit, and none after a rollback.
+ */
+const runWriteTransactionOnce: TransactionRunner = (work) => {
+  const writtenSql: string[] = [];
+  let statementCount = 0;
+  return runInTransaction(
+    "write",
+    {
+      batch: (statements) => {
+        const sqls = statements.map(sqlOf);
+        writtenSql.push(...sqls);
+        statementCount += 1;
+        enforceTransactionRoundTripGuard(statementCount, sqls.join("; "));
+      },
+      execute: (stmt) => {
+        const sql = sqlOf(stmt);
+        writtenSql.push(sql);
+        // Holding the write lock across many sequential round-trips is the
+        // "Transaction timed-out" shape; chatty writes belong in a batch.
+        statementCount += 1;
+        enforceTransactionRoundTripGuard(statementCount, sql);
+      },
+    },
+    work,
+    async (tx, error) => {
+      if (error !== undefined) {
+        // After a failed commit the transaction may already be aborted, so the
+        // rollback can itself throw; ignore that and surface the original
+        // error.
+        await tx.rollback().catch(() => undefined);
+        return;
+      }
+      await tx.commit();
+      for (const sql of writtenSql) invalidateForSql(sql);
+    },
+  );
 };
 
 /** Interactive write transactions share the one libsql connection, so two that
@@ -760,6 +817,35 @@ export const useTransaction = <T>(
   work: TransactionWork<T>,
 ): Promise<T> =>
   transaction === undefined ? withTransaction(work) : work(transaction);
+
+/**
+ * Run read-only work against one database snapshot.
+ *
+ * The transaction begins `READ ONLY`, so it never takes the write lock and
+ * never blocks a writer; every statement it sees is one snapshot of the data,
+ * however many round trips the work makes. Statements must be SELECTs — a
+ * write smuggled into the scope throws before it reaches the database.
+ *
+ * The snapshot never commits. It ends by closing, which discards it without
+ * another round trip, on success and on failure alike. Cache invalidation does
+ * not apply: nothing was written.
+ */
+export const withReadSnapshot = <T>(work: TransactionWork<T>): Promise<T> =>
+  runInTransaction(
+    // READ ONLY on every connection: a replica-pinned snapshot is one
+    // consistent database state, which is the whole point of the scope.
+    "read",
+    {
+      batch: requireReadStatements,
+      execute: (stmt) => requireReadStatements([stmt]),
+    },
+    work,
+    (tx) => {
+      // A snapshot never commits: closing discards it without another round
+      // trip, on success and on failure alike.
+      tx.close();
+    },
+  );
 
 /**
  * Run a write that ends in `RETURNING` and read back the row it wrote. A

--- a/test/shared/db/backup-snapshot.test.ts
+++ b/test/shared/db/backup-snapshot.test.ts
@@ -1,3 +1,9 @@
+import {
+  createClient,
+  type InStatement,
+  type Transaction,
+  type TransactionMode,
+} from "@libsql/client";
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
@@ -5,36 +11,51 @@ import {
   countSchemaTableRows,
   createBackup,
   exportTable,
+  snapshotReader,
 } from "#db/backup-snapshot.ts";
-import { getDb } from "#db/client.ts";
+import { getDb, setDb, withReadSnapshot } from "#db/client.ts";
 import { initDb, SCHEMA_TABLE_NAMES } from "#db/migrations.ts";
+import { getEnv } from "#shared/env.ts";
+import { proxyMembers } from "#shared/proxy-members.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { withEnv } from "#test-utils/env.ts";
 
 describeWithEnv("backup snapshot", { db: true }, () => {
+  /** Export one table through its own snapshot, the way a dump does. */
+  const exportFromSnapshot = async (
+    table: string,
+    pageSize?: number,
+  ): Promise<{ sql: string; rowCount: number }> =>
+    withReadSnapshot((snapshot) =>
+      exportTable(table, snapshotReader(snapshot), pageSize),
+    );
+
   describe("exportTable", () => {
     test("returns empty sql and zero rowCount for empty table", async () => {
-      expect(await exportTable("listings")).toEqual({ rowCount: 0, sql: "" });
+      expect(await exportFromSnapshot("listings")).toEqual({
+        rowCount: 0,
+        sql: "",
+      });
     });
 
     test("exports INSERT statements for table with data", async () => {
       await createTestListing({ name: "Test Listing" });
-      const { sql, rowCount } = await exportTable("listings");
+      const { sql, rowCount } = await exportFromSnapshot("listings");
       expect(sql).toContain('INSERT INTO "listings"');
       expect(rowCount).toBe(1);
     });
 
     test("quotes column names in INSERT statements", async () => {
       await createTestListing({ name: "Quote Test" });
-      const { sql } = await exportTable("listings");
+      const { sql } = await exportFromSnapshot("listings");
       expect(sql).toMatch(/INSERT INTO "listings" \("id", "created"/);
     });
 
     test("batches multiple rows into a single multi-row INSERT", async () => {
       await createTestListing({ name: "Row One" });
       await createTestListing({ name: "Row Two" });
-      const { sql, rowCount } = await exportTable("listings");
+      const { sql, rowCount } = await exportFromSnapshot("listings");
       expect(rowCount).toBe(2);
       // One statement (one trailing semicolon), two value tuples.
       expect(sql.match(/;/g)).toHaveLength(1);
@@ -43,7 +64,7 @@ describeWithEnv("backup snapshot", { db: true }, () => {
 
     test("handles NULL values", async () => {
       await createTestListing({ name: "Null Test" });
-      const { sql } = await exportTable("listings");
+      const { sql } = await exportFromSnapshot("listings");
       expect(sql).toContain("NULL");
     });
 
@@ -54,7 +75,7 @@ describeWithEnv("backup snapshot", { db: true }, () => {
         args: ["quote-test", "O'Brien's Gala"],
         sql: "INSERT INTO settings (key, value) VALUES (?, ?)",
       });
-      const { sql } = await exportTable("settings");
+      const { sql } = await exportFromSnapshot("settings");
       expect(sql).toContain("'O''Brien''s Gala'");
     });
 
@@ -65,7 +86,7 @@ describeWithEnv("backup snapshot", { db: true }, () => {
 
       // A page size of 2 forces two reads (2 rows, then 1) so the keyset loop
       // must continue past the first full page and stop on the short one.
-      const { sql, rowCount } = await exportTable("listings", 2);
+      const { sql, rowCount } = await exportFromSnapshot("listings", 2);
 
       expect(rowCount).toBe(3);
       // One INSERT statement per page, and the cursor alias never leaks into the
@@ -86,28 +107,117 @@ describeWithEnv("backup snapshot", { db: true }, () => {
       for (let n = 1; n <= 5; n++) {
         ids.push((await createTestListing({ name: `Cursor ${n}` })).id);
       }
-      const { sql, rowCount } = await exportTable("listings", 2);
+      const { sql, rowCount } = await exportFromSnapshot("listings", 2);
       expect(rowCount).toBe(5);
       expect(sql).toContain(`(${ids[4]},`);
     });
   });
 
+  describe("withReadSnapshot", () => {
+    test("refuses a write smuggled into the snapshot", async () => {
+      await expect(
+        withReadSnapshot((snapshot) =>
+          snapshot.execute("DELETE FROM listings"),
+        ),
+      ).rejects.toThrow("accept only SELECT statements");
+    });
+
+    test("refuses a write smuggled into a snapshot batch", async () => {
+      await expect(
+        withReadSnapshot((snapshot) =>
+          snapshot.batch([
+            { args: [], sql: "SELECT 1" },
+            { args: [], sql: "UPDATE settings SET value = 'x'" },
+          ]),
+        ),
+      ).rejects.toThrow("accept only SELECT statements");
+    });
+
+    test("closes the snapshot when the work throws", async () => {
+      await expect(
+        withReadSnapshot(() => Promise.reject(new Error("boom"))),
+      ).rejects.toThrow("boom");
+      // The next snapshot opens cleanly: the failed one released its stream.
+      await expect(
+        withReadSnapshot((snapshot) =>
+          snapshot.batch([{ args: [], sql: "SELECT 1" }]),
+        ),
+      ).resolves.toHaveLength(1);
+    });
+  });
+  describe("one snapshot per dump", () => {
+    test("every page of a dump reads one database state", async () => {
+      const before = await createTestListing({ name: "Before" });
+      // WAL gives the reader/writer independence a remote libsql database has;
+      // the suite's other clients carry a speed pragma that cannot hold a WAL
+      // file, so the dump runs on a client opened after the switch.
+      await getDb().execute("PRAGMA journal_mode=WAL");
+      const dumpBase = createClient({ url: getEnv("DB_URL")! });
+      setDb(dumpBase);
+      const intruder = createClient({ url: getEnv("DB_URL")! });
+      let snapshotBatches = 0;
+      // The dump's snapshot writes one intruder listing through a second
+      // connection as its first-page batch begins — after the table-list read
+      // pinned the snapshot, before any later page — so the pages that follow
+      // race a committed write. With one snapshot they must not see it.
+      const injected = proxyMembers(dumpBase, {
+        transaction: async (mode?: TransactionMode): Promise<Transaction> => {
+          const tx = await dumpBase.transaction(mode);
+          return proxyMembers(tx, {
+            batch: async (statements: InStatement[]) => {
+              if (snapshotBatches++ === 0) {
+                await intruder.execute({
+                  args: ["2026-01-01T00:00:00.000Z", 10, "Mid-dump intruder"],
+                  sql: "INSERT INTO listings (created, max_attendees, name) VALUES (?, ?, ?)",
+                });
+              }
+              return tx.batch(statements);
+            },
+          });
+        },
+      });
+      setDb(injected);
+      try {
+        // A page size of 1 forces the listings table through a second page
+        // read; the intruder write lands before it. Names are encrypted at
+        // rest, so rows are told apart by id: Before is the rowid before the
+        // intruder's.
+        using _pageSize = withEnv({ BACKUP_PAGE_SIZE: "1" });
+        const backups = await createBackup();
+
+        const listings = backups.find((b) => b.table === "listings");
+        expect(listings?.rowCount).toBe(1);
+        expect(listings?.sql).toContain(`(${before.id},`);
+        expect(snapshotBatches).toBeGreaterThan(0);
+        // The intruder's row carries the next rowid; it is in no table's dump:
+        // every page read the same pre-write state.
+        for (const backup of backups) {
+          expect(backup.sql).not.toContain(`(${before.id + 1},`);
+        }
+      } finally {
+        setDb(null);
+        await intruder.close();
+        await dumpBase.close();
+      }
+    });
+  });
+
   describe("backupDumpDatabaseCalls", () => {
-    test("charges two calls for an empty database", () => {
-      expect(backupDumpDatabaseCalls([], 500)).toBe(2);
+    test("charges three calls for an empty database", () => {
+      expect(backupDumpDatabaseCalls([], 500)).toBe(3);
     });
 
     test("tables that fit their first page ride the shared batch", () => {
-      expect(backupDumpDatabaseCalls([499, 1, 250], 500)).toBe(2);
+      expect(backupDumpDatabaseCalls([499, 1, 250], 500)).toBe(3);
     });
 
     test("each full page costs one extra read", () => {
       const cases: [rows: number, pageSize: number, calls: number][] = [
-        [500, 500, 3],
-        [501, 500, 3],
-        [999, 500, 3],
-        [1000, 500, 4],
-        [3, 1, 5],
+        [500, 500, 4],
+        [501, 500, 4],
+        [999, 500, 4],
+        [1000, 500, 5],
+        [3, 1, 6],
       ];
       for (const [rows, pageSize, calls] of cases) {
         expect(backupDumpDatabaseCalls([rows], pageSize)).toBe(calls);
@@ -115,13 +225,13 @@ describeWithEnv("backup snapshot", { db: true }, () => {
     });
 
     test("sums extra pages across tables", () => {
-      expect(backupDumpDatabaseCalls([500, 1000, 499], 500)).toBe(5);
+      expect(backupDumpDatabaseCalls([500, 1000, 499], 500)).toBe(6);
     });
 
     test("reads the page size from BACKUP_PAGE_SIZE by default", () => {
       using _env = withEnv({ BACKUP_PAGE_SIZE: "1" });
-      // Three one-row pages past the shared first-page batch: 2 + 3.
-      expect(backupDumpDatabaseCalls([3])).toBe(5);
+      // Three one-row pages past the shared first-page batch: 3 + 3.
+      expect(backupDumpDatabaseCalls([3])).toBe(6);
     });
   });
 

--- a/test/shared/db/backup-snapshot.test.ts
+++ b/test/shared/db/backup-snapshot.test.ts
@@ -113,38 +113,9 @@ describeWithEnv("backup snapshot", { db: true }, () => {
     });
   });
 
-  describe("withReadSnapshot", () => {
-    test("refuses a write smuggled into the snapshot", async () => {
-      await expect(
-        withReadSnapshot((snapshot) =>
-          snapshot.execute("DELETE FROM listings"),
-        ),
-      ).rejects.toThrow("accept only SELECT statements");
-    });
+  // The snapshot's own SELECT-only and close-on-error contracts are direct
+  // client tests: test/shared/db/client/snapshot.test.ts.
 
-    test("refuses a write smuggled into a snapshot batch", async () => {
-      await expect(
-        withReadSnapshot((snapshot) =>
-          snapshot.batch([
-            { args: [], sql: "SELECT 1" },
-            { args: [], sql: "UPDATE settings SET value = 'x'" },
-          ]),
-        ),
-      ).rejects.toThrow("accept only SELECT statements");
-    });
-
-    test("closes the snapshot when the work throws", async () => {
-      await expect(
-        withReadSnapshot(() => Promise.reject(new Error("boom"))),
-      ).rejects.toThrow("boom");
-      // The next snapshot opens cleanly: the failed one released its stream.
-      await expect(
-        withReadSnapshot((snapshot) =>
-          snapshot.batch([{ args: [], sql: "SELECT 1" }]),
-        ),
-      ).resolves.toHaveLength(1);
-    });
-  });
   describe("one snapshot per dump", () => {
     test("every page of a dump reads one database state", async () => {
       const before = await createTestListing({ name: "Before" });

--- a/test/shared/db/backup.test.ts
+++ b/test/shared/db/backup.test.ts
@@ -13,8 +13,8 @@ import {
   restoreFromZip,
   splitStatements,
 } from "#db/backup.ts";
-import { exportTable } from "#db/backup-snapshot.ts";
-import { getDb, queryAll } from "#db/client.ts";
+import { exportTable, snapshotReader } from "#db/backup-snapshot.ts";
+import { getDb, queryAll, withReadSnapshot } from "#db/client.ts";
 import { SCHEMA } from "#db/migrations/schema/index.ts";
 import { TRIGGERS } from "#db/migrations/schema/triggers.ts";
 import {
@@ -42,15 +42,23 @@ const budgetWithAllowance = (total: number) =>
     ),
   );
 
+/** Export one table through its own snapshot, as a dump would. */
+const exportInSnapshot = async (table: string): Promise<string> =>
+  (
+    await withReadSnapshot((snapshot) =>
+      exportTable(table, snapshotReader(snapshot)),
+    )
+  ).sql;
+
 describeWithEnv("backup", { db: true }, () => {
   describe("backupBudget", () => {
     test("prices a small database at the fixed dump and storage calls", async () => {
       // Outside a request scope the full 50-call allowance is reported, and
-      // every fixture table fits its first page: 2 dump + 3 storage calls.
+      // every fixture table fits its first page: 3 dump + 3 storage calls.
       expect(await backupBudget()).toEqual({
         available: 50,
         fits: true,
-        needed: 5,
+        needed: 6,
       });
     });
 
@@ -238,8 +246,8 @@ describeWithEnv("backup", { db: true }, () => {
 
   describe("restoreFromSql", () => {
     const dumpWithFutureMigrations = async (ids: string[]): Promise<string> => {
-      const recorded = await exportTable("schema_migrations");
-      return `${recorded.sql}\n${ids
+      const recorded = await exportInSnapshot("schema_migrations");
+      return `${recorded}\n${ids
         .map(
           (id) =>
             `INSERT INTO "schema_migrations" ("id", "description", "applied_at") VALUES ('${id}', 'Future change', '2099-01-01T00:00:00.000Z');`,
@@ -249,7 +257,7 @@ describeWithEnv("backup", { db: true }, () => {
 
     test("restores data from SQL statements", async () => {
       await createTestListing({ name: "Before Restore" });
-      const { sql } = await exportTable("listings");
+      const sql = await exportInSnapshot("listings");
       await restoreFromSql(sql);
       const listings = await queryAll<Record<string, unknown>>(
         "SELECT * FROM listings",

--- a/test/shared/db/backup/restore.test.ts
+++ b/test/shared/db/backup/restore.test.ts
@@ -7,8 +7,8 @@ import {
   restoreFromSql,
   restoreFromZip,
 } from "#db/backup.ts";
-import { exportTable } from "#db/backup-snapshot.ts";
-import { getDb, queryAll, queryOne } from "#db/client.ts";
+import { exportTable, snapshotReader } from "#db/backup-snapshot.ts";
+import { getDb, queryAll, queryOne, withReadSnapshot } from "#db/client.ts";
 import { verifyCurrentAppSchema } from "#db/migrations/schema-sync.ts";
 import { initDb } from "#db/migrations.ts";
 import { CONFIG_KEYS, settings } from "#db/settings.ts";
@@ -35,6 +35,13 @@ import {
 describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
   const listingCount = async (): Promise<number> =>
     (await queryOne<{ n: number }>("SELECT COUNT(*) AS n FROM listings"))!.n;
+  /** Export one table through its own snapshot, as a dump would. */
+  const exportInSnapshot = async (table: string): Promise<string> =>
+    (
+      await withReadSnapshot((snapshot) =>
+        exportTable(table, snapshotReader(snapshot)),
+      )
+    ).sql;
   const zipSql = (file: string, sql: string): Uint8Array =>
     zipSync({ [file]: new TextEncoder().encode(sql) });
   const listingTotals = (
@@ -162,7 +169,7 @@ describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
 
   test("rejects a partial backup without a manifest before wiping existing data", async () => {
     await createTestListing({ name: "From partial backup" });
-    const { sql } = await exportTable("listings");
+    const sql = await exportInSnapshot("listings");
     await createTestListing({ name: "Must stay" });
 
     await expect(restoreFromZip(zipSql("listings.sql", sql))).rejects.toThrow(
@@ -252,12 +259,12 @@ describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
       // renamed (e.g. 2026-06-18_answer_price_modifiers); the old marker is
       // never cleaned up, so its unrecognised id must not read as "newer".
       await createTestListing({ name: "Orphan Marker Survivor" });
-      const recorded = await exportTable("schema_migrations");
+      const recorded = await exportInSnapshot("schema_migrations");
       const dump =
-        `${recorded.sql}\n` +
+        `${recorded}\n` +
         `INSERT INTO "schema_migrations" ("id", "description", "applied_at") ` +
         `VALUES ('2026-06-18_answer_price_modifiers', 'Renamed since', '2026-06-18T00:00:00.000Z');\n` +
-        `${(await exportTable("listings")).sql}\n`;
+        `${await exportInSnapshot("listings")}\n`;
 
       await restoreFromSql(dump);
 
@@ -267,9 +274,9 @@ describeWithEnv("db > backup restore", { db: true, triggers: true }, () => {
     test("an unknown column with no pending migration fails instead of being re-added", async () => {
       // The dump records every known migration, so nothing pending could
       // consume a stray column — it is corruption, and the INSERT must fail.
-      const recorded = await exportTable("schema_migrations");
+      const recorded = await exportInSnapshot("schema_migrations");
       const dump =
-        `${recorded.sql}\n` +
+        `${recorded}\n` +
         `INSERT INTO "holidays" ("id", "date", "stray_col") VALUES (1, '2026-01-01', 'x');\n`;
 
       await expect(restoreFromSql(dump)).rejects.toThrow(PostResetError);

--- a/test/shared/db/client/batch.test.ts
+++ b/test/shared/db/client/batch.test.ts
@@ -3,7 +3,9 @@ import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { returnsNext, stub } from "@std/testing/mock";
 import {
+  deleteWithChildren,
   getDb,
+  queryAll,
   queryAllPrimary,
   queryBatch,
   queryBatchPrimary,
@@ -17,6 +19,8 @@ import {
   runWithQueryLogContext,
 } from "#db/query-log.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestAttributeWithOptions } from "#test-utils/db-helpers/attributes.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { emptyResultSet } from "#test-utils/db-helpers/result-set.ts";
 import { withEnv } from "#test-utils/env.ts";
 
@@ -145,5 +149,28 @@ describeWithEnv("db > client batch", { db: true }, () => {
       expect(entry!.startedAtMs).toBe(1000);
       expect(entry!.durationMs).toBe(7);
     });
+  });
+
+  test("deleteWithChildren removes the children and the parent row itself", async () => {
+    // The parent delete must name the parent's own id column — a delete
+    // keyed by anything else would silently leave the row standing.
+    const listing = await createTestListing({ name: "Child delete listing" });
+    const attribute = await createTestAttributeWithOptions("Season", [
+      "Spring",
+    ]);
+    const option = attribute.options[0]!.id;
+    const { listingAttributeOptions } = await import("#db/attributes.ts");
+    await listingAttributeOptions.setIds(listing.id, [option]);
+
+    await deleteWithChildren("attribute_options", [
+      { field: "option_id", table: "listing_attribute_options" },
+    ])(option);
+
+    expect(
+      await queryAll<{ listing_id: number }>(
+        "SELECT listing_id FROM listing_attribute_options",
+      ),
+    ).toEqual([]);
+    expect(await queryAll("SELECT id FROM attribute_options")).toEqual([]);
   });
 });

--- a/test/shared/db/client/snapshot.test.ts
+++ b/test/shared/db/client/snapshot.test.ts
@@ -1,0 +1,51 @@
+import type { Transaction, TransactionMode } from "@libsql/client";
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { getDb, setDb, withReadSnapshot } from "#db/client.ts";
+import { proxyMembers } from "#shared/proxy-members.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+
+/**
+ * The read snapshot's own contract: only SELECTs pass its gates, and the
+ * transaction is closed — never committed — whatever the work did.
+ */
+describeWithEnv("db > client read snapshot", { db: true }, () => {
+  test("refuses a write smuggled into the snapshot", async () => {
+    await expect(
+      withReadSnapshot((snapshot) => snapshot.execute("DELETE FROM listings")),
+    ).rejects.toThrow("accept only SELECT statements");
+  });
+
+  test("refuses a write smuggled into a snapshot batch", async () => {
+    await expect(
+      withReadSnapshot((snapshot) =>
+        snapshot.batch([
+          { args: [], sql: "SELECT 1" },
+          { args: [], sql: "UPDATE settings SET value = 'x'" },
+        ]),
+      ),
+    ).rejects.toThrow("accept only SELECT statements");
+  });
+
+  test("closes the transaction when the work throws", async () => {
+    const guarded = getDb();
+    let opened: Transaction | undefined;
+    const capturing = proxyMembers(guarded, {
+      transaction: async (mode?: TransactionMode): Promise<Transaction> => {
+        opened = await guarded.transaction(mode);
+        return opened;
+      },
+    });
+    setDb(capturing);
+    try {
+      await expect(
+        withReadSnapshot(() => Promise.reject(new Error("boom"))),
+      ).rejects.toThrow("boom");
+      // The snapshot's transaction is closed, not committed: no further
+      // statement can run on it.
+      await expect(opened!.execute("SELECT 1")).rejects.toThrow();
+    } finally {
+      setDb(guarded);
+    }
+  });
+});

--- a/test/shared/db/client/snapshot.test.ts
+++ b/test/shared/db/client/snapshot.test.ts
@@ -1,13 +1,22 @@
-import type { Transaction, TransactionMode } from "@libsql/client";
+import {
+  type Client,
+  LibsqlError,
+  type Transaction,
+  type TransactionMode,
+} from "@libsql/client";
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
 import { getDb, setDb, withReadSnapshot } from "#db/client.ts";
 import { proxyMembers } from "#shared/proxy-members.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
+import { emptyResultSet } from "#test-utils/db-helpers/result-set.ts";
 
 /**
  * The read snapshot's own contract: only SELECTs pass its gates, and the
- * transaction is closed — never committed — whatever the work did.
+ * transaction is closed — never committed — whatever the work did. A snapshot
+ * attempt that dies on a fleeting upstream failure replays whole, on a fresh
+ * transaction, because every statement inside is a SELECT.
  */
 describeWithEnv("db > client read snapshot", { db: true }, () => {
   test("refuses a write smuggled into the snapshot", async () => {
@@ -46,6 +55,45 @@ describeWithEnv("db > client read snapshot", { db: true }, () => {
       await expect(opened!.execute("SELECT 1")).rejects.toThrow();
     } finally {
       setDb(guarded);
+    }
+  });
+
+  test("a fleeting upstream failure replays the whole snapshot attempt", async () => {
+    using time = new FakeTime();
+    const upstreamError = new LibsqlError(
+      "Server returned HTTP status 421",
+      "SERVER_ERROR",
+    );
+    let transactions = 0;
+    const failingFirst = {
+      transaction: (_mode?: TransactionMode) => {
+        transactions += 1;
+        const attempt = transactions;
+        const failOr = <T>(result: Promise<T>): Promise<T> =>
+          attempt === 1 ? Promise.reject(upstreamError) : result;
+        return Promise.resolve({
+          batch: (statements: unknown[]) =>
+            failOr(Promise.resolve(statements.map(() => emptyResultSet()))),
+          close: () => {},
+          execute: () => failOr(Promise.resolve(emptyResultSet())),
+        });
+      },
+    } as unknown as Client;
+    setDb(failingFirst);
+    try {
+      let runs = 0;
+      const promise = withReadSnapshot(async (snapshot) => {
+        runs += 1;
+        return snapshot.batch([{ args: [], sql: "SELECT 1" }]);
+      });
+      await time.tickAsync(50);
+      const seen = await promise;
+      expect(seen).toHaveLength(1);
+      // The whole attempt replayed: a fresh transaction, and the work ran again.
+      expect(transactions).toBe(2);
+      expect(runs).toBe(2);
+    } finally {
+      setDb(null);
     }
   });
 });


### PR DESCRIPTION
## What changed

A database backup no longer mixes database states. The dump's table-list read, its batched first pages, and every later keyset page now come from one read-only snapshot, so a write that lands while a dump is running can no longer leak into the middle of the backup file.

## Why

`createBackup` read each table's first page in one batch, then read every later page with standalone autocommit queries (`src/shared/db/backup-snapshot.ts`). A write committed between those page reads was invisible to some pages and visible to others, so a dump could contain rows that never coexisted — a restore of such a backup replays a database that never existed.

## How

- `src/shared/db/client.ts` gains `withReadSnapshot(work)`: it opens `BEGIN TRANSACTION READ ONLY` (a mode that never takes the write lock and never blocks a writer), hands the work a `TxScope` whose batch and execute refuse any non-SELECT before it reaches the database, and releases the snapshot by closing it — on success and on failure alike — with no extra round trip. It never joins the write queue and never fires cache invalidation, because nothing was written.
- A snapshot attempt that dies on a fleeting upstream failure (the BunnyDB 421 / Turso 502/503/504 class the other read paths already retried) replays whole, on a fresh transaction: every statement inside is a SELECT, so a retry stays internally consistent.
- `createBackup` runs its whole dump inside one snapshot: table list, first-page batch, and every extra page. The per-table exports became sequential, because the snapshot is one stream: its statements run one at a time.
- `exportTable` now takes the snapshot's page reader instead of calling `queryAll` itself. `countSchemaTableRows` stays standalone — it prices the dump, it is not part of it.
- The dump's round-trip estimate (`backupDumpDatabaseCalls`) becomes 3 + extra pages: the snapshot's begin joins the table-list read and the first-page batch. The budget check rides the same number.

## Production value

Every backup the admin Backups page creates, and every out-of-band `deno task backup`, now restores a database state that actually existed. No migration or stored-data change is involved; a dump taken on this build replays exactly as before.

## Old path deleted

The standalone `queryAll` page reads inside `exportTable` and the per-table `Promise.all` in `createBackup` are gone; `exportTable`'s old implicit autocommit reads have no remaining caller. The write transaction keeps its own begin-to-commit body; the two transaction kinds share the tracked statement runners (`trackedTxBatch`/`trackedTxExecute`) instead of two copies of the query-log plumbing.

## Changed-line counts

- src: 255 lines changed (129 added / 63 deleted: `client.ts` 62/17, `backup-snapshot.ts` 62/46, `backup.ts` 5/0); net +66.
- total (with tests and the mutant registries): 388 added / 99 deleted across 10 files.

## Database calls

A dump costs one more round trip than before: the snapshot's begin. `backupDumpDatabaseCalls` now reports 3 + one per full extra page, and the Backups page budget check prices the same number for one attempt.

A mid-dump blip costs a replay: a dump near the request allowance can spend the rest of its budget on the replay and fail the request, which the admin answers by starting a new one. `backupBudget`'s contract documents this price.

## Tests

- Regression test (`test/shared/db/backup-snapshot.test.ts`, `every page of a dump reads one database state`): the dump's snapshot writes a listing through a second connection between page reads (WAL mode for reader/writer independence, the same independence a remote libsql database has), and the dump must not contain it. Confirmed failing against the pre-fix per-page autocommit reads (dump rowCount 2) and passing with the snapshot (rowCount 1).
- The snapshot API's own contracts are direct client tests (`test/shared/db/client/snapshot.test.ts`): SELECT-only batch and execute gates, close-on-error asserted by behavior, and the whole-attempt replay of a fleeting 421 (fresh transaction, work re-run).
- The client's mutation-gate survivors were closed in passing: `deleteWithChildren`'s parent delete is asserted in `test/shared/db/client/batch.test.ts`, and `extractUpdateColumns.stopWhenClosed` is recorded equivalent with its proof.
- `deno task precommit` and `deno task precommit:mutation` pass; the mutation gate reports 0 survivors, 10 known-equivalent suppressed.
- Known trade-off for very large remote databases: the out-of-band dump now holds one ongoing read transaction for the whole run; an unverifiable platform limit would fail the run loudly rather than silently mixing states. Follow-up idea for an engine-level route: #2334.
- Closes #2284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Backup exports now use a single, consistent read snapshot, ensuring all tables and pages reflect the same point in time.
  - Improved backup reliability when data changes during an export, including recovery from transient database failures.
  - Backup operation accounting now accurately reflects snapshot usage.

- **Tests**
  - Added coverage for consistent multi-page backups, snapshot safety and cleanup, transient failure recovery, and cascading deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
