### PR TITLE
Record precommit progress for read-only diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ cov_profile/
 .deno/
 .deno-cache/
 .local-data/
+.diagnostics/
 .mutation-runs/
 .pi-worktrees/
 .security-worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1577,6 +1577,9 @@ query logging and table-scoped cache invalidation stay automatic.
 
 ## Scripts
 
+- `agent-diagnose` - The Nix-built host diagnostic tool reports read-only
+  process, check, and Git lock facts. Use the immutable path from OpenCode's
+  global instructions. See [Precommit status records](docs/precommit-status.md).
 - `deno task start` - Run the server
 - `deno task dev` - Run the server with `--watch`, restarting it whenever a
   source file changes. `build:static` runs once at the start, so an edit to a

--- a/docs/precommit-status.md
+++ b/docs/precommit-status.md
@@ -1,0 +1,40 @@
+# Precommit status records
+
+Precommit records its progress under `.diagnostics/precommit/`. Each invocation
+owns one UUID JSON file. Atomic replacement publishes complete records.
+
+The Nix-built `agent-diagnose checks` command reads these records. Its source
+lives in the dotfiles `modules/agent-diagnostics/` module, not this repository.
+OpenCode's global instructions name the permitted immutable executable.
+
+## Stored facts
+
+Each record contains the PID, creation time, latest transition time, state,
+step, step completion time, and exit code. It contains no arguments, paths,
+error text, or log output. The producer uses canonical UTC timestamps.
+
+| State     | Required facts                                                     |
+| --------- | ------------------------------------------------------------------ |
+| `waiting` | No step, completion time, or exit code.                            |
+| `running` | A declared step and no exit code. The completion time is optional. |
+| `passed`  | Exit code zero.                                                    |
+| `failed`  | A nonzero exit code.                                               |
+
+`updatedAt` records transitions, not a heartbeat. A completed step can remain
+visible while the invocation waits at the optional push prompt. Abrupt
+termination leaves the last record. A stored PID does not prove process identity
+or current activity.
+
+Records remain after completion. The directory is ignored by Git and excluded
+from mutation snapshots. The diagnostic reader reports truncation when its
+record or output limits prevent a complete result.
+
+## Implementation
+
+`PrecommitStatusSchema` in `scripts/precommit/status-schema.ts` validates record
+facts. `PRECOMMIT_STEP_NAMES` derives labels from the actual step definitions.
+`runWithPrecommitStatus` in `scripts/precommit/status.ts` records transitions.
+`scripts/precommit/runner.ts` connects the producer to the real checks.
+
+Direct tests in `test/scripts/precommit/status*.test.ts` cover concurrent
+invocations, complete atomic records, failures, privacy, and schema boundaries.

--- a/scripts/mutation/isolation-state.ts
+++ b/scripts/mutation/isolation-state.ts
@@ -31,6 +31,7 @@ const SKIPPED_TOP_LEVEL_NAMES = new Set([
   ".deno-cache",
   ".deno_cache",
   ".devenv",
+  ".diagnostics",
   ".direnv",
   ".do",
   ".git",

--- a/scripts/precommit/runner.ts
+++ b/scripts/precommit/runner.ts
@@ -6,6 +6,10 @@ import { withPrecommitLock } from "./lock.ts";
 import { getMergeConflictWarning } from "./merge-warning.ts";
 import { promptToPushCheckedInChanges, shouldPushFromAnswer } from "./push.ts";
 import { runChecksBeforePush } from "./run-order.ts";
+import {
+  type PrecommitStatusProducer,
+  runWithPrecommitStatus,
+} from "./status.ts";
 import { getSteps, type Step } from "./steps.ts";
 import {
   canPrompt,
@@ -93,13 +97,13 @@ const runStep = async (step: Step): Promise<boolean> => {
   return success;
 };
 
-const runSteps = async (): Promise<void> => {
+const runSteps = async (status: PrecommitStatusProducer): Promise<void> => {
   const steps = getSteps();
   for (const step of steps) {
-    const passed = await runStep(step);
+    const passed = await status.runStep(step.name, () => runStep(step));
     if (!passed) {
       console.log(`\n${red("precommit failed")} at ${step.name}`);
-      Deno.exit(1);
+      throw new Error("Precommit check failed");
     }
   }
 
@@ -115,28 +119,31 @@ const pushCheckedInChanges = async (): Promise<void> => {
   });
   if (!pushSucceeded) {
     console.log(red("git push failed"));
-    Deno.exit(1);
+    throw new Error("Git push failed");
   }
 };
 
 export const main = async (): Promise<void> => {
-  const ci = isCi();
-  if (ci && !Deno.env.get("CI")) Deno.env.set("CI", "1");
-  // Cap test parallelism for the run. CI uses every thread; a local git hook
-  // uses (threads / 2) - 1 so the editor and foreground work keep headroom.
-  // A valid explicit DENO_JOBS wins; replace invalid values with the default.
-  const jobs = resolveDenoJobs(
-    navigator.hardwareConcurrency,
-    ci,
-    Deno.env.get("DENO_JOBS"),
-  );
-  Deno.env.set("DENO_JOBS", String(jobs));
-  console.log(bold(ci ? "precommit (ci)" : "precommit"));
-  await warnAboutMergeConflicts();
-  await runChecksBeforePush(
-    ci,
-    runSteps,
-    pushCheckedInChanges,
-    withPrecommitLock,
-  );
+  await runWithPrecommitStatus(async (status) => {
+    const ci = isCi();
+    if (ci && !Deno.env.get("CI")) Deno.env.set("CI", "1");
+    // Cap test parallelism for the run. CI uses every thread; a local git hook
+    // uses (threads / 2) - 1 so the editor and foreground work keep headroom.
+    // A valid explicit DENO_JOBS wins; replace invalid values with the default.
+    const jobs = resolveDenoJobs(
+      navigator.hardwareConcurrency,
+      ci,
+      Deno.env.get("DENO_JOBS"),
+    );
+    Deno.env.set("DENO_JOBS", String(jobs));
+    console.log(bold(ci ? "precommit (ci)" : "precommit"));
+    await warnAboutMergeConflicts();
+    await runChecksBeforePush(
+      ci,
+      () => runSteps(status),
+      pushCheckedInChanges,
+      withPrecommitLock,
+    );
+    return 0;
+  });
 };

--- a/scripts/precommit/status-schema.ts
+++ b/scripts/precommit/status-schema.ts
@@ -1,0 +1,60 @@
+import * as v from "valibot";
+import { integerAtLeast } from "#shared/validation/number.ts";
+import { isInstant } from "#shared/validation/timestamp.ts";
+import { PRECOMMIT_STEP_NAMES } from "./steps.ts";
+
+export const PRECOMMIT_STATUS_DIR = ".diagnostics/precommit";
+
+const UuidSchema = v.pipe(v.string(), v.uuid());
+export const PrecommitStatusFilenameSchema = v.pipe(
+  v.string(),
+  v.endsWith(".json"),
+  v.check((name) => v.is(UuidSchema, name.slice(0, -5))),
+);
+
+const TimestampSchema = v.pipe(v.string(), v.check(isInstant));
+const StepSchema = v.picklist(PRECOMMIT_STEP_NAMES);
+const statusSchema = <
+  const State extends string,
+  const Fields extends v.ObjectEntries,
+>(
+  state: State,
+  fields: Fields,
+) =>
+  v.strictObject({
+    ...fields,
+    createdAt: TimestampSchema,
+    pid: integerAtLeast(1),
+    state: v.literal(state),
+    updatedAt: TimestampSchema,
+  });
+const terminalFields = {
+  step: v.nullable(StepSchema),
+  stepCompletedAt: v.nullable(TimestampSchema),
+};
+
+export const PrecommitStatusSchema = v.pipe(
+  v.variant("state", [
+    statusSchema("waiting", {
+      exitCode: v.null(),
+      step: v.null(),
+      stepCompletedAt: v.null(),
+    }),
+    statusSchema("running", {
+      exitCode: v.null(),
+      step: StepSchema,
+      stepCompletedAt: v.nullable(TimestampSchema),
+    }),
+    statusSchema("passed", {
+      ...terminalFields,
+      exitCode: v.literal(0),
+    }),
+    statusSchema("failed", {
+      ...terminalFields,
+      exitCode: v.pipe(v.number(), v.integer(), v.notValue(0)),
+    }),
+  ]),
+  v.check((record) => record.step !== null || record.stepCompletedAt === null),
+);
+
+export type PrecommitStatus = v.InferOutput<typeof PrecommitStatusSchema>;

--- a/scripts/precommit/status.ts
+++ b/scripts/precommit/status.ts
@@ -1,0 +1,86 @@
+import { join } from "node:path";
+import * as v from "valibot";
+import { removeIfPresent } from "#scripts/cleanup.ts";
+import { projectRoot } from "#scripts/project-root.ts";
+import {
+  PRECOMMIT_STATUS_DIR,
+  type PrecommitStatus,
+  PrecommitStatusFilenameSchema,
+  PrecommitStatusSchema,
+} from "./status-schema.ts";
+
+export interface PrecommitStatusProducer {
+  runStep(name: string, run: () => Promise<boolean>): Promise<boolean>;
+}
+
+/** One invocation owns one record. Only complete JSON replaces the public file. */
+export const runWithPrecommitStatus = async (
+  run: (status: PrecommitStatusProducer) => Promise<number>,
+  directory = join(projectRoot, PRECOMMIT_STATUS_DIR),
+): Promise<number> => {
+  const filename = v.parse(
+    PrecommitStatusFilenameSchema,
+    `${crypto.randomUUID()}.json`,
+  );
+  const path = join(directory, filename);
+  const createdAt = new Date().toISOString();
+  let current: PrecommitStatus = {
+    createdAt,
+    exitCode: null,
+    pid: Deno.pid,
+    state: "waiting",
+    step: null,
+    stepCompletedAt: null,
+    updatedAt: createdAt,
+  };
+  const save = async (next: unknown): Promise<void> => {
+    const record = v.parse(PrecommitStatusSchema, next);
+    const temporary = await Deno.makeTempFile({
+      dir: directory,
+      suffix: ".tmp",
+    });
+    try {
+      await Deno.writeTextFile(temporary, JSON.stringify(record));
+      await Deno.rename(temporary, path);
+      current = record;
+    } finally {
+      await removeIfPresent(temporary);
+    }
+  };
+  const finish = (exitCode: number): Promise<void> =>
+    save({
+      ...current,
+      exitCode,
+      state: exitCode === 0 ? "passed" : "failed",
+      updatedAt: new Date().toISOString(),
+    });
+
+  await Deno.mkdir(directory, { recursive: true });
+  await save(current);
+  try {
+    const exitCode = await run({
+      runStep: async (step, action): Promise<boolean> => {
+        await save({
+          ...current,
+          state: "running",
+          step,
+          stepCompletedAt: null,
+          updatedAt: new Date().toISOString(),
+        });
+        const passed = await action();
+        const completedAt = new Date().toISOString();
+        await save({
+          ...current,
+          stepCompletedAt: completedAt,
+          updatedAt: completedAt,
+        });
+        return passed;
+      },
+    });
+    await finish(exitCode);
+    return exitCode;
+  } catch (error) {
+    await finish(1);
+    throw error;
+  }
+};

--- a/scripts/precommit/steps.ts
+++ b/scripts/precommit/steps.ts
@@ -1,4 +1,3 @@
-import { readSlowTestsReport } from "#scripts/test-durations.ts";
 import { filterTestOutput, testProgressFromLine } from "./output.ts";
 
 /**
@@ -20,56 +19,65 @@ export interface Step {
   summary?: StepSummary;
 }
 
+const STEPS = [
+  // Always run read-only `lint:ci` (Deno Markdown + Biome code checks) so
+  // local precommit is exactly as strict as CI without changing the checkout.
+  // Run `deno task lint` separately to auto-fix formatting before committing.
+  { cmd: ["task", "lint:ci"], name: "lint" },
+  { cmd: ["task", "typecheck"], name: "typecheck" },
+  // An exact baseline and reviewed false positives turn the whole-repository
+  // field scan into a ratchet. It follows typecheck because it asks the same
+  // compiler program which symbol each mention reaches.
+  {
+    cmd: ["task", "check:unread-fields"],
+    name: "check:unread-fields",
+  },
+  { cmd: ["task", "cpd"], name: "cpd" },
+  // The half of duplication jscpd cannot see: two functions with one shape
+  // and different names. jscpd compares tokens as written, so a rename hides
+  // a copy from it (see "Code Duplication" in AGENTS.md).
+  { cmd: ["task", "check:shapes"], name: "check:shapes" },
+  // Guard the user-facing copy catalog against the mechanical simple-language
+  // rules (see the "Simple Language" section of AGENTS.md).
+  { cmd: ["task", "check:copy"], name: "check:copy" },
+  // Hold comments to the length and width limits, which the formatter cannot
+  // do — Biome never reflows comment text (see "Comments are short" in
+  // AGENTS.md, and docs/comment-policy.md for how the limits ratchet down).
+  { cmd: ["task", "check:comments"], name: "check:comments" },
+  // Keep one module to one name: no file importing the same module twice, and
+  // no import spelling a module longer than its own alias allows (see
+  // "Imports name a module one way" in AGENTS.md).
+  { cmd: ["task", "check:imports"], name: "check:imports" },
+  // Hold the payment e2e to the catalog's own words: every label it clicks
+  // or asserts must be copy src/locales/en renders (or a t("…") call), so a
+  // copy rename fails here instead of the schedule-only nightly run.
+  {
+    cmd: ["task", "check:e2e-labels"],
+    name: "check:e2e-labels",
+  },
+  // Catch a known-equivalent entry that no longer points at a real mutant on
+  // the branch that moved it, rather than in review. Resolution only — the
+  // audit that re-proves equivalence runs lint and type-check per entry and
+  // stays an on-demand tool.
+  { cmd: ["task", "check:equivalents"], name: "check:equivalents" },
+  { cmd: ["task", "build:edge"], name: "build:edge" },
+  {
+    cmd: ["task", "test:coverage"],
+    filterOutput: filterTestOutput,
+    name: "test:coverage",
+    progress: testProgressFromLine,
+    summary: async (): Promise<string | undefined> => {
+      const { readSlowTestsReport } = await import(
+        "#scripts/test-durations.ts"
+      );
+      return (await readSlowTestsReport()) || undefined;
+    },
+  },
+] as const;
+
+export const PRECOMMIT_STEP_NAMES = STEPS.map((step) => step.name);
+
 export const getSteps = (): Step[] => {
   const deno = Deno.execPath();
-  return [
-    // Always run read-only `lint:ci` (Deno Markdown + Biome code checks) so
-    // local precommit is exactly as strict as CI without changing the checkout.
-    // Run `deno task lint` separately to auto-fix formatting before committing.
-    { cmd: [deno, "task", "lint:ci"], name: "lint" },
-    { cmd: [deno, "task", "typecheck"], name: "typecheck" },
-    // An exact baseline and reviewed false positives turn the whole-repository
-    // field scan into a ratchet. It follows typecheck because it asks the same
-    // compiler program which symbol each mention reaches.
-    {
-      cmd: [deno, "task", "check:unread-fields"],
-      name: "check:unread-fields",
-    },
-    { cmd: [deno, "task", "cpd"], name: "cpd" },
-    // The half of duplication jscpd cannot see: two functions with one shape
-    // and different names. jscpd compares tokens as written, so a rename hides
-    // a copy from it (see "Code Duplication" in AGENTS.md).
-    { cmd: [deno, "task", "check:shapes"], name: "check:shapes" },
-    // Guard the user-facing copy catalog against the mechanical simple-language
-    // rules (see the "Simple Language" section of AGENTS.md).
-    { cmd: [deno, "task", "check:copy"], name: "check:copy" },
-    // Hold comments to the length and width limits, which the formatter cannot
-    // do — Biome never reflows comment text (see "Comments are short" in
-    // AGENTS.md, and docs/comment-policy.md for how the limits ratchet down).
-    { cmd: [deno, "task", "check:comments"], name: "check:comments" },
-    // Keep one module to one name: no file importing the same module twice, and
-    // no import spelling a module longer than its own alias allows (see
-    // "Imports name a module one way" in AGENTS.md).
-    { cmd: [deno, "task", "check:imports"], name: "check:imports" },
-    // Hold the payment e2e to the catalog's own words: every label it clicks
-    // or asserts must be copy src/locales/en renders (or a t("…") call), so a
-    // copy rename fails here instead of the schedule-only nightly run.
-    {
-      cmd: [deno, "task", "check:e2e-labels"],
-      name: "check:e2e-labels",
-    },
-    // Catch a known-equivalent entry that no longer points at a real mutant on
-    // the branch that moved it, rather than in review. Resolution only — the
-    // audit that re-proves equivalence runs lint and type-check per entry and
-    // stays an on-demand tool.
-    { cmd: [deno, "task", "check:equivalents"], name: "check:equivalents" },
-    { cmd: [deno, "task", "build:edge"], name: "build:edge" },
-    {
-      cmd: [deno, "task", "test:coverage"],
-      filterOutput: filterTestOutput,
-      name: "test:coverage",
-      progress: testProgressFromLine,
-      summary: async () => (await readSlowTestsReport()) || undefined,
-    },
-  ];
+  return STEPS.map((step) => ({ ...step, cmd: [deno, ...step.cmd] }));
 };

--- a/test/scripts/precommit/status-import.test.ts
+++ b/test/scripts/precommit/status-import.test.ts
@@ -1,0 +1,14 @@
+// test-groups: run-alone
+import { expect } from "@std/expect";
+
+Deno.test({
+  async fn() {
+    const { PrecommitStatusSchema } = await import(
+      "#scripts/precommit/status-schema.ts"
+    );
+    const { safeParse } = await import("valibot");
+    expect(safeParse(PrecommitStatusSchema, {}).success).toBe(false);
+  },
+  name: "precommit status schema imports without runtime IO permissions",
+  permissions: "none",
+});

--- a/test/scripts/precommit/status-schema.test.ts
+++ b/test/scripts/precommit/status-schema.test.ts
@@ -1,0 +1,88 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import * as v from "valibot";
+import {
+  PRECOMMIT_STATUS_DIR,
+  PrecommitStatusFilenameSchema,
+  PrecommitStatusSchema,
+} from "#scripts/precommit/status-schema.ts";
+import { getSteps, PRECOMMIT_STEP_NAMES } from "#scripts/precommit/steps.ts";
+
+const timestamp = "2026-09-10T10:00:00.000Z";
+const waiting = {
+  createdAt: timestamp,
+  exitCode: null,
+  pid: 123,
+  state: "waiting",
+  step: null,
+  stepCompletedAt: null,
+  updatedAt: timestamp,
+};
+
+describe("precommit status schema", () => {
+  test("names the shared relative record directory", () => {
+    expect(PRECOMMIT_STATUS_DIR).toBe(".diagnostics/precommit");
+  });
+
+  test("accepts only UUID JSON filenames", () => {
+    expect(
+      v.is(PrecommitStatusFilenameSchema, `${crypto.randomUUID()}.json`),
+    ).toBe(true);
+    for (const filename of ["../run.json", "run.json", ".tmp", "secret.json"]) {
+      expect(v.is(PrecommitStatusFilenameSchema, filename)).toBe(false);
+    }
+  });
+
+  test("derives safe step labels from the actual checks", () => {
+    expect(PRECOMMIT_STEP_NAMES).toEqual(getSteps().map((step) => step.name));
+    for (const step of PRECOMMIT_STEP_NAMES) {
+      expect(
+        v.is(PrecommitStatusSchema, { ...waiting, state: "running", step }),
+      ).toBe(true);
+    }
+  });
+
+  test("accepts queued, completed-step, and terminal records", () => {
+    for (const changes of [
+      {},
+      { state: "running", step: "lint", stepCompletedAt: timestamp },
+      { exitCode: 0, state: "passed" },
+      { exitCode: 1, state: "failed" },
+      { exitCode: -1, state: "failed" },
+      { exitCode: Number.MAX_SAFE_INTEGER + 1, state: "failed" },
+      { exitCode: 2, state: "failed", step: "lint" },
+    ]) {
+      expect(v.is(PrecommitStatusSchema, { ...waiting, ...changes })).toBe(
+        true,
+      );
+    }
+  });
+
+  test("rejects invalid state facts and extra private fields", () => {
+    for (const changes of [
+      { pid: 0 },
+      { pid: 1.5 },
+      { pid: Number.MAX_SAFE_INTEGER + 1 },
+      { createdAt: "not a date" },
+      { updatedAt: "2026-02-30T10:00:00.000Z" },
+      { state: "unknown" },
+      { step: "lint" },
+      { stepCompletedAt: timestamp },
+      { exitCode: 0 },
+      { state: "running" },
+      { state: "running", step: "secret command" },
+      { exitCode: 1, state: "running", step: "lint" },
+      { state: "passed" },
+      { exitCode: 1, state: "passed" },
+      { exitCode: 0, state: "failed" },
+      { exitCode: -0, state: "failed" },
+      { exitCode: 1.5, state: "failed" },
+      { exitCode: 1, state: "failed", stepCompletedAt: timestamp },
+      { command: "private command" },
+    ]) {
+      expect(v.is(PrecommitStatusSchema, { ...waiting, ...changes })).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/test/scripts/precommit/status.test.ts
+++ b/test/scripts/precommit/status.test.ts
@@ -1,0 +1,253 @@
+import { join } from "node:path";
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { FakeTime } from "@std/testing/time";
+import * as v from "valibot";
+import { precommitLockAt } from "#scripts/precommit/lock.ts";
+import { runChecksBeforePush } from "#scripts/precommit/run-order.ts";
+import { runWithPrecommitStatus } from "#scripts/precommit/status.ts";
+import {
+  type PrecommitStatus,
+  PrecommitStatusFilenameSchema,
+  PrecommitStatusSchema,
+} from "#scripts/precommit/status-schema.ts";
+
+describe("precommit status producer", () => {
+  let directory: string;
+  beforeEach(async () => {
+    directory = await Deno.makeTempDir();
+  });
+  afterEach(async () => {
+    await Deno.remove(directory, { recursive: true });
+  });
+
+  const records = async (): Promise<PrecommitStatus[]> => {
+    const result: PrecommitStatus[] = [];
+    for await (const entry of Deno.readDir(directory)) {
+      if (!entry.name.endsWith(".json")) continue;
+      v.parse(PrecommitStatusFilenameSchema, entry.name);
+      result.push(
+        v.parse(
+          PrecommitStatusSchema,
+          JSON.parse(await Deno.readTextFile(join(directory, entry.name))),
+        ),
+      );
+    }
+    return result;
+  };
+
+  const record = async (): Promise<PrecommitStatus> => {
+    const found = await records();
+    expect(found).toHaveLength(1);
+    return found[0]!;
+  };
+
+  test("persists transitions without a heartbeat or private data", async () => {
+    using time = new FakeTime("2026-09-10T10:00:00.000Z");
+    const createdAt = new Date().toISOString();
+    const result = await runWithPrecommitStatus(async (status) => {
+      expect(await record()).toEqual({
+        createdAt,
+        exitCode: null,
+        pid: Deno.pid,
+        state: "waiting",
+        step: null,
+        stepCompletedAt: null,
+        updatedAt: createdAt,
+      });
+      time.tick(1000);
+      await status.runStep("lint", async () => {
+        expect(await record()).toEqual({
+          createdAt,
+          exitCode: null,
+          pid: Deno.pid,
+          state: "running",
+          step: "lint",
+          stepCompletedAt: null,
+          updatedAt: new Date().toISOString(),
+        });
+        const active = await record();
+        time.tick(1000);
+        expect(await record()).toEqual(active);
+        return true;
+      });
+      expect((await record()).stepCompletedAt).toBe(new Date().toISOString());
+      expect((await record()).updatedAt).toBe(new Date().toISOString());
+      time.tick(1000);
+      await status.runStep("typecheck", async () => {
+        expect((await record()).stepCompletedAt).toBeNull();
+        expect((await record()).step).toBe("typecheck");
+        return true;
+      });
+      time.tick(1000);
+      return 0;
+    }, directory);
+    expect(result).toBe(0);
+    expect(await record()).toEqual({
+      createdAt,
+      exitCode: 0,
+      pid: Deno.pid,
+      state: "passed",
+      step: "typecheck",
+      stepCompletedAt: "2026-09-10T10:00:03.000Z",
+      updatedAt: new Date().toISOString(),
+    });
+  });
+
+  test("retains a failed step completion before the final exit code", async () => {
+    const exitCode = await runWithPrecommitStatus(async (status) => {
+      expect(await status.runStep("lint", () => Promise.resolve(false))).toBe(
+        false,
+      );
+      expect((await record()).stepCompletedAt).not.toBeNull();
+      return 3;
+    }, directory);
+    expect(exitCode).toBe(3);
+    expect((await record()).state).toBe("failed");
+    expect((await record()).exitCode).toBe(3);
+  });
+
+  test("records thrown failures without the error text or a false completion", async () => {
+    const error = new Error("SECRET command args logs");
+    await expect(
+      runWithPrecommitStatus(async (status) => {
+        await status.runStep("lint", () => Promise.reject(error));
+        return 0;
+      }, directory),
+    ).rejects.toBe(error);
+    const failed = await record();
+    expect(failed.state).toBe("failed");
+    expect(failed.exitCode).toBe(1);
+    expect(failed.stepCompletedAt).toBeNull();
+    expect(JSON.stringify(failed)).not.toContain("SECRET");
+  });
+
+  test("records a failure before a step starts", async () => {
+    const error = new Error("Lock failed");
+    await expect(
+      runWithPrecommitStatus(() => Promise.reject(error), directory),
+    ).rejects.toBe(error);
+    expect((await record()).state).toBe("failed");
+    expect((await record()).step).toBeNull();
+  });
+
+  test("rejects an unknown label before the action or any private write", async () => {
+    let called = false;
+    await expect(
+      runWithPrecommitStatus(async (status) => {
+        await status.runStep("SECRET command", () => {
+          called = true;
+          return Promise.resolve(true);
+        });
+        return 0;
+      }, directory),
+    ).rejects.toThrow();
+    expect(called).toBe(false);
+    expect((await record()).state).toBe("failed");
+    expect((await record()).step).toBeNull();
+    expect(JSON.stringify(await record())).not.toContain("SECRET");
+  });
+
+  test("retains completed checks when the push fails", async () => {
+    const error = new Error("Push failed");
+    await expect(
+      runWithPrecommitStatus(async (status) => {
+        await runChecksBeforePush(
+          true,
+          async () => {
+            await status.runStep("lint", () => Promise.resolve(true));
+          },
+          () => Promise.reject(error),
+          () => Promise.reject(new Error("CI must not acquire the lock")),
+        );
+        return 0;
+      }, directory),
+    ).rejects.toBe(error);
+    expect((await record()).state).toBe("failed");
+    expect((await record()).step).toBe("lint");
+    expect((await record()).stepCompletedAt).not.toBeNull();
+  });
+
+  test("keeps separate queued records while the real lock serialises checks", async () => {
+    const lock = precommitLockAt(join(directory, "checks.lock"));
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const queued = Promise.withResolvers<void>();
+    let pushes = 0;
+    const run = (first: boolean): Promise<number> =>
+      runWithPrecommitStatus(async (status) => {
+        if (!first) queued.resolve();
+        await runChecksBeforePush(
+          false,
+          async () => {
+            await status.runStep("lint", async () => {
+              if (first) {
+                entered.resolve();
+                await release.promise;
+              }
+              return true;
+            });
+          },
+          async () => {
+            pushes += 1;
+          },
+          lock,
+        );
+        return 0;
+      }, directory);
+    const first = run(true);
+    await entered.promise;
+    const second = run(false);
+    await queued.promise;
+    try {
+      expect((await records()).map((item) => item.state).sort()).toEqual([
+        "running",
+        "waiting",
+      ]);
+    } finally {
+      release.resolve();
+      await Promise.all([first, second]);
+    }
+    expect((await records()).map((item) => item.state)).toEqual([
+      "passed",
+      "passed",
+    ]);
+    expect(pushes).toBe(2);
+  });
+
+  test("replaces complete JSON atomically and removes temporary files", async () => {
+    const rename = Deno.rename;
+    const previous: Array<string | null> = [];
+    using _rename = stub(Deno, "rename", async (oldPath, newPath) => {
+      const next = v.parse(
+        PrecommitStatusSchema,
+        JSON.parse(await Deno.readTextFile(oldPath)),
+      );
+      expect(String(oldPath)).not.toBe(String(newPath));
+      const existing = await records();
+      previous.push(existing[0]?.state ?? null);
+      await rename(oldPath, newPath);
+      expect(await record()).toEqual(next);
+    });
+    await runWithPrecommitStatus(async (status) => {
+      await status.runStep("lint", () => Promise.resolve(true));
+      return 0;
+    }, directory);
+    expect(previous).toEqual([null, "waiting", "running", "running"]);
+    const entries = [];
+    for await (const entry of Deno.readDir(directory)) entries.push(entry.name);
+    expect(entries).toHaveLength(1);
+  });
+
+  test("surfaces atomic write failures without a partial record", async () => {
+    const error = new Error("Disk failure");
+    using _rename = stub(Deno, "rename", () => Promise.reject(error));
+    await expect(
+      runWithPrecommitStatus(() => Promise.resolve(0), directory),
+    ).rejects.toBe(error);
+    const entries = [];
+    for await (const entry of Deno.readDir(directory)) entries.push(entry.name);
+    expect(entries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Precommit now records its state so the host-level `agent-diagnose checks` command can inspect progress without command arguments or logs.

Each invocation owns one JSON record under `.diagnostics/precommit/`. Atomic replacement publishes complete records before the lock wait, around each step, and at completion.

## Behaviour

- Store the PID, timestamps, declared step, completion time, state, and exit code.
- Reject invalid record states and undeclared step labels.
- Keep simultaneous invocations separate.
- Preserve the last recorded state after abrupt termination. A record does not prove that its process still exists.
- Exclude diagnostic records from Git and mutation snapshots.
- Derive step labels from the actual check definitions.

The shared runner in `scripts/precommit/runner.ts` replaces console-only progress with console output plus sanitised records. The native diagnostic executable remains in dotfiles. `docs/precommit-status.md` describes the record contract.

## Validation

- `devenv shell deno task precommit` passed after the rebase onto current main, including the full coverage suite.
- `devenv shell deno task precommit:mutation` completed with no changed source files to mutate.
- Direct tests cover queued runs, concurrent lock holders, atomic replacement, failures, private-field rejection, and permission-free schema imports.
- The Git commit hook passed without a controlling terminal. No hook was bypassed.

## Scope

This PR changes no application source files, database schema, or provider calls. It contains 709 changed lines across 11 files: 635 additions and 74 deletions.

The user-facing fix for #2344 ships separately in #2355.