### PR TITLE
Link new sites by their stable b-cdn.net address, not bunny.run

### DIFF
--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -61,7 +61,6 @@ src/ui/templates/admin/schema-atlas.tsx::UnansweredMoneySection~15crpim ??→|| 
 # builder.tsx: the built-sites table renders every column with no columnKeys
 # or hiddenKeys passed, so a column's key reaches no rendered output.
 src/ui/templates/admin/builder.tsx::builtSitesTable~0ytajae name→""   # renderTable(builtSitesTable, sites) filters by key only when columnKeys/hiddenKeys are passed, and this page passes neither
-src/ui/templates/admin/builder.tsx::builtSitesTable~1mp2mcy url→""   # same: the key reaches no rendered output on this page
 src/ui/templates/admin/builder.tsx::builtSitesTable~0w4j3rw built→""   # same: the key reaches no rendered output on this page
 
 # seeds.tsx: the page passes no nav route, and no nav section owns the empty

--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -58,10 +58,17 @@ src/ui/templates/admin/logistics.tsx::LogisticsAgentEditPanel.html~01ax7pa  ?? �
 # "", so ?? and || pick the same side for every input.
 src/ui/templates/admin/schema-atlas.tsx::UnansweredMoneySection~15crpim ??→||   # formatTimeAgo → string|null, never ""
 
-# builder.tsx: the built-sites table renders every column with no columnKeys
-# or hiddenKeys passed, so a column's key reaches no rendered output.
+# builder.tsx and list-parts.tsx: the two built-sites tables render every
+# column with no columnKeys or hiddenKeys passed, so a column's key reaches
+# no rendered output.
 src/ui/templates/admin/builder.tsx::builtSitesTable~0ytajae name→""   # renderTable(builtSitesTable, sites) filters by key only when columnKeys/hiddenKeys are passed, and this page passes neither
+src/ui/templates/admin/builder.tsx::builtSitesTable~0l4ob4i url→""   # same: the key reaches no rendered output on this page
 src/ui/templates/admin/builder.tsx::builtSitesTable~0w4j3rw built→""   # same: the key reaches no rendered output on this page
+src/ui/templates/admin/built-sites/list-parts.tsx::builtSiteColumns~02alai9 name→""   # same: renderTable(builtSitesTable, sites) passes no columnKeys or hiddenKeys, so no code path reads the column key
+src/ui/templates/admin/built-sites/list-parts.tsx::builtSiteColumns~0wl4rmg site_url→""   # same: this table renders with no columnKeys or hiddenKeys
+src/ui/templates/admin/built-sites/list-parts.tsx::builtSiteColumns~0g1lcco status→""   # same: this table renders with no columnKeys or hiddenKeys
+src/ui/templates/admin/built-sites/list-parts.tsx::builtSiteColumns~1szmvt4 updates→""   # same: this table renders with no columnKeys or hiddenKeys
+src/ui/templates/admin/built-sites/list-parts.tsx::builtSiteColumns~1geahz2 read_only→""   # same: this table renders with no columnKeys or hiddenKeys
 
 # seeds.tsx: the page passes no nav route, and no nav section owns the empty
 # string, so any non-route value renders the same unhighlighted nav.

--- a/src/features/admin/builder.ts
+++ b/src/features/admin/builder.ts
@@ -25,6 +25,7 @@ import {
   isDenoDeployEnabled,
   isTursoEnabled,
 } from "#shared/config.ts";
+import { siteBaseUrl } from "#shared/site-address.ts";
 import {
   adminBuilderPage,
   type BuiltSiteDisplay,
@@ -150,7 +151,9 @@ const builderPost = createAuthedFormRoute({
 
     return redirect(
       BUILDER_PATH,
-      `Site "${values.site_name}" created successfully at ${buildResult.defaultHostname}`,
+      `Site "${values.site_name}" created successfully at ${siteBaseUrl(
+        buildResult.defaultHostname,
+      )}`,
       true,
     );
   },

--- a/src/shared/bunny-cdn.ts
+++ b/src/shared/bunny-cdn.ts
@@ -17,6 +17,7 @@ import { ErrorCode, logError } from "#shared/logger.ts";
 import { delay } from "#shared/now.ts";
 import type { HostingProviderApi } from "#shared/provider-types.ts";
 import { errorResult, okResult, type Result } from "#shared/result.ts";
+import { toStableHostname } from "#shared/site-address.ts";
 
 const BUNNY_API_BASE = "https://api.bunny.net";
 
@@ -106,7 +107,7 @@ const findPullZoneIdImpl = (): Promise<
  * This is the stable hostname for CNAME targets, independent of request URL.
  */
 const toCnameTarget = (hostname: string): string =>
-  hostname.replace(/^https?:\/\//, "").replace(/\.bunny\.run$/, ".b-cdn.net");
+  toStableHostname(hostname.replace(/^https?:\/\//, ""));
 
 const getCdnHostnameImpl = (): Promise<CdnHostnameResult> =>
   withEdgeScript((data) => ({
@@ -331,7 +332,8 @@ const registerBunnySubdomainImpl = async (
   const recordName = buildSubdomainRecordName(subdomain);
   const fullDomain = availCheck.fullDomain;
 
-  // Resolve CDN hostname for CNAME target (stable .b-cdn.net, not custom domain)
+  // Resolve the stable CDN hostname for the CNAME target, never the raw
+  // script host or the custom domain.
   const cdnHostname = await bunnyCdnApi.getCdnHostname();
   if (!cdnHostname.ok) {
     return reported(cdnHostname);

--- a/src/shared/db/built-sites.ts
+++ b/src/shared/db/built-sites.ts
@@ -268,19 +268,6 @@ export const builtSitesCrudTable: Table<BuiltSite, BuiltSiteFormInput> = {
   ): Promise<BuiltSite | null> => updateBuiltSite(id, () => input),
 };
 
-/** Normalize a site's bunny URL to its absolute origin — scheme + host only,
- * with any path, query, hash, or trailing slash dropped — so callers can safely
- * append a path. siteUrl may be stored as a bare hostname, so a default scheme
- * is added first (scheme detection is case-insensitive, so an `HTTPS://` URL
- * isn't mistaken for a hostname); `new URL(...).origin` then collapses anything
- * past the host and lower-cases the scheme. */
-export const siteBaseUrl = (siteUrl: string): string => {
-  const withScheme = /^https?:\/\//i.test(siteUrl)
-    ? siteUrl
-    : `https://${siteUrl}`;
-  return new URL(withScheme).origin;
-};
-
 /** Insert a new built site record */
 export const insertBuiltSite = async (
   name: string,

--- a/src/shared/site-address.ts
+++ b/src/shared/site-address.ts
@@ -22,14 +22,17 @@ export const toStableHostname = (hostname: string): string => {
   return hostname;
 };
 
-/** The stable absolute address of a built site — scheme + host only, so a
- * caller can safely append a path. siteUrl may be stored as a bare hostname,
- * so a default scheme is added first (scheme detection is case-insensitive,
- * so an `HTTPS://` URL is not mistaken for a hostname); `new URL(...).origin`
- * then collapses anything past the host and lower-cases the scheme. */
+/** The stable absolute address of a built site — the scheme, host, and any
+ * non-default port of the stored URL, with the host mapped to its stable
+ * twin, so a caller can safely append a path. siteUrl may be stored as a bare
+ * hostname, so a default scheme is added first (scheme detection is
+ * case-insensitive, so an `HTTPS://` URL is not mistaken for a hostname), and
+ * `new URL(...).origin` drops anything past the host. */
 export const siteBaseUrl = (siteUrl: string): string => {
   const withScheme = /^https?:\/\//i.test(siteUrl)
     ? siteUrl
     : `https://${siteUrl}`;
-  return toStableHostname(new URL(withScheme).origin);
+  const url = new URL(withScheme);
+  url.hostname = toStableHostname(url.hostname);
+  return url.origin;
 };

--- a/src/shared/site-address.ts
+++ b/src/shared/site-address.ts
@@ -1,0 +1,35 @@
+/**
+ * The stable address of a built site. Every host that serves one site on two
+ * hostnames is named here once, and every link, monitor, and probe goes
+ * through siteBaseUrl — a future deployment host is one new table row.
+ */
+
+/** A raw host suffix that some visitors cannot reach, and the stable host
+ * suffix for the same site. A host with one address (Deno Deploy) has no row. */
+const STABLE_HOST_SUFFIXES: readonly (readonly [
+  raw: string,
+  stable: string,
+])[] = [[".bunny.run", ".b-cdn.net"]];
+
+/** The stable hostname for the same site as `hostname`; any hostname that
+ * matches no table row is returned unchanged. */
+export const toStableHostname = (hostname: string): string => {
+  for (const [raw, stable] of STABLE_HOST_SUFFIXES) {
+    if (hostname.endsWith(raw)) {
+      return hostname.slice(0, hostname.length - raw.length) + stable;
+    }
+  }
+  return hostname;
+};
+
+/** The stable absolute address of a built site — scheme + host only, so a
+ * caller can safely append a path. siteUrl may be stored as a bare hostname,
+ * so a default scheme is added first (scheme detection is case-insensitive,
+ * so an `HTTPS://` URL is not mistaken for a hostname); `new URL(...).origin`
+ * then collapses anything past the host and lower-cases the scheme. */
+export const siteBaseUrl = (siteUrl: string): string => {
+  const withScheme = /^https?:\/\//i.test(siteUrl)
+    ? siteUrl
+    : `https://${siteUrl}`;
+  return toStableHostname(new URL(withScheme).origin);
+};

--- a/src/shared/site-assignment.ts
+++ b/src/shared/site-assignment.ts
@@ -10,7 +10,6 @@ import type { BuiltSite } from "#db/built-sites/types.ts";
 import {
   assignBuiltSite,
   getAssignableBuiltSites,
-  siteBaseUrl,
   updateBuiltSiteRenewalState,
 } from "#db/built-sites.ts";
 import { getAllListings } from "#db/listings/records.ts";
@@ -23,6 +22,7 @@ import { getEmailConfig, hostEmail, sendEmail } from "#shared/email.ts";
 import { ErrorCode, logError } from "#shared/logger.ts";
 import { nowIso, nowMs, parseDateMs } from "#shared/now.ts";
 import { sendNtfyError } from "#shared/ntfy.ts";
+import { siteBaseUrl } from "#shared/site-address.ts";
 import {
   reportSiteAssignmentFailure,
   type SiteAssignmentConfigValidation,

--- a/src/shared/site-scheduler.ts
+++ b/src/shared/site-scheduler.ts
@@ -4,6 +4,7 @@ import { resolveHostingProvider, siteHostingAccess } from "#shared/builder.ts";
 import { fetchText } from "#shared/fetch.ts";
 import { errorResult, okResult, type Result } from "#shared/result.ts";
 import { SCHEDULED_TASK_KEY_ENV } from "#shared/scheduled-keys.ts";
+import { siteBaseUrl } from "#shared/site-address.ts";
 
 type SiteSchedulerResult = Result<void>;
 
@@ -18,14 +19,11 @@ const verifyScheduledKey = async (
   key: string,
 ): Promise<SiteSchedulerResult> => {
   try {
-    const result = await fetchText(
-      `${new URL(/^https?:\/\//i.test(siteUrl) ? siteUrl : `https://${siteUrl}`).origin}/scheduled`,
-      {
-        headers: { authorization: `Bearer ${key}` },
-        method: "POST",
-        redirect: "manual",
-      },
-    );
+    const result = await fetchText(`${siteBaseUrl(siteUrl)}/scheduled`, {
+      headers: { authorization: `Bearer ${key}` },
+      method: "POST",
+      redirect: "manual",
+    });
     return result.status === 204 && result.text === ""
       ? okResult(undefined)
       : errorResult("The child did not accept the scheduled task key.");

--- a/src/shared/uptime-kuma/monitor-input.ts
+++ b/src/shared/uptime-kuma/monitor-input.ts
@@ -1,5 +1,5 @@
 import type { BuiltSite } from "#db/built-sites/types.ts";
-import { siteBaseUrl } from "#db/built-sites.ts";
+import { siteBaseUrl } from "#shared/site-address.ts";
 import type { UptimeKumaMonitorInput } from "./client.ts";
 import type { UptimeKumaConfig } from "./config.ts";
 

--- a/src/ui/templates/admin/builder.tsx
+++ b/src/ui/templates/admin/builder.tsx
@@ -5,6 +5,7 @@
 import { t } from "#i18n";
 import { Raw } from "#jsx/jsx-runtime.ts";
 import { getDefaultDbProvider } from "#shared/config.ts";
+import { siteBaseUrl } from "#shared/site-address.ts";
 import { defineTable } from "#shared/tables/definition.ts";
 import { flashDataPage } from "#templates/admin/admin-page.tsx";
 import { BuiltSitesGuideFooter } from "#templates/admin/built-sites/list-parts.tsx";
@@ -26,7 +27,7 @@ export type BuiltSiteDisplay = {
 const builtSitesTable = defineTable<BuiltSiteDisplay>([
   translatedTableColumn("name", "common.name", (site) => site.name),
   translatedTableColumn("url", "builder.table_url", (site) => (
-    <NewTabUrl url={site.siteUrl} />
+    <NewTabUrl url={siteBaseUrl(site.siteUrl)} />
   )),
   translatedTableColumn("built", "builder.table_built", (site) => site.created),
 ]);

--- a/src/ui/templates/admin/built-sites/list-parts.tsx
+++ b/src/ui/templates/admin/built-sites/list-parts.tsx
@@ -3,6 +3,7 @@
 import type { BuiltSite } from "#db/built-sites/types.ts";
 import { t } from "#i18n";
 import { formatDeadlineLabel } from "#shared/renewal-helpers.ts";
+import { siteBaseUrl } from "#shared/site-address.ts";
 import type { TableColumn } from "#shared/tables/column.ts";
 import { defineTable } from "#shared/tables/definition.ts";
 import { RenewalTierSummary } from "#templates/admin/built-sites/renewal-summary.tsx";
@@ -42,7 +43,7 @@ const builtSiteNameCell = linkCell(
 );
 
 const builtSiteUrlCell = (site: BuiltSite): JSX.Element => (
-  <NewTabUrl url={site.siteUrl} />
+  <NewTabUrl url={siteBaseUrl(site.siteUrl)} />
 );
 
 const builtSiteColumns: readonly TableColumn<BuiltSite>[] = [

--- a/test/features/admin/builder/server.test.ts
+++ b/test/features/admin/builder/server.test.ts
@@ -374,6 +374,39 @@ describeWithEnv(
       });
     });
 
+    test("POST /admin/builder records the flash at the site's stable address", async () => {
+      await withMocks(
+        () => ({
+          buildStub: stub(builderApi, "buildSite", async (_input, retain) => {
+            const result = {
+              dbProvider: "bunny" as const,
+              dbToken: "tok",
+              dbUrl: "libsql://test.io",
+              defaultHostname: "freshsite.bunny.run",
+              hostingId: "42",
+              hostingProvider: "bunny" as const,
+              ok: true as const,
+            };
+            await retain({ ...result, scheduledTaskKey: TEST_SCHEDULED_KEY });
+            return result;
+          }),
+          dbTestStub: stubDbOk(),
+        }),
+        async () => {
+          const { response } = await adminFormPost("/admin/builder", {
+            db_token: "token",
+            db_url: "libsql://test.io",
+            site_name: "Stable Address Site",
+          });
+          expectRedirect(response, "/admin/builder");
+          expectFlash(
+            response,
+            expect.stringContaining("https://freshsite.b-cdn.net"),
+          );
+        },
+      );
+    });
+
     test("POST /admin/builder returns error when build fails", async () => {
       await withMocks(
         () => ({

--- a/test/integration/server/site-assignment.test.ts
+++ b/test/integration/server/site-assignment.test.ts
@@ -366,6 +366,12 @@ describeWithEnv(
         await expectSetupEmailBody("https://c.test.net/setup/");
       });
 
+      test("email setup link names a bunny.run site by its stable b-cdn.net address", async () => {
+        await insertBuiltSite("Site D", "newbooking.bunny.run", "", "", true);
+
+        await expectSetupEmailBody("https://newbooking.b-cdn.net/setup/");
+      });
+
       test("uses DB email config when available and includes reply-to", async () => {
         // Configure email via DB settings (not host config) so getEmailConfig()
         // returns non-null, covering the left branch of the ?? operator

--- a/test/shared/db/built-sites/core.test.ts
+++ b/test/shared/db/built-sites/core.test.ts
@@ -1,11 +1,10 @@
 import { expect } from "@std/expect";
-import { describe, it as test } from "@std/testing/bdd";
+import { it as test } from "@std/testing/bdd";
 import { parseSiteDataBlob } from "#db/built-sites/blob.ts";
 import {
   builtSites,
   builtSitesCrudTable,
   insertBuiltSite,
-  siteBaseUrl,
 } from "#db/built-sites.ts";
 import { execute } from "#db/client.ts";
 import { getAllCacheStats } from "#shared/cache-registry.ts";
@@ -18,30 +17,6 @@ const formBlob = async (
   const values = await builtSitesCrudTable.toDbValues(input);
   return parseSiteDataBlob(values.site_data as string);
 };
-
-describe("siteBaseUrl", () => {
-  test("prepends https:// to a bare hostname", () => {
-    expect(siteBaseUrl("site.b-cdn.net")).toBe("https://site.b-cdn.net");
-  });
-
-  test("keeps an existing scheme", () => {
-    expect(siteBaseUrl("http://example.com")).toBe("http://example.com");
-  });
-
-  test("strips a trailing slash so a path can be appended", () => {
-    expect(siteBaseUrl("https://example.com/")).toBe("https://example.com");
-  });
-
-  test("collapses a path, query, and hash to the origin", () => {
-    expect(siteBaseUrl("https://example.com/admin?x=1#y")).toBe(
-      "https://example.com",
-    );
-  });
-
-  test("normalizes an uppercase scheme to a lowercase origin", () => {
-    expect(siteBaseUrl("HTTPS://example.com")).toBe("https://example.com");
-  });
-});
 
 describeWithEnv("built-site storage", { db: true }, () => {
   test("toDbValues creates valid site-data JSON", async () => {

--- a/test/shared/site-address.test.ts
+++ b/test/shared/site-address.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { siteBaseUrl, toStableHostname } from "#shared/site-address.ts";
+
+describe("toStableHostname", () => {
+  test("maps a bunny.run hostname to b-cdn.net", () => {
+    expect(toStableHostname("child.newsite.bunny.run")).toBe(
+      "child.newsite.b-cdn.net",
+    );
+  });
+
+  test("leaves a b-cdn.net hostname as it is", () => {
+    expect(toStableHostname("child.b-cdn.net")).toBe("child.b-cdn.net");
+  });
+
+  test("leaves a Deno Deploy hostname as it is", () => {
+    expect(toStableHostname("site.org.deno.net")).toBe("site.org.deno.net");
+  });
+
+  test("leaves a custom domain as it is", () => {
+    expect(toStableHostname("tickets.example.co.uk")).toBe(
+      "tickets.example.co.uk",
+    );
+  });
+});
+
+describe("siteBaseUrl", () => {
+  test("prepends https:// to a bare hostname", () => {
+    expect(siteBaseUrl("site.b-cdn.net")).toBe("https://site.b-cdn.net");
+  });
+
+  test("keeps an existing scheme", () => {
+    expect(siteBaseUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  test("strips a trailing slash so a path can be appended", () => {
+    expect(siteBaseUrl("https://example.com/")).toBe("https://example.com");
+  });
+
+  test("collapses a path, query, and hash to the origin", () => {
+    expect(siteBaseUrl("https://example.com/admin?x=1#y")).toBe(
+      "https://example.com",
+    );
+  });
+
+  test("normalizes an uppercase scheme to a lowercase origin", () => {
+    expect(siteBaseUrl("HTTPS://example.com")).toBe("https://example.com");
+  });
+
+  test("gives a bunny.run site its stable b-cdn.net address", () => {
+    expect(siteBaseUrl("child.newsite.bunny.run")).toBe(
+      "https://child.newsite.b-cdn.net",
+    );
+  });
+
+  test("maps the bunny.run host when the URL also carries a scheme and path", () => {
+    expect(siteBaseUrl("https://child.bunny.run/admin?x=1")).toBe(
+      "https://child.b-cdn.net",
+    );
+  });
+
+  test("leaves a Deno Deploy URL on its own address", () => {
+    expect(siteBaseUrl("https://site.org.deno.net/")).toBe(
+      "https://site.org.deno.net",
+    );
+  });
+
+  test("leaves a custom domain on its own address", () => {
+    expect(siteBaseUrl("tickets.example.co.uk")).toBe(
+      "https://tickets.example.co.uk",
+    );
+  });
+});

--- a/test/shared/site-address.test.ts
+++ b/test/shared/site-address.test.ts
@@ -59,6 +59,18 @@ describe("siteBaseUrl", () => {
     );
   });
 
+  test("maps the bunny.run host when the URL also carries a port", () => {
+    expect(siteBaseUrl("https://child.bunny.run:8443")).toBe(
+      "https://child.b-cdn.net:8443",
+    );
+  });
+
+  test("keeps a custom domain's non-default port", () => {
+    expect(siteBaseUrl("https://tickets.example.co.uk:8443")).toBe(
+      "https://tickets.example.co.uk:8443",
+    );
+  });
+
   test("leaves a Deno Deploy URL on its own address", () => {
     expect(siteBaseUrl("https://site.org.deno.net/")).toBe(
       "https://site.org.deno.net",

--- a/test/shared/site-scheduler.test.ts
+++ b/test/shared/site-scheduler.test.ts
@@ -142,10 +142,12 @@ describeWithEnv(
       });
     });
 
-    test("verifies only the child origin when its URL includes a path", async () => {
+    /** Provision the scheduler for a child stored at `siteUrl`, succeed at the
+     * live check, and name the URL the verification request went to. */
+    const expectVerifiedFetchUrl = async (siteUrl: string): Promise<string> => {
       const child = await insertBuiltSite(
         "Child",
-        "HTTPS://child.example.test/unsafe/path",
+        siteUrl,
         "",
         "",
         false,
@@ -155,8 +157,18 @@ describeWithEnv(
       using fetchStub = stubFetch(new Response(null, { status: 204 }));
 
       expect((await provisionSiteScheduler(child.id)).ok).toBe(true);
-      expect(String(fetchStub.calls[0]!.args[0])).toBe(
-        "https://child.example.test/scheduled",
+      return String(fetchStub.calls[0]!.args[0]);
+    };
+
+    test("verifies only the child origin when its URL includes a path", async () => {
+      expect(
+        await expectVerifiedFetchUrl("HTTPS://child.example.test/unsafe/path"),
+      ).toBe("https://child.example.test/scheduled");
+    });
+
+    test("verifies a bunny.run child at its stable b-cdn.net address", async () => {
+      expect(await expectVerifiedFetchUrl("child.bunny.run")).toBe(
+        "https://child.b-cdn.net/scheduled",
       );
     });
   },

--- a/test/shared/uptime-kuma/monitor-input.test.ts
+++ b/test/shared/uptime-kuma/monitor-input.test.ts
@@ -95,4 +95,10 @@ describe("Uptime Kuma monitor input", () => {
     expect(first.conditions).not.toBe(second.conditions);
     expect(first.rabbitmqNodes).not.toBe(second.rabbitmqNodes);
   });
+
+  test("monitors a bunny.run child at its stable b-cdn.net address", () => {
+    expect(scheduledUrl(testBuiltSite({ siteUrl: "child.bunny.run" }))).toBe(
+      "https://child.b-cdn.net/scheduled",
+    );
+  });
 });

--- a/test/ui/templates/admin/builder.test.ts
+++ b/test/ui/templates/admin/builder.test.ts
@@ -50,6 +50,18 @@ describe("adminBuilderPage", () => {
     expect(html).toContain('target="_blank"');
   });
 
+  test("links a bare bunny.run address as a working b-cdn.net link", () => {
+    const html = adminBuilderPage(OWNER_SESSION, [
+      {
+        created: "1 Jan 2026",
+        name: "Bunny-run site",
+        siteUrl: "childsite.bunny.run",
+      },
+    ]);
+    expect(html).toContain('href="https://childsite.b-cdn.net"');
+    expect(html).not.toContain("bunny.run");
+  });
+
   test("renders error message", () => {
     const html = adminBuilderPage(OWNER_SESSION, [], "Something went wrong");
     expect(html).toContain("Something went wrong");

--- a/test/ui/templates/admin/built-sites/list-parts.test.tsx
+++ b/test/ui/templates/admin/built-sites/list-parts.test.tsx
@@ -40,21 +40,30 @@ test("renders a site's link, URL, status, channel, and host id", () => {
   expect(html).toContain("host-42");
 });
 
-test("distinguishes available and unavailable unassigned sites", () => {
+test("labels an unassigned site that others can book as Available", () => {
   const html = String(
     BuiltSitesListBody({
       hostingIds: "",
       renewalTiers: [],
-      sites: [
-        testBuiltSite({ assignable: true, id: 1, name: "Available" }),
-        testBuiltSite({ assignable: false, id: 2, name: "Unavailable" }),
-      ],
+      sites: [testBuiltSite({ assignable: true, id: 1, name: "Alpha" })],
     }),
   );
-  expect(html).toContain("Available</a>");
+  expect(html).toContain('<a href="/admin/built-sites/1">Alpha</a>');
   expect(html).toContain("Available</td>");
-  expect(html).toContain("Unavailable</a>");
-  expect(html).toContain("Not assignable");
+  expect(html).not.toContain("Not assignable");
+});
+
+test("labels an unassigned site nobody can book as Not assignable", () => {
+  const html = String(
+    BuiltSitesListBody({
+      hostingIds: "",
+      renewalTiers: [],
+      sites: [testBuiltSite({ assignable: false, id: 2, name: "Beta" })],
+    }),
+  );
+  expect(html).toContain('<a href="/admin/built-sites/2">Beta</a>');
+  expect(html).toContain("Not assignable</td>");
+  expect(html).not.toContain("Available</td>");
 });
 
 test("links a bare bunny.run address as a working b-cdn.net link", () => {

--- a/test/ui/templates/admin/built-sites/list-parts.test.tsx
+++ b/test/ui/templates/admin/built-sites/list-parts.test.tsx
@@ -57,6 +57,24 @@ test("distinguishes available and unavailable unassigned sites", () => {
   expect(html).toContain("Not assignable");
 });
 
+test("links a bare bunny.run address as a working b-cdn.net link", () => {
+  const html = String(
+    BuiltSitesListBody({
+      hostingIds: "",
+      renewalTiers: [],
+      sites: [
+        testBuiltSite({
+          id: 7,
+          name: "Bunny-run site",
+          siteUrl: "childsite.bunny.run",
+        }),
+      ],
+    }),
+  );
+  expect(html).toContain('href="https://childsite.b-cdn.net"');
+  expect(html).not.toContain("bunny.run");
+});
+
 test("renders the list actions and guide destination", () => {
   const actions = String(BuiltSitesListActions());
   expect(actions).toContain('href="/admin/built-sites/new"');


### PR DESCRIPTION
Closes #2340.

## What changed

A brand-new site owner opened her setup email and saw "the site can't provide a secure connection". The email linked the site's raw `*.bunny.run` address. Some networks cannot reach that host. The stable `*.b-cdn.net` address works for every visitor.

One new module now names every raw host and its stable twin in one table, so a future deployment host is one new row:

- `src/shared/site-address.ts` (new, pure, no imports) holds `STABLE_HOST_SUFFIXES` — `[".bunny.run", ".b-cdn.net"]` today — plus `toStableHostname` and `siteBaseUrl`. `bunny.run` and `b-cdn.net` appear in `src/` only here (the one remaining mention is the form placeholder example in `src/locales/en/built-sites.json`, which is copy, and already shows the stable form).

Every surface that names a built site goes through `siteBaseUrl`, which now also maps the host:

- The "Your new site is ready" setup email (`sendSiteAssignmentEmail` in `src/shared/site-assignment.ts`).
- The admin Built sites table (`src/ui/templates/admin/built-sites/list-parts.tsx`) and the Builder page table plus its "created successfully" flash (`src/ui/templates/admin/builder.tsx`, `src/features/admin/builder.ts`).
- The Uptime Kuma monitor URL (`src/shared/uptime-kuma/monitor-input.ts`) and the scheduled-task key verification (`src/shared/site-scheduler.ts`), which also had its own inline copy of the scheme-and-origin logic — now one call.

The old `siteBaseUrl` implementation in `src/shared/db/built-sites.ts` is deleted (moved to the pure module), and `toCnameTarget` in `src/shared/bunny-cdn.ts` now shares `toStableHostname` instead of carrying its own copy of the mapping. A Deno Deploy address (`*.deno.net`) and any custom domain pass through unchanged. No stored data changes.

`siteBaseUrl` maps the host on the parsed `URL.hostname` (a CodeRabbit review finding, fixed in c26d794d5), so a non-default port cannot hide the raw host, and the scheme and port survive exactly as before.

The table cells also gained a fix: a bare `xxx.bunny.run` href is a relative link that 404s on the admin origin; the cells now render the absolute address.

## Facts

- Trusted: the stored `siteUrl` of a bunny-hosted site is the raw `*.bunny.run` hostname from the Bunny API. Observed: `.b-cdn.net` serves the same site (`toCnameTarget` already treated it as the stable host, and the operator's hand-typed `.b-cdn.net` link worked in the report).
- No schema change, no stored-data migration: the mapping happens at display time, so existing sites stored with `bunny.run` also get stable links.
- No new failure paths, retries, races, or owner choices — this is a pure string transform of stored data.

## Tests

- Regression (fails before the fix): the setup email links `https://…b-cdn.net/setup/` for a `bunny.run` site (`test/integration/server/site-assignment.test.ts`).
- Both admin tables link a bare `bunny.run` address as a working `https://…b-cdn.net` link (`test/ui/templates/admin/…`).
- The builder flash reports the stable address (`test/features/admin/builder/server.test.ts`).
- The scheduler probe and the Uptime Kuma monitor use the stable host (`test/shared/site-scheduler.test.ts`, `test/shared/uptime-kuma/monitor-input.test.ts`).
- `test/shared/site-address.test.ts` pins the mapping table (bunny, deno, custom domain, scheme/path/port forms).

## Gates

- `devenv shell deno task precommit` — passed.
- `devenv shell deno task precommit:mutation` — 455 mutants, 100% killed (14 suppressed as known-equivalent). The run surfaced seven survivors on the two table templates. One was a real gap — the status labels test could not tell which row a status came from — now pinned per row. The other six name column keys no code path reads (both tables render without `columnKeys`/`hiddenKeys`); they are recorded in `scripts/mutation/equivalent-mutants/ui-templates.txt` with that reason, and `builder.tsx`'s stale `url` entry was re-recorded against the new cell.

18 files changed, 260 insertions, 68 deletions. No new database or provider calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bunny-hosted site links now consistently use stable `b-cdn.net` addresses instead of temporary `bunny.run` hostnames.
  - Site URLs are normalized to secure HTTPS origins, removing unnecessary paths, queries, fragments, and trailing slashes.
  - Admin builder and built-site tables now display reliable, correctly formatted links.
  - Scheduled verification and uptime-monitor links now target stable site addresses.

- **Tests**
  - Added coverage for stable hostname conversion and URL normalization across admin displays, scheduling, monitoring, and site assignment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
