### PR TITLE
Delete the ledger exports no rule asks for

### DIFF
--- a/scripts/cpd-renamed/allowed.json
+++ b/scripts/cpd-renamed/allowed.json
@@ -528,14 +528,6 @@
     "secondStart": 136
   },
   {
-    "first": "src/shared/ledger/project.ts",
-    "firstStart": 41,
-    "hash": "bdc331c52b2bc3274b9932d5a6281d066002238233f2cbe972d6a2ab55436859",
-    "reason": "the curried tail is the ledger projection convention; both bodies already read through the one balanceOf fold, and the negation is the cost operation itself, not a liftable parameter",
-    "second": "src/shared/ledger/project.ts",
-    "secondStart": 47
-  },
-  {
     "first": "src/shared/payment-idempotency.ts",
     "firstStart": 15,
     "hash": "dda5ab07c7e1887dea8761dbe94db053dc28ab1876646f6896e57300f7b71cc2",

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -36,7 +36,6 @@ src/shared/ledger/reconcile.ts::multisetDiff~06icm7q  ?? → ||   # multisetDiff
 src/shared/ledger/reconcile.ts::multisetDiff.count~06icm7q  ?? → ||   # multisetDiff: Map<string,number>.get count; 0 ?? 0 === 0 || 0
 src/shared/ledger/reconcile.ts::reconcileLegs.want~1kc2onf  ?? → ||   # expected.get(): LegFingerprint[]|undefined — an array is always truthy
 src/shared/ledger/reconcile.ts::reconcileLegs.got~15zy9vn  ?? → ||   # observed.get(): LegFingerprint[]|undefined — an array is always truthy
-src/shared/ledger/reverse.ts::reverseOf.memo~0ibvp6e  ?? → ||   # reverseOf memo: string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/mappers.ts::refundKind~1mw4vn3  ?? → ||   # REFUND_KIND[kind]: every value is non-empty and a miss is undefined — never "", so ?? and || coincide
 src/shared/accounting/mappers.ts::mapRefund.kind~0rfpt43  ?? → ||   # refundKind(leg.kind ?? ""): string|undefined, only falsy-non-null is "" and "" ?? "" === "" || ""
 src/shared/accounting/store.ts::planGroup.existing~1qc9xlq  ?? → ||   # planGroup existingByGroup.get(): Transfer[]|undefined — an array is always truthy

--- a/src/shared/ledger/project.ts
+++ b/src/shared/ledger/project.ts
@@ -5,11 +5,9 @@
  * carry or compare.
  */
 
-import { costAccount, revenueAccount } from "#accounting/accounts.ts";
 import { filter } from "#fp";
-import { instantToEpochMs, isInstant } from "#shared/validation/timestamp.ts";
+import { instantToEpochMs } from "#shared/validation/timestamp.ts";
 import { accountKey, sameAccount } from "./account.ts";
-import { legMatches, sumLegs } from "./legs.ts";
 import type { AccountRef, Transfer } from "./types.ts";
 
 /** Every account's balance, keyed by {@link accountKey}. */
@@ -36,52 +34,6 @@ export const balanceOf =
   (acct: AccountRef) =>
   (transfers: Transfer[]): number =>
     allBalances(transfers).get(accountKey(acct)) ?? 0;
-
-/** Positive cost total for one listing. Cost legs source `cost:<listingId>`. */
-export const costOfListing =
-  (listingId: number) =>
-  (transfers: Transfer[]): number =>
-    -balanceOf(costAccount(listingId))(transfers);
-
-/** Gross listing revenue less servicing costs. */
-export const profitOfListing =
-  (listingId: number) =>
-  (transfers: Transfer[]): number =>
-    balanceOf(revenueAccount(listingId))(transfers) -
-    costOfListing(listingId)(transfers);
-
-/** Total amount across transfers of one kind (e.g. cash refunded). */
-export const sumOfKind =
-  (kind: string) =>
-  (transfers: Transfer[]): number =>
-    sumLegs(legMatches({ kind }))(transfers);
-
-/**
- * Transfers whose business time falls in the half-open window [from, to).
- * Bounds are compared as instants, not strings, so a whole-second bound like
- * `2026-02-01T00:00:00Z` still includes the canonical `2026-02-01T00:00:00.000Z`.
- * Invalid bounds are rejected up front via {@link isInstant}, so an impossible
- * date (e.g. `2026-02-30`) can't silently shift the window. An inverted window
- * (`from` after `to`) throws rather than silently returning an empty slice,
- * which would read as zero revenue/refunds for what is really a swapped-argument
- * bug.
- */
-export const inPeriod =
-  (from: string, to: string) =>
-  (transfers: Transfer[]): Transfer[] => {
-    if (!isInstant(from) || !isInstant(to)) {
-      throw new Error(`inPeriod: invalid bound (from=${from}, to=${to})`);
-    }
-    const fromMs = instantToEpochMs(from);
-    const toMs = instantToEpochMs(to);
-    if (fromMs > toMs) {
-      throw new Error(`inPeriod: inverted window (from=${from}, to=${to})`);
-    }
-    return filter((t: Transfer) => {
-      const at = instantToEpochMs(t.occurredAt);
-      return at >= fromMs && at < toMs;
-    })(transfers);
-  };
 
 /**
  * One line of an account statement: the transfer, its signed effect on the

--- a/src/shared/ledger/reverse.ts
+++ b/src/shared/ledger/reverse.ts
@@ -1,7 +1,10 @@
-/** Pure construction of a reversing transfer (admin void/correction). */
+/**
+ * Whether one ledger leg exactly undoes another — the check the store runs on
+ * a leg carrying a `reversesId` before it inserts it.
+ */
 
 import { sameAccount } from "./account.ts";
-import type { AccountRef, Transfer, TransferInput } from "./types.ts";
+import type { AccountRef } from "./types.ts";
 
 /** The fields that decide whether one leg exactly undoes another. */
 type DirectedAmount = {
@@ -12,9 +15,8 @@ type DirectedAmount = {
 
 /**
  * True when `leg` exactly undoes `original`: same amount, with source and
- * destination swapped. A freshly built reversal (see {@link reverseOf}) satisfies
- * this by construction; the store also checks a leg carrying a `reversesId`
- * against it before inserting, so a bad link can't void nothing.
+ * destination swapped. The store checks a leg carrying a `reversesId` against
+ * this before inserting, so a bad link can't void nothing.
  */
 export const isInverseOf = (
   leg: DirectedAmount,
@@ -23,35 +25,3 @@ export const isInverseOf = (
   leg.amount === original.amount &&
   sameAccount(leg.source, original.destination) &&
   sameAccount(leg.destination, original.source);
-
-/**
- * Metadata the caller supplies for a reversal — the ledger reads no clock and
- * generates no ids, so the new occurredAt/reference/eventGroup/actor are inputs.
- */
-export type ReversalMeta = {
-  readonly occurredAt: string;
-  readonly reference: string;
-  readonly eventGroup: string;
-  readonly postedBy: string;
-  readonly kind?: string;
-  readonly memo?: string;
-};
-
-/**
- * Build the transfer that exactly undoes `t`: same amount, swapped ends, linked
- * back via `reversesId`. Used only for admin void/correction — refunds are
- * modelled separately (they need many rows per original, so they do not use the
- * one-time `reversesId` link).
- */
-export const reverseOf = (t: Transfer, meta: ReversalMeta): TransferInput => ({
-  amount: t.amount,
-  destination: t.source,
-  eventGroup: meta.eventGroup,
-  kind: meta.kind ?? "reversal",
-  memo: meta.memo ?? "",
-  occurredAt: meta.occurredAt,
-  postedBy: meta.postedBy,
-  reference: meta.reference,
-  reversesId: t.id,
-  source: t.destination,
-});

--- a/test/integration/code-quality.test.ts
+++ b/test/integration/code-quality.test.ts
@@ -84,14 +84,8 @@ const LIBRARY_PATHS = [
   // production caller. Each entry below names the rule it answers in
   // docs/payment-aggregate-acceptance.md, or says that no rule asks for it. A
   // module leaves this list when its last unconsumed export gains a caller.
-  "shared/ledger/project.ts", // profitOfListing, sumOfKind: no rule
   "shared/ledger/reconcile.ts", // reconcileExternal, reconcileLegs: rule 2
   "shared/accounting/queries.ts", // whole-account reads: rules 1 and 3
-  // Only tests call reverseOf, and no rule asks for it: reverse.ts scopes it to
-  // an admin void or correction, and refunds use a separate multi-row model.
-  // The usage check cannot see this, because the {@link reverseOf} in its own
-  // JSDoc reads as a production use. isInverseOf beside it has a live caller.
-  "shared/ledger/reverse.ts",
   // The site-pages feature is being wired in incrementally,
   // foundation-first: the pure core + DB layer landed before the admin CRUD /
   // public route / recursive-nav slices that consume them, so — like the

--- a/test/shared/accounting/queries/projections.test.ts
+++ b/test/shared/accounting/queries/projections.test.ts
@@ -12,7 +12,8 @@ import {
 import { emptyRange } from "#accounting/range.ts";
 import { postTransfers } from "#accounting/store.ts";
 import { account } from "#shared/ledger/account.ts";
-import { balanceOf, sumOfKind } from "#shared/ledger/project.ts";
+import { legMatches, sumLegs } from "#shared/ledger/legs.ts";
+import { balanceOf } from "#shared/ledger/project.ts";
 import { tx, useTransactionalDb } from "#test-utils/ledger.ts";
 
 // jscpd:ignore-end
@@ -127,14 +128,16 @@ describe("db > accounting > SQL figures agree with pure projections", () => {
     await seedMixedLedger();
     const all = await allTransfers();
     const totals = await ledgerTotals(emptyRange);
-    expect(totals.refunded).toBe(sumOfKind(KIND.refundCash)(all));
+    expect(totals.refunded).toBe(
+      sumLegs(legMatches({ kind: KIND.refundCash }))(all),
+    );
     expect(totals.fees).toBe(balanceOf(feeIncome)(all));
     expect(totals.due).toBe(
       -(balanceOf(attendee1)(all) + balanceOf(attendee2)(all)),
     );
     expect(totals.income).toBe(
-      sumOfKind(KIND.sale)(all) +
-        sumOfKind(MANUAL_LISTING_INCOME)(all) +
+      sumLegs(legMatches({ kind: KIND.sale }))(all) +
+        sumLegs(legMatches({ kind: MANUAL_LISTING_INCOME }))(all) +
         WRITE_UP -
         WRITE_DOWN,
     );
@@ -152,10 +155,14 @@ describe("db > accounting > SQL figures agree with pure projections", () => {
     ] as const) {
       const breakdown = await listingMoneyTotals(emptyRange, [listingId]);
       const legs = await transfersByAccount(revenue);
-      expect(breakdown.grossSales).toBe(sumOfKind(KIND.sale)(legs));
-      expect(breakdown.refunds).toBe(sumOfKind(KIND.refundSale)(legs));
+      expect(breakdown.grossSales).toBe(
+        sumLegs(legMatches({ kind: KIND.sale }))(legs),
+      );
+      expect(breakdown.refunds).toBe(
+        sumLegs(legMatches({ kind: KIND.refundSale }))(legs),
+      );
       expect(breakdown.externalIncome).toBe(
-        sumOfKind(MANUAL_LISTING_INCOME)(legs),
+        sumLegs(legMatches({ kind: MANUAL_LISTING_INCOME }))(legs),
       );
       // Recognised income - refunds - external costs must be exactly the
       // account's net ledger balance: the reconciliation the module promises.

--- a/test/shared/ledger/project.test.ts
+++ b/test/shared/ledger/project.test.ts
@@ -4,11 +4,7 @@ import { account, accountKey } from "#shared/ledger/account.ts";
 import {
   allBalances,
   balanceOf,
-  costOfListing,
-  inPeriod,
-  profitOfListing,
   statementFor,
-  sumOfKind,
 } from "#shared/ledger/project.ts";
 import { makeTransfer } from "#test-utils/transfer-factory.ts";
 
@@ -61,112 +57,6 @@ describe("allBalances", () => {
     const a = makeTransfer({ amount: 100, destination: revenue, id: 1 });
     const b = makeTransfer({ amount: 30, destination: attendee, id: 2 });
     expect(allBalances([a, b])).toEqual(allBalances([b, a]));
-  });
-});
-
-describe("sumOfKind", () => {
-  it("counts only the named kind (a refund is its cash leg, not doubled)", () => {
-    const ts = [
-      makeTransfer({ amount: 5000, kind: "refund_reversal" }),
-      makeTransfer({ amount: 2000, kind: "refund_cash" }),
-      makeTransfer({ amount: 800, kind: "refund_cash" }),
-    ];
-    // Only the refund_cash legs (2000 + 800) — never the reversal's 5000, and
-    // distinct amounts so summing the *other* kinds would give a different total.
-    expect(sumOfKind("refund_cash")(ts)).toBe(2800);
-    // A kind absent from the slice sums to zero, not to the legs it excludes.
-    expect(sumOfKind("sale")(ts)).toBe(0);
-  });
-});
-
-describe("listing cost/profit projections", () => {
-  it("reports positive servicing cost and subtracts it from gross revenue", () => {
-    const listingId = 45;
-    const ts = [
-      makeTransfer({
-        amount: 20000,
-        destination: account("revenue", listingId),
-        source: attendee,
-      }),
-      makeTransfer({
-        amount: 9000,
-        destination: world,
-        source: account("cost", listingId),
-      }),
-    ];
-    expect(costOfListing(listingId)(ts)).toBe(9000);
-    expect(profitOfListing(listingId)(ts)).toBe(11000);
-  });
-});
-
-describe("inPeriod", () => {
-  it("includes the start and excludes the end (half-open window)", () => {
-    const ts = [
-      makeTransfer({ id: 1, occurredAt: "2026-01-01T00:00:00.000Z" }),
-      makeTransfer({ id: 2, occurredAt: "2026-02-01T00:00:00.000Z" }),
-      makeTransfer({ id: 3, occurredAt: "2026-03-01T00:00:00.000Z" }),
-    ];
-    const got = inPeriod(
-      "2026-02-01T00:00:00.000Z",
-      "2026-03-01T00:00:00.000Z",
-    )(ts);
-    expect(got.map((t) => t.id)).toEqual([2]);
-  });
-
-  it("includes a canonical .000Z transfer at a whole-second bound", () => {
-    const ts = [
-      makeTransfer({ id: 1, occurredAt: "2026-02-01T00:00:00.000Z" }),
-    ];
-    // Whole-second bounds (no milliseconds): a lexicographic compare would
-    // exclude the canonical .000Z value; instant comparison includes it.
-    const got = inPeriod("2026-02-01T00:00:00Z", "2026-03-01T00:00:00Z")(ts);
-    expect(got.map((t) => t.id)).toEqual([1]);
-  });
-
-  it("accepts a Temporal-only bound form without silently emptying the window", () => {
-    // A bracketed IANA annotation parses under Temporal but is NaN to Date.parse;
-    // a Date.parse-based window would skip the inverted-bound check and return
-    // nothing for what is a valid range.
-    const ts = [
-      makeTransfer({ id: 1, occurredAt: "2026-02-15T00:00:00.000Z" }),
-    ];
-    const got = inPeriod(
-      "2026-02-01T00:00:00+00:00[UTC]",
-      "2026-03-01T00:00:00+00:00[UTC]",
-    )(ts);
-    expect(got.map((t) => t.id)).toEqual([1]);
-  });
-
-  it("throws on a non-ISO period bound", () => {
-    expect(() => inPeriod("nonsense", "2026-03-01T00:00:00.000Z")([])).toThrow(
-      "invalid bound",
-    );
-  });
-
-  it("throws on an unparseable (month 13) bound", () => {
-    expect(() =>
-      inPeriod("2026-01-01T00:00:00.000Z", "2026-13-01T00:00:00Z")([]),
-    ).toThrow("invalid bound");
-  });
-
-  it("throws on an overflow date bound (Feb 30 normalises away)", () => {
-    expect(() =>
-      inPeriod("2026-02-30T00:00:00Z", "2026-03-01T00:00:00.000Z")([]),
-    ).toThrow("invalid bound");
-  });
-
-  it("throws on an inverted window (from after to)", () => {
-    // A swapped range would otherwise silently match nothing, reading as zero
-    // revenue/refunds instead of a bad request.
-    expect(() =>
-      inPeriod("2026-03-01T00:00:00.000Z", "2026-02-01T00:00:00.000Z")([]),
-    ).toThrow("inverted window");
-  });
-
-  it("allows an empty window where from equals to", () => {
-    const bound = "2026-02-01T00:00:00.000Z";
-    const ts = [makeTransfer({ occurredAt: bound })];
-    expect(inPeriod(bound, bound)(ts)).toEqual([]);
   });
 });
 

--- a/test/shared/ledger/reverse.test.ts
+++ b/test/shared/ledger/reverse.test.ts
@@ -1,75 +1,29 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { account } from "#shared/ledger/account.ts";
-import { balanceOf } from "#shared/ledger/project.ts";
-import { isInverseOf, reverseOf } from "#shared/ledger/reverse.ts";
+import { isInverseOf } from "#shared/ledger/reverse.ts";
 import { makeTransfer } from "#test-utils/transfer-factory.ts";
-
-const meta = {
-  eventGroup: "void-1",
-  occurredAt: "2026-04-01T00:00:00.000Z",
-  postedBy: "user:3",
-  reference: "void-ref",
-};
-
-describe("reverseOf", () => {
-  it("swaps the ends, keeps the amount, and links via reversesId", () => {
-    const original = makeTransfer({
-      amount: 5000,
-      destination: account("revenue", 45),
-      id: 7,
-      source: account("attendee", 88),
-    });
-    const rev = reverseOf(original, meta);
-    expect(rev.source).toEqual(original.destination);
-    expect(rev.destination).toEqual(original.source);
-    expect(rev.amount).toBe(5000);
-    expect(rev.reversesId).toBe(7);
-    expect(rev.kind).toBe("reversal");
-    expect(rev.memo).toBe("");
-  });
-
-  it("honours an explicit kind and memo", () => {
-    const rev = reverseOf(makeTransfer({}), {
-      ...meta,
-      kind: "correction",
-      memo: "fat-finger",
-    });
-    expect(rev.kind).toBe("correction");
-    expect(rev.memo).toBe("fat-finger");
-    // An explicit empty kind is preserved, not silently replaced by the default
-    // (`?? "reversal"` keeps "", where `|| "reversal"` would override it).
-    expect(reverseOf(makeTransfer({}), { ...meta, kind: "" }).kind).toBe("");
-  });
-
-  it("nets the affected account back to zero once both are posted", () => {
-    const revenue = account("revenue", 45);
-    const original = makeTransfer({
-      amount: 5000,
-      destination: revenue,
-      id: 7,
-      source: account("attendee", 88),
-    });
-    const reversal = makeTransfer({ ...reverseOf(original, meta), id: 8 });
-    expect(balanceOf(revenue)([original])).toBe(5000);
-    expect(balanceOf(revenue)([original, reversal])).toBe(0);
-  });
-});
 
 describe("isInverseOf", () => {
   const original = makeTransfer({
     amount: 5000,
     destination: account("revenue", 45),
+    id: 7,
     source: account("attendee", 88),
   });
+  // The leg a reversal posts: the original's ends swapped, same amount.
+  const reversal = {
+    amount: 5000,
+    destination: account("attendee", 88),
+    source: account("revenue", 45),
+  };
 
-  it("accepts the leg that reverseOf builds", () => {
-    expect(isInverseOf(reverseOf(original, meta), original)).toBe(true);
+  it("accepts the leg that exactly undoes the original", () => {
+    expect(isInverseOf(reversal, original)).toBe(true);
   });
 
   it("rejects a different amount or direction", () => {
-    const inverse = reverseOf(original, meta);
-    expect(isInverseOf({ ...inverse, amount: 4000 }, original)).toBe(false);
+    expect(isInverseOf({ ...reversal, amount: 4000 }, original)).toBe(false);
     // Same direction as the original (ends not swapped).
     expect(isInverseOf(original, original)).toBe(false);
   });


### PR DESCRIPTION
## What changed

Five ledger exports that only tests ever called are gone, with their tests:

- `profitOfListing` and `sumOfKind` (`src/shared/ledger/project.ts`) — the two the issue names. Profit per listing and totals by kind appear nowhere in `docs/payment-aggregate-acceptance.md`.
- `reverseOf` and its `ReversalMeta` (`src/shared/ledger/reverse.ts`) — the admin void/correction builder the contract does not name. `isInverseOf` stays: the accounting conflict check calls it, and removing `reverseOf` also removes the `{@link reverseOf}` JSDoc the dead-export scanner misread as a production use — the exact blind spot the issue flags.
- `costOfListing` — not in the issue's count, but its only caller was `profitOfListing`, so it became dead the moment that went.
- `inPeriod` — also not in the count, but only tests ever called it; the whole-file exemption in the dead-export scanner masked it, the same class of blind spot the issue describes for `reverse.ts`. Its tests went with it.

The two modules also leave the dead-export exemption list in `test/integration/code-quality.test.ts`, which only shrinks.

## Why

The issue's own logic: these exports answer no rule in the payment-aggregate acceptance contract. Remove dead code says an export only tests call is deleted, and recovered from history when a caller arrives. The five rule-backed exports (`reconcileExternal`, `reconcileLegs`, `allTransfers`, `recentTransfers`, `accountBalance`) are untouched and still wait for the payment-aggregate owner's decision.

## Tests

- `test/shared/ledger/project.test.ts` and `reverse.test.ts` lose exactly the describes of the deleted exports; `balanceOf`, `allBalances` and `statementFor` coverage is unchanged.
- `test/shared/accounting/queries/projections.test.ts` used `sumOfKind` as the expected side of its SQL-vs-pure-folds cross-checks. It now reads the production pair `sumOfKind` wrapped — `sumLegs(legMatches({ kind }))` from `src/shared/ledger/legs.ts` — both of which have live production callers, so no production logic is reimplemented in the test.
- The registries that pointed at the deleted pairs lose their entries: the `cpd-renamed` pair for `costOfListing`/`profitOfListing` (stale — pair resolved) and the equivalent-mutant entry for `reverseOf.memo`.
- `deno task precommit` passes; `deno task precommit:mutation` reports 21 mutants, 0 survivors, 2 known-equivalent suppressed.

## Changed-line counts

- src: 64 lines changed (8 added / 56 deleted); net −48.
- total (src + tests + registries): 33 added / 275 deleted.

Closes #2294