### PR TITLE
Remove deno-lint-ignore directives from a linter we no longer run

### DIFF
--- a/scripts/check-comments/rules.ts
+++ b/scripts/check-comments/rules.ts
@@ -30,7 +30,7 @@ export interface CommentIssue {
  * build does, so no limit may apply to them.
  */
 const DIRECTIVE =
-  /jscpd:ignore|<reference|deno-lint-ignore|biome-ignore|@ts-expect-error|@ts-ignore|@ts-nocheck|@ts-self-types|deno-fmt-ignore|test-groups:|sourceMappingURL/;
+  /jscpd:ignore|<reference|biome-ignore|@ts-expect-error|@ts-ignore|@ts-nocheck|@ts-self-types|deno-fmt-ignore|test-groups:|sourceMappingURL/;
 
 /** How many newlines `content` holds between `from` and `to`. */
 const newlinesBetween = (content: string, from: number, to: number): number => {

--- a/src/ui/client/admin/csrf.ts
+++ b/src/ui/client/admin/csrf.ts
@@ -5,7 +5,6 @@ export const csrfPost = async (
   url: string,
   csrfToken: string,
   extraBody = "",
-  // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
   const body = `csrf_token=${encodeURIComponent(csrfToken)}${extraBody}`;
   const res = await fetch(url, {

--- a/test/features/admin/attendees-edit.test.ts
+++ b/test/features/admin/attendees-edit.test.ts
@@ -115,7 +115,6 @@ const setupTaggedRefresh = async (
 const submitRefreshPayment = async (
   attendee: Attendee,
   refundedPredicate: (reference: string) => Promise<boolean>,
-  // deno-lint-ignore no-explicit-any
   expectedFlash: string | any = expect.stringContaining("refunded"),
   succeeded = true,
 ): Promise<string[]> => {

--- a/test/features/admin/built-sites/actions.test.ts
+++ b/test/features/admin/built-sites/actions.test.ts
@@ -1,4 +1,3 @@
-// deno-lint-ignore-file no-explicit-any
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";

--- a/test/features/api/packages/helpers.ts
+++ b/test/features/api/packages/helpers.ts
@@ -113,7 +113,6 @@ export const withAddonGetPackage = async (
   memberId: number,
   childId: number,
   slug: string,
-  // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
   await listingChildren.setIds(memberId, [childId]);
   return (await (await apiGet(`/api/packages/${slug}`)).json()).package;

--- a/test/features/api/request-schemas.test.ts
+++ b/test/features/api/request-schemas.test.ts
@@ -7,7 +7,6 @@ import {
   PackageChildrenSchema,
 } from "#routes/api/request-schemas.ts";
 
-// deno-lint-ignore no-explicit-any
 type Schema = any;
 
 const parse = (schema: Schema, input: unknown) => v.safeParse(schema, input);

--- a/test/features/images.test.ts
+++ b/test/features/images.test.ts
@@ -42,7 +42,6 @@ describeWithEnv(
         const encrypted = await encryptBytes(imageData);
 
         await withCdnProxy(
-          // deno-lint-ignore no-explicit-any
           () => new Response(encrypted as any, { status: 200 }),
           async () => {
             const response = await proxyRequest();

--- a/test/integration/attachment-route.test.ts
+++ b/test/integration/attachment-route.test.ts
@@ -70,7 +70,6 @@ describeWithEnv(
           const encrypted = await encryptBytes(data);
           installUrlHandler(originalFetch, (url) => {
             if (url.includes("storage.bunnycdn.com")) {
-              // deno-lint-ignore no-explicit-any
               return Promise.resolve(new Response(encrypted as any));
             }
             return null;

--- a/test/integration/renewals.test.ts
+++ b/test/integration/renewals.test.ts
@@ -52,7 +52,6 @@ const makeRenewalEntry = (
     { quantity },
   );
 
-// deno-lint-ignore no-explicit-any
 type SecretStub = any;
 
 type StubResult = { ok: true } | { ok: false; error: string };

--- a/test/integration/server/attendees/placeholder-refresh.test.ts
+++ b/test/integration/server/attendees/placeholder-refresh.test.ts
@@ -33,7 +33,6 @@ const submitRefreshPayment = async (
   refundedPredicate: (reference: string) => Promise<boolean>,
   // The expected flash message varies: "refunded" on first post, "up to date"
   // on retry. Accept any because expect.stringContaining returns a matcher.
-  // deno-lint-ignore no-explicit-any
   expectedFlash: any = expect.stringContaining("refunded"),
 ): Promise<void> => {
   await withRefreshPaymentProbe(

--- a/test/integration/server/settings/apple-wallet.test.ts
+++ b/test/integration/server/settings/apple-wallet.test.ts
@@ -55,7 +55,6 @@ const fetchPkpassResponse = (token: string) =>
   awaitTestRequest(`/wallet/${token}.pkpass`);
 
 /** Fetch and parse pass.json from a pkpass response */
-// deno-lint-ignore no-explicit-any
 const parsePkpassJson = async (token: string): Promise<Record<string, any>> => {
   const response = await fetchPkpassResponse(token);
   const bytes = new Uint8Array(await response.arrayBuffer());

--- a/test/scripts/check-comments/rules.test.ts
+++ b/test/scripts/check-comments/rules.test.ts
@@ -59,14 +59,13 @@ describe("readComments", () => {
     const source = [
       "/* jscpd:ignore-start */",
       '/// <reference lib="dom" />',
-      "// deno-lint-ignore no-explicit-any",
       "// biome-ignore lint: needed",
       "// @ts-expect-error deliberate",
       "// test-groups: run-alone",
       "// kept",
     ].join("\n");
     expect(readComments(source)).toEqual([
-      { column: 0, line: 7, text: "// kept" },
+      { column: 0, line: 6, text: "// kept" },
     ]);
   });
 

--- a/test/scripts/check-comments/rules.test.ts
+++ b/test/scripts/check-comments/rules.test.ts
@@ -73,6 +73,13 @@ describe("readComments", () => {
     const found = readComments("// prefer a named type over a cast\n");
     expect(found).toHaveLength(1);
   });
+
+  // The directive family retired with deno lint, so its comments are prose.
+  test("keeps a deno-lint-ignore comment as prose", () => {
+    expect(readComments("// deno-lint-ignore no-explicit-any\n")).toEqual([
+      { column: 0, line: 1, text: "// deno-lint-ignore no-explicit-any" },
+    ]);
+  });
 });
 
 describe("comment-length rule", () => {

--- a/test/scripts/stripe-mock/ports.test.ts
+++ b/test/scripts/stripe-mock/ports.test.ts
@@ -28,7 +28,6 @@ import {
 describe("stripe-mock ports and environment", () => {
   test("keeps a reserved port unavailable until release", () =>
     retryWhilePortTaken(
-      // deno-lint-ignore require-await -- retryWhilePortTaken awaits the attempt
       async () => {
         const reserved = reserveAvailablePort();
         let listener: Deno.Listener | undefined;

--- a/test/test-utils/assertions.ts
+++ b/test/test-utils/assertions.ts
@@ -118,16 +118,14 @@ export const fetchListingExportCsv = async (
 };
 
 export const expectJsonResponse =
-  // deno-lint-ignore no-explicit-any
-    <T = any>(status: number, assertions?: (body: T) => void) =>
-    async (response: Response): Promise<T> => {
-      expect(response.status).toBe(status);
-      const body = (await response.json()) as T;
-      assertions?.(body);
-      return body;
-    };
+  <T = any>(status: number, assertions?: (body: T) => void) =>
+  async (response: Response): Promise<T> => {
+    expect(response.status).toBe(status);
+    const body = (await response.json()) as T;
+    assertions?.(body);
+    return body;
+  };
 
-// deno-lint-ignore no-explicit-any
 export const assertJson = async <T = any>(
   request: Promise<Response>,
   status: number,
@@ -383,7 +381,6 @@ export const parseFlashCookie = (
 
 export const expectFlash = (
   response: Response,
-  // deno-lint-ignore no-explicit-any
   message: string | any,
   succeeded = true,
 ): Response => {
@@ -414,19 +411,18 @@ export const expectErrorFlash = (response: Response, text: string): void => {
 };
 
 export const expectRedirectWithFlash =
-  // deno-lint-ignore no-explicit-any
-    (location: string, message?: string | any, succeeded = true) =>
-    (response: Response): Response => {
-      const actualLocation = expectRedirect(response);
-      const url = new URL(actualLocation, "http://localhost");
-      const flashId = url.searchParams.get("flash");
-      expect(flashId).toBeDefined();
-      url.searchParams.delete("flash");
-      const clean = url.pathname + url.search + url.hash;
-      expect(clean).toBe(location);
-      expectFlash(response, message, succeeded);
-      return response;
-    };
+  (location: string, message?: string | any, succeeded = true) =>
+  (response: Response): Response => {
+    const actualLocation = expectRedirect(response);
+    const url = new URL(actualLocation, "http://localhost");
+    const flashId = url.searchParams.get("flash");
+    expect(flashId).toBeDefined();
+    url.searchParams.delete("flash");
+    const clean = url.pathname + url.search + url.hash;
+    expect(clean).toBe(location);
+    expectFlash(response, message, succeeded);
+    return response;
+  };
 
 /** Lazy default follow cookie: the owner test session, which can GET any admin
  *  page, so the destination renders for the common admin case without the
@@ -475,7 +471,6 @@ const sessionCookieFromResponse = (response: Response): string | null => {
 export const expectFlashRedirect =
   (
     location: string,
-    // deno-lint-ignore no-explicit-any
     message: string | any,
     succeeded = true,
     cookie?: string,
@@ -568,7 +563,6 @@ export const getHeader = (response: Response, name: string): string =>
 /** Assert `fn` throws an error of `errorClass` and (optionally) whose message
  *  matches `pattern`. Runs `fn` twice — once per assertion — so only use for
  *  idempotent predicates (validators, pure checks), not stateful operations. */
-// deno-lint-ignore no-explicit-any
 export const expectThrows = (
   fn: () => unknown,
   errorClass: any,

--- a/test/test-utils/mocks.ts
+++ b/test/test-utils/mocks.ts
@@ -103,7 +103,6 @@ export const mockMultipartRequest = (
   const formData = new FormData();
   appendTestFormValues(formData, data);
   if (file) {
-    // deno-lint-ignore no-explicit-any
     const blob = new Blob([file.data as any], { type: file.contentType });
     formData.append(file.fieldName, blob, file.name);
   }
@@ -203,9 +202,7 @@ export const withMockBunnyCdnApi = async (
 ): Promise<void> => {
   const originals: Partial<typeof bunnyCdnApi> = {};
   for (const key of Object.keys(overrides) as (keyof typeof bunnyCdnApi)[]) {
-    // deno-lint-ignore no-explicit-any
     originals[key] = bunnyCdnApi[key] as any;
-    // deno-lint-ignore no-explicit-any
     bunnyCdnApi[key] = overrides[key] as any;
   }
   try {
@@ -484,7 +481,6 @@ export const stubReleaseFetch = (
   });
 
 export const useFetchStub = () => {
-  // deno-lint-ignore no-explicit-any
   type FetchStubRef = { current: any };
   const ref: FetchStubRef = { current: null };
 

--- a/test/test-utils/settings-handlers.ts
+++ b/test/test-utils/settings-handlers.ts
@@ -10,7 +10,6 @@ export const formFrom = (data: Record<string, string>): FormParams =>
   new FormParams(new URLSearchParams(data));
 
 /** A null AuthSession for handlers that never read the session. */
-// deno-lint-ignore no-explicit-any
 export const nullSession = null as any as AuthSession;
 
 /** The most recent activity-log message, or "" when the log is empty. */


### PR DESCRIPTION
## What changed

Deleted the 22 `deno-lint-ignore` and `deno-lint-ignore-file` directives
across `src/` and `test/`. `src/ui/client/admin/csrf.ts` was the last one in
`src/`; the rest lived in test helpers and integration tests.

## Why they are inert

The repo linted with `deno lint` before Biome took over (#1141 ran Biome after
deno lint; the deno lint half was later dropped). Nothing calls `deno lint`
today: `deno task lint` and `deno task lint:ci` both run `scripts/biome.ts`, and
no workflow or script invokes the subcommand. Biome only reads `biome-ignore`
comments, so every `deno-lint-ignore` was a comment that suppressed nothing.

Most silenced `no-explicit-any`, a rule Biome has `off` anyway; one silenced
`require-await`. A reader who trusts these directives believes a lint rule is
being suppressed where none exists.

## What stayed

- The prose comments above the directives where they still explain the code,
  for example the flash-message note in `placeholder-refresh.test.ts`.
- The census prose in `docs/comment-policy.md`, which records a measurement
  taken at a named commit.

With the last real directive gone, the comment checker's `deno-lint-ignore`
arm in `scripts/check-comments/rules.ts` matched nothing in the `src/` tree it
scans, and only its own test fixture exercised it. A review thread caught this,
and 9390a2f80 removes the arm and the fixture line; the drops-directives test
still pins the exemption with five other directive kinds. A second review
thread asked for the removal to be pinned, so e00468c39 adds
`keeps a deno-lint-ignore comment as prose` to the checker's suite — verified
by restoring the arm locally, watching that test fail, and removing it again.

The signatures the directives sat inside re-wrap after removal; that is Biome
formatting the now-clean parameter lists.

## Verification

Full precommit passed in the commit hook for every commit: typecheck, lint,
cpd, build, and the complete test suite. `deno task check:comments` passes with
the narrowed directive list, and the checker's own suite is green at 43/43.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated comment validation to no longer exempt `deno-lint-ignore` directives.
  - Removed obsolete lint-suppression comments across application and test code.
  - Preserved existing runtime behavior, test behavior, and public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
