### PR TITLE
Declare the content form length limits once

### DIFF
--- a/src/features/admin/content-form-fields.ts
+++ b/src/features/admin/content-form-fields.ts
@@ -17,10 +17,8 @@ import { slugFieldBase } from "#templates/fields/validators.ts";
 // jscpd:ignore-end
 
 /**
- * The character limits of the shared SEO/content fields, keyed by the field
- * name the form and the stored column both use. The form field's `maxlength`
- * reads from here, so a new content editor reusing these fields imports the
- * same limits instead of restating them.
+ * The shared SEO/content fields' character limits, keyed by the form field
+ * name a new content editor imports.
  */
 export const CONTENT_FIELD_LIMITS = {
   content: MAX_TEXTAREA_LENGTH,

--- a/src/features/admin/content-form-fields.ts
+++ b/src/features/admin/content-form-fields.ts
@@ -16,15 +16,24 @@ import { slugFieldBase } from "#templates/fields/validators.ts";
 
 // jscpd:ignore-end
 
-const MAX_NAME = 128;
-const MAX_META_TITLE = 64;
-const MAX_META_DESCRIPTION = 160;
+/**
+ * The character limits of the shared SEO/content fields, keyed by the field
+ * name the form and the stored column both use. The form field's `maxlength`
+ * reads from here, so a new content editor reusing these fields imports the
+ * same limits instead of restating them.
+ */
+export const CONTENT_FIELD_LIMITS = {
+  content: MAX_TEXTAREA_LENGTH,
+  meta_description: 160,
+  meta_title: 64,
+  name: 128,
+} as const;
 
 /** The required display-name field (each editor supplies its own label). */
 const contentNameField = (label: string) =>
   ({
     label,
-    maxlength: MAX_NAME,
+    maxlength: CONTENT_FIELD_LIMITS.name,
     name: "name",
     required: true,
     type: "text",
@@ -49,14 +58,14 @@ const seoMetaFields = () =>
     {
       hint: t("fields.meta_title_hint"),
       label: t("fields.meta_title"),
-      maxlength: MAX_META_TITLE,
+      maxlength: CONTENT_FIELD_LIMITS.meta_title,
       name: "meta_title",
       type: "text",
     },
     {
       hint: t("fields.meta_description_hint"),
       label: t("fields.meta_description"),
-      maxlength: MAX_META_DESCRIPTION,
+      maxlength: CONTENT_FIELD_LIMITS.meta_description,
       name: "meta_description",
       type: "text",
     },
@@ -68,7 +77,7 @@ const markdownContentField = () =>
     hintHtml: formattingHint(),
     label: t("fields.content"),
     markdown: true,
-    maxlength: MAX_TEXTAREA_LENGTH,
+    maxlength: CONTENT_FIELD_LIMITS.content,
     name: "content",
     type: "textarea",
   }) as const;

--- a/test/features/admin/content-form-fields.test.ts
+++ b/test/features/admin/content-form-fields.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
 import {
+  CONTENT_FIELD_LIMITS,
   contentFieldValues,
   contentSlugField,
   defineContentForms,
@@ -32,37 +33,47 @@ describe("content form fields", () => {
     ]);
   });
 
-  test("the name field is required text capped at 128 characters", () => {
+  test("the name field is required text capped at the declared name limit", () => {
     const name = forms.createForm.fields[0];
     expect(JSON.parse(JSON.stringify(name))).toEqual({
       label: "Thing name",
-      maxlength: 128,
+      maxlength: CONTENT_FIELD_LIMITS.name,
       name: "name",
       required: true,
       type: "text",
     });
   });
 
-  test("the SEO meta pair keeps its 64 and 160 character caps", () => {
+  test("the SEO meta pair keeps the declared meta_title and meta_description caps", () => {
     const byName = new Map(forms.createForm.fields.map((f) => [f.name, f]));
     expect(byName.get("meta_title")).toMatchObject({
-      maxlength: 64,
+      maxlength: CONTENT_FIELD_LIMITS.meta_title,
       type: "text",
     });
     expect(byName.get("meta_description")).toMatchObject({
-      maxlength: 160,
+      maxlength: CONTENT_FIELD_LIMITS.meta_description,
       type: "text",
     });
   });
 
-  test("the content field is a markdown textarea with the shared cap", () => {
+  test("the content field is a markdown textarea with the declared content cap", () => {
     const content = forms.createForm.fields.at(-1);
     expect(content).toMatchObject({
       markdown: true,
-      maxlength: MAX_TEXTAREA_LENGTH,
+      maxlength: CONTENT_FIELD_LIMITS.content,
       name: "content",
       type: "textarea",
     });
+  });
+
+  test("every shared limit is declared once in CONTENT_FIELD_LIMITS", () => {
+    // The table is the one place a new content editor imports its limits
+    // from, so each shared field's maxlength must read from it.
+    expect(CONTENT_FIELD_LIMITS.meta_description).toBe(160);
+    expect(CONTENT_FIELD_LIMITS.meta_title).toBe(64);
+    expect(CONTENT_FIELD_LIMITS.name).toBe(128);
+    // The body rides the shared textarea limit.
+    expect(CONTENT_FIELD_LIMITS.content).toBe(MAX_TEXTAREA_LENGTH);
   });
 
   test("only the edit form's slug links to the public page", () => {

--- a/test/features/admin/content-form-fields.test.ts
+++ b/test/features/admin/content-form-fields.test.ts
@@ -44,7 +44,7 @@ describe("content form fields", () => {
     });
   });
 
-  test("the SEO meta pair keeps the declared meta_title and meta_description caps", () => {
+  test("the SEO Title and SEO Description fields keep their declared caps", () => {
     const byName = new Map(forms.createForm.fields.map((f) => [f.name, f]));
     expect(byName.get("meta_title")).toMatchObject({
       maxlength: CONTENT_FIELD_LIMITS.meta_title,


### PR DESCRIPTION
## What changed

The shared SEO/content form fields' character limits now live in one exported table, `CONTENT_FIELD_LIMITS` in `src/features/admin/content-form-fields.ts`, keyed by the field name the form and the stored column both use (`name`, `meta_title`, `meta_description`, `content`). Every field's `maxlength` reads from it.

## Why

The three limits were private module constants (`MAX_NAME = 128`, `MAX_META_TITLE = 64`, `MAX_META_DESCRIPTION = 160`). No other module could import them, so a new content form reusing these fields had to restate magic numbers — and a restated number can drift from the form validation the first table drove. The issue names the exemplar: the limit is declared once, and the form field reads from the declaration.

## Production value

The Pages and News editors render their `maxlength`s from the table today; the next content editor imports the same table instead of copying numbers.

## Old path deleted

`MAX_NAME`, `MAX_META_TITLE` and `MAX_META_DESCRIPTION` are gone — no wrapper, no alias; the table is the single declaration and the fields are its only readers.

## Changed-line counts

- src: 21 lines changed (14 added / 7 deleted); net +7.
- total (src + test): 32 added / 14 deleted.

## Tests

`test/features/admin/content-form-fields.test.ts` now reads the table: each shared field's `maxlength` must equal the limit declared under its own field name, and the content entry must equal the shared `MAX_TEXTAREA_LENGTH` it delegates to — so field-to-table drift and table edits both fail a test. The tests name the fields the way the site labels them ("SEO Title", "SEO Description" — `src/locales/en/site-pages.json`). `deno task precommit` and `deno task precommit:mutation` pass (all mutants detected).

Closes #2271
