### PR TITLE
Drop dead entries from Biome's noConsole exemption list

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -151,12 +151,7 @@
       }
     },
     {
-      "includes": [
-        "src/index.ts",
-        "src/app/index.ts",
-        "src/shared/logger.ts",
-        "src/ui/client/order.ts"
-      ],
+      "includes": ["src/shared/logger.ts", "src/ui/client/order.ts"],
       "linter": {
         "rules": {
           "suspicious": {


### PR DESCRIPTION
## What changed

`biome.json` exempted four named files from Biome's `suspicious/noConsole` error rule. Two of the four were dead:

- `src/app/index.ts` was deleted in the domain-first layout change (#1080). The exemption has matched no file since.
- `src/index.ts` no longer logs. `Deno.serve` prints the startup line itself, and the file header says so.

The override now names only the two real console boundaries: `src/shared/logger.ts` and `src/ui/client/order.ts`.

## Why

An exemption that no longer matches the code hides a rule that should guard it. If a future change adds a `console` call to `src/index.ts`, the lint now fails instead of passing silently.

## Verification

- `deno task lint:ci` passes over all 4,199 files with the narrowed override. This proves `src/index.ts` has no console call left, so the rule guards it again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting rules so console usage is permitted only in designated logging and order-processing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->