### PR TITLE
Drop the pre-prek hook prek kept running beside the managed one

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -40,6 +40,7 @@ let
     deno = "${deno}/bin/deno";
     denoVersion = "2.5.6";
     chromium = lib.optionalString browserTools "${pkgs.chromium}/bin/chromium";
+    legacyHookCleanup = toString ./scripts/devenv/remove-legacy-hook.sh;
   };
 in
 {

--- a/scripts/devenv/remove-legacy-hook.sh
+++ b/scripts/devenv/remove-legacy-hook.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prek kept the repo's pre-migration commit hook as pre-commit.legacy and runs
+# it beside the managed hook. The legacy wrapper runs the suite with the
+# caller's PATH, so a caller without util-linux fails the Git hook output
+# tests, and every commit pays for the suite twice. Activation removes it,
+# because the managed hook already runs the same precommit with the nix bin
+# PATH. A legacy file that carries anything but the known wrapper stays.
+hooks_dir="$(git rev-parse --git-path hooks 2>/dev/null)" || exit 0
+legacy="${hooks_dir}/pre-commit.legacy"
+[ -f "$legacy" ] || exit 0
+known_wrapper='#!/usr/bin/env sh
+# Installed by tickets flake.nix
+exec deno task precommit'
+if [ "$(cat "$legacy")" = "$known_wrapper" ]; then
+  rm "$legacy" || echo "tickets: could not remove $legacy" >&2
+fi

--- a/scripts/devenv/shell.sh
+++ b/scripts/devenv/shell.sh
@@ -34,3 +34,8 @@ chromium="@chromium@"
 if [ -n "$chromium" ]; then
   export CHROMIUM_EXECUTABLE="$chromium"
 fi
+
+# prek kept the repo's pre-migration commit hook beside the managed one and
+# runs both, so every commit pays for the suite twice and the bare hook breaks
+# when the caller's PATH lacks util-linux.
+bash @legacyHookCleanup@

--- a/test/scripts/devenv/remove-legacy-hook.test.ts
+++ b/test/scripts/devenv/remove-legacy-hook.test.ts
@@ -1,0 +1,90 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { withTempDir } from "#test-utils/files.ts";
+
+/** The exact pre-migration wrapper prek kept as pre-commit.legacy. */
+const KNOWN_LEGACY = `#!/usr/bin/env sh
+# Installed by tickets flake.nix
+exec deno task precommit
+`;
+
+const MANAGED_HOOK = "#!/bin/sh\n: the managed hook\n";
+
+/** The repo-relative script, as an absolute path for a cwd'd subprocess. */
+const removalScript = new URL(
+  "../../../scripts/devenv/remove-legacy-hook.sh",
+  import.meta.url,
+);
+
+/** Plant a git repo whose hooks dir holds the managed hook plus `legacy`. */
+const withLegacyRepo = (
+  legacy: string | null,
+  run: (repo: string) => Promise<number>,
+): Promise<number> =>
+  withTempDir(async (repo) => {
+    const git = new Deno.Command("git", {
+      args: ["init", "--quiet", repo],
+      stdin: "null",
+    });
+    expect((await git.output()).code).toBe(0);
+    await Deno.mkdir(`${repo}/.git/hooks`, { recursive: true });
+    if (legacy !== null) {
+      await Deno.writeTextFile(`${repo}/.git/hooks/pre-commit.legacy`, legacy);
+    }
+    await Deno.writeTextFile(`${repo}/.git/hooks/pre-commit`, MANAGED_HOOK);
+    return await run(repo);
+  });
+
+const runRemoval = async (cwd: string): Promise<number> => {
+  const run = new Deno.Command("bash", {
+    args: [removalScript.pathname],
+    cwd,
+    stderr: "inherit",
+    stdin: "null",
+    stdout: "inherit",
+  });
+  return (await run.output()).code;
+};
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const legacyHook = (repo: string): string =>
+  `${repo}/.git/hooks/pre-commit.legacy`;
+
+describe("remove-legacy-hook.sh", () => {
+  test("removes the preserved pre-migration wrapper, not the managed hook", async () => {
+    await withLegacyRepo(KNOWN_LEGACY, async (repo) => {
+      await runRemoval(repo);
+      expect(await fileExists(legacyHook(repo))).toBe(false);
+      expect(await Deno.readTextFile(`${repo}/.git/hooks/pre-commit`)).toBe(
+        MANAGED_HOOK,
+      );
+      return 0;
+    });
+  });
+
+  test("keeps a legacy hook a person changed", async () => {
+    await withLegacyRepo(`${KNOWN_LEGACY}# extra line\n`, async (repo) => {
+      await runRemoval(repo);
+      expect(await fileExists(legacyHook(repo))).toBe(true);
+      return 0;
+    });
+  });
+
+  test("stays a quiet no-op outside a git repo", async () => {
+    const code = await withTempDir((dir) => runRemoval(dir));
+    expect(code).toBe(0);
+  });
+
+  test("stays a quiet no-op when no legacy hook exists", async () => {
+    const code = await withLegacyRepo(null, (repo) => runRemoval(repo));
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #2357.

## What changed

Shell activation now removes a leftover `.git/hooks/pre-commit.legacy`
when its text is exactly the repo's pre-migration wrapper. The removal
runs once per activation, through a new
`scripts/devenv/remove-legacy-hook.sh` wired into activation via
`@legacyHookCleanup@` in `devenv.nix`, next to the existing
`@runtimeSetup@`.

## Why

When git-hooks.nix switched this repo to prek, prek preserved the hook
that was already installed as `pre-commit.legacy` and keeps running it
after the managed hook. The legacy wrapper is three lines:

```sh
#!/usr/bin/env sh
# Installed by tickets flake.nix
exec deno task precommit
```

It runs the whole suite with the caller's PATH, so every commit paid
for the six-minute suite twice, and a caller without util-linux on PATH
failed the eight Git hook output tests -- BusyBox `script` answers
`unrecognized option '--return'` -- which blocked the commit. Both
parts are the bug #2357 records.

## The evidence

- The `.diagnostics/precommit/` records showed two `test:coverage`
  runs per commit, one failing and one passing.
- `/proc/<pid>/environ` of the failing run holds both
  `PREK_RUNNING_LEGACY=1` and the wrapper's own
  `LD_LIBRARY_PATH`, and its `PATH` carries no nix bin prefix: prek
  ran the bare legacy wrapper beside the managed one.
- Under that PATH, `script` and `setsid` resolve to BusyBox, which
  is what all eight failing tests hit.

The removal is content-gated: a legacy hook someone changed stays in
place. Outside a repo, or with no legacy hook, the script is a quiet
no-op that never blocks entering the shell.

## Tests and gates

- `test/scripts/devenv/remove-legacy-hook.test.ts` covers the
  removal, the untouched managed hook, a changed legacy hook kept, and
  both no-op paths.
- `devenv shell deno task precommit` passed on this exact tree.
- `devenv shell deno task precommit:mutation` skipped: the branch
  changes no `src/` files.
- The fix commit itself went through the real pre-commit hook with no
  `--no-verify`: one `test:coverage` run in the diagnostics, and
  `precommit....Passed`. Before the fix, the same command was blocked
  by the eight failing tests.

## Changed lines

4 files, +114, no deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development environment setup now automatically removes the obsolete legacy Git hook when it matches the known wrapper.
  - Prevents duplicate pre-commit checks and avoids failures caused by PATH-dependent hook execution.
  - Existing customized hooks are preserved, and cleanup safely skips repositories where the legacy hook is absent or cannot be identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->