### PR TITLE
Keep precommit hook output captured for noninteractive callers

### DIFF
--- a/scripts/devenv/precommit.sh
+++ b/scripts/devenv/precommit.sh
@@ -3,9 +3,16 @@
 # shellcheck source=/dev/null
 source @runtimeSetup@
 
-# Prek captures both streams. Keep live progress when a terminal is available.
-if { exec >/dev/tty; } 2>/dev/null; then
-  exec 2>&1
+# Prek captures both streams, so callers see hook output only once the run
+# ends. prek's own stdout names the caller: a person's terminal gets live
+# output there; captured callers (CI, agents) keep output in their pipes.
+if { exec 3<>"/proc/$PPID/fd/1"; } 2>/dev/null; then
+  if [ -t 3 ]; then
+    if { exec >/dev/tty; } 2>/dev/null; then
+      exec 2>&1
+    fi
+  fi
+  exec 3>&-
 fi
 
 exec deno task precommit

--- a/test/scripts/devenv/precommit.test.ts
+++ b/test/scripts/devenv/precommit.test.ts
@@ -31,6 +31,7 @@ describe("Git hook output", () => {
         `: >"$CAPTURE_OUT" 2>"$CAPTURE_ERR"; exec bash -euo pipefail -c '${hookRun}'`,
         "/dev/null",
       ],
+      env: {},
       err: "",
       live: "task\nprecommit\nsetup=ready\nfd0=no\nfd1=yes\nfd2=yes\nerror output\n",
       name: "shows live terminal output to an interactive caller",
@@ -46,14 +47,37 @@ describe("Git hook output", () => {
         captured,
         "/dev/null",
       ],
+      env: {},
       err: "error output\n",
       live: "",
-      name: "keeps captured output for a piped caller",
+      name: "keeps captured output for a caller writing to a file",
+      out: capturedLines,
+      program: "script",
+    },
+    {
+      // The parent's stdout is a real pipe, the shape CI and agents see.
+      // `exec bash -o pipefail -c "<CMD>"` keeps the hook's exit status the
+      // pipeline's and lets $HOOK expand only inside the hook's own bash.
+      args: [
+        "--quiet",
+        "--return",
+        "--flush",
+        "--command",
+        'exec bash -o pipefail -c "$PIPE_BODY"',
+        "/dev/null",
+      ],
+      env: {
+        PIPE_BODY: `bash -euo pipefail -c '${hookRun}' 2>"$CAPTURE_ERR" | cat >"$CAPTURE_OUT"`,
+      },
+      err: "error output\n",
+      live: "",
+      name: "keeps captured output for a caller on a pipe",
       out: capturedLines,
       program: "script",
     },
     {
       args: ["--fork", "--wait", "bash", "-c", captured],
+      env: {},
       err: "error output\n",
       live: "",
       name: "preserves captured output without a controlling terminal",
@@ -73,6 +97,7 @@ describe("Git hook output", () => {
           const result = await new Deno.Command(mode.program, {
             args: mode.args,
             env: {
+              ...mode.env,
               CAPTURE_ERR: `${dir}/stderr`,
               CAPTURE_OUT: `${dir}/stdout`,
               HOOK: hook,

--- a/test/scripts/devenv/precommit.test.ts
+++ b/test/scripts/devenv/precommit.test.ts
@@ -15,10 +15,12 @@ exit "$HOOK_STATUS"
 `;
 
 describe("Git hook output", () => {
-  // Capture both streams inside the PTY, as prek does for its child.
-  const command =
-    'bash -euo pipefail -c "$HOOK" </dev/null >"$CAPTURE_OUT" 2>"$CAPTURE_ERR"';
-  const expected = "task\nprecommit\nsetup=ready\nfd0=no\n";
+  // prek runs the hook under itself with both streams captured. The parent
+  // shell here stands in for prek, and its stdout says who is calling.
+  const hookRun = 'bash -c "$HOOK" </dev/null';
+  const captured = `bash -euo pipefail -c '${hookRun}' >"$CAPTURE_OUT" 2>"$CAPTURE_ERR"`;
+  const capturedLines =
+    "task\nprecommit\nsetup=ready\nfd0=no\nfd1=no\nfd2=no\n";
   for (const mode of [
     {
       args: [
@@ -26,21 +28,36 @@ describe("Git hook output", () => {
         "--return",
         "--flush",
         "--command",
-        command,
+        `: >"$CAPTURE_OUT" 2>"$CAPTURE_ERR"; exec bash -euo pipefail -c '${hookRun}'`,
         "/dev/null",
       ],
       err: "",
-      live: `${expected}fd1=yes\nfd2=yes\nerror output\n`,
-      name: "shows live terminal output",
+      live: "task\nprecommit\nsetup=ready\nfd0=no\nfd1=yes\nfd2=yes\nerror output\n",
+      name: "shows live terminal output to an interactive caller",
       out: "",
       program: "script",
     },
     {
-      args: ["--fork", "--wait", "bash", "-c", command],
+      args: [
+        "--quiet",
+        "--return",
+        "--flush",
+        "--command",
+        captured,
+        "/dev/null",
+      ],
       err: "error output\n",
       live: "",
-      name: "preserves captured output",
-      out: `${expected}fd1=no\nfd2=no\n`,
+      name: "keeps captured output for a piped caller",
+      out: capturedLines,
+      program: "script",
+    },
+    {
+      args: ["--fork", "--wait", "bash", "-c", captured],
+      err: "error output\n",
+      live: "",
+      name: "preserves captured output without a controlling terminal",
+      out: capturedLines,
       program: "setsid",
     },
   ]) {


### PR DESCRIPTION
## Summary

The commit hook now decides where its output goes by looking at prek's own stdout. A person at a terminal keeps live precommit progress. Captured callers such as CI and agents receive hook output through their pipes instead of losing it to the terminal.

## Problem

`scripts/devenv/precommit.sh` redirected both streams to `/dev/tty` whenever a controlling terminal existed. An agent committing through captured pipes has a controlling terminal, so all hook output — including failure diagnostics — went to the invoker's terminal. The caller saw only the exit code.

`setsid` worked around this by removing the controlling terminal. The workaround also removed the caller's session identity and prevented the hook from ever writing to a terminal.

## Verified behaviour

I probed the pinned prek 0.3.11 with a failing hook:

- Hooks always receive non-tty stdin, even when prek runs at a terminal. A stdin-based gate would break live output for people.
- The hook runs as a direct child of prek, and prek's own stdout is `/dev/pts/N` for an interactive caller and a pipe or socket for CI and agents.

So the hook reads `/proc/$PPID/fd/1`: when that file is a terminal, the caller is a person, and the hook writes live output to `/dev/tty` as before. Otherwise output stays in the pipes prek captures. The check uses only shell built-ins, and every step tolerates failure in conditions, so the wrapper's `errexit` and `nounset` stay safe.

## Tests

Each mode runs with exit statuses 0 and 37:

- An interactive caller at a pseudo-terminal sees live output; the capture files stay empty. stdin is `/dev/null`, matching what prek really gives hooks.
- A caller whose stdout is a regular file keeps all hook output captured.
- A caller whose stdout is a genuine pipe keeps all hook output captured, and the hook's exit status survives the pipeline.
- A session without a controlling terminal keeps captured output, as before.

No application source, database, or provider behaviour changes. Full `deno task precommit` passed on the branch through the commit hook, and the commits themselves ran captured, without `setsid`.