### PR TITLE
Show live precommit progress in terminal Git hooks

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -16,6 +16,7 @@ let
     git
     jq
     openssl
+    util-linux
   ];
 
   runtimeSetup = pkgs.replaceVars ./scripts/devenv/library-path.sh {

--- a/scripts/devenv/precommit.sh
+++ b/scripts/devenv/precommit.sh
@@ -2,4 +2,10 @@
 
 # shellcheck source=/dev/null
 source @runtimeSetup@
+
+# Prek captures both streams. Keep live progress when a terminal is available.
+if { exec >/dev/tty; } 2>/dev/null; then
+  exec 2>&1
+fi
+
 exec deno task precommit

--- a/test/scripts/devenv/precommit.test.ts
+++ b/test/scripts/devenv/precommit.test.ts
@@ -1,0 +1,81 @@
+import { expect } from "@std/expect";
+import { dirname } from "@std/path";
+import { describe, it as test } from "@std/testing/bdd";
+import { fakeCommand } from "#test-utils/stripe-mock/helpers.ts";
+
+const withFakeDeno = fakeCommand("deno");
+const probe = `
+printf '%s\\n' "$@" "setup=$HOOK_SETUP"
+for fd in 0 1 2; do
+  if [ -t "$fd" ]; then terminal=yes; else terminal=no; fi
+  printf 'fd%s=%s\\n' "$fd" "$terminal"
+done
+printf 'error output\\n' >&2
+exit "$HOOK_STATUS"
+`;
+
+describe("Git hook output", () => {
+  // Capture both streams inside the PTY, as prek does for its child.
+  const command =
+    'bash -euo pipefail -c "$HOOK" </dev/null >"$CAPTURE_OUT" 2>"$CAPTURE_ERR"';
+  const expected = "task\nprecommit\nsetup=ready\nfd0=no\n";
+  for (const mode of [
+    {
+      args: [
+        "--quiet",
+        "--return",
+        "--flush",
+        "--command",
+        command,
+        "/dev/null",
+      ],
+      err: "",
+      live: `${expected}fd1=yes\nfd2=yes\nerror output\n`,
+      name: "shows live terminal output",
+      out: "",
+      program: "script",
+    },
+    {
+      args: ["--fork", "--wait", "bash", "-c", command],
+      err: "error output\n",
+      live: "",
+      name: "preserves captured output",
+      out: `${expected}fd1=no\nfd2=no\n`,
+      program: "setsid",
+    },
+  ]) {
+    for (const status of [0, 37]) {
+      test(`${mode.name} with exit status ${status}`, async () => {
+        await withFakeDeno(probe, async (fake) => {
+          const dir = dirname(fake);
+          const setup = `${dir}/setup.sh`;
+          await Deno.writeTextFile(setup, "export HOOK_SETUP=ready\n");
+          const hook = (
+            await Deno.readTextFile("scripts/devenv/precommit.sh")
+          ).replace("@runtimeSetup@", JSON.stringify(setup));
+          const result = await new Deno.Command(mode.program, {
+            args: mode.args,
+            env: {
+              CAPTURE_ERR: `${dir}/stderr`,
+              CAPTURE_OUT: `${dir}/stdout`,
+              HOOK: hook,
+              HOOK_STATUS: String(status),
+              PATH: `${dir}:${Deno.env.get("PATH")}`,
+            },
+            stderr: "piped",
+            stdin: "null",
+            stdout: "piped",
+          }).output();
+          const output = new TextDecoder()
+            .decode(result.stdout)
+            .replaceAll("\r\n", "\n");
+          expect(result.code).toBe(status);
+          expect(new TextDecoder().decode(result.stderr)).toBe("");
+          expect(output).toBe(mode.live);
+          expect(await Deno.readTextFile(`${dir}/stdout`)).toBe(mode.out);
+          expect(await Deno.readTextFile(`${dir}/stderr`)).toBe(mode.err);
+        });
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Git commits now show the existing precommit runner output when a terminal is available, rather than only the outer hook status.

This PR contains the hook-output changes that remained uncommitted when #2330 merged. It starts from current main and contains none of that earlier PR history.

## Behaviour

- `scripts/devenv/precommit.sh` opens `/dev/tty` for stdout when a terminal is available. It sends stderr to the same terminal.
- Without a terminal, stdout and stderr retain their original destinations. An unavailable terminal produces no extra diagnostic.
- Standard input, runtime setup, pinned tools, checks, and exit status remain unchanged. A failed check still blocks the commit.
- `devenv.nix` adds pinned `util-linux` tools for the terminal tests. `script` supplies a terminal, and `setsid` supplies a process without one.

Prek still manages the hook and the staged files. The same `deno task precommit` command remains the single implementation of the gate.

## Validation

- Four regression tests cover terminal and captured output with exit statuses 0 and 37.
- The terminal tests first failed against the original wrapper. The captured-output tests passed before and after the fix.
- `devenv shell -- deno task test:files test/scripts/devenv/precommit.test.ts` passed.
- `devenv shell deno task precommit` passed again on current main, including typecheck, lint, duplication checks, the edge build, and tests with coverage.
- The commit hook also passed without an exemption.

## Scope

Three files, 88 added lines: seven tooling lines and 81 test lines. No application source, database calls, provider calls, or deployment changes. The source mutation gate does not apply because this PR changes no `src/` files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Developer Experience**
  - Improved pre-commit output so progress remains visible in terminal environments while captured output continues to work as before.
  - Added `util-linux` to development checks.

- **Tests**
  - Added coverage for terminal and non-terminal pre-commit execution.
  - Verified output routing, setup propagation, live versus buffered output, and preservation of command exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->