### PR TITLE
Fill the promo code box from a ?promo= URL parameter

### DIFF
--- a/scripts/mutation/equivalent-mutants/ui-templates.txt
+++ b/scripts/mutation/equivalent-mutants/ui-templates.txt
@@ -6,6 +6,7 @@ src/ui/templates/layout.tsx::Layout.resolvedTheme~0oltraa  ?? → ||   # Theme i
 # Parent/child per-unit render (reservations contact-fields.ts).
 src/ui/templates/public/reservations/contact-fields.ts::pagePaid~07x8o1n  ?? → ||   # addOns?.some(...) is boolean|undefined; ?? and || agree on every boolean and on undefined
 src/ui/templates/public/reservations/form.tsx::TicketPageForm.html~1470qil   → "mutated"   # TicketPageForm's only caller supplies YYYY-MM-DD options; the fallback affects HTML only if it equals an option, which "mutated" never can
+src/ui/templates/public/reservations/form.tsx::PromoCodeField.value~0sldo6s  ?? → ||   # prefillPromo is a string or undefined, and the fallback is "", the only falsy string — so ?? and || pick the same side for every value (same class as settings-statuses renderStatusFields.value)
 src/ui/templates/public/reservations/ticket-page.tsx::ticketPage~0nmjfxs  ?? → ||   # questions is QuestionWithAnswers[]|undefined, and every present array, including [], is truthy
 src/ui/templates/public/reservations/ticket-page.tsx::ticketPage~0pcr5er  ?? → ||   # childDatesById is a ReadonlyMap|undefined, and every present Map, including an empty one, is truthy
 src/ui/templates/public/reservations/ticket-page.tsx::cartConflicts.concealed.childrenByParentId~1gqpisn  ?? → ||   # childrenByParentId is Map<...>|undefined, and every present Map, including an empty one, is truthy — no falsy-non-null value exists, so ?? and || pick the same operand

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -463,13 +463,23 @@ export const handleTicket = async (args: BookingRequest): Promise<Response> => {
   return applyHiddenNoindex(response, ctx.pageHidden);
 };
 
+/** Parse a `?promo=` code for pre-fill: trimmed for display, null when blank.
+ * Case stays as typed because the submit-time code lookup matches without
+ * case. */
+const parsePromoParam = (value: string | null): string | null => {
+  const trimmed = value?.trim() ?? "";
+  return trimmed !== "" ? trimmed : null;
+};
+
 /**
  * Build a booking pre-fill from query params: per-listing quantities from
  * `?q_<id>=n` (the order page redirects into `/ticket/<slugs>?q_<id>=1…` to
- * land the visitor with their chosen items selected) and the date selector
+ * land the visitor with their chosen items selected), the date selector
  * from `?date=YYYY-MM-DD` (the /listings date filter carries the searched
- * date into a daily listing's Book CTA, #51). A package needs no count
- * pre-fill — its selector already defaults to one bundle.
+ * date into a daily listing's Book CTA, #51), and the promo box from
+ * `?promo=<code>` (a marketing link lands the code in the box, #2367). A
+ * package needs no count pre-fill — its selector already defaults to one
+ * bundle.
  */
 export const parseQuantityPrefill = (
   request: Request,
@@ -484,8 +494,13 @@ export const parseQuantityPrefill = (
     }
   }
   const date = parseIsoDateParam(params.get("date"));
-  if (map.size === 0 && date === null) return;
-  return { listings: map, ...(date !== null ? { date } : {}) };
+  const promo = parsePromoParam(params.get("promo"));
+  if (map.size === 0 && date === null && promo === null) return;
+  return {
+    listings: map,
+    ...(date !== null ? { date } : {}),
+    ...(promo !== null ? { promo } : {}),
+  };
 };
 
 /**

--- a/src/features/public/ticket-submit.ts
+++ b/src/features/public/ticket-submit.ts
@@ -466,10 +466,8 @@ export const handleTicket = async (args: BookingRequest): Promise<Response> => {
 /** Parse a `?promo=` code for pre-fill: trimmed for display, null when blank.
  * Case stays as typed because the submit-time code lookup matches without
  * case. */
-const parsePromoParam = (value: string | null): string | null => {
-  const trimmed = value?.trim() ?? "";
-  return trimmed !== "" ? trimmed : null;
-};
+const parsePromoParam = (value: string | null): string | null =>
+  value === null ? null : value.trim() || null;
 
 /**
  * Build a booking pre-fill from query params: per-listing quantities from

--- a/src/ui/templates/public/reservations/form.tsx
+++ b/src/ui/templates/public/reservations/form.tsx
@@ -117,8 +117,13 @@ const AddOnsFieldset = ({ addOns }: { addOns: AddOnOption[] }): JSX.Element => (
 );
 
 /** Promo-code text input, shown when any active modifier is unlocked by a code.
- * The entered value is restored on a validation-error re-render. */
-const PromoCodeField = (): JSX.Element => (
+ * The value a failed submit kept comes first; a `?promo=` URL code fills the
+ * box only when nothing was typed. */
+const PromoCodeField = ({
+  prefillPromo,
+}: {
+  prefillPromo: string | undefined;
+}): JSX.Element => (
   <div class="promo-code">
     <label>
       {t("public.promo.heading")}
@@ -126,7 +131,7 @@ const PromoCodeField = (): JSX.Element => (
         name="promo_code"
         placeholder={t("public.promo.placeholder")}
         type="text"
-        value={savedFormValue("promo_code")}
+        value={savedFormValue("promo_code") || prefillPromo || ""}
       />
     </label>
   </div>
@@ -238,7 +243,7 @@ export const TicketPageForm = ({
         questions.length > 0 &&
         renderQuestions(questions, questionListingMap)}
       {addOns && addOns.length > 0 && <AddOnsFieldset addOns={addOns} />}
-      {promoCodesEnabled && <PromoCodeField />}
+      {promoCodesEnabled && <PromoCodeField prefillPromo={prefill?.promo} />}
       {terms && <Raw html={renderTermsAndCheckbox(terms)} />}
       {/* Continue is rendered first so it stays the form's default submit: an
           implicit submit (Enter in a text field) completes the booking, not the

--- a/src/ui/templates/public/reservations/form.tsx
+++ b/src/ui/templates/public/reservations/form.tsx
@@ -13,7 +13,7 @@ import { formatDatetimeLabel } from "#shared/dates.ts";
 import { CsrfForm } from "#shared/forms/csrf-form.tsx";
 import type { Field } from "#shared/forms/field.ts";
 import { renderFields } from "#shared/forms/rendering.tsx";
-import { savedFormValue } from "#shared/forms/saved-data.ts";
+import { getSavedFormData, savedFormValue } from "#shared/forms/saved-data.ts";
 import { renderMarkdown } from "#shared/markdown.ts";
 import { Badge } from "#templates/components/badge.tsx";
 import { ErrorNote } from "#templates/components/error.tsx";
@@ -117,8 +117,9 @@ const AddOnsFieldset = ({ addOns }: { addOns: AddOnOption[] }): JSX.Element => (
 );
 
 /** Promo-code text input, shown when any active modifier is unlocked by a code.
- * The value a failed submit kept comes first; a `?promo=` URL code fills the
- * box only when nothing was typed. */
+ * A value the buyer's own submit carried wins — the code they kept, or the
+ * empty box they cleared; a `?promo=` URL code fills the box only when their
+ * submit named nothing. */
 const PromoCodeField = ({
   prefillPromo,
 }: {
@@ -131,7 +132,11 @@ const PromoCodeField = ({
         name="promo_code"
         placeholder={t("public.promo.placeholder")}
         type="text"
-        value={savedFormValue("promo_code") || prefillPromo || ""}
+        value={
+          getSavedFormData()?.has("promo_code")
+            ? savedFormValue("promo_code")
+            : (prefillPromo ?? "")
+        }
       />
     </label>
   </div>

--- a/src/ui/templates/public/reservations/types.ts
+++ b/src/ui/templates/public/reservations/types.ts
@@ -48,11 +48,12 @@ export type ChildRenderCtx = {
 
 /**
  * Pre-fill for the booking page: per-listing quantities (and optional price), an
- * optional pre-filled name/date, and — only for signed QR links — a token
- * re-submitted as a hidden field to authorise a price override. Any scenario that
- * lands a visitor on a booking form with listings pre-selected builds one: the QR
- * flow sets a single listing plus a `token`; the order cart sets many listings
- * (quantity 1 each) and no token.
+ * optional pre-filled name/date, the promo code from a `?promo=` URL parameter,
+ * and — only for signed QR links — a token re-submitted as a hidden field to
+ * authorise a price override. Any scenario that lands a visitor on a booking
+ * form with listings pre-selected builds one: the QR flow sets a single
+ * listing plus a `token`; the order cart sets many listings (quantity 1 each)
+ * and no token.
  */
 export type BookingPrefill = {
   /** Per-listing pre-fill — keyed by listing id */
@@ -61,6 +62,8 @@ export type BookingPrefill = {
   name?: string;
   /** Pre-fill date selector (for daily listings) */
   date?: string;
+  /** Pre-fill the promo code box (the `?promo=` URL parameter) */
+  promo?: string;
   /** Opaque signed token re-submitted via a hidden input to verify a price
    * override. Only signed QR booking links set this. */
   token?: string;

--- a/test/features/public/ticket-submit.test.ts
+++ b/test/features/public/ticket-submit.test.ts
@@ -103,4 +103,22 @@ describe("parseQuantityPrefill", () => {
       ),
     ).toEqual({ date: "2026-09-12", listings: new Map() });
   });
+
+  test("reads a promo code with its surrounding spaces trimmed", () => {
+    expect(
+      parseQuantityPrefill(
+        new Request("https://example.com/ticket/a?promo=%20save10%20"),
+        listings,
+      ),
+    ).toEqual({ listings: new Map(), promo: "save10" });
+  });
+
+  test("treats a blank promo code as no prefill", () => {
+    expect(
+      parseQuantityPrefill(
+        new Request("https://example.com/ticket/a?promo=%20%20"),
+        listings,
+      ),
+    ).toBeUndefined();
+  });
 });

--- a/test/features/public/ticket-submit/submit.test.ts
+++ b/test/features/public/ticket-submit/submit.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The submit orchestration of `ticket-submit.ts`: which path a priced order
+ * takes (paid checkout, free reservation, owed free booking), the Square
+ * email rule during field validation, and the site-menu choice of the page a
+ * submit comes from. These tests sit at the source's mirror path so the
+ * mutation gate runs them against its submit logic.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { getAttendeeOrderSummary } from "#db/attendees/balance.ts";
+import { hashPhone } from "#db/contact-preferences.ts";
+import { modifiersTable } from "#db/modifiers.ts";
+import { settings } from "#db/settings.ts";
+import { stubWebhookFetch } from "#test/shared/webhook/helpers.ts";
+import {
+  assertPublicHtml,
+  expectFlash,
+  expectRedirect,
+} from "#test-utils/assertions.ts";
+import { setContactVisits } from "#test-utils/contact-preferences.ts";
+import { submitTicketForm } from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { latestAttendee } from "#test-utils/reservation/helpers.ts";
+import { enablePublicSite, setupStripe } from "#test-utils/settings.ts";
+
+describeWithEnv("ticket submit", { db: true, triggers: true }, () => {
+  describe("the page a submit comes from", () => {
+    test("drops the site menu when the public site is off", async () => {
+      const listing = await createTestListing({ maxAttendees: 50 });
+      const html = await assertPublicHtml(`/ticket/${listing.slug}`, "<h1>");
+      // With the public site off (the default), the menu's Home/Listings
+      // links would only bounce a visitor to the admin login, so no menu.
+      expect(html).not.toContain("admin-nav-group");
+    });
+
+    test("shows the site menu on a normal page when the public site is on", async () => {
+      await enablePublicSite();
+      const listing = await createTestListing({ maxAttendees: 50 });
+      const html = await assertPublicHtml(`/ticket/${listing.slug}`, "<h1>");
+      expect(html).toContain('<div class="admin-nav-group">');
+      expect(html).toContain('aria-label="Site menu"');
+    });
+
+    test("still drops the menu in iframe mode when the public site is on", async () => {
+      await enablePublicSite();
+      const listing = await createTestListing({ maxAttendees: 50 });
+      const html = await assertPublicHtml(
+        `/ticket/${listing.slug}?iframe=true`,
+        'class="iframe"',
+      );
+      expect(html).not.toContain("admin-nav-group");
+    });
+  });
+
+  describe("completing a submitted booking", () => {
+    test("keeps a zero-total order off the checkout while payments are enabled", async () => {
+      await setupStripe("sk_test_fake_key");
+      const listing = await createTestListing({
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice: 0,
+      });
+
+      const response = await submitTicketForm(listing.slug, {
+        email: "free@example.com",
+        name: "Free Buyer",
+      });
+
+      expectRedirect(response, "https://example.com/thanks");
+    });
+
+    test("still charges a one-penny order through the checkout", async () => {
+      await setupStripe();
+      const listing = await createTestListing({
+        thankYouUrl: "https://example.com",
+        unitPrice: 1,
+      });
+
+      const response = await submitTicketForm(listing.slug, {
+        email: "penny@example.com",
+        name: "Penny Buyer",
+      });
+
+      expectRedirect(response, "checkout.stripe.com");
+    });
+
+    describe("with no payment provider configured", () => {
+      const webhook = stubWebhookFetch();
+
+      test("records a paid order as owed, never as collected", async () => {
+        const listing = await createTestListing({
+          thankYouUrl: "",
+          unitPrice: 1000,
+          webhookUrl: "https://example.com/hook",
+        });
+
+        const response = await submitTicketForm(listing.slug, {
+          email: "owed@example.com",
+          name: "Owed Buyer",
+        });
+
+        expectRedirect(response, "/ticket/reserved");
+        const attendee = await latestAttendee();
+        // The £10.00 sale leg stands with no payment leg posted: the whole
+        // order stays owed to the site.
+        expect(attendee.remainingBalance).toBe(1000);
+        const summary = await getAttendeeOrderSummary(attendee.id);
+        expect(summary.depositPaid).toBe(0);
+        expect(summary.fullPrice).toBe(1000);
+        // The registration webhook says the same: nothing was collected and
+        // the full order is owed, because a provider-less booking charges
+        // every line zero.
+        const payload = webhook.firstBody();
+        expect(payload.price_paid).toBe(0);
+        expect(payload.amount_owed).toBe(1000);
+      });
+    });
+  });
+
+  describe("the Square email rule on paid bookings", () => {
+    /** A booking page that collects a phone number instead of an email, so
+     * the Square email rule is the only thing that can demand one. */
+    const phoneOnlyListing = (unitPrice: number) =>
+      createTestListing({
+        fields: "phone",
+        thankYouUrl: "https://example.com/thanks",
+        unitPrice,
+      });
+
+    /** Square chosen without credentials: the field rules treat bookings as
+     * paid, while payments stay disabled so nothing reaches a checkout. */
+    const chooseSquare = () => settings.update.paymentProvider("square");
+
+    /** A phone with one stored visit, so repricing sees a returning buyer. */
+    const RETURNING_PHONE = "07700900001";
+    const seedReturningBuyer = async (): Promise<void> => {
+      await setContactVisits(await hashPhone(RETURNING_PHONE), 1);
+    };
+
+    /** A one-penny price change only a returning buyer's repricing sees: the
+     * initial price ran at the buyer's unknown visit count (zero). */
+    const returningBuyerPriceChange = (direction: "charge" | "discount") =>
+      modifiersTable.insert({
+        calcKind: "fixed",
+        calcValue: 1,
+        direction,
+        minVisits: 1,
+        name:
+          direction === "charge" ? "Regular visitor fee" : "Regular visitor",
+      });
+
+    /** Submit the page as the returning phone buyer and expect Square's
+     * email demand — the demand a free booking never triggers. */
+    const expectEmailDemanded = async (listing: { slug: string }) => {
+      const response = await submitTicketForm(listing.slug, {
+        name: "Phone Buyer",
+        phone: RETURNING_PHONE,
+      });
+      expect(response.status).toBe(302);
+      expectFlash(
+        response,
+        expect.stringContaining("Your Email is required"),
+        false,
+      );
+    };
+
+    test("lets a phone-only free booking through", async () => {
+      await chooseSquare();
+      const listing = await phoneOnlyListing(0);
+
+      const response = await submitTicketForm(listing.slug, {
+        name: "Phone Buyer",
+        phone: RETURNING_PHONE,
+      });
+
+      expectRedirect(response, "https://example.com/thanks");
+    });
+
+    test("still demands the email a one-penny order required from the start", async () => {
+      await chooseSquare();
+      await seedReturningBuyer();
+      const listing = await phoneOnlyListing(1);
+      await returningBuyerPriceChange("discount");
+
+      await expectEmailDemanded(listing);
+    });
+
+    test("demands the email a repriced order turns paid", async () => {
+      await chooseSquare();
+      await seedReturningBuyer();
+      const listing = await phoneOnlyListing(0);
+      await returningBuyerPriceChange("charge");
+
+      await expectEmailDemanded(listing);
+    });
+  });
+});

--- a/test/features/public/ticket-submit/submit.test.ts
+++ b/test/features/public/ticket-submit/submit.test.ts
@@ -138,12 +138,16 @@ describeWithEnv("ticket submit", { db: true, triggers: true }, () => {
       await setContactVisits(await hashPhone(RETURNING_PHONE), 1);
     };
 
-    /** A one-penny price change only a returning buyer's repricing sees: the
-     * initial price ran at the buyer's unknown visit count (zero). */
-    const returningBuyerPriceChange = (direction: "charge" | "discount") =>
+    /** A price change only a returning buyer's repricing sees: the initial
+     * price ran at the buyer's unknown visit count (zero). `calcValue` is in
+     * whole currency units, so a penny-sized change is 0.01. */
+    const returningBuyerPriceChange = (
+      direction: "charge" | "discount",
+      calcValue: number,
+    ) =>
       modifiersTable.insert({
         calcKind: "fixed",
-        calcValue: 1,
+        calcValue,
         direction,
         minVisits: 1,
         name:
@@ -181,7 +185,7 @@ describeWithEnv("ticket submit", { db: true, triggers: true }, () => {
       await chooseSquare();
       await seedReturningBuyer();
       const listing = await phoneOnlyListing(1);
-      await returningBuyerPriceChange("discount");
+      await returningBuyerPriceChange("discount", 1);
 
       await expectEmailDemanded(listing);
     });
@@ -190,7 +194,9 @@ describeWithEnv("ticket submit", { db: true, triggers: true }, () => {
       await chooseSquare();
       await seedReturningBuyer();
       const listing = await phoneOnlyListing(0);
-      await returningBuyerPriceChange("charge");
+      // A penny onto a returning buyer's order, so the repriced order
+      // becomes paid after the initial free price passed validation.
+      await returningBuyerPriceChange("charge", 0.01);
 
       await expectEmailDemanded(listing);
     });

--- a/test/integration/server/calculate.test.ts
+++ b/test/integration/server/calculate.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "@std/expect";
 import { it as test } from "@std/testing/bdd";
 import { stub } from "@std/testing/mock";
-import { hmacHash } from "#crypto/hashing.ts";
 import { attendeeStatuses } from "#db/attendee-statuses.ts";
 import { getDb } from "#db/client.ts";
 import { setGroupPackageMembers } from "#db/groups.ts";
@@ -11,12 +10,12 @@ import { answersTable, questionsTable } from "#db/questions/tables.ts";
 import { settings } from "#db/settings.ts";
 import { handleRequest } from "#routes";
 import { formatCurrency } from "#shared/currency.ts";
-import { normalizeCode } from "#shared/price-modifier.ts";
 import { extractCsrfToken } from "#test-utils/csrf.ts";
 import { describeWithEnv } from "#test-utils/db.ts";
 import { createTestGroup } from "#test-utils/db-helpers/groups.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
+import { createSave10Promo } from "#test-utils/reservation/helpers.ts";
 import { setupStripe } from "#test-utils/settings.ts";
 
 /** GET the booking page for `pageSlug` to mint a CSRF token, then POST the
@@ -465,14 +464,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
       name: "Workshop",
       unitPrice: 1000,
     });
-    await modifiersTable.insert({
-      calcKind: "percent",
-      calcValue: 10,
-      codeIndex: await hmacHash(normalizeCode("SAVE10")),
-      direction: "discount",
-      name: "10% off",
-      trigger: "code",
-    });
+    await createSave10Promo();
     return listing;
   };
 
@@ -495,7 +487,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     const html = await quoteSave10Promo();
 
     // Discount line shown with modifier name and negative amount.
-    expect(html).toContain("10% off");
+    expect(html).toContain("SAVE10");
     expect(html).toContain(formatCurrency(-100));
     // Total reflects the discounted price (10% off £10.00 = £9.00).
     expect(html).toContain(formatCurrency(900));
@@ -508,7 +500,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     // The ticket line is the full £10.00 list price, so the discount isn't
     // baked into it — the modifier is itemised separately on its own row...
     expect(html).toContain(formatCurrency(1000));
-    expect(html).toContain("10% off");
+    expect(html).toContain("SAVE10");
     expect(html).toContain(formatCurrency(-100));
     // ...and only the total carries the £9.00 discounted figure.
     expect(html).toContain(formatCurrency(900));
@@ -520,7 +512,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     // Full price — no promo code entered, no discount line.
     expect(html).toContain(formatCurrency(1000));
     expect(html).not.toContain(formatCurrency(900));
-    expect(html).not.toContain("10% off");
+    expect(html).not.toContain("SAVE10");
   });
 
   test("does not apply a promo code discount when a wrong code is submitted", async () => {
@@ -529,7 +521,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     // Full price — wrong promo code, no discount line.
     expect(html).toContain(formatCurrency(1000));
     expect(html).not.toContain(formatCurrency(900));
-    expect(html).not.toContain("10% off");
+    expect(html).not.toContain("SAVE10");
   });
 
   /** Turn the seeded public-default status into a reservation charging `amount`,
@@ -569,7 +561,7 @@ describeWithEnv("server (/calculate running total)", { db: true }, () => {
     const html = await quotePromoListing({ promo_code: "save10" });
 
     // Lowercase variant of the code should still match.
-    expect(html).toContain("10% off");
+    expect(html).toContain("SAVE10");
     expect(html).toContain(formatCurrency(-100));
     expect(html).toContain(formatCurrency(900));
   });

--- a/test/integration/server/public/ticket-promo-prefill.test.ts
+++ b/test/integration/server/public/ticket-promo-prefill.test.ts
@@ -1,0 +1,114 @@
+import { expect } from "@std/expect";
+import { describe, it as test } from "@std/testing/bdd";
+import { handleRequest } from "#routes";
+import { formatCurrency } from "#shared/currency.ts";
+import { followRedirectWithFlash } from "#test-utils/assertions.ts";
+import {
+  extractCsrfToken,
+  extractInputValue,
+  submitMultiTicketForm,
+} from "#test-utils/csrf.ts";
+import { describeWithEnv } from "#test-utils/db.ts";
+import { createTestListing } from "#test-utils/db-helpers/listings.ts";
+import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
+import { createSave10Promo } from "#test-utils/reservation/helpers.ts";
+import { setupStripe } from "#test-utils/settings.ts";
+
+/** A listing plus the shared SAVE10 code-triggered modifier, so the booking
+ * page shows the promo box and the code answers a real discount. */
+const setupPromoListing = async () => {
+  await setupStripe();
+  const listing = await createTestListing({
+    maxQuantity: 5,
+    name: "Workshop",
+    unitPrice: 1000,
+  });
+  await createSave10Promo();
+  return listing;
+};
+
+/** The rendered promo box value on a GET, or null when the page has no box. */
+const promoBoxValue = async (path: string): Promise<string | null> => {
+  const response = await handleRequest(mockRequest(path));
+  expect(response.status).toBe(200);
+  return extractInputValue(await response.text(), "promo_code");
+};
+
+describeWithEnv(
+  "server public > ticket promo prefill",
+  { db: true, triggers: true },
+  () => {
+    describe("GET /ticket/:slug?promo=", () => {
+      test("fills the promo code box from the URL parameter", async () => {
+        const listing = await setupPromoListing();
+        expect(
+          await promoBoxValue(`/ticket/${listing.slug}?promo=SAVE10`),
+        ).toBe("SAVE10");
+      });
+
+      test("trims surrounding spaces off the URL code", async () => {
+        const listing = await setupPromoListing();
+        expect(
+          await promoBoxValue(`/ticket/${listing.slug}?promo=%20save10%20`),
+        ).toBe("save10");
+      });
+
+      test("treats a blank URL code as no prefill", async () => {
+        const listing = await setupPromoListing();
+        expect(await promoBoxValue(`/ticket/${listing.slug}?promo=%20`)).toBe(
+          "",
+        );
+      });
+
+      test("fills the one shared promo box on a multi-listing URL", async () => {
+        const listing1 = await createTestListing({ name: "Promo Page One" });
+        const listing2 = await createTestListing({ name: "Promo Page Two" });
+        await createSave10Promo();
+        const html = await (
+          await handleRequest(
+            mockRequest(
+              `/ticket/${listing1.slug}+${listing2.slug}?promo=summer-sale`,
+            ),
+          )
+        ).text();
+        expect((html.match(/name="promo_code"/g) ?? []).length).toBe(1);
+        expect(extractInputValue(html, "promo_code")).toBe("summer-sale");
+      });
+    });
+
+    test("keeps the typed code after a failed submit", async () => {
+      const listing = await setupPromoListing();
+      // A missing name fails validation; the page that follows the redirect
+      // must still hold the code the buyer typed, not an empty box.
+      const response = await submitMultiTicketForm(listing.slug, {
+        [`quantity_${listing.id}`]: "1",
+        email: "buyer@example.com",
+        name: "",
+        promo_code: "typed-code",
+      });
+      expect(response.status).toBe(302);
+      const page = await followRedirectWithFlash(response, handleRequest);
+      const html = await page.text();
+      expect(extractInputValue(html, "promo_code")).toBe("typed-code");
+    });
+
+    test("a code from the URL reaches the discounted quote", async () => {
+      const listing = await setupPromoListing();
+      const page = await handleRequest(
+        mockRequest(`/ticket/${listing.slug}?promo=SAVE10`),
+      );
+      const html = await page.text();
+      // Quote with exactly the value the box holds, as the browser would.
+      const quote = await handleRequest(
+        mockFormRequest(`/calculate/${listing.slug}`, {
+          [`quantity_${listing.id}`]: "1",
+          csrf_token: extractCsrfToken(html) ?? "",
+          promo_code: extractInputValue(html, "promo_code") ?? "",
+        }),
+      );
+      const quoteHtml = await quote.text();
+      expect(quoteHtml).toContain("SAVE10");
+      expect(quoteHtml).toContain(formatCurrency(900));
+    });
+  },
+);

--- a/test/integration/server/public/ticket-slug-get.test.ts
+++ b/test/integration/server/public/ticket-slug-get.test.ts
@@ -17,7 +17,7 @@ import {
   deactivateTestListing,
 } from "#test-utils/db-helpers/listings.ts";
 import { mockFormRequest, mockRequest } from "#test-utils/mocks.ts";
-import { enablePublicSite, withSetting } from "#test-utils/settings.ts";
+import { withSetting } from "#test-utils/settings.ts";
 
 // jscpd:ignore-end
 
@@ -192,27 +192,6 @@ describeWithEnv(
           "A &lt;b&gt;great&lt;/b&gt; listing",
         );
         expect(html).not.toContain('class="iframe"');
-        // With the public site off (the default), the menu's Home/Listings
-        // links would only bounce a visitor to the admin login, so no menu.
-        expect(html).not.toContain("admin-nav-group");
-      });
-
-      test("shows the site menu on a normal page when the public site is on", async () => {
-        await enablePublicSite();
-        const listing = await createTestListing({ maxAttendees: 50 });
-        const html = await assertPublicHtml(`/ticket/${listing.slug}`, "<h1>");
-        expect(html).toContain('<div class="admin-nav-group">');
-        expect(html).toContain('aria-label="Site menu"');
-      });
-
-      test("still drops the menu in iframe mode when the public site is on", async () => {
-        await enablePublicSite();
-        const listing = await createTestListing({ maxAttendees: 50 });
-        const html = await assertPublicHtml(
-          `/ticket/${listing.slug}?iframe=true`,
-          'class="iframe"',
-        );
-        expect(html).not.toContain("admin-nav-group");
       });
 
       test("does not set CSRF cookies (uses signed tokens instead)", async () => {

--- a/test/test-utils/reservation/helpers.ts
+++ b/test/test-utils/reservation/helpers.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { stub } from "@std/testing/mock";
+import { hmacHash } from "#crypto/hashing.ts";
 import {
   attendeeStatuses,
   requirePublicDefaultStatus,
@@ -11,6 +12,7 @@ import { getDb } from "#db/client.ts";
 import { modifiersTable } from "#db/modifiers.ts";
 import { settings } from "#db/settings.ts";
 import type { RefundRequest } from "#payment/refund-attempt.ts";
+import { normalizeCode } from "#shared/price-modifier.ts";
 import { submitTicketForm } from "#test-utils/csrf.ts";
 import { createTestListing } from "#test-utils/db-helpers/listings.ts";
 import { signMeta } from "#test-utils/factories.ts";
@@ -185,11 +187,14 @@ export const createProgrammeCharge = (
   });
 
 /** The "SAVE10" promo-code discount shared by every test that prices a
- * booking through a 10%-off code rather than an automatic modifier. */
-export const createSave10Promo = () =>
+ * booking through a 10%-off code rather than an automatic modifier. Carries
+ * the blind index, so the code lookup finds it through `promo_code` form
+ * fields, not only through an explicit modifier reference. */
+export const createSave10Promo = async () =>
   modifiersTable.insert({
     calcKind: "percent",
     calcValue: 10,
+    codeIndex: await hmacHash(normalizeCode("SAVE10")),
     direction: "discount",
     name: "SAVE10",
     trigger: "code",

--- a/test/ui/templates/public/reservations/form.test.ts
+++ b/test/ui/templates/public/reservations/form.test.ts
@@ -171,11 +171,6 @@ describe("ticketPage — fields & form", () => {
     expect(html).toContain('data-listing-ids="1"');
   });
 
-  test("omits the promo-code field when promo codes are disabled", () => {
-    const html = singleListingPageHtml();
-    expect(html).not.toContain('name="promo_code"');
-  });
-
   test("renders an opt-in add-on selector with its price label", () => {
     const listings = [
       ticketListing({
@@ -208,45 +203,6 @@ describe("ticketPage — fields & form", () => {
       expect(html).toContain(
         'max="5" min="0" name="addon_7" placeholder="0" type="number" value="2"',
       );
-    } finally {
-      clearSavedFormData();
-    }
-  });
-
-  test("restores the submitted promo code", () => {
-    setSavedFormData(new FormParams({ promo_code: "SAVE20" }));
-    try {
-      const html = singleListingPageHtml({ promoCodesEnabled: true });
-      expect(html).toContain('<div class="promo-code"><label>Promo code');
-      expect(html).toContain(
-        'name="promo_code" placeholder="Optional" type="text" value="SAVE20"',
-      );
-    } finally {
-      clearSavedFormData();
-    }
-  });
-
-  test("prefills the promo code from the URL", () => {
-    const html = singleListingPageHtml({
-      prefill: { listings: new Map(), promo: "save10" },
-      promoCodesEnabled: true,
-    });
-    expect(html).toContain(
-      'name="promo_code" placeholder="Optional" type="text" value="save10"',
-    );
-  });
-
-  test("restores the submitted promo code ahead of the URL code", () => {
-    setSavedFormData(new FormParams({ promo_code: "TYPED" }));
-    try {
-      const html = singleListingPageHtml({
-        prefill: { listings: new Map(), promo: "url-code" },
-        promoCodesEnabled: true,
-      });
-      expect(html).toContain(
-        'name="promo_code" placeholder="Optional" type="text" value="TYPED"',
-      );
-      expect(html).not.toContain('value="url-code"');
     } finally {
       clearSavedFormData();
     }

--- a/test/ui/templates/public/reservations/form.test.ts
+++ b/test/ui/templates/public/reservations/form.test.ts
@@ -226,6 +226,32 @@ describe("ticketPage — fields & form", () => {
     }
   });
 
+  test("prefills the promo code from the URL", () => {
+    const html = singleListingPageHtml({
+      prefill: { listings: new Map(), promo: "save10" },
+      promoCodesEnabled: true,
+    });
+    expect(html).toContain(
+      'name="promo_code" placeholder="Optional" type="text" value="save10"',
+    );
+  });
+
+  test("restores the submitted promo code ahead of the URL code", () => {
+    setSavedFormData(new FormParams({ promo_code: "TYPED" }));
+    try {
+      const html = singleListingPageHtml({
+        prefill: { listings: new Map(), promo: "url-code" },
+        promoCodesEnabled: true,
+      });
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value="TYPED"',
+      );
+      expect(html).not.toContain('value="url-code"');
+    } finally {
+      clearSavedFormData();
+    }
+  });
+
   test("prefills the name and signed token", () => {
     const html = renderForm({
       fields: [{ label: "Name", name: "name", type: "text" }],

--- a/test/ui/templates/public/reservations/form/promo-code.test.ts
+++ b/test/ui/templates/public/reservations/form/promo-code.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The promo-code box on the booking form: its presence with codes enabled,
+ * the value a failed submit kept, and the `?promo=` URL pre-fill that fills
+ * the box only when nothing was typed. Kept apart from the catch-all form
+ * test file so each stays under the size limit.
+ */
+
+import { expect } from "@std/expect";
+import { beforeAll, describe, it as test } from "@std/testing/bdd";
+import { FormParams } from "#shared/form-data.ts";
+import {
+  clearSavedFormData,
+  setSavedFormData,
+} from "#shared/forms/saved-data.ts";
+import {
+  registerPublicTemplateHooks,
+  singleListingPageHtml,
+} from "#test/ui/templates/helpers.ts";
+import { setupAdminPageTest } from "#test-utils/admin-page-test.ts";
+
+describe("the promo-code box", () => {
+  beforeAll(setupAdminPageTest);
+  registerPublicTemplateHooks();
+
+  test("omits the box when promo codes are disabled", () => {
+    const html = singleListingPageHtml();
+    expect(html).not.toContain('name="promo_code"');
+  });
+
+  test("restores the submitted promo code", () => {
+    setSavedFormData(new FormParams({ promo_code: "SAVE20" }));
+    try {
+      const html = singleListingPageHtml({ promoCodesEnabled: true });
+      expect(html).toContain('<div class="promo-code"><label>Promo code');
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value="SAVE20"',
+      );
+    } finally {
+      clearSavedFormData();
+    }
+  });
+
+  test("prefills the promo code from the URL", () => {
+    const html = singleListingPageHtml({
+      prefill: { listings: new Map(), promo: "save10" },
+      promoCodesEnabled: true,
+    });
+    expect(html).toContain(
+      'name="promo_code" placeholder="Optional" type="text" value="save10"',
+    );
+  });
+
+  test("restores the submitted promo code ahead of the URL code", () => {
+    setSavedFormData(new FormParams({ promo_code: "TYPED" }));
+    try {
+      const html = singleListingPageHtml({
+        prefill: { listings: new Map(), promo: "url-code" },
+        promoCodesEnabled: true,
+      });
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value="TYPED"',
+      );
+      expect(html).not.toContain('value="url-code"');
+    } finally {
+      clearSavedFormData();
+    }
+  });
+});

--- a/test/ui/templates/public/reservations/form/promo-code.test.ts
+++ b/test/ui/templates/public/reservations/form/promo-code.test.ts
@@ -65,4 +65,20 @@ describe("the promo-code box", () => {
       clearSavedFormData();
     }
   });
+
+  test("keeps the box empty when the buyer cleared the code", () => {
+    setSavedFormData(new FormParams({ promo_code: "" }));
+    try {
+      const html = singleListingPageHtml({
+        prefill: { listings: new Map(), promo: "url-code" },
+        promoCodesEnabled: true,
+      });
+      expect(html).toContain(
+        'name="promo_code" placeholder="Optional" type="text" value=""',
+      );
+      expect(html).not.toContain('value="url-code"');
+    } finally {
+      clearSavedFormData();
+    }
+  });
 });


### PR DESCRIPTION
Fixes #2367.

## What changed

A booking link like `/ticket/<listing>?promo=example-code` now lands the
code in the promo box, the same way `?date=` lands a searched date (#51).
A visitor coming from a marketing page no longer retypes the code.

## How it works

- `parseQuantityPrefill` (`src/features/public/ticket-submit.ts`) reads
  `?promo=`, trims surrounding spaces, and ignores a blank value. Every
  booking-page entry shares this parser, so single-listing, multi-listing
  (`/ticket/a+b`), group, order, and renewal pages behave the same.
- `BookingPrefill` grows an optional `promo`.
- The promo box now honours the buyer's own submit above the URL: a code
  they kept, or an empty box they cleared, stays as they left it after a
  validation error; the URL code fills only a box their submit never
  named (per the coderabbit review).
- The code is not validated at render time and keeps its case, because the
  submit-time code lookup trims and lower-cases before it matches.

## Tests

- Unit: `parseQuantityPrefill` promo parsing (trim, blank, combined).
- Template (`form/promo-code.test.ts`): the box holds the URL code, a
  saved submit value wins over it, and a cleared box stays empty.
- Integration (`ticket-promo-prefill.test.ts`): the box fills from the URL
  on single and multi-listing pages, a failed submit keeps the typed code,
  and a real URL code reaches the discounted quote through the normal path.
- `createSave10Promo` now carries the blind code index so the promo is
  found through the real code lookup; `calculate.test.ts` uses the shared
  helper.

The mutation gate initially survived 14 mutants in the two touched source
files because the booking-path tests lived where the gate never looks. The
submit orchestration now has its own mirror-located suite
(`ticket-submit/submit.test.ts`) covering the free/paid/owed path split
around totals of 0 and 1 minor unit, the Square email rule at first
validation and at repricing, and the site-menu choice of the rendered page
(moved from `ticket-slug-get.test.ts`, one implementation).

## Gates

- `devenv shell deno task precommit` — passed on every commit.
- `devenv shell deno task precommit:mutation` — 152/152 killed
  (5 provably-equivalent suppressed), 100%, re-run after every commit.

## Counts

- 66 src lines changed across 3 files.
- No schema or provider changes; no new database calls (the URL parameter
  is read from the request).