### PR TITLE
Pre-fill the promo code box from a ?promo= URL parameter

### DIFF
--- a/scripts/mutation/equivalent-mutants/features.txt
+++ b/scripts/mutation/equivalent-mutants/features.txt
@@ -230,6 +230,7 @@ src/features/public/ticket-submit/parse.ts::validateFormState.selectedQty~1bh9sz
 src/features/public/ticket-submit/parse.ts::validateFormState.selectedQty~1bh9sz0  0 → ""   # "" parses to null then the outer fallback supplies 0; the literal "0" parses to 0 directly
 src/features/public/ticket-submit/parse.ts::parseCustomPrices.qty~0q3jgeq  ?? → ||   # the quantities map holds whole counts, and 0 is the fallback, so 0 || 0 = 0 ?? 0
 src/features/public/ticket-submit/parse.ts::parsePackageCount~1t2qol5  ?? → ||   # the parser answers a whole number or null, and 0 is the fallback, so 0 || 0 = 0 ?? 0
+src/features/public/ticket-submit.ts::parseQuantityPrefill.promo~0tck3kx  ?? → ||   # URLSearchParams.get answers a string or null, and the only falsy string is the empty fallback
 src/features/public/ticket-submit.ts::parseQuantityPrefill.qty~15gaxm3  ?? → ||   # URLSearchParams.get answers a string or null, and the only falsy string is the empty fallback
 src/features/public/ticket-submit.ts::parseQuantityPrefill.qty~15gaxm3   → "mutated"   # an absent quantity uses the fallback, and both fallback strings fail the positive-integer parser
 src/features/public/ticket-submit.ts::renderTicketFlow.prefill~160lbzo  ?? → ||   # a supplied prefill is an object, so every present value is truthy

--- a/scripts/mutation/equivalent-mutants/shared-a-l.txt
+++ b/scripts/mutation/equivalent-mutants/shared-a-l.txt
@@ -95,6 +95,10 @@ src/shared/crypto/utils.ts::constantTimeEqual~0nflsgj  ?? → ||   # bufB[i]: nu
 # non-null string is "" which equals the "" fallback, so ?? and || agree.
 src/shared/forms/saved-data.ts::savedFormValue~1w1m8os  ?? → ||   # getString(): string|undefined, "" ?? "" === "" || ""
 
+# getSavedFieldValue: readSubmittedFieldValue answers string|null; the only
+# nullish value is null, and "" already equals the "" fallback, so ?? and || agree.
+src/shared/forms/saved-data.ts::getSavedFieldValue~1y12b7e  ?? → ||   # string|null over the fallback "", so "" ?? "" === "" || ""
+
 # resize.ts writes each output pixel's channels exactly once into a freshly
 # zeroed Uint8ClampedArray, so `out[o] = x` and `out[o] += x` are identical
 # (0 + x === x). No input can revisit an index, so no test can distinguish them.

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -37,6 +37,7 @@ import type { FormParams } from "#shared/form-data.ts";
 import { getIframeMode } from "#shared/iframe.ts";
 /* jscpd:ignore-end */
 import type { CheckoutIntent } from "#shared/payments.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
 import { parsePositiveInt } from "#shared/validation/number.ts";
 import {
   orderSummary,
@@ -466,10 +467,12 @@ export const handleTicket = async (args: BookingRequest): Promise<Response> => {
 /**
  * Build a booking pre-fill from query params: per-listing quantities from
  * `?q_<id>=n` (the order page redirects into `/ticket/<slugs>?q_<id>=1…` to
- * land the visitor with their chosen items selected) and the date selector
+ * land the visitor with their chosen items selected), the date selector
  * from `?date=YYYY-MM-DD` (the /listings date filter carries the searched
- * date into a daily listing's Book CTA, #51). A package needs no count
- * pre-fill — its selector already defaults to one bundle.
+ * date into a daily listing's Book CTA, #51), and the promo-code box from
+ * `?promo=<code>` (an operator's link lands the code pre-typed, #2367). A
+ * package needs no count pre-fill — its selector already defaults to one
+ * bundle.
  */
 export const parseQuantityPrefill = (
   request: Request,
@@ -484,8 +487,13 @@ export const parseQuantityPrefill = (
     }
   }
   const date = parseIsoDateParam(params.get("date"));
-  if (map.size === 0 && date === null) return;
-  return { listings: map, ...(date !== null ? { date } : {}) };
+  const promo = normalizeCode(params.get("promo") ?? "");
+  if (map.size === 0 && date === null && promo === "") return;
+  return {
+    listings: map,
+    ...(date !== null ? { date } : {}),
+    ...(promo !== "" ? { promo } : {}),
+  };
 };
 
 /**

--- a/src/shared/forms/saved-data.ts
+++ b/src/shared/forms/saved-data.ts
@@ -29,6 +29,14 @@ export const getSavedFormData = (): FormParams | null =>
 export const savedFormValue = (name: string): string =>
   savedFormScope.current().form?.getString(name) ?? "";
 
+/** The submitted value of one field, or null when this form never carried
+ * it — the distinction a pre-filled field needs: a submitted empty string is
+ * the buyer's choice, an absent field is not. */
+export const savedFormValueOrNull = (name: string): string | null => {
+  const form = savedFormScope.current().form;
+  return form?.has(name) ? form.getString(name) : null;
+};
+
 /** Return a restorable field value without exposing passwords or files. */
 export const getSavedFieldValue = (field: Field): string => {
   const form = savedFormScope.current().form;

--- a/src/ui/templates/public/reservations/form.tsx
+++ b/src/ui/templates/public/reservations/form.tsx
@@ -13,7 +13,10 @@ import { formatDatetimeLabel } from "#shared/dates.ts";
 import { CsrfForm } from "#shared/forms/csrf-form.tsx";
 import type { Field } from "#shared/forms/field.ts";
 import { renderFields } from "#shared/forms/rendering.tsx";
-import { savedFormValue } from "#shared/forms/saved-data.ts";
+import {
+  savedFormValue,
+  savedFormValueOrNull,
+} from "#shared/forms/saved-data.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import { Badge } from "#templates/components/badge.tsx";
 import { ErrorNote } from "#templates/components/error.tsx";
@@ -117,8 +120,9 @@ const AddOnsFieldset = ({ addOns }: { addOns: AddOnOption[] }): JSX.Element => (
 );
 
 /** Promo-code text input, shown when any active modifier is unlocked by a code.
- * The entered value is restored on a validation-error re-render; a `?promo=`
- * link value fills the box only when nothing was entered. */
+ * A submitted value wins — even an empty one, so a buyer who cleared the box
+ * does not get the URL code back on a validation re-render; a `?promo=` link
+ * value fills the box only when nothing was submitted. */
 const PromoCodeField = ({
   prefilled,
 }: {
@@ -131,7 +135,7 @@ const PromoCodeField = ({
         name="promo_code"
         placeholder={t("public.promo.placeholder")}
         type="text"
-        value={savedFormValue("promo_code") || prefilled || ""}
+        value={savedFormValueOrNull("promo_code") ?? prefilled ?? ""}
       />
     </label>
   </div>

--- a/src/ui/templates/public/reservations/form.tsx
+++ b/src/ui/templates/public/reservations/form.tsx
@@ -117,8 +117,13 @@ const AddOnsFieldset = ({ addOns }: { addOns: AddOnOption[] }): JSX.Element => (
 );
 
 /** Promo-code text input, shown when any active modifier is unlocked by a code.
- * The entered value is restored on a validation-error re-render. */
-const PromoCodeField = (): JSX.Element => (
+ * The entered value is restored on a validation-error re-render; a `?promo=`
+ * link value fills the box only when nothing was entered. */
+const PromoCodeField = ({
+  prefilled,
+}: {
+  prefilled: string | undefined;
+}): JSX.Element => (
   <div class="promo-code">
     <label>
       {t("public.promo.heading")}
@@ -126,7 +131,7 @@ const PromoCodeField = (): JSX.Element => (
         name="promo_code"
         placeholder={t("public.promo.placeholder")}
         type="text"
-        value={savedFormValue("promo_code")}
+        value={savedFormValue("promo_code") || prefilled || ""}
       />
     </label>
   </div>
@@ -238,7 +243,7 @@ export const TicketPageForm = ({
         questions.length > 0 &&
         renderQuestions(questions, questionListingMap)}
       {addOns && addOns.length > 0 && <AddOnsFieldset addOns={addOns} />}
-      {promoCodesEnabled && <PromoCodeField />}
+      {promoCodesEnabled && <PromoCodeField prefilled={prefill?.promo} />}
       {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
       {/* Continue is rendered first so it stays the form's default submit: an
           implicit submit (Enter in a text field) completes the booking, not the

--- a/src/ui/templates/public/reservations/types.ts
+++ b/src/ui/templates/public/reservations/types.ts
@@ -61,6 +61,8 @@ export type BookingPrefill = {
   name?: string;
   /** Pre-fill date selector (for daily listings) */
   date?: string;
+  /** Pre-fill the promo-code box from `?promo=` (already normalized) */
+  promo?: string;
   /** Opaque signed token re-submitted via a hidden input to verify a price
    * override. Only signed QR booking links set this. */
   token?: string;

--- a/test/features/public/ticket-submit.test.ts
+++ b/test/features/public/ticket-submit.test.ts
@@ -103,4 +103,37 @@ describe("parseQuantityPrefill", () => {
       ),
     ).toEqual({ date: "2026-09-12", listings: new Map() });
   });
+
+  test("reads a promo code without case or surrounding spaces", () => {
+    expect(
+      parseQuantityPrefill(
+        new Request("https://example.com/ticket/a?promo=%20Summer25%20"),
+        listings,
+      ),
+    ).toEqual({ listings: new Map(), promo: "summer25" });
+  });
+
+  test("keeps the promo code beside quantities and the date", () => {
+    expect(
+      parseQuantityPrefill(
+        new Request(
+          "https://example.com/ticket/a?q_7=2&date=2026-09-12&promo=Summer25",
+        ),
+        listings,
+      ),
+    ).toEqual({
+      date: "2026-09-12",
+      listings: new Map([[7, { quantity: 2 }]]),
+      promo: "summer25",
+    });
+  });
+
+  test("ignores a promo code that is only spaces", () => {
+    expect(
+      parseQuantityPrefill(
+        new Request("https://example.com/ticket/a?promo=%20%20"),
+        listings,
+      ),
+    ).toBeUndefined();
+  });
 });

--- a/test/features/public/ticket-submit/submit-paths.test.ts
+++ b/test/features/public/ticket-submit/submit-paths.test.ts
@@ -5,10 +5,8 @@
 
 import { expect } from "@std/expect";
 import { describe, it as test } from "@std/testing/bdd";
-import { attendeeStatuses } from "#db/attendee-statuses.ts";
 import { getAttendeeBalanceState } from "#db/attendees/balance.ts";
 import { getAttendeesRaw } from "#db/attendees/queries.ts";
-import { getDb } from "#db/client.ts";
 import { type ModifierInput, modifiersTable } from "#db/modifiers.ts";
 import { settings } from "#db/settings.ts";
 import { formatCurrency } from "#shared/currency.ts";
@@ -24,6 +22,7 @@ import {
 } from "#test-utils/email.ts";
 import { awaitTestRequest, useFetchStub } from "#test-utils/mocks.ts";
 import { setupAnswerTier } from "#test-utils/modifiers.ts";
+import { setPublicReservation } from "#test-utils/reservation/helpers.ts";
 import { enablePublicSite } from "#test-utils/settings.ts";
 
 /** Select Square as the payment provider without giving it credentials, so
@@ -66,16 +65,6 @@ const expectReturningBuyerRejectedForEmail = async (
   });
 
   expectFlash(response, expect.stringContaining("Email is required"), false);
-};
-
-/** Turn the public-default status into a reservation charging `amount`, so a
- * booking without a provider still faces a deposit split. */
-const setPublicReservation = async (amount: string): Promise<void> => {
-  await getDb().execute({
-    args: [amount],
-    sql: "UPDATE attendee_statuses SET is_reservation = 1, reservation_amount = ? WHERE is_public_default = 1",
-  });
-  attendeeStatuses.invalidate();
 };
 
 describeWithEnv("ticket submit paths", { db: true, triggers: true }, () => {

--- a/test/features/public/ticket-submit/submit-paths.test.ts
+++ b/test/features/public/ticket-submit/submit-paths.test.ts
@@ -1,0 +1,269 @@
+/** Route-level tests of the ticket submit and quote paths in
+ * `src/features/public/ticket-submit.ts`: the Square email rule, the
+ * provider-less owed booking, the no-provider quote messages, the quote's
+ * CSRF rejection, the site-menu gate, and the one-listing group page. */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { attendeeStatuses } from "#db/attendee-statuses.ts";
+import { getAttendeeBalanceState } from "#db/attendees/balance.ts";
+import { getAttendeesRaw } from "#db/attendees/queries.ts";
+import { getDb } from "#db/client.ts";
+import { modifiersTable } from "#db/modifiers.ts";
+import { settings } from "#db/settings.ts";
+import { formatCurrency } from "#shared/currency.ts";
+import { assertPublicHtml, expectFlash } from "#test-utils/assertions.ts";
+import { quoteTicketHtml, submitTicketForm } from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestAttendeeDirect } from "#test-utils/db-helpers/attendees.ts";
+import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { awaitTestRequest } from "#test-utils/mocks.ts";
+import { setupAnswerTier } from "#test-utils/modifiers.ts";
+import { enablePublicSite } from "#test-utils/settings.ts";
+
+/** Select Square as the payment provider without giving it credentials, so
+ * the paid-field rules apply while bookings still take the provider-less
+ * path (nothing can be charged through Square in tests). */
+const selectProviderSquare = async (): Promise<void> => {
+  await settings.update.paymentProvider("square");
+};
+
+/** Turn the public-default status into a reservation charging `amount`, so a
+ * booking without a provider still faces a deposit split. */
+const setPublicReservation = async (amount: string): Promise<void> => {
+  await getDb().execute({
+    args: [amount],
+    sql: "UPDATE attendee_statuses SET is_reservation = 1, reservation_amount = ? WHERE is_public_default = 1",
+  });
+  attendeeStatuses.invalidate();
+};
+
+describeWithEnv("ticket submit paths", { db: true, triggers: true }, () => {
+  describe("the Square email rule", () => {
+    test("requires email for a paid booking even when the listing asks only for a name", async () => {
+      await selectProviderSquare();
+      const listing = await createTestListing({
+        fields: "",
+        maxAttendees: 50,
+        unitPrice: 1000,
+      });
+
+      const response = await submitTicketForm(listing.slug, {
+        name: "John Doe",
+      });
+
+      expectFlash(
+        response,
+        expect.stringContaining("Email is required"),
+        false,
+      );
+    });
+
+    test("requires email for a one-penny paid booking", async () => {
+      await selectProviderSquare();
+      const listing = await createTestListing({
+        fields: "",
+        maxAttendees: 50,
+        unitPrice: 1,
+      });
+
+      const response = await submitTicketForm(listing.slug, {
+        name: "John Doe",
+      });
+
+      expectFlash(
+        response,
+        expect.stringContaining("Email is required"),
+        false,
+      );
+    });
+
+    test("books a free booking without email", async () => {
+      await selectProviderSquare();
+      const listing = await createTestListing({
+        fields: "",
+        maxAttendees: 50,
+      });
+
+      const response = await submitTicketForm(listing.slug, {
+        name: "John Doe",
+      });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe(
+        "https://example.com/thanks",
+      );
+    });
+
+    test("re-checks the email rule when repricing raises a one-penny total", async () => {
+      await selectProviderSquare();
+      const listing = await createTestListing({
+        fields: "phone",
+        maxAttendees: 50,
+      });
+      // A one-penny surcharge for returning buyers: the first pass (no
+      // contact, zero visits) prices the order free, the repriced order
+      // with the buyer's real visit count costs a penny — and a paid order
+      // under Square must carry an email.
+      await modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 1,
+        direction: "charge",
+        minVisits: 1,
+        name: "Returning buyer fee",
+      });
+      await createTestAttendeeDirect(
+        listing.id,
+        "Returning Buyer",
+        "returning@example.com",
+        1,
+        "07700 900000",
+      );
+
+      const response = await submitTicketForm(listing.slug, {
+        name: "John Doe",
+        phone: "07700 900000",
+      });
+
+      expectFlash(
+        response,
+        expect.stringContaining("Email is required"),
+        false,
+      );
+    });
+  });
+
+  test("charges nothing now for a provider-less paid booking with a deposit status", async () => {
+    await setPublicReservation("50%");
+    const listing = await createTestListing({
+      maxAttendees: 50,
+      thankYouUrl: "https://example.com/thanks",
+      unitPrice: 1000,
+    });
+
+    const response = await submitTicketForm(listing.slug, {
+      email: "john@example.com",
+      name: "John Doe",
+    });
+
+    expect(response.status).toBe(302);
+    const [attendee] = await getAttendeesRaw(listing.id);
+    expect(attendee?.remaining_balance).toBe(1000);
+    // The ledger agrees: the full value is owed, nothing was collected.
+    expect(
+      (await getAttendeeBalanceState(attendee!.id))?.remainingBalance,
+    ).toBe(1000);
+  });
+
+  describe("quotes without a payment provider", () => {
+    test("tells the buyer they owe the full value of a paid order", async () => {
+      const listing = await createTestListing({
+        maxQuantity: 5,
+        unitPrice: 1000,
+      });
+
+      const html = await quoteTicketHtml(listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      });
+
+      expect(html).toContain(
+        `No online payment is needed now — you'll owe ${formatCurrency(
+          1000,
+        )} for this booking.`,
+      );
+      expect(html).not.toContain("No payment required");
+    });
+
+    test("tells the buyer a free order needs no payment", async () => {
+      const listing = await createTestListing({ maxQuantity: 5 });
+
+      const html = await quoteTicketHtml(listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      });
+
+      expect(html).toContain("No payment required for this booking.");
+      expect(html).not.toContain("you'll owe");
+    });
+
+    test("tells the buyer they owe a one-penny order", async () => {
+      const listing = await createTestListing({
+        maxQuantity: 5,
+        unitPrice: 1,
+      });
+
+      const html = await quoteTicketHtml(listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      });
+
+      expect(html).toContain(
+        `you'll owe ${formatCurrency(1)} for this booking.`,
+      );
+    });
+
+    test("rejects a quote without a CSRF token as 403", async () => {
+      const listing = await createTestListing({ maxQuantity: 5 });
+
+      const response = await awaitTestRequest(`/calculate/${listing.slug}`, {
+        data: { [`quantity_${listing.id}`]: "1" },
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    test("quotes cleanly for an answer tier a new buyer cannot reach", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      // Sold out, but gated behind a returning buyer's visit count — a
+      // quote strips PII, so it runs at zero visits and cannot see the
+      // tier. It must quote normally instead of reporting it sold out.
+      const { answerId, questionId } = await setupAnswerTier(listing, {
+        minVisits: 1,
+      });
+
+      const html = await quoteTicketHtml(listing.slug, {
+        [`question_${questionId}`]: String(answerId),
+        [`quantity_${listing.id}`]: "1",
+      });
+
+      expect(html).toContain("No payment required for this booking.");
+      expect(html).not.toContain("no longer available");
+    });
+  });
+
+  describe("the site menu on the booking page", () => {
+    test("shows the menu when the public site is on", async () => {
+      await enablePublicSite();
+      const listing = await createTestListing({ maxAttendees: 50 });
+
+      await assertPublicHtml(
+        `/ticket/${listing.slug}`,
+        'aria-label="Site menu"',
+      );
+    });
+
+    test("hides the menu when the public site is off", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+
+      const html = await assertPublicHtml(`/ticket/${listing.slug}`);
+      expect(html).not.toContain('aria-label="Site menu"');
+    });
+  });
+
+  test("renders a one-listing group page rather than 404", async () => {
+    const group = await createTestGroup({ name: "Solo Group" });
+    await createTestListing({
+      groupId: group.id,
+      maxAttendees: 50,
+      name: "Only Member",
+    });
+
+    // A single member still renders the booking form — the all-children 404
+    // must fire only when nothing standalone remains.
+    await assertPublicHtml(
+      `/ticket/${group.slug}`,
+      "Solo Group",
+      "Continue",
+      `action="/ticket/${group.slug}"`,
+    );
+  });
+});

--- a/test/features/public/ticket-submit/submit-paths.test.ts
+++ b/test/features/public/ticket-submit/submit-paths.test.ts
@@ -9,7 +9,7 @@ import { attendeeStatuses } from "#db/attendee-statuses.ts";
 import { getAttendeeBalanceState } from "#db/attendees/balance.ts";
 import { getAttendeesRaw } from "#db/attendees/queries.ts";
 import { getDb } from "#db/client.ts";
-import { modifiersTable } from "#db/modifiers.ts";
+import { type ModifierInput, modifiersTable } from "#db/modifiers.ts";
 import { settings } from "#db/settings.ts";
 import { formatCurrency } from "#shared/currency.ts";
 import { assertPublicHtml, expectFlash } from "#test-utils/assertions.ts";
@@ -18,7 +18,11 @@ import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestAttendeeDirect } from "#test-utils/db-helpers/attendees.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
-import { awaitTestRequest } from "#test-utils/mocks.ts";
+import {
+  configureTestEmail,
+  expectSingleTicketSvg,
+} from "#test-utils/email.ts";
+import { awaitTestRequest, useFetchStub } from "#test-utils/mocks.ts";
 import { setupAnswerTier } from "#test-utils/modifiers.ts";
 import { enablePublicSite } from "#test-utils/settings.ts";
 
@@ -27,6 +31,41 @@ import { enablePublicSite } from "#test-utils/settings.ts";
  * path (nothing can be charged through Square in tests). */
 const selectProviderSquare = async (): Promise<void> => {
   await settings.update.paymentProvider("square");
+};
+
+/** Book under Square as a buyer whose phone number carries one previous
+ * booking, with a visit-gated modifier live, and assert the paid-order email
+ * rule rejects the form. The listing asks for a phone (so the repricing pass
+ * can resolve the buyer's visit count) but never an email; only what the
+ * modifier does to the repriced total differs between callers. */
+const expectReturningBuyerRejectedForEmail = async (
+  unitPrice: number,
+  modifier: Pick<
+    ModifierInput,
+    "calcKind" | "calcValue" | "direction" | "name"
+  >,
+): Promise<void> => {
+  await selectProviderSquare();
+  const listing = await createTestListing({
+    fields: "phone",
+    maxAttendees: 50,
+    unitPrice,
+  });
+  await modifiersTable.insert({ ...modifier, minVisits: 1 });
+  await createTestAttendeeDirect(
+    listing.id,
+    "Returning Buyer",
+    "returning@example.com",
+    1,
+    "07700 900000",
+  );
+
+  const response = await submitTicketForm(listing.slug, {
+    name: "John Doe",
+    phone: "07700 900000",
+  });
+
+  expectFlash(response, expect.stringContaining("Email is required"), false);
 };
 
 /** Turn the public-default status into a reservation charging `amount`, so a
@@ -79,6 +118,18 @@ describeWithEnv("ticket submit paths", { db: true, triggers: true }, () => {
       );
     });
 
+    test("keeps requiring email for a one-penny order a discount would make free", async () => {
+      // A returning buyer's 100% discount re-prices the £0.01 order to
+      // nothing — but the order was paid when the form was first checked,
+      // so the email Square demands of paid orders must still be there.
+      await expectReturningBuyerRejectedForEmail(1, {
+        calcKind: "percent",
+        calcValue: 100,
+        direction: "discount",
+        name: "Loyalty",
+      });
+    });
+
     test("books a free booking without email", async () => {
       await selectProviderSquare();
       const listing = await createTestListing({
@@ -97,63 +148,48 @@ describeWithEnv("ticket submit paths", { db: true, triggers: true }, () => {
     });
 
     test("re-checks the email rule when repricing raises a one-penny total", async () => {
-      await selectProviderSquare();
-      const listing = await createTestListing({
-        fields: "phone",
-        maxAttendees: 50,
-      });
       // A one-penny surcharge for returning buyers: the first pass (no
       // contact, zero visits) prices the order free, the repriced order
-      // with the buyer's real visit count costs a penny — and a paid order
-      // under Square must carry an email.
-      await modifiersTable.insert({
+      // with the buyer's real visit count costs exactly a penny — and a
+      // paid order under Square must carry an email.
+      await expectReturningBuyerRejectedForEmail(0, {
         calcKind: "fixed",
-        calcValue: 1,
+        calcValue: 0.01,
         direction: "charge",
-        minVisits: 1,
         name: "Returning buyer fee",
       });
-      await createTestAttendeeDirect(
-        listing.id,
-        "Returning Buyer",
-        "returning@example.com",
-        1,
-        "07700 900000",
-      );
-
-      const response = await submitTicketForm(listing.slug, {
-        name: "John Doe",
-        phone: "07700 900000",
-      });
-
-      expectFlash(
-        response,
-        expect.stringContaining("Email is required"),
-        false,
-      );
     });
   });
+  describe("a provider-less paid booking with a deposit status", () => {
+    const fetch = useFetchStub();
 
-  test("charges nothing now for a provider-less paid booking with a deposit status", async () => {
-    await setPublicReservation("50%");
-    const listing = await createTestListing({
-      maxAttendees: 50,
-      thankYouUrl: "https://example.com/thanks",
-      unitPrice: 1000,
+    test("charges nothing now, records the full value owed, and shows no paid price", async () => {
+      await configureTestEmail();
+      await setPublicReservation("50%");
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice: 1000,
+      });
+
+      const response = await submitTicketForm(listing.slug, {
+        email: "john@example.com",
+        name: "John Doe",
+      });
+
+      // The ledger records the full value as owed and nothing collected —
+      // the 50% deposit status cannot take a deposit with no provider
+      // configured. The ticket attachment prices the booking by what the
+      // buyer was charged, so it carries no paid price either.
+      expect(response.status).toBe(302);
+      const [attendee] = await getAttendeesRaw(listing.id);
+      expect(
+        (await getAttendeeBalanceState(attendee!.id))?.remainingBalance,
+      ).toBe(1000);
+      const svg = expectSingleTicketSvg(fetch.getFetchJsonBody());
+      expect(svg).not.toContain("Price:");
+      expect(svg).toContain("Qty: 1");
     });
-
-    const response = await submitTicketForm(listing.slug, {
-      email: "john@example.com",
-      name: "John Doe",
-    });
-
-    expect(response.status).toBe(302);
-    const [attendee] = await getAttendeesRaw(listing.id);
-    expect(attendee?.remaining_balance).toBe(1000);
-    // The ledger agrees: the full value is owed, nothing was collected.
-    expect(
-      (await getAttendeeBalanceState(attendee!.id))?.remainingBalance,
-    ).toBe(1000);
   });
 
   describe("quotes without a payment provider", () => {

--- a/test/integration/server/calculate.test.ts
+++ b/test/integration/server/calculate.test.ts
@@ -5,40 +5,25 @@ import { hmacHash } from "#crypto/hashing.ts";
 import { attendeeStatuses } from "#db/attendee-statuses.ts";
 import { getDb } from "#db/client.ts";
 import { setGroupPackageMembers } from "#db/groups.ts";
-import { modifiersTable, setModifierAnswers } from "#db/modifiers.ts";
-import { listingQuestions } from "#db/questions/queries.ts";
-import { answersTable, questionsTable } from "#db/questions/tables.ts";
+import { modifiersTable } from "#db/modifiers.ts";
 import { settings } from "#db/settings.ts";
 import { handleRequest } from "#routes";
 import { formatCurrency } from "#shared/currency.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
-import { extractCsrfToken } from "#test-utils/csrf.ts";
+import { postRunningTotal } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
-import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
+import { mockFormRequest } from "#test-utils/mocks.ts";
+import { setupAnswerTier } from "#test-utils/modifiers.ts";
 import { setupStripe } from "#test-utils/settings.ts";
-
-/** GET the booking page for `pageSlug` to mint a CSRF token, then POST the
- * given inputs to `/calculate/<postSlug>` exactly as the running total would. */
-const calculate = async (
-  pageSlug: string,
-  postSlug: string,
-  data: Record<string, string>,
-): Promise<Response> => {
-  const page = await handleRequest(mockRequest(`/ticket/${pageSlug}`));
-  const csrf = extractCsrfToken(await page.text()) ?? "";
-  return handleRequest(
-    mockFormRequest(`/calculate/${postSlug}`, { csrf_token: csrf, ...data }),
-  );
-};
 
 /** POST a quote for a single-slug page (page and post slug are the same) and
  * return just its HTML. */
 const quote = async (
   slug: string,
   data: Record<string, string>,
-): Promise<string> => (await calculate(slug, slug, data)).text();
+): Promise<string> => (await postRunningTotal(slug, slug, data)).text();
 
 /** Quote a package by its package count and return the summary HTML. */
 const quotePackage = (
@@ -56,7 +41,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       unitPrice: 1500,
     });
 
-    const response = await calculate(listing.slug, listing.slug, {
+    const response = await postRunningTotal(listing.slug, listing.slug, {
       [`quantity_${listing.id}`]: "1",
     });
     expect(response.status).toBe(200);
@@ -91,7 +76,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       { listingId: member.id, price: null },
     ]);
 
-    const response = await calculate(group.slug, group.slug, {
+    const response = await postRunningTotal(group.slug, group.slug, {
       [`package_quantity_${group.id}`]: "1",
     });
     expect(response.status).toBe(200);
@@ -166,7 +151,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     ]);
 
     // "abc" → 0 packages → empty order.
-    const response = await calculate(group.slug, group.slug, {
+    const response = await postRunningTotal(group.slug, group.slug, {
       [`package_quantity_${group.id}`]: "abc",
     });
     expect(await response.text()).toContain("select at least one");
@@ -264,7 +249,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     });
 
     const html = await (
-      await calculate(listing.slug, listing.slug, {
+      await postRunningTotal(listing.slug, listing.slug, {
         [`quantity_${listing.id}`]: "2",
       })
     ).text();
@@ -287,7 +272,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     });
 
     // No name/email/phone sent — a quote must not require them.
-    const response = await calculate(listing.slug, listing.slug, {
+    const response = await postRunningTotal(listing.slug, listing.slug, {
       [`quantity_${listing.id}`]: "3",
     });
     expect(response.status).toBe(200);
@@ -297,7 +282,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
   test("shows a prompt when nothing is selected", async () => {
     const listing = await createTestListing({ maxQuantity: 5, name: "Seat" });
 
-    const response = await calculate(listing.slug, listing.slug, {
+    const response = await postRunningTotal(listing.slug, listing.slug, {
       [`quantity_${listing.id}`]: "0",
     });
     expect(response.status).toBe(200);
@@ -330,7 +315,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       unitPrice: 2000,
     });
 
-    const response = await calculate("festival", "festival", {
+    const response = await postRunningTotal("festival", "festival", {
       [`quantity_${listing.id}`]: "1",
     });
     expect(response.status).toBe(200);
@@ -351,7 +336,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     });
 
     const html = await (
-      await calculate(listing.slug, listing.slug, {
+      await postRunningTotal(listing.slug, listing.slug, {
         [`quantity_${listing.id}`]: "1",
       })
     ).text();
@@ -369,7 +354,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     });
 
     const html = await (
-      await calculate(listing.slug, listing.slug, {
+      await postRunningTotal(listing.slug, listing.slug, {
         [`quantity_${listing.id}`]: "1",
       })
     ).text();
@@ -380,36 +365,18 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
   test("rejects a sold-out answer tier in the quote", async () => {
     await setupStripe();
     const listing = await createTestListing({ maxAttendees: 50 });
-    const question = await questionsTable.insert({
-      displayType: "radio",
-      text: "T-shirt size?",
-    });
-    const answer = await answersTable.insert({
-      questionId: question.id,
-      sortOrder: 0,
-      text: "Small",
-    });
-    await listingQuestions.setIds(listing.id, [question.id]);
     // A stock-limited answer tier with no stock left, selected by the quote.
-    const tier = await modifiersTable.insert({
-      calcKind: "fixed",
-      calcValue: 5,
-      direction: "charge",
-      name: "VIP upgrade",
-      stock: 0,
-      trigger: "answer",
-    });
-    await setModifierAnswers(tier.id, [answer.id]);
+    const { answerId, modifierId, questionId } = await setupAnswerTier(listing);
 
     const selection = {
-      [`question_${question.id}`]: String(answer.id),
+      [`question_${questionId}`]: String(answerId),
       [`quantity_${listing.id}`]: "1",
     };
     expect(await quote(listing.slug, selection)).toContain(
       "no longer available",
     );
 
-    await modifiersTable.update(tier.id, { minVisits: 1 });
+    await modifiersTable.update(modifierId, { minVisits: 1 });
     expect(await quote(listing.slug, selection)).not.toContain(
       "no longer available",
     );
@@ -431,7 +398,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     );
     try {
       const html = await (
-        await calculate(listing.slug, listing.slug, {
+        await postRunningTotal(listing.slug, listing.slug, {
           [`quantity_${listing.id}`]: "1",
         })
       ).text();
@@ -552,7 +519,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     });
 
     const html = await (
-      await calculate(listing.slug, listing.slug, {
+      await postRunningTotal(listing.slug, listing.slug, {
         [`quantity_${listing.id}`]: "1",
       })
     ).text();

--- a/test/integration/server/calculate.test.ts
+++ b/test/integration/server/calculate.test.ts
@@ -1,36 +1,21 @@
+/** The `/calculate` running total: the plain quote mechanics — a priced
+ * summary, booking-fee extras, PII stripping, the empty prompt, CSRF
+ * rejection, sold-out answer tiers, capacity, and unknown slugs. Package,
+ * promo-code, and deposit quotes live in focused files beside this one. */
+
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { hmacHash } from "#crypto/hashing.ts";
-import { attendeeStatuses } from "#db/attendee-statuses.ts";
-import { getDb } from "#db/client.ts";
-import { setGroupPackageMembers } from "#db/groups.ts";
 import { modifiersTable } from "#db/modifiers.ts";
 import { settings } from "#db/settings.ts";
 import { handleRequest } from "#routes";
 import { formatCurrency } from "#shared/currency.ts";
-import { normalizeCode } from "#shared/price-modifier.ts";
-import { postRunningTotal } from "#test-utils/csrf.ts";
+import { postRunningTotal, quoteTicketHtml } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
-import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { mockFormRequest } from "#test-utils/mocks.ts";
 import { setupAnswerTier } from "#test-utils/modifiers.ts";
 import { setupStripe } from "#test-utils/settings.ts";
-
-/** POST a quote for a single-slug page (page and post slug are the same) and
- * return just its HTML. */
-const quote = async (
-  slug: string,
-  data: Record<string, string>,
-): Promise<string> => (await postRunningTotal(slug, slug, data)).text();
-
-/** Quote a package by its package count and return the summary HTML. */
-const quotePackage = (
-  group: { id: number; slug: string },
-  count: string,
-): Promise<string> =>
-  quote(group.slug, { [`package_quantity_${group.id}`]: count });
 
 describeWithEnv("server (/calculate running total)", { db: true }, () => {
   test("returns a priced summary for a valid selection", async () => {
@@ -51,192 +36,6 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     expect(html).toContain(formatCurrency(1500));
     expect(html).toContain("order-summary-total");
     expect(html).toContain("Total");
-  });
-
-  test("a hidden package's quote fragment names the package, never a member", async () => {
-    // /calculate shares prepareOrder with the submit path, so the quote's line
-    // rows must carry the SAME masking a hidden package's checkout applies — a
-    // refactor that scoped hidePackageMemberNames to the submit branch alone
-    // would leak the concealed member here.
-    await setupStripe();
-    const group = await createTestGroup({
-      hidden: false,
-      isPackage: true,
-      name: "Mystery Box",
-      slug: "mystery-box",
-    });
-    const { groups } = await import("#db/groups.ts");
-    await groups.table.update(group.id, { hidePackageListings: true });
-    const member = await createTestListing({
-      groupId: group.id,
-      name: "Secret Contents",
-      unitPrice: 1200,
-    });
-    await setGroupPackageMembers(group.id, [
-      { listingId: member.id, price: null },
-    ]);
-
-    const response = await postRunningTotal(group.slug, group.slug, {
-      [`package_quantity_${group.id}`]: "1",
-    });
-    expect(response.status).toBe(200);
-    const html = await response.text();
-    expect(html).toContain("Mystery Box");
-    expect(html).toContain(formatCurrency(1200));
-    expect(html).not.toContain("Secret Contents");
-  });
-
-  test("quotes a package member at its override price, not its base price", async () => {
-    await setupStripe();
-    const group = await createTestGroup({
-      isPackage: true,
-      name: "Day Pass",
-      slug: "day-pass",
-    });
-    const member = await createTestListing({
-      groupId: group.id,
-      maxQuantity: 5,
-      name: "Pass Member",
-      unitPrice: 5000,
-    });
-    await setGroupPackageMembers(group.id, [
-      { listingId: member.id, price: 1500 },
-    ]);
-
-    // A package is booked by package count, not per-member quantities.
-    const html = await quotePackage(group, "1");
-    // The package override (1500) prices the line — not the 5000 base.
-    expect(html).toContain(formatCurrency(1500));
-    expect(html).not.toContain(formatCurrency(5000));
-  });
-
-  test("quotes an explicit-free package member at zero, not its base price", async () => {
-    await setupStripe();
-    const group = await createTestGroup({
-      isPackage: true,
-      name: "Free Pass",
-      slug: "free-pass",
-    });
-    const member = await createTestListing({
-      groupId: group.id,
-      maxQuantity: 5,
-      name: "Free Member",
-      unitPrice: 5000,
-    });
-    // An explicit free override (0), distinct from "no override" which would
-    // charge the 5000 base.
-    await setGroupPackageMembers(group.id, [
-      { listingId: member.id, price: 0 },
-    ]);
-
-    const html = await quotePackage(group, "1");
-    expect(html).toContain(formatCurrency(0));
-    expect(html).not.toContain(formatCurrency(5000));
-  });
-
-  test("an absent or invalid package quantity quotes nothing", async () => {
-    await setupStripe();
-    const group = await createTestGroup({
-      isPackage: true,
-      name: "Zero Pkg",
-      slug: "zero-pkg",
-    });
-    const member = await createTestListing({
-      groupId: group.id,
-      name: "Z",
-      unitPrice: 5000,
-    });
-    await setGroupPackageMembers(group.id, [
-      { listingId: member.id, price: 1000 },
-    ]);
-
-    // "abc" → 0 packages → empty order.
-    const response = await postRunningTotal(group.slug, group.slug, {
-      [`package_quantity_${group.id}`]: "abc",
-    });
-    expect(await response.text()).toContain("select at least one");
-  });
-
-  test("multiplies a package member's line by its quantity and the package count", async () => {
-    await setupStripe();
-    const group = await createTestGroup({
-      isPackage: true,
-      name: "Bundle",
-      slug: "bundle-qty",
-    });
-    const member = await createTestListing({
-      groupId: group.id,
-      maxQuantity: 50,
-      name: "Bundled",
-      unitPrice: 5000,
-    });
-    // 3 of this listing per package, overridden to 1000 each.
-    await setGroupPackageMembers(group.id, [
-      { listingId: member.id, price: 1000, quantity: 3 },
-    ]);
-
-    // 2 packages → 6 units × 1000 = 6000.
-    const html = await quotePackage(group, "2");
-    expect(html).toContain(formatCurrency(6000));
-  });
-
-  test("clamps the package count to the tightest member's capacity", async () => {
-    await setupStripe();
-    const group = await createTestGroup({
-      isPackage: true,
-      name: "Capped",
-      slug: "capped-pkg",
-    });
-    const member = await createTestListing({
-      groupId: group.id,
-      maxAttendees: 100,
-      maxQuantity: 2,
-      name: "Limited",
-      unitPrice: 4000,
-    });
-    await setGroupPackageMembers(group.id, [
-      { listingId: member.id, price: 1000 },
-    ]);
-
-    // The member caps the package at 2 (max_quantity); a crafted count of 5
-    // clamps to 2 → 2 × 1000 = 2000, never 5 × 1000.
-    const html = await quotePackage(group, "5");
-    expect(html).toContain(formatCurrency(2000));
-    expect(html).not.toContain(formatCurrency(5000));
-  });
-
-  test("caps the package count by the group's shared pool across members", async () => {
-    await setupStripe();
-    const group = await createTestGroup({
-      isPackage: true,
-      maxAttendees: 2,
-      name: "Shared Pool",
-      slug: "shared-pool",
-    });
-    const a = await createTestListing({
-      groupId: group.id,
-      maxAttendees: 100,
-      maxQuantity: 10,
-      name: "Pool A",
-      unitPrice: 0,
-    });
-    const b = await createTestListing({
-      groupId: group.id,
-      maxAttendees: 100,
-      maxQuantity: 10,
-      name: "Pool B",
-      unitPrice: 0,
-    });
-    await setGroupPackageMembers(group.id, [
-      { listingId: a.id, price: 1000 },
-      { listingId: b.id, price: 1000 },
-    ]);
-
-    // The group holds 2; one package consumes 1 A + 1 B = 2 spots, so only one
-    // package fits. Posting 2 clamps to 1 → 1×1000 + 1×1000 = 2000, not 4000.
-    const html = await quotePackage(group, "2");
-    expect(html).toContain(formatCurrency(2000));
-    expect(html).not.toContain(formatCurrency(4000));
   });
 
   test("prices a multi-unit line with a booking-fee extra line", async () => {
@@ -304,64 +103,6 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     expect(await response.text()).toContain("order-summary-message");
   });
 
-  test("prices a group booking posted to the group slug", async () => {
-    await setupStripe();
-    const group = await createTestGroup({ name: "Festival", slug: "festival" });
-    const listing = await createTestListing({
-      groupId: group.id,
-      hidden: true,
-      maxQuantity: 5,
-      name: "Day Pass",
-      unitPrice: 2000,
-    });
-
-    const response = await postRunningTotal("festival", "festival", {
-      [`quantity_${listing.id}`]: "1",
-    });
-    expect(response.status).toBe(200);
-    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
-    const html = await response.text();
-    expect(html).toContain("Day Pass");
-    expect(html).toContain(formatCurrency(2000));
-  });
-
-  test("shows the full value as owed when payments are disabled", async () => {
-    // No payment provider configured: the submit path still completes the
-    // booking but records the full value as the amount owed (like a zero-deposit
-    // reservation), so the quote must surface that figure.
-    const listing = await createTestListing({
-      maxQuantity: 5,
-      name: "Paid Seat",
-      unitPrice: 1,
-    });
-
-    const html = await (
-      await postRunningTotal(listing.slug, listing.slug, {
-        [`quantity_${listing.id}`]: "1",
-      })
-    ).text();
-    // The smallest paid value must remain distinct from a free booking.
-    expect(html).toContain("you'll owe");
-    expect(html).toContain(formatCurrency(1));
-  });
-
-  test("shows no amount owed for a free booking when payments are disabled", async () => {
-    // A genuinely free order owes nothing, so the quote keeps the free wording.
-    const listing = await createTestListing({
-      maxQuantity: 5,
-      name: "Free Seat",
-      unitPrice: 0,
-    });
-
-    const html = await (
-      await postRunningTotal(listing.slug, listing.slug, {
-        [`quantity_${listing.id}`]: "1",
-      })
-    ).text();
-    expect(html).toContain("No payment required");
-    expect(html).not.toContain("you'll owe");
-  });
-
   test("rejects a sold-out answer tier in the quote", async () => {
     await setupStripe();
     const listing = await createTestListing({ maxAttendees: 50 });
@@ -372,12 +113,12 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       [`question_${questionId}`]: String(answerId),
       [`quantity_${listing.id}`]: "1",
     };
-    expect(await quote(listing.slug, selection)).toContain(
+    expect(await quoteTicketHtml(listing.slug, selection)).toContain(
       "no longer available",
     );
 
     await modifiersTable.update(modifierId, { minVisits: 1 });
-    expect(await quote(listing.slug, selection)).not.toContain(
+    expect(await quoteTicketHtml(listing.slug, selection)).not.toContain(
       "no longer available",
     );
   });
@@ -421,123 +162,5 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       mockFormRequest("/calculate/missing-a+missing-b", {}),
     );
     expect(response.status).toBe(404);
-  });
-
-  /** Set up a listing at £10.00 with a 10%-off promo code modifier ("SAVE10").
-   * Returns the listing so tests can build their /calculate POST body. */
-  const setupPromoListing = async () => {
-    await setupStripe();
-    const listing = await createTestListing({
-      maxQuantity: 5,
-      name: "Workshop",
-      unitPrice: 1000,
-    });
-    await modifiersTable.insert({
-      calcKind: "percent",
-      calcValue: 10,
-      codeIndex: await hmacHash(normalizeCode("SAVE10")),
-      direction: "discount",
-      name: "10% off",
-      trigger: "code",
-    });
-    return listing;
-  };
-
-  /** Quote one ticket on the promo listing, optionally sending a promo code,
-   * and return the summary HTML. */
-  const quotePromoListing = async (
-    extra: Record<string, string> = {},
-  ): Promise<string> => {
-    const listing = await setupPromoListing();
-    return quote(listing.slug, {
-      [`quantity_${listing.id}`]: "1",
-      ...extra,
-    });
-  };
-
-  const quoteSave10Promo = (): Promise<string> =>
-    quotePromoListing({ promo_code: "SAVE10" });
-
-  test("applies a promo code discount when the correct code is submitted", async () => {
-    const html = await quoteSave10Promo();
-
-    // Discount line shown with modifier name and negative amount.
-    expect(html).toContain("10% off");
-    expect(html).toContain(formatCurrency(-100));
-    // Total reflects the discounted price (10% off £10.00 = £9.00).
-    expect(html).toContain(formatCurrency(900));
-    expect(html).toContain("order-summary-total");
-  });
-
-  test("shows the listing price before modifiers, not the discounted line price", async () => {
-    const html = await quoteSave10Promo();
-
-    // The ticket line is the full £10.00 list price, so the discount isn't
-    // baked into it — the modifier is itemised separately on its own row...
-    expect(html).toContain(formatCurrency(1000));
-    expect(html).toContain("10% off");
-    expect(html).toContain(formatCurrency(-100));
-    // ...and only the total carries the £9.00 discounted figure.
-    expect(html).toContain(formatCurrency(900));
-  });
-
-  test("does not apply a promo code discount when no code is submitted", async () => {
-    const html = await quotePromoListing();
-
-    // Full price — no promo code entered, no discount line.
-    expect(html).toContain(formatCurrency(1000));
-    expect(html).not.toContain(formatCurrency(900));
-    expect(html).not.toContain("10% off");
-  });
-
-  test("does not apply a promo code discount when a wrong code is submitted", async () => {
-    const html = await quotePromoListing({ promo_code: "WRONGCODE" });
-
-    // Full price — wrong promo code, no discount line.
-    expect(html).toContain(formatCurrency(1000));
-    expect(html).not.toContain(formatCurrency(900));
-    expect(html).not.toContain("10% off");
-  });
-
-  /** Turn the seeded public-default status into a reservation charging `amount`,
-   * so the quote prices each line as a deposit rather than the full price. */
-  const setPublicReservation = async (amount: string): Promise<void> => {
-    await getDb().execute({
-      args: [amount],
-      sql: "UPDATE attendee_statuses SET is_reservation = 1, reservation_amount = ? WHERE is_public_default = 1",
-    });
-    attendeeStatuses.invalidate();
-  };
-
-  test("shows the deposit charged now for a reservation, not the full list price", async () => {
-    await setupStripe();
-    await setPublicReservation("10%");
-    const listing = await createTestListing({
-      maxQuantity: 5,
-      name: "Weekend Pass",
-      unitPrice: 2000,
-    });
-
-    const html = await (
-      await postRunningTotal(listing.slug, listing.slug, {
-        [`quantity_${listing.id}`]: "1",
-      })
-    ).text();
-
-    // A deposit summary shows what's due now (10% of £20.00 = £2.00), not the
-    // full £20.00 list price — the deposit already reflects the reservation.
-    expect(html).toContain("Weekend Pass");
-    expect(html).toContain(formatCurrency(200));
-    expect(html).not.toContain(formatCurrency(2000));
-    expect(html).toContain("order-summary-total");
-  });
-
-  test("applies a promo code discount case-insensitively", async () => {
-    const html = await quotePromoListing({ promo_code: "save10" });
-
-    // Lowercase variant of the code should still match.
-    expect(html).toContain("10% off");
-    expect(html).toContain(formatCurrency(-100));
-    expect(html).toContain(formatCurrency(900));
   });
 });

--- a/test/integration/server/calculate/deposits.test.ts
+++ b/test/integration/server/calculate/deposits.test.ts
@@ -1,0 +1,74 @@
+/** Deposit and owed quotes on the `/calculate` running total: with no
+ * provider a paid order surfaces the full value as owed, a free order owes
+ * nothing, and a reservation status prices each line as its deposit. */
+
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { formatCurrency } from "#shared/currency.ts";
+import { postRunningTotal } from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { setPublicReservation } from "#test-utils/reservation/helpers.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+describeWithEnv("server (/calculate deposit quotes)", { db: true }, () => {
+  test("shows the full value as owed when payments are disabled", async () => {
+    // No payment provider configured: the submit path still completes the
+    // booking but records the full value as the amount owed (like a zero-deposit
+    // reservation), so the quote must surface that figure.
+    const listing = await createTestListing({
+      maxQuantity: 5,
+      name: "Paid Seat",
+      unitPrice: 1,
+    });
+
+    const html = await (
+      await postRunningTotal(listing.slug, listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      })
+    ).text();
+    // The smallest paid value must remain distinct from a free booking.
+    expect(html).toContain("you'll owe");
+    expect(html).toContain(formatCurrency(1));
+  });
+
+  test("shows no amount owed for a free booking when payments are disabled", async () => {
+    // A genuinely free order owes nothing, so the quote keeps the free wording.
+    const listing = await createTestListing({
+      maxQuantity: 5,
+      name: "Free Seat",
+      unitPrice: 0,
+    });
+
+    const html = await (
+      await postRunningTotal(listing.slug, listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      })
+    ).text();
+    expect(html).toContain("No payment required");
+    expect(html).not.toContain("you'll owe");
+  });
+
+  test("shows the deposit charged now for a reservation, not the full list price", async () => {
+    await setupStripe();
+    await setPublicReservation("10%");
+    const listing = await createTestListing({
+      maxQuantity: 5,
+      name: "Weekend Pass",
+      unitPrice: 2000,
+    });
+
+    const html = await (
+      await postRunningTotal(listing.slug, listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+      })
+    ).text();
+
+    // A deposit summary shows what's due now (10% of £20.00 = £2.00), not the
+    // full £20.00 list price — the deposit already reflects the reservation.
+    expect(html).toContain("Weekend Pass");
+    expect(html).toContain(formatCurrency(200));
+    expect(html).not.toContain(formatCurrency(2000));
+    expect(html).toContain("order-summary-total");
+  });
+});

--- a/test/integration/server/calculate/packages.test.ts
+++ b/test/integration/server/calculate/packages.test.ts
@@ -1,0 +1,225 @@
+/** Package and group quotes on the `/calculate` running total: what a
+ * package costs (member overrides, per-package quantities, capacity clamps),
+ * and what a hidden package's fragment is allowed to name. */
+
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { setGroupPackageMembers } from "#db/groups.ts";
+import { formatCurrency } from "#shared/currency.ts";
+import { postRunningTotal, quoteTicketHtml } from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** Quote a package by its package count and return the summary HTML. */
+const quotePackage = (
+  group: { id: number; slug: string },
+  count: string,
+): Promise<string> =>
+  quoteTicketHtml(group.slug, { [`package_quantity_${group.id}`]: count });
+
+describeWithEnv("server (/calculate package quotes)", { db: true }, () => {
+  test("a hidden package's quote fragment names the package, never a member", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      hidden: false,
+      isPackage: true,
+      name: "Mystery Box",
+      slug: "mystery-box",
+    });
+    const { groups } = await import("#db/groups.ts");
+    await groups.table.update(group.id, { hidePackageListings: true });
+    const member = await createTestListing({
+      groupId: group.id,
+      name: "Secret Contents",
+      unitPrice: 1200,
+    });
+    await setGroupPackageMembers(group.id, [
+      { listingId: member.id, price: null },
+    ]);
+
+    const response = await postRunningTotal(group.slug, group.slug, {
+      [`package_quantity_${group.id}`]: "1",
+    });
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Mystery Box");
+    expect(html).toContain(formatCurrency(1200));
+    expect(html).not.toContain("Secret Contents");
+  });
+
+  test("quotes a package member at its override price, not its base price", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      isPackage: true,
+      name: "Day Pass",
+      slug: "day-pass",
+    });
+    const member = await createTestListing({
+      groupId: group.id,
+      maxQuantity: 5,
+      name: "Pass Member",
+      unitPrice: 5000,
+    });
+    await setGroupPackageMembers(group.id, [
+      { listingId: member.id, price: 1500 },
+    ]);
+
+    // A package is booked by package count, not per-member quantities.
+    const html = await quotePackage(group, "1");
+    // The package override (1500) prices the line — not the 5000 base.
+    expect(html).toContain(formatCurrency(1500));
+    expect(html).not.toContain(formatCurrency(5000));
+  });
+
+  test("quotes an explicit-free package member at zero, not its base price", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      isPackage: true,
+      name: "Free Pass",
+      slug: "free-pass",
+    });
+    const member = await createTestListing({
+      groupId: group.id,
+      maxQuantity: 5,
+      name: "Free Member",
+      unitPrice: 5000,
+    });
+    // An explicit free override (0), distinct from "no override" which would
+    // charge the 5000 base.
+    await setGroupPackageMembers(group.id, [
+      { listingId: member.id, price: 0 },
+    ]);
+
+    const html = await quotePackage(group, "1");
+    expect(html).toContain(formatCurrency(0));
+    expect(html).not.toContain(formatCurrency(5000));
+  });
+
+  test("an absent or invalid package quantity quotes nothing", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      isPackage: true,
+      name: "Zero Pkg",
+      slug: "zero-pkg",
+    });
+    const member = await createTestListing({
+      groupId: group.id,
+      name: "Z",
+      unitPrice: 5000,
+    });
+    await setGroupPackageMembers(group.id, [
+      { listingId: member.id, price: 1000 },
+    ]);
+
+    // "abc" → 0 packages → empty order.
+    const response = await postRunningTotal(group.slug, group.slug, {
+      [`package_quantity_${group.id}`]: "abc",
+    });
+    expect(await response.text()).toContain("select at least one");
+  });
+
+  test("multiplies a package member's line by its quantity and the package count", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      isPackage: true,
+      name: "Bundle",
+      slug: "bundle-qty",
+    });
+    const member = await createTestListing({
+      groupId: group.id,
+      maxQuantity: 50,
+      name: "Bundled",
+      unitPrice: 5000,
+    });
+    // 3 of this listing per package, overridden to 1000 each.
+    await setGroupPackageMembers(group.id, [
+      { listingId: member.id, price: 1000, quantity: 3 },
+    ]);
+
+    // 2 packages → 6 units × 1000 = 6000.
+    const html = await quotePackage(group, "2");
+    expect(html).toContain(formatCurrency(6000));
+  });
+
+  test("clamps the package count to the tightest member's capacity", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      isPackage: true,
+      name: "Capped",
+      slug: "capped-pkg",
+    });
+    const member = await createTestListing({
+      groupId: group.id,
+      maxAttendees: 100,
+      maxQuantity: 2,
+      name: "Limited",
+      unitPrice: 4000,
+    });
+    await setGroupPackageMembers(group.id, [
+      { listingId: member.id, price: 1000 },
+    ]);
+
+    // The member caps the package at 2 (max_quantity); a crafted count of 5
+    // clamps to 2 → 2 × 1000 = 2000, never 5 × 1000.
+    const html = await quotePackage(group, "5");
+    expect(html).toContain(formatCurrency(2000));
+    expect(html).not.toContain(formatCurrency(5000));
+  });
+
+  test("caps the package count by the group's shared pool across members", async () => {
+    await setupStripe();
+    const group = await createTestGroup({
+      isPackage: true,
+      maxAttendees: 2,
+      name: "Shared Pool",
+      slug: "shared-pool",
+    });
+    const a = await createTestListing({
+      groupId: group.id,
+      maxAttendees: 100,
+      maxQuantity: 10,
+      name: "Pool A",
+      unitPrice: 0,
+    });
+    const b = await createTestListing({
+      groupId: group.id,
+      maxAttendees: 100,
+      maxQuantity: 10,
+      name: "Pool B",
+      unitPrice: 0,
+    });
+    await setGroupPackageMembers(group.id, [
+      { listingId: a.id, price: 1000 },
+      { listingId: b.id, price: 1000 },
+    ]);
+
+    // The group holds 2; one package consumes 1 A + 1 B = 2 spots, so only one
+    // package fits. Posting 2 clamps to 1 → 1×1000 + 1×1000 = 2000, not 4000.
+    const html = await quotePackage(group, "2");
+    expect(html).toContain(formatCurrency(2000));
+    expect(html).not.toContain(formatCurrency(4000));
+  });
+
+  test("prices a group booking posted to the group slug", async () => {
+    await setupStripe();
+    const group = await createTestGroup({ name: "Festival", slug: "festival" });
+    const listing = await createTestListing({
+      groupId: group.id,
+      hidden: true,
+      maxQuantity: 5,
+      name: "Day Pass",
+      unitPrice: 2000,
+    });
+
+    const response = await postRunningTotal("festival", "festival", {
+      [`quantity_${listing.id}`]: "1",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    const html = await response.text();
+    expect(html).toContain("Day Pass");
+    expect(html).toContain(formatCurrency(2000));
+  });
+});

--- a/test/integration/server/calculate/promo-codes.test.ts
+++ b/test/integration/server/calculate/promo-codes.test.ts
@@ -1,0 +1,98 @@
+/** Promo-code quotes on the `/calculate` running total: a real code
+ * discounts the total, an absent or wrong code changes nothing, and the
+ * ticket line keeps the list price with the discount itemised separately. */
+
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { hmacHash } from "#crypto/hashing.ts";
+import { modifiersTable } from "#db/modifiers.ts";
+import { formatCurrency } from "#shared/currency.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
+import { quoteTicketHtml } from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** Set up a listing at £10.00 with a 10%-off promo code modifier ("SAVE10").
+ * Returns the listing so tests can build their /calculate POST body. */
+const setupPromoListing = async () => {
+  await setupStripe();
+  const listing = await createTestListing({
+    maxQuantity: 5,
+    name: "Workshop",
+    unitPrice: 1000,
+  });
+  await modifiersTable.insert({
+    calcKind: "percent",
+    calcValue: 10,
+    codeIndex: await hmacHash(normalizeCode("SAVE10")),
+    direction: "discount",
+    name: "10% off",
+    trigger: "code",
+  });
+  return listing;
+};
+
+/** Quote one ticket on the promo listing, optionally sending a promo code,
+ * and return the summary HTML. */
+const quotePromoListing = async (
+  extra: Record<string, string> = {},
+): Promise<string> => {
+  const listing = await setupPromoListing();
+  return quoteTicketHtml(listing.slug, {
+    [`quantity_${listing.id}`]: "1",
+    ...extra,
+  });
+};
+
+describeWithEnv("server (/calculate promo-code quotes)", { db: true }, () => {
+  test("applies a promo code discount when the correct code is submitted", async () => {
+    const html = await quotePromoListing({ promo_code: "SAVE10" });
+
+    // Discount line shown with modifier name and negative amount.
+    expect(html).toContain("10% off");
+    expect(html).toContain(formatCurrency(-100));
+    // Total reflects the discounted price (10% off £10.00 = £9.00).
+    expect(html).toContain(formatCurrency(900));
+    expect(html).toContain("order-summary-total");
+  });
+
+  test("shows the listing price before modifiers, not the discounted line price", async () => {
+    const html = await quotePromoListing({ promo_code: "SAVE10" });
+
+    // The ticket line is the full £10.00 list price, so the discount isn't
+    // baked into it — the modifier is itemised separately on its own row...
+    expect(html).toContain(formatCurrency(1000));
+    expect(html).toContain("10% off");
+    expect(html).toContain(formatCurrency(-100));
+    // ...and only the total carries the £9.00 discounted figure.
+    expect(html).toContain(formatCurrency(900));
+  });
+
+  test("does not apply a promo code discount when no code is submitted", async () => {
+    const html = await quotePromoListing();
+
+    // Full price — no promo code entered, no discount line.
+    expect(html).toContain(formatCurrency(1000));
+    expect(html).not.toContain(formatCurrency(900));
+    expect(html).not.toContain("10% off");
+  });
+
+  test("does not apply a promo code discount when a wrong code is submitted", async () => {
+    const html = await quotePromoListing({ promo_code: "WRONGCODE" });
+
+    // Full price — wrong promo code, no discount line.
+    expect(html).toContain(formatCurrency(1000));
+    expect(html).not.toContain(formatCurrency(900));
+    expect(html).not.toContain("10% off");
+  });
+
+  test("applies a promo code discount case-insensitively", async () => {
+    const html = await quotePromoListing({ promo_code: "save10" });
+
+    // Lowercase variant of the code should still match.
+    expect(html).toContain("10% off");
+    expect(html).toContain(formatCurrency(-100));
+    expect(html).toContain(formatCurrency(900));
+  });
+});

--- a/test/integration/server/payments/purchase.test.ts
+++ b/test/integration/server/payments/purchase.test.ts
@@ -9,7 +9,10 @@ import { ProviderCheckoutError } from "#payment/checkout-failure.ts";
 import { normalizeCode } from "#shared/price-modifier.ts";
 import { stripePaymentProvider } from "#shared/stripe-provider.ts";
 import { expectFlash, expectRedirect } from "#test-utils/assertions.ts";
-import { stubCheckout } from "#test-utils/checkout.ts";
+import {
+  capturedModifierQuantity,
+  stubCheckout,
+} from "#test-utils/checkout.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { bookAttendee } from "#test-utils/db-helpers/attendee-payments.ts";
@@ -244,14 +247,14 @@ describeWithEnv("server (payment flow)", { db: true, triggers: true }, () => {
         });
 
         expect(response.status).toBe(302);
-        const byId = new Map(
-          (getCaptured()?.modifiers ?? []).map((m) => [m.id, m]),
-        );
+        const intent = getCaptured();
         // The add-on is applied at the chosen quantity, the promo at quantity 1,
         // and the unselected add-on is absent.
-        expect(byId.get(addOn.id)?.quantity).toBe(2);
-        expect(byId.get(promo.id)?.quantity).toBe(1);
-        expect(byId.has(skippedAddOn.id)).toBe(false);
+        expect(capturedModifierQuantity(intent, addOn.id)).toBe(2);
+        expect(capturedModifierQuantity(intent, promo.id)).toBe(1);
+        expect(capturedModifierQuantity(intent, skippedAddOn.id)).toBe(
+          undefined,
+        );
       } finally {
         checkout.restore();
       }

--- a/test/integration/server/public/ticket-promo-prefill.test.ts
+++ b/test/integration/server/public/ticket-promo-prefill.test.ts
@@ -94,11 +94,7 @@ describeWithEnv(
       const listing = await setupPromoListing();
 
       // The buyer lands via the operator's link, then types their own code.
-      await assertPublicHtml(
-        `/ticket/${listing.slug}?promo=Summer25`,
-        'name="promo_code"',
-      );
-      const failed = await submitTicketForm(listing.slug, {
+      const failed = await submitTicketForm(`${listing.slug}?promo=Summer25`, {
         email: "john@example.com",
         name: "",
         promo_code: "typed99",

--- a/test/integration/server/public/ticket-promo-prefill.test.ts
+++ b/test/integration/server/public/ticket-promo-prefill.test.ts
@@ -1,0 +1,167 @@
+import { expect } from "@std/expect";
+import { it as test } from "@std/testing/bdd";
+import { hmacHash } from "#crypto/hashing.ts";
+import { modifiersTable } from "#db/modifiers.ts";
+import { handleRequest } from "#routes";
+import { formatCurrency } from "#shared/currency.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
+import {
+  assertPublicHtml,
+  expectFlash,
+  followRedirectWithFlash,
+} from "#test-utils/assertions.ts";
+import {
+  capturedModifierQuantity,
+  stubCheckout,
+} from "#test-utils/checkout.ts";
+import {
+  extractCsrfToken,
+  extractInputValue,
+  hasInputWithValue,
+  submitTicketForm,
+} from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { mockFormRequest } from "#test-utils/mocks.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** A whole-order 10% discount unlocked by `code`, so the page offers the
+ * promo box and the code can be matched at submit. */
+const insertPromoModifier = async (code: string) =>
+  await modifiersTable.insert({
+    calcKind: "percent",
+    calcValue: 10,
+    codeIndex: await hmacHash(normalizeCode(code)),
+    direction: "discount",
+    name: code,
+    trigger: "code",
+  });
+
+/** A free listing plus the "Summer25" promo code — the page a buyer lands on
+ * from an operator's `?promo=` link. */
+const setupPromoListing = async () => {
+  const listing = await createTestListing({
+    maxAttendees: 50,
+    thankYouUrl: "https://example.com",
+  });
+  await insertPromoModifier("Summer25");
+  return listing;
+};
+
+describeWithEnv(
+  "server public > ?promo= prefill",
+  { db: true, triggers: true },
+  () => {
+    test("fills the promo box from the URL without case or spaces", async () => {
+      const listing = await setupPromoListing();
+
+      const html = await assertPublicHtml(
+        `/ticket/${listing.slug}?promo=%20Summer25%20`,
+        'name="promo_code"',
+      );
+
+      expect(hasInputWithValue(html, "promo_code", "summer25")).toBe(true);
+    });
+
+    test("fills the promo box for an unknown code — matching happens at submit", async () => {
+      const listing = await setupPromoListing();
+
+      const html = await assertPublicHtml(
+        `/ticket/${listing.slug}?promo=nosuchcode`,
+        'name="promo_code"',
+      );
+
+      expect(hasInputWithValue(html, "promo_code", "nosuchcode")).toBe(true);
+    });
+
+    test("fills the one shared promo box on a multi-listing page", async () => {
+      const a = await setupPromoListing();
+      const b = await createTestListing({
+        maxAttendees: 50,
+        thankYouUrl: "https://example.com",
+      });
+
+      const html = await assertPublicHtml(
+        `/ticket/${a.slug}+${b.slug}?promo=summer25`,
+        'name="promo_code"',
+      );
+
+      expect(html.split('name="promo_code"').length - 1).toBe(1);
+      expect(hasInputWithValue(html, "promo_code", "summer25")).toBe(true);
+    });
+
+    test("keeps the typed code after a failed submit, not the URL code", async () => {
+      const listing = await setupPromoListing();
+
+      // The buyer lands via the operator's link, then types their own code.
+      await assertPublicHtml(
+        `/ticket/${listing.slug}?promo=Summer25`,
+        'name="promo_code"',
+      );
+      const failed = await submitTicketForm(listing.slug, {
+        email: "john@example.com",
+        name: "",
+        promo_code: "typed99",
+      });
+      expectFlash(
+        failed,
+        expect.stringContaining("Your Name is required"),
+        false,
+      );
+
+      const html = await (
+        await followRedirectWithFlash(failed, handleRequest)
+      ).text();
+      expect(hasInputWithValue(html, "promo_code", "typed99")).toBe(true);
+      expect(hasInputWithValue(html, "promo_code", "summer25")).toBe(false);
+    });
+
+    test("applies the prefilled code's discount through the submit path", async () => {
+      await setupStripe();
+      const listing = await createTestListing({
+        maxAttendees: 50,
+        maxQuantity: 5,
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice: 1000,
+      });
+      const promo = await insertPromoModifier("Summer25");
+
+      // The link lands the code in the box; the browser submits what the box
+      // holds, so both legs below price the prefilled value itself.
+      const html = await assertPublicHtml(
+        `/ticket/${listing.slug}?promo=Summer25`,
+        'name="promo_code"',
+      );
+      const sent = extractInputValue(html, "promo_code");
+      expect(sent).toBe("summer25");
+
+      // The running total (the same pricing pass submit runs) shows 10% off a
+      // £10.00 ticket: the discount line and the £9.00 total.
+      const quoteHtml = await (
+        await handleRequest(
+          mockFormRequest(`/calculate/${listing.slug}`, {
+            [`quantity_${listing.id}`]: "1",
+            csrf_token: extractCsrfToken(html) ?? "",
+            promo_code: sent ?? "",
+          }),
+        )
+      ).text();
+      expect(quoteHtml).toContain("Summer25");
+      expect(quoteHtml).toContain(formatCurrency(900));
+
+      // And a paid submit carries the matched promo into the checkout intent.
+      const { checkout, getCaptured } = stubCheckout("cs_promo_prefill");
+      try {
+        const response = await submitTicketForm(listing.slug, {
+          email: "john@example.com",
+          name: "John Doe",
+          promo_code: sent ?? "",
+        });
+        expect(response.status).toBe(302);
+        expect(capturedModifierQuantity(getCaptured(), promo.id)).toBe(1);
+      } finally {
+        checkout.restore();
+      }
+    });
+  },
+);

--- a/test/shared/email/registration.test.ts
+++ b/test/shared/email/registration.test.ts
@@ -13,7 +13,10 @@ import {
 } from "#shared/subrequest-budget.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
-import { configureTestEmail } from "#test-utils/email.ts";
+import {
+  configureTestEmail,
+  expectSingleTicketSvg,
+} from "#test-utils/email.ts";
 import { makeTestEntry as makeEntry } from "#test-utils/factories.ts";
 import { useFetchStub } from "#test-utils/mocks.ts";
 import { countDatabaseCalls } from "#test-utils/subrequest-budget.ts";
@@ -24,23 +27,6 @@ const setupAndSendRegistration = async (
 ) => {
   await configureTestEmail(opts);
   return await sendRegistrationEmails(entries ?? [makeEntry()], "GBP");
-};
-
-/** Decode a base64 SVG attachment back to its UTF-8 source. */
-const decodeSvgAttachment = (content: string): string => {
-  const binary = atob(content);
-  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-};
-
-/** Assert the email body carries exactly one `ticket.svg` attachment and return
- * its decoded SVG source. */
-const expectSingleTicketSvg = (body: {
-  attachments: { filename: string; content: string }[];
-}): string => {
-  expect(body.attachments).toHaveLength(1);
-  expect(body.attachments[0]!.filename).toBe("ticket.svg");
-  return decodeSvgAttachment(body.attachments[0]!.content);
 };
 
 const createHiddenPackage = async (name: string): Promise<number> => {

--- a/test/shared/forms/saved-data.test.ts
+++ b/test/shared/forms/saved-data.test.ts
@@ -7,6 +7,8 @@ import {
   clearSavedFormData,
   getSavedFormData,
   runWithSavedFormContext,
+  savedFormValue,
+  savedFormValueOrNull,
   setSavedFormData,
 } from "#shared/forms/saved-data.ts";
 import { entityToFieldValues } from "#shared/forms/values.ts";
@@ -205,6 +207,25 @@ describe("saved form data", () => {
     setSavedFormData(new FormParams("name=Alice"));
     clearSavedFormData();
     expect(getSavedFormData()).toBeNull();
+  });
+
+  test("savedFormValueOrNull tells an absent field from an empty one", () => {
+    setSavedFormData(new FormParams("promo_code=&name=Ada"));
+    expect(savedFormValueOrNull("name")).toBe("Ada");
+    // An explicitly cleared field is the buyer's choice, not an absence.
+    expect(savedFormValueOrNull("promo_code")).toBe("");
+    expect(savedFormValueOrNull("phone")).toBeNull();
+  });
+
+  test("savedFormValueOrNull answers null with no saved form", () => {
+    expect(savedFormValueOrNull("name")).toBeNull();
+  });
+
+  test("savedFormValue answers the trimmed value, or empty with no form", () => {
+    setSavedFormData(new FormParams("name=%20Ada%20"));
+    expect(savedFormValue("name")).toBe("Ada");
+    clearSavedFormData();
+    expect(savedFormValue("name")).toBe("");
   });
 
   test("saved data set inside a scope stays within that scope", async () => {

--- a/test/test-utils/checkout.ts
+++ b/test/test-utils/checkout.ts
@@ -125,10 +125,10 @@ export const johnCheckoutSession = (
       });
 
 /** Find the captured intent's line item for `listing` and assert its
- *  `unitPrice` — the shared "this folded line was charged X" check behind
- *  every test that inspects the outgoing intent's per-line prices. Pass the
- *  captured intent (`getCaptured()`), the listing whose price to check, and the
- *  expected unit price in the smallest currency unit (e.g. pence). */
+ * `unitPrice` — the shared "this folded line was charged X" check behind
+ * every test that inspects the outgoing intent's per-line prices. Pass the
+ * captured intent (`getCaptured()`), the listing whose price to check, and the
+ * expected unit price in the smallest currency unit (e.g. pence). */
 export const expectCapturedItemPriced = (
   intent: CheckoutIntent | undefined,
   listing: { id: number },
@@ -137,3 +137,11 @@ export const expectCapturedItemPriced = (
   const item = intent?.items.find((i) => i.listingId === listing.id);
   expect(item?.unitPrice).toBe(unitPrice);
 };
+
+/** The quantity the captured intent applied to the given modifier — the
+ * shared "was this modifier applied, and how many times" check. */
+export const capturedModifierQuantity = (
+  intent: CheckoutIntent | undefined,
+  modifierId: number,
+): number | undefined =>
+  intent?.modifiers?.find((m) => m.id === modifierId)?.quantity;

--- a/test/test-utils/csrf.ts
+++ b/test/test-utils/csrf.ts
@@ -161,6 +161,33 @@ export const submitMultiTicketForm = async (
   });
 };
 
+/** GET the booking page for `pageSlug` to mint a CSRF token, then POST the
+ *  given inputs to `/calculate/<postSlug>` exactly as the running total
+ *  would. */
+export const postRunningTotal = async (
+  pageSlug: string,
+  postSlug: string,
+  data: Record<string, string>,
+): Promise<Response> => {
+  const { mockFormRequest, sendToApp } = await import("#test-utils/mocks.ts");
+  const { csrfToken } = await getPageWithCsrf(`/ticket/${pageSlug}`);
+  return sendToApp(
+    mockFormRequest(`/calculate/${postSlug}`, {
+      ...data,
+      csrf_token: csrfToken,
+    }),
+  );
+};
+
+/** Quote a single-slug booking page and return just its summary HTML. */
+export const quoteTicketHtml = async (
+  slug: string,
+  data: Record<string, string>,
+): Promise<string> => {
+  const response = await postRunningTotal(slug, slug, data);
+  return response.text();
+};
+
 /** Submits the joint ticket form as "John Doe", booking `quantity1` of
  *  listing1 and `quantity2` of listing2 — the generic two-listing booking
  *  shape reused by almost every multi-listing test scenario that doesn't

--- a/test/test-utils/email.ts
+++ b/test/test-utils/email.ts
@@ -49,6 +49,23 @@ export const configureTestEmail = async (
   await settings.loadKeys(ALL_SETTINGS_KEYS);
 };
 
+/** Decode a base64 SVG attachment back to its UTF-8 source. */
+export const decodeSvgAttachment = (content: string): string => {
+  const binary = atob(content);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+};
+
+/** Assert the email body carries exactly one `ticket.svg` attachment and return
+ * its decoded SVG source. */
+export const expectSingleTicketSvg = (body: {
+  attachments: { filename: string; content: string }[];
+}): string => {
+  expect(body.attachments).toHaveLength(1);
+  expect(body.attachments[0]!.filename).toBe("ticket.svg");
+  return decodeSvgAttachment(body.attachments[0]!.content);
+};
+
 /**
  * The per-describe state shared by the contact-form and support-message unit
  * tests: a `fetch` stub installed on demand, an env scope the tests

--- a/test/test-utils/modifiers.ts
+++ b/test/test-utils/modifiers.ts
@@ -4,6 +4,7 @@ import {
   getAllModifiers,
   type ModifierInput,
   modifiersTable,
+  setModifierAnswers,
 } from "#db/modifiers.ts";
 
 /** Insert a modifier through the production table, defaulting to a £5 charge. */
@@ -126,4 +127,41 @@ export const expectModifierUsage = async (
 ): Promise<void> => {
   expect(await modifierUsageAmount(modifierId)).toBe(usageAmount);
   expect(await modifierAggregates(modifierId)).toEqual(aggregates);
+};
+
+/** Create a radio question with one answer on `listing`, plus a sold-out
+ * answer-triggered £5 charge modifier linked to that answer — the stock-limited
+ * tier shape behind the sold-out answer-tier tests. `overrides` retune the
+ * tier (minVisits, stock, name, …). */
+export const setupAnswerTier = async (
+  listing: { id: number },
+  overrides: Partial<ModifierInput> = {},
+): Promise<{ answerId: number; modifierId: number; questionId: number }> => {
+  const [{ answersTable, questionsTable }, { listingQuestions }] =
+    await Promise.all([
+      import("#db/questions/tables.ts"),
+      import("#db/questions/queries.ts"),
+    ]);
+  const question = await questionsTable.insert({
+    displayType: "radio",
+    text: "T-shirt size?",
+  });
+  const answer = await answersTable.insert({
+    questionId: question.id,
+    sortOrder: 0,
+    text: "Small",
+  });
+  await listingQuestions.setIds(listing.id, [question.id]);
+  const modifier = await insertModifier({
+    name: "VIP upgrade",
+    stock: 0,
+    trigger: "answer",
+    ...overrides,
+  });
+  await setModifierAnswers(modifier.id, [answer.id]);
+  return {
+    answerId: answer.id,
+    modifierId: modifier.id,
+    questionId: question.id,
+  };
 };

--- a/test/ui/templates/public/reservations/form.test.ts
+++ b/test/ui/templates/public/reservations/form.test.ts
@@ -171,11 +171,6 @@ describe("ticketPage — fields & form", () => {
     expect(html).toContain('data-listing-ids="1"');
   });
 
-  test("omits the promo-code field when promo codes are disabled", () => {
-    const html = singleListingPageHtml();
-    expect(html).not.toContain('name="promo_code"');
-  });
-
   test("renders an opt-in add-on selector with its price label", () => {
     const listings = [
       ticketListing({
@@ -211,52 +206,6 @@ describe("ticketPage — fields & form", () => {
     } finally {
       clearSavedFormData();
     }
-  });
-
-  test("restores the submitted promo code", () => {
-    setSavedFormData(new FormParams({ promo_code: "SAVE20" }));
-    try {
-      const html = singleListingPageHtml({ promoCodesEnabled: true });
-      expect(html).toContain('<div class="promo-code"><label>Promo code');
-      expect(html).toContain(
-        'name="promo_code" placeholder="Optional" type="text" value="SAVE20"',
-      );
-    } finally {
-      clearSavedFormData();
-    }
-  });
-
-  test("fills the promo box from the ?promo= prefill", () => {
-    const html = singleListingPageHtml({
-      prefill: { listings: new Map(), promo: "summer25" },
-      promoCodesEnabled: true,
-    });
-    expect(html).toContain(
-      'name="promo_code" placeholder="Optional" type="text" value="summer25"',
-    );
-  });
-
-  test("restores the submitted promo code before the ?promo= prefill", () => {
-    setSavedFormData(new FormParams({ promo_code: "TYPED99" }));
-    try {
-      const html = singleListingPageHtml({
-        prefill: { listings: new Map(), promo: "summer25" },
-        promoCodesEnabled: true,
-      });
-      expect(html).toContain(
-        'name="promo_code" placeholder="Optional" type="text" value="TYPED99"',
-      );
-      expect(html).not.toContain('value="summer25"');
-    } finally {
-      clearSavedFormData();
-    }
-  });
-
-  test("leaves the promo box empty with no ?promo= prefill", () => {
-    const html = singleListingPageHtml({ promoCodesEnabled: true });
-    expect(html).toContain(
-      'name="promo_code" placeholder="Optional" type="text" value=""',
-    );
   });
 
   test("prefills the name and signed token", () => {

--- a/test/ui/templates/public/reservations/form.test.ts
+++ b/test/ui/templates/public/reservations/form.test.ts
@@ -226,6 +226,39 @@ describe("ticketPage — fields & form", () => {
     }
   });
 
+  test("fills the promo box from the ?promo= prefill", () => {
+    const html = singleListingPageHtml({
+      prefill: { listings: new Map(), promo: "summer25" },
+      promoCodesEnabled: true,
+    });
+    expect(html).toContain(
+      'name="promo_code" placeholder="Optional" type="text" value="summer25"',
+    );
+  });
+
+  test("restores the submitted promo code before the ?promo= prefill", () => {
+    setSavedFormData(new FormParams({ promo_code: "TYPED99" }));
+    try {
+      const html = singleListingPageHtml({
+        prefill: { listings: new Map(), promo: "summer25" },
+        promoCodesEnabled: true,
+      });
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value="TYPED99"',
+      );
+      expect(html).not.toContain('value="summer25"');
+    } finally {
+      clearSavedFormData();
+    }
+  });
+
+  test("leaves the promo box empty with no ?promo= prefill", () => {
+    const html = singleListingPageHtml({ promoCodesEnabled: true });
+    expect(html).toContain(
+      'name="promo_code" placeholder="Optional" type="text" value=""',
+    );
+  });
+
   test("prefills the name and signed token", () => {
     const html = renderForm({
       fields: [{ label: "Name", name: "name", type: "text" }],

--- a/test/ui/templates/public/reservations/form/promo-code-field.test.ts
+++ b/test/ui/templates/public/reservations/form/promo-code-field.test.ts
@@ -1,0 +1,90 @@
+/** Promo-code field rendering on the booking form: when the box shows at
+ * all, and which value it holds — a submitted value (including an explicitly
+ * cleared one) always wins over the `?promo=` URL pre-fill. */
+
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { FormParams } from "#shared/form-data.ts";
+import {
+  clearSavedFormData,
+  setSavedFormData,
+} from "#shared/forms/saved-data.ts";
+import {
+  registerPublicTemplateHooks,
+  singleListingPageHtml,
+} from "#test/ui/templates/helpers.ts";
+import { setupAdminPageTest } from "#test-utils/admin-page-test.ts";
+
+describe("the promo-code field", () => {
+  beforeAll(setupAdminPageTest);
+  registerPublicTemplateHooks();
+
+  test("omits the field when promo codes are disabled", () => {
+    const html = singleListingPageHtml();
+    expect(html).not.toContain('name="promo_code"');
+  });
+
+  test("restores the submitted promo code", () => {
+    setSavedFormData(new FormParams({ promo_code: "SAVE20" }));
+    try {
+      const html = singleListingPageHtml({ promoCodesEnabled: true });
+      expect(html).toContain('<div class="promo-code"><label>Promo code');
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value="SAVE20"',
+      );
+    } finally {
+      clearSavedFormData();
+    }
+  });
+
+  test("fills the box from the ?promo= prefill", () => {
+    const html = singleListingPageHtml({
+      prefill: { listings: new Map(), promo: "summer25" },
+      promoCodesEnabled: true,
+    });
+    expect(html).toContain(
+      'name="promo_code" placeholder="Optional" type="text" value="summer25"',
+    );
+  });
+
+  test("restores the submitted promo code before the ?promo= prefill", () => {
+    setSavedFormData(new FormParams({ promo_code: "TYPED99" }));
+    try {
+      const html = singleListingPageHtml({
+        prefill: { listings: new Map(), promo: "summer25" },
+        promoCodesEnabled: true,
+      });
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value="TYPED99"',
+      );
+      expect(html).not.toContain('value="summer25"');
+    } finally {
+      clearSavedFormData();
+    }
+  });
+
+  test("keeps an explicitly cleared promo code empty", () => {
+    // A buyer who deleted the code and failed validation submitted an empty
+    // field: that choice wins, so the URL code must not come back.
+    setSavedFormData(new FormParams({ promo_code: "" }));
+    try {
+      const html = singleListingPageHtml({
+        prefill: { listings: new Map(), promo: "summer25" },
+        promoCodesEnabled: true,
+      });
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value=""',
+      );
+      expect(html).not.toContain('value="summer25"');
+    } finally {
+      clearSavedFormData();
+    }
+  });
+
+  test("leaves the box empty with no ?promo= prefill", () => {
+    const html = singleListingPageHtml({ promoCodesEnabled: true });
+    expect(html).toContain(
+      'name="promo_code" placeholder="Optional" type="text" value=""',
+    );
+  });
+});


### PR DESCRIPTION
Closes #2367.

## What changed

A booking page link can now carry the promo code in the URL, so an
operator can send readers of a listings page straight to a discounted
order:

```text
https://tickets.example.com/ticket/example-listing?promo=example-code
```

- `parseQuantityPrefill` (`src/features/public/ticket-submit.ts`) reads
  `?promo=<code>` beside the existing `?q_<id>=` and `?date=` params, and
  normalizes it with `normalizeCode` — trimmed and lower-cased, the same
  normalization the code lookup uses — so mixed case and surrounding
  spaces in the link both work.
- `BookingPrefill` carries the code (`promo?: string`), and
  `PromoCodeField` fills the box from it whenever nothing was submitted.
  A submitted value always wins — including an explicitly cleared one
  (`savedFormValueOrNull` tells a cleared field from an absent field), so
  a buyer who deletes the code and fails validation does not get the URL
  code back.
- The code is not validated at render time. An unknown code fills the
  box and applies no discount, exactly like a code typed by hand. A
  multi-listing page (`/ticket/a+b?promo=…`) fills its one shared promo
  box.

## Tests

- `test/integration/server/public/ticket-promo-prefill.test.ts` — the
  rendered box holds the code (case/space-insensitive), an unknown code
  still fills the box, the one shared box on a multi-listing page, a
  failed submit (posted from the operator's link URL) keeps the typed
  code, and the prefilled code reaches the discounted £9.00 total and
  rides the submit path into the checkout intent.
- `test/ui/templates/public/reservations/form/promo-code-field.test.ts`
  pins the field itself: when it renders at all, and which value it
  holds — submitted (typed or explicitly cleared) beats the URL
  pre-fill, which beats empty.
- Unit tests for the parse (`parseQuantityPrefill`), the helper contract
  (`savedFormValueOrNull`), and the form render order.
- The mutation gate surfaced survivors on
  `src/features/public/ticket-submit.ts` (mostly pre-existing payment
  paths). `test/features/public/ticket-submit/submit-paths.test.ts` now
  covers them all: the Square email rule at the first and repriced
  totals, the provider-less paid booking's zero-deposit owed ledger and
  its ticket attachment showing no paid price, the no-provider quote
  messages, the quote's 403 CSRF rejection, the site-menu gate, and the
  one-listing group page. The branch passes the gate at 100%; two
  genuinely equivalent mutants (`?? → ||` over string-or-null fallbacks)
  are recorded in the equivalent-mutants registry.
- Repeated test shapes were folded into shared helpers
  (`capturedModifierQuantity`, `postRunningTotal`, `quoteTicketHtml`,
  `setupAnswerTier`, `expectSingleTicketSvg`), and the existing suites
  now use them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Promo codes can now be prefilled from booking URLs.
  - Promo codes are normalized by trimming whitespace and ignoring letter case.
  - Prefilled promo codes are applied during quoting and checkout when valid.
  - User-entered or cleared promo codes are preserved when forms are re-rendered.

- **Bug Fixes**
  - Empty submitted promo-code values are now distinguished from missing values, preventing unwanted restoration of URL defaults.

- **Tests**
  - Expanded coverage for promo-code prefilling, validation, pricing, checkout, deposits, packages, and public booking flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->